### PR TITLE
Pubby stuff I forgot to add in

### DIFF
--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -22678,6 +22678,7 @@
 	name = "Research Director's Office";
 	req_access_txt = "30"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/rd)
 "bAt" = (

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -36276,6 +36276,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"eiu" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
 "ejn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -38161,6 +38175,20 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"fZK" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/cargo/warehouse/upper)
 "fZV" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/blue,
@@ -49509,20 +49537,6 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
-"rYZ" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/cargo/warehouse/upper)
 "sah" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -53768,20 +53782,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
-"vYM" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/cargo/storage)
 "vYN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -75476,7 +75476,7 @@ lGp
 aij
 lGp
 pEp
-agy
+adE
 eTi
 wxa
 fmp
@@ -75733,7 +75733,7 @@ quw
 rJS
 quw
 rka
-agy
+adE
 jTV
 wxa
 fmp
@@ -75990,7 +75990,7 @@ sdk
 lPO
 sdk
 rcR
-agy
+adE
 dfu
 wxa
 ubq
@@ -76247,7 +76247,7 @@ tqM
 akP
 tqM
 kPM
-agy
+adE
 tTq
 wxa
 eaA
@@ -76504,7 +76504,7 @@ alA
 alA
 mrR
 kPM
-agy
+adE
 nfc
 wxa
 wxa
@@ -76761,7 +76761,7 @@ aen
 aen
 duH
 rkv
-agy
+adE
 agy
 aen
 aen
@@ -100461,8 +100461,8 @@ mdx
 dWw
 mXc
 saR
-rYZ
-vYM
+fZK
+eiu
 eCB
 ahW
 vHj

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -11023,7 +11023,7 @@
 /area/hallway/primary/central)
 "aJa" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "aJc" = (
@@ -31083,6 +31083,7 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "cfU" = (
@@ -33140,6 +33141,13 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"cql" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "cqp" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -38921,6 +38929,11 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
+"gHX" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "gIC" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -39858,7 +39871,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/trinary/filter/critical{
-	dir = 1
+	dir = 1;
+	filter_type = "n2"
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
@@ -40177,10 +40191,17 @@
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "igj" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/turf/open/floor/engine,
-/area/engineering/supermatter/room)
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/main)
 "igu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -40592,6 +40613,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter/room)
 "iEQ" = (
@@ -42834,8 +42856,8 @@
 /turf/open/floor/grass,
 /area/science/genetics)
 "lmU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/turf/open/floor/engine,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
 /area/engineering/supermatter/room)
 "lmV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -44787,6 +44809,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "nww" = (
@@ -46973,11 +46996,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "pEK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/turf/open/floor/engine,
+/turf/closed/wall/r_wall,
 /area/engineering/supermatter/room)
 "pFy" = (
 /obj/structure/disposalpipe/segment{
@@ -49761,6 +49781,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
 "slC" = (
@@ -84894,8 +84915,8 @@ bYK
 cOG
 cOG
 cOG
-vAE
-vAE
+xXQ
+xXQ
 cdL
 cer
 ceV
@@ -85152,7 +85173,7 @@ cbW
 cbW
 fIc
 pBN
-cbW
+pyA
 cdM
 njS
 xmE
@@ -85409,12 +85430,12 @@ cbW
 cai
 cbe
 cca
-cbW
-orZ
-nZX
+pyA
+igj
+lmU
 iEJ
-nZX
-nZX
+pEK
+pEK
 nZX
 nZX
 nZX
@@ -85666,14 +85687,14 @@ cbW
 cai
 cbf
 ccb
-cbW
+pyA
 cdO
 cbj
 ceX
 wdp
 cfS
+cql
 eoo
-pEK
 bCk
 xqI
 imB
@@ -85930,8 +85951,8 @@ eHY
 mUJ
 uBs
 uBs
-lmU
-sWj
+wza
+gHX
 nZX
 nZX
 nZX
@@ -86187,7 +86208,7 @@ fwi
 wza
 cfU
 qmK
-lmU
+wza
 nwg
 ujj
 eoo
@@ -86444,8 +86465,8 @@ xfz
 ptC
 cfV
 cgu
-igj
-upV
+mUJ
+aJa
 aJa
 upV
 lWv

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -52643,10 +52643,10 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "uos" = (
-/obj/machinery/computer/camera_advanced/base_construction,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/computer/camera_advanced/base_construction/aux,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "uoS" = (

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -13009,12 +13009,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"aRu" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/atmos/air_output{
-	dir = 1
-	},
-/turf/open/floor/engine/air,
-/area/engineering/atmos)
 "aRB" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron/dark,
@@ -25479,6 +25473,16 @@
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "bKS" = (
+/obj/structure/chair/stool/bar/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron,
+/area/engineering/lobby)
+"bKT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/meter,
+/turf/closed/wall/r_wall,
+/area/engineering/lobby)
+"bKV" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
@@ -25489,7 +25493,7 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"bKT" = (
+"bKY" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Atmospherics Monitoring";
@@ -25504,7 +25508,22 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"bKV" = (
+"bLb" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
+/area/hallway/primary/aft)
+"bLc" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Monitoring";
 	dir = 1
@@ -25516,7 +25535,7 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"bKY" = (
+"bLd" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/atmospherics,
 /obj/item/clothing/head/welding{
@@ -25533,45 +25552,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"bLb" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/storage/belt/utility,
-/obj/item/t_scanner,
-/obj/item/t_scanner,
-/obj/item/t_scanner,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/item/grenade/chem_grenade/smart_metal_foam,
-/obj/item/grenade/chem_grenade/smart_metal_foam,
-/obj/machinery/newscaster/directional/south,
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"bLc" = (
-/obj/structure/table,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/stack/sheet/glass,
-/obj/item/stack/rods/fifty,
-/obj/item/pipe_dispenser,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"bLd" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Pure to Port"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -25599,14 +25579,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/mixing)
-"bLp" = (
-/obj/machinery/power/turbine{
-	dir = 4;
-	luminosity = 2
-	},
-/obj/structure/cable,
-/turf/open/floor/engine/vacuum,
-/area/maintenance/disposal/incinerator)
 "bLq" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Monastery Transit"
@@ -25758,20 +25730,21 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "bLV" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/storage/belt/utility,
+/obj/item/t_scanner,
+/obj/item/t_scanner,
+/obj/item/t_scanner,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/white/corner{
-	dir = 1
-	},
-/area/hallway/primary/aft)
+/obj/item/grenade/chem_grenade/smart_metal_foam,
+/obj/item/grenade/chem_grenade/smart_metal_foam,
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "bLX" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/table/reinforced,
@@ -25890,7 +25863,19 @@
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos)
 "bMk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
+/obj/structure/table,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/stack/sheet/glass,
+/obj/item/stack/rods/fifty,
+/obj/item/pipe_dispenser,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bMl" = (
@@ -26043,20 +26028,20 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "bMW" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/rnd/production/circuit_imprinter,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "bMX" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/turf/closed/wall/r_wall,
-/area/engineering/lobby)
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Pure to Port"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "bMY" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -26083,9 +26068,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bNb" = (
-/obj/machinery/firealarm/directional/west,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bNg" = (
@@ -26096,6 +26079,12 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bNj" = (
+/obj/machinery/firealarm/directional/west,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
+"bNk" = (
 /obj/machinery/shower{
 	dir = 8
 	},
@@ -26104,16 +26093,6 @@
 	departmentType = 2;
 	name = "Atmos RC"
 	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"bNk" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Air to Port"
-	},
-/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bNl" = (
@@ -26308,16 +26287,16 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bOc" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -26333,19 +26312,19 @@
 	},
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/structure/chair/stool/bar/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "bOe" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/rnd/production/protolathe/department/engineering,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "bOf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/closed/wall/r_wall,
 /area/engineering/lobby)
 "bOg" = (
@@ -26394,18 +26373,18 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bOn" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Mix to Port"
+/obj/machinery/light{
+	dir = 8
 	},
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Air to Port"
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bOo" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/computer/atmos_control/tank/nitrous_tank{
-	dir = 8
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Mix to Port"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -26514,6 +26493,7 @@
 	dir = 8
 	},
 /obj/machinery/newscaster/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "bON" = (
@@ -26621,10 +26601,14 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bPg" = (
-/obj/machinery/light/small{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/turf/open/floor/engine/n2o,
+/obj/machinery/computer/atmos_control/tank/nitrous_tank{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "bPh" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
@@ -27049,10 +27033,10 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bQH" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/n2o{
-	dir = 1
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/engine/n2o,
 /area/engineering/atmos)
 "bQJ" = (
 /obj/machinery/suit_storage_unit/atmos,
@@ -27191,6 +27175,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
+"bRn" = (
+/obj/machinery/requests_console/directional/east{
+	department = "Atmospherics";
+	departmentType = 2;
+	name = "Atmos RC"
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "bRp" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -27219,7 +27211,6 @@
 /obj/machinery/navbeacon/wayfinding/atmos,
 /obj/machinery/door/firedoor/heavy,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "bRs" = (
@@ -27267,10 +27258,10 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bRz" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrous_input{
-	dir = 8
+/obj/machinery/atmospherics/components/trinary/filter/atmos/n2o{
+	dir = 1
 	},
-/turf/open/floor/engine/n2o,
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "bRC" = (
 /obj/structure/window/reinforced{
@@ -27461,13 +27452,15 @@
 "bSa" = (
 /obj/structure/table,
 /obj/item/toy/cards/deck,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "bSc" = (
-/obj/structure/grille,
-/turf/open/space,
-/area/space/nearstation)
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrous_input{
+	dir = 8
+	},
+/turf/open/floor/engine/n2o,
+/area/engineering/atmos)
 "bSd" = (
 /obj/machinery/light{
 	dir = 4
@@ -27498,9 +27491,9 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bSg" = (
-/obj/machinery/holopad,
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/obj/structure/grille,
+/turf/open/space,
+/area/space/nearstation)
 "bSh" = (
 /obj/machinery/light{
 	dir = 4
@@ -27512,14 +27505,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bSj" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bSk" = (
@@ -27688,7 +27674,14 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bSS" = (
-/obj/machinery/pipedispenser/disposal/transit_tube,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bST" = (
@@ -27696,10 +27689,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bSU" = (
-/obj/machinery/atmospherics/components/trinary/mixer{
-	dir = 1;
-	name = "plasma mixer"
-	},
+/obj/machinery/pipedispenser/disposal/transit_tube,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bSV" = (
@@ -28013,33 +28003,30 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bTK" = (
+/obj/machinery/atmospherics/components/trinary/mixer{
+	dir = 1;
+	name = "plasma mixer"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
+"bTO" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"bTO" = (
+"bTP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"bTP" = (
+"bTQ" = (
 /obj/machinery/shower{
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"bTQ" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/computer/atmos_control/tank/toxin_tank{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bTR" = (
@@ -28233,10 +28220,14 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bUx" = (
-/obj/machinery/light/small{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/turf/open/floor/engine/plasma,
+/obj/machinery/computer/atmos_control/tank/toxin_tank{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "bUC" = (
 /obj/structure/flora/ausbushes/fernybush,
@@ -28540,26 +28531,10 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bVn" = (
-/obj/structure/plaque/static_plaque/atmos{
-	pixel_y = 32
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics Entrance"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "bVo" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
@@ -29061,6 +29036,15 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bWP" = (
+/obj/structure/plaque/static_plaque/atmos{
+	pixel_y = 32
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics Entrance"
+	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -29253,7 +29237,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bXB" = (
-/obj/machinery/vending/wardrobe/atmos_wardrobe,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -29263,13 +29246,11 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bXC" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/structure/fireaxecabinet{
-	pixel_y = 32
-	},
+/obj/machinery/vending/wardrobe/atmos_wardrobe,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -29808,8 +29789,9 @@
 /turf/open/space,
 /area/space/nearstation)
 "bZT" = (
-/obj/machinery/camera{
-	c_tag = "Atmospherics Mixing"
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/structure/fireaxecabinet{
+	pixel_y = 32
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -29817,7 +29799,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/structure/reagent_dispensers/fueltank/large,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
@@ -34539,6 +34520,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/library)
+"cBd" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "cBk" = (
 /obj/machinery/vending/boozeomat,
 /turf/closed/wall,
@@ -34767,6 +34754,7 @@
 /obj/machinery/airalarm/directional/west,
 /obj/structure/cable,
 /obj/structure/chair/stool/bar/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "cCW" = (
@@ -34865,14 +34853,6 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"cIR" = (
-/obj/machinery/requests_console/directional/east{
-	department = "Atmospherics";
-	departmentType = 2;
-	name = "Atmos RC"
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/atmos)
 "cJo" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating{
@@ -34949,6 +34929,10 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
+"cPd" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
 "cPy" = (
 /obj/machinery/light{
 	dir = 8
@@ -35038,6 +35022,10 @@
 	},
 /turf/open/floor/iron,
 /area/medical/medbay/central)
+"cRm" = (
+/obj/machinery/door/poddoor/incinerator_atmos_aux,
+/turf/open/floor/engine/vacuum,
+/area/space/nearstation)
 "cRA" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -35049,6 +35037,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
+"cRY" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/oxygen_input{
+	dir = 1
+	},
+/turf/open/floor/engine/o2,
+/area/engineering/atmos)
 "cSf" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
@@ -35445,12 +35439,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
-"drU" = (
-/obj/machinery/computer/turbine_computer{
-	id = "incineratorturbine"
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/disposal/incinerator)
 "dsv" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -35473,10 +35461,20 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "dsR" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxin_input{
-	dir = 8
+/obj/machinery/camera{
+	c_tag = "Atmospherics Mixing"
 	},
-/turf/open/floor/engine/plasma,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/fueltank/large,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "dtj" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
@@ -35676,6 +35674,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/bar/atrium)
+"dFK" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "dFU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -36141,6 +36146,12 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/science)
+"egk" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/oxygen_output{
+	dir = 1
+	},
+/turf/open/floor/engine/o2,
+/area/engineering/atmos)
 "egK" = (
 /obj/structure/girder,
 /turf/open/floor/plating{
@@ -36452,6 +36463,14 @@
 /obj/item/storage/bag/tray/cafeteria,
 /turf/open/floor/iron/white,
 /area/security/prison)
+"evU" = (
+/obj/effect/turf_decal/box/white,
+/obj/effect/turf_decal/arrows/white{
+	color = "#0000FF";
+	pixel_y = 15
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "ewb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -36678,6 +36697,14 @@
 	},
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
+"eHK" = (
+/obj/machinery/power/turbine{
+	dir = 4;
+	luminosity = 2
+	},
+/obj/structure/cable,
+/turf/open/floor/engine/vacuum,
+/area/maintenance/disposal/incinerator)
 "eHY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -36754,12 +36781,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"eMs" = (
-/obj/effect/turf_decal/box/white{
-	color = "#52B4E9"
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "eNo" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 9
@@ -36828,11 +36849,6 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/department/engine)
-"eOS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/disposal/incinerator)
 "eOZ" = (
 /obj/structure/closet,
 /obj/item/clothing/suit/judgerobe,
@@ -37229,8 +37245,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "feh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxin_input{
+	dir = 8
+	},
+/turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "fei" = (
 /obj/effect/turf_decal/tile/blue{
@@ -37543,6 +37561,13 @@
 /obj/machinery/atmospherics/components/trinary/filter,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
+"fsP" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
+	dir = 1
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/engineering/atmos)
 "ftb" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
@@ -37595,10 +37620,7 @@
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "fuR" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/visible{
-	dir = 4
-	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "fvq" = (
@@ -37739,9 +37761,8 @@
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "fDm" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Supermatter Mix Pump"
+/obj/machinery/atmospherics/pipe/layer_manifold/visible{
+	dir = 4
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -37885,8 +37906,8 @@
 /area/security/prison/safe)
 "fJw" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "incinerator mix pump"
+	dir = 8;
+	name = "Supermatter Mix Pump"
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -38018,6 +38039,12 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"fQy" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "fQD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38072,8 +38099,8 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "fUc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/structure/chair/stool/bar/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "fUA" = (
@@ -38286,6 +38313,13 @@
 	},
 /turf/open/floor/iron,
 /area/command/bridge)
+"gig" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
+/turf/open/floor/plating/airless,
+/area/engineering/atmos)
 "gii" = (
 /obj/structure/chair,
 /obj/machinery/newscaster/directional/east,
@@ -38477,10 +38511,6 @@
 	heat_capacity = 1e+006
 	},
 /area/hallway/secondary/exit/departure_lounge)
-"gqp" = (
-/obj/machinery/door/poddoor/incinerator_atmos_main,
-/turf/open/floor/engine/vacuum,
-/area/maintenance/disposal/incinerator)
 "gqx" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/table,
@@ -38636,12 +38666,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"gwQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/atmos)
 "gxe" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -32
@@ -38908,6 +38932,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
 /area/medical/storage)
+"gGn" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/air_input{
+	dir = 1
+	},
+/turf/open/floor/engine/air,
+/area/engineering/atmos)
 "gGs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -39012,14 +39042,6 @@
 /obj/effect/spawner/randomsnackvend,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"gMt" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/light,
-/turf/open/floor/iron/dark,
-/area/maintenance/disposal/incinerator)
 "gMA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39448,6 +39470,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
+"hnV" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "hnY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
@@ -39501,14 +39535,6 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/engineering/atmos)
-"hrR" = (
-/obj/machinery/door/airlock/atmos{
-	name = "HFR";
-	req_access_txt = "24"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "htK" = (
 /obj/structure/disposalpipe/segment,
@@ -40165,6 +40191,12 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"ibw" = (
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "ibD" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -40278,6 +40310,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"igC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/turf/open/space/basic,
+/area/space/nearstation)
 "igE" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -40633,12 +40669,12 @@
 /turf/open/floor/iron/dark,
 /area/service/library)
 "iBq" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "incinerator mix pump"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "iBw" = (
 /obj/effect/turf_decal/stripes/white/line{
@@ -40860,10 +40896,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/warden)
-"iMK" = (
-/obj/machinery/door/poddoor/incinerator_atmos_aux,
-/turf/open/floor/engine/vacuum,
-/area/space/nearstation)
 "iNg" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/green{
@@ -40914,10 +40946,12 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "iQR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 1
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/turf/open/floor/plating,
 /area/engineering/atmos)
 "iRs" = (
 /obj/effect/turf_decal/tile/blue{
@@ -40963,6 +40997,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"iVT" = (
+/obj/machinery/door/airlock/atmos{
+	name = "HFR";
+	req_access_txt = "24"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "iWV" = (
 /obj/machinery/light{
 	dir = 4
@@ -40984,12 +41026,6 @@
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron/white,
 /area/security/prison)
-"iXz" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/disposal/incinerator)
 "iYH" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay";
@@ -41329,7 +41365,9 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "jty" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "jtJ" = (
@@ -41542,6 +41580,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"jKs" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1;
+	frequency = 1441;
+	id = "inc_in"
+	},
+/turf/open/floor/plating/airless,
+/area/maintenance/disposal/incinerator)
 "jKE" = (
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 1
@@ -41556,10 +41602,7 @@
 /turf/open/floor/iron/white,
 /area/medical/psychology)
 "jMl" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "N2 to Pure"
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "jMt" = (
@@ -41614,6 +41657,12 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)
+"jOk" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrogen_input{
+	dir = 1
+	},
+/turf/open/floor/engine/n2,
+/area/engineering/atmos)
 "jOl" = (
 /obj/machinery/light{
 	dir = 8
@@ -41632,10 +41681,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
-"jOx" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/disposal/incinerator)
 "jOB" = (
 /turf/open/floor/plating,
 /area/commons/storage/emergency/starboard)
@@ -41656,10 +41701,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/science)
-"jRv" = (
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
 "jRG" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
@@ -41870,12 +41911,9 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "keN" = (
-/obj/machinery/computer/atmos_control/tank/carbon_tank{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "N2 to Pure"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -42013,6 +42051,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"klp" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "Atmospherics External Access";
+	req_access_txt = "24"
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal/incinerator)
 "klB" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -42056,19 +42104,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/cryo)
-"koA" = (
-/obj/machinery/power/compressor{
-	comp_id = "incineratorturbine";
-	dir = 8;
-	luminosity = 2
-	},
-/obj/machinery/camera{
-	c_tag = "Turbine Chamber";
-	network = list("turbine")
-	},
-/obj/structure/cable,
-/turf/open/floor/engine/vacuum,
-/area/maintenance/disposal/incinerator)
 "koW" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -42087,6 +42122,12 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/stairs/left,
 /area/service/abandoned_gambling_den)
+"kqc" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "kqH" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -42440,12 +42481,6 @@
 /obj/machinery/newscaster/security_unit/directional/south,
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
-"kGY" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/air_input{
-	dir = 1
-	},
-/turf/open/floor/engine/air,
-/area/engineering/atmos)
 "kHO" = (
 /obj/structure/bed/dogbed/renault,
 /mob/living/simple_animal/pet/fox/renault,
@@ -42469,6 +42504,10 @@
 /obj/machinery/light,
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"kHY" = (
+/obj/structure/sign/warning/fire,
+/turf/closed/wall/r_wall,
+/area/space)
 "kIo" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -42491,6 +42530,10 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/security/brig)
+"kJU" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/maintenance/disposal/incinerator)
 "kKz" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -42503,18 +42546,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"kMq" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "kMt" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -42658,16 +42689,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"kTL" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "kTU" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/effect/turf_decal/tile/green{
@@ -42770,13 +42791,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/explab)
-"kWy" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 5
-	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating/airless,
-/area/engineering/atmos)
 "kXe" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -42796,16 +42810,6 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/grass,
 /area/medical/psychology)
-"kZM" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "kZU" = (
 /obj/structure/table/wood/fancy,
 /obj/structure/sign/painting/library_secure{
@@ -42821,6 +42825,10 @@
 /obj/machinery/light/dim,
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
+"lag" = (
+/obj/machinery/light/small,
+/turf/open/floor/engine/air,
+/area/engineering/atmos)
 "lao" = (
 /obj/machinery/exodrone_launcher,
 /obj/effect/turf_decal/stripes/line,
@@ -42921,11 +42929,6 @@
 /obj/item/pen,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
-"ldG" = (
-/obj/structure/lattice,
-/obj/structure/grille/broken,
-/turf/open/space/basic,
-/area/space/nearstation)
 "lem" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -42955,6 +42958,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "lgj" = (
@@ -43073,6 +43077,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/library/lounge)
+"lnh" = (
+/obj/machinery/computer/turbine_computer{
+	id = "incineratorturbine"
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "lnn" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -43334,28 +43344,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/gateway)
-"lDk" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/engineering/atmos)
 "lDw" = (
 /obj/structure/flora/grass/jungle,
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/science/genetics)
-"lDS" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "lEn" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -43505,16 +43498,6 @@
 /obj/structure/plasticflaps/opaque,
 /turf/open/floor/plating,
 /area/cargo/storage)
-"lMl" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	name = "Atmospherics External Access";
-	req_access_txt = "24"
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal/incinerator)
 "lMQ" = (
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
@@ -43578,10 +43561,14 @@
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
 "lQQ" = (
-/obj/machinery/light/small{
+/obj/machinery/computer/atmos_control/tank/carbon_tank{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/turf/open/floor/engine/co2,
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "lRh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
@@ -43781,13 +43768,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet,
 /area/service/library)
-"mcS" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
-	dir = 1
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engineering/atmos)
 "mcV" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -44040,10 +44020,16 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "mrv" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/o2{
+/obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/engine/co2,
+/area/engineering/atmos)
+"mrH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "mrR" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -44103,13 +44089,11 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "mvA" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+/obj/machinery/atmospherics/components/trinary/filter/atmos/o2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
-/turf/open/space,
-/area/space/nearstation)
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "mvJ" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -44132,10 +44116,6 @@
 /obj/item/gun/ballistic/shotgun/toy,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"mwG" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/dark,
-/area/maintenance/disposal/incinerator)
 "mxg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -44433,6 +44413,16 @@
 /obj/structure/flora/junglebush/b,
 /turf/open/floor/grass,
 /area/medical/psychology)
+"mNv" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "mNN" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/command/glass{
@@ -44486,11 +44476,20 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "mOH" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/carbon_input{
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
+/turf/open/space,
+/area/space/nearstation)
+"mPP" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/engine/co2,
-/area/engineering/atmos)
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "mQc" = (
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	id = "Supermatter";
@@ -44639,6 +44638,10 @@
 /obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"mYX" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "mZi" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -44662,9 +44665,11 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "mZO" = (
-/obj/structure/grille,
-/turf/open/space,
-/area/space)
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/carbon_input{
+	dir = 8
+	},
+/turf/open/floor/engine/co2,
+/area/engineering/atmos)
 "mZR" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
@@ -44899,6 +44904,18 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"njg" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "njH" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45008,6 +45025,7 @@
 "nnl" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/soda_cans/lemon_lime,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "nox" = (
@@ -45065,10 +45083,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"nqQ" = (
-/obj/machinery/light/small,
-/turf/open/floor/engine/o2,
-/area/engineering/atmos)
 "nqV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/iron/dark,
@@ -45452,12 +45466,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
-"nNe" = (
-/obj/effect/turf_decal/box/white{
-	color = "#EFB341"
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "nNk" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
@@ -45532,13 +45540,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "nSc" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/obj/structure/grille,
+/turf/open/space,
+/area/space)
 "nSe" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -45555,19 +45559,6 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
-"nTh" = (
-/obj/structure/table,
-/obj/item/circuitboard/machine/HFR_core,
-/obj/item/circuitboard/machine/HFR_fuel_input,
-/obj/item/circuitboard/machine/HFR_interface,
-/obj/item/circuitboard/machine/HFR_moderator_input,
-/obj/item/circuitboard/machine/HFR_waste_output,
-/obj/item/stack/cable_coil{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/disposal/incinerator)
 "nTt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -45689,16 +45680,6 @@
 /obj/item/spear,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"nWv" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/turf/open/floor/plating,
-/area/maintenance/disposal/incinerator)
 "nWw" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -46008,12 +45989,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
-"omN" = (
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/public/glass/incinerator/atmos_exterior,
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/maintenance/disposal/incinerator)
 "omS" = (
 /obj/effect/decal/cleanable/ash{
 	pixel_x = 4
@@ -46383,6 +46358,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"oCb" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/atmos/air_output{
+	dir = 1
+	},
+/turf/open/floor/engine/air,
+/area/engineering/atmos)
 "oCi" = (
 /obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -46594,6 +46575,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
+"oOo" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrogen_output{
+	dir = 1
+	},
+/turf/open/floor/engine/n2,
+/area/engineering/atmos)
 "oOy" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -46846,10 +46833,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/execution/transfer)
-"oXr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
-/turf/open/space/basic,
-/area/space/nearstation)
 "oXU" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -46937,12 +46920,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/server)
-"pdS" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "pec" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -47106,12 +47083,10 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "pln" = (
+/obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
-	},
-/obj/machinery/computer/atmos_control/tank/nitrogen_tank{
-	dir = 1
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -47291,7 +47266,6 @@
 "pwa" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "pwI" = (
@@ -47370,12 +47344,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
-"pCJ" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/oxygen_input{
-	dir = 1
-	},
-/turf/open/floor/engine/o2,
-/area/engineering/atmos)
 "pDf" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -47409,7 +47377,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/computer/atmos_control/tank/nitrogen_tank{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "pEp" = (
@@ -47488,6 +47458,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"pGV" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/maintenance/disposal/incinerator)
 "pGZ" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lantern{
@@ -47505,12 +47480,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"pHj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "pHo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -47602,10 +47571,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"pMJ" = (
-/obj/machinery/light/small,
-/turf/open/floor/engine/air,
-/area/engineering/atmos)
 "pMM" = (
 /obj/machinery/airalarm/kitchen_cold_room{
 	pixel_y = 22
@@ -48479,12 +48444,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
-"qyg" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrogen_input{
-	dir = 1
-	},
-/turf/open/floor/engine/n2,
-/area/engineering/atmos)
 "qyR" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -48569,11 +48528,11 @@
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
 "qFJ" = (
-/obj/machinery/light,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "qGk" = (
@@ -48622,12 +48581,10 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "qIz" = (
+/obj/machinery/light,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
-	},
-/obj/machinery/computer/atmos_control/tank/oxygen_tank{
-	dir = 1
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -48662,6 +48619,10 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"qIT" = (
+/obj/machinery/light/small,
+/turf/open/floor/engine/n2,
+/area/engineering/atmos)
 "qJm" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -48696,6 +48657,12 @@
 	name = "Holodeck Projector Floor"
 	},
 /area/holodeck/rec_center)
+"qKG" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engineering/atmos)
 "qLo" = (
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
@@ -48754,19 +48721,6 @@
 "qOE" = (
 /turf/open/floor/iron/dark,
 /area/service/library/lounge)
-"qPa" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/disposal/incinerator)
 "qPu" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -49067,6 +49021,12 @@
 /obj/effect/spawner/randomarcade,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
+"rjl" = (
+/obj/effect/turf_decal/box/white{
+	color = "#EFB341"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "rka" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -49086,16 +49046,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/prison)
-"rlb" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	name = "Atmospherics External Access";
-	req_access_txt = "24"
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal/incinerator)
 "rle" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -49181,7 +49131,6 @@
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "rnQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "roa" = (
@@ -49540,6 +49489,16 @@
 	},
 /turf/open/floor/iron,
 /area/medical/cryo)
+"ryS" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "rzp" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
@@ -49632,14 +49591,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
-"rBT" = (
-/obj/effect/turf_decal/box/white,
-/obj/effect/turf_decal/arrows/white{
-	color = "#0000FF";
-	pixel_y = 15
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "rCe" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -49724,6 +49675,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"rFv" = (
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "rGo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
@@ -49979,6 +49936,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"rQM" = (
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/public/glass/incinerator/atmos_exterior,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/maintenance/disposal/incinerator)
 "rQV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50450,6 +50413,16 @@
 /obj/item/shard,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"ssU" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "stc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/iron/white,
@@ -50510,6 +50483,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/genetics)
+"svD" = (
+/obj/machinery/light/small,
+/turf/open/floor/engine/o2,
+/area/engineering/atmos)
 "svN" = (
 /obj/structure/sign/departments/restroom{
 	pixel_y = 32
@@ -50562,14 +50539,6 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
 /turf/open/floor/plating,
 /area/engineering/atmos)
-"sxH" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 1;
-	frequency = 1441;
-	id = "inc_in"
-	},
-/turf/open/floor/plating/airless,
-/area/maintenance/disposal/incinerator)
 "sxT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -50755,7 +50724,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/computer/atmos_control/tank/air_tank{
+/obj/machinery/computer/atmos_control/tank/oxygen_tank{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -51182,13 +51151,10 @@
 "taw" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
+/obj/machinery/computer/atmos_control/tank/air_tank{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -51494,6 +51460,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"tlJ" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "Atmospherics External Access";
+	req_access_txt = "24"
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal/incinerator)
 "tlN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51510,6 +51486,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/plating/airless,
 /area/engineering/atmos)
+"tna" = (
+/turf/open/space/basic,
+/area/maintenance/disposal/incinerator)
 "tnY" = (
 /obj/machinery/button/door{
 	id = "aux_base_shutters";
@@ -51617,6 +51596,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"ttA" = (
+/obj/machinery/power/compressor{
+	comp_id = "incineratorturbine";
+	dir = 8;
+	luminosity = 2
+	},
+/obj/machinery/camera{
+	c_tag = "Turbine Chamber";
+	network = list("turbine")
+	},
+/obj/structure/cable,
+/turf/open/floor/engine/vacuum,
+/area/maintenance/disposal/incinerator)
 "ttN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51627,12 +51619,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"tuu" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/disposal/incinerator)
 "tuy" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Test Chamber";
@@ -51669,10 +51655,17 @@
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "tvr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 9
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
-/turf/closed/wall/r_wall,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "tvy" = (
 /obj/structure/disposalpipe/segment,
@@ -52035,12 +52028,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/medical/virology)
-"tNz" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/oxygen_output{
-	dir = 1
-	},
-/turf/open/floor/engine/o2,
-/area/engineering/atmos)
 "tOf" = (
 /obj/structure/sign/poster/random{
 	pixel_y = 32
@@ -52373,6 +52360,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
+"udE" = (
+/obj/structure/table,
+/obj/item/circuitboard/machine/HFR_core,
+/obj/item/circuitboard/machine/HFR_fuel_input,
+/obj/item/circuitboard/machine/HFR_interface,
+/obj/item/circuitboard/machine/HFR_moderator_input,
+/obj/item/circuitboard/machine/HFR_waste_output,
+/obj/item/stack/cable_coil{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "udR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -52488,6 +52488,19 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"uhR" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "uib" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -53473,6 +53486,13 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"uWA" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "uWC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -53916,12 +53936,6 @@
 	luminosity = 2
 	},
 /area/maintenance/department/science)
-"vqY" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrogen_output{
-	dir = 1
-	},
-/turf/open/floor/engine/n2,
-/area/engineering/atmos)
 "vrx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
@@ -54153,12 +54167,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
-"vDa" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/disposal/incinerator)
 "vDh" = (
 /obj/item/target,
 /obj/structure/training_machine,
@@ -54182,9 +54190,6 @@
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/iron,
 /area/security/prison)
-"vFe" = (
-/turf/open/space/basic,
-/area/maintenance/disposal/incinerator)
 "vFs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -54305,9 +54310,11 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "vLx" = (
-/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 9
+	},
 /turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
+/area/engineering/atmos)
 "vLy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -54503,13 +54510,6 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"vRY" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
-/turf/open/floor/plating/airless,
-/area/engineering/atmos)
 "vSB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -54536,18 +54536,6 @@
 /obj/machinery/light/no_nightlight/directional/north,
 /turf/open/floor/iron,
 /area/security/prison)
-"vTl" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "vTL" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/iron,
@@ -54751,10 +54739,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "wfp" = (
-/obj/structure/lattice,
 /obj/structure/grille,
-/turf/open/space,
-/area/space)
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "wfr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -54886,12 +54873,10 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "wjT" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/engineering/atmos)
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space,
+/area/space)
 "wkA" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -54995,6 +54980,16 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/freezer,
 /area/security/prison/toilet)
+"woV" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/plating,
+/area/maintenance/disposal/incinerator)
 "woX" = (
 /obj/structure/sign/painting/library_secure{
 	pixel_y = -32
@@ -55132,11 +55127,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "wwr" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 5
+	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "wwG" = (
@@ -55313,6 +55307,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "wDC" = (
@@ -55436,13 +55431,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/service/lawoffice)
-"wGa" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "wGM" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -55614,10 +55602,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse/upper)
-"wPf" = (
-/obj/machinery/light/small,
-/turf/open/floor/engine/n2,
-/area/engineering/atmos)
 "wPl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -55651,10 +55635,6 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"wQc" = (
-/obj/structure/sign/warning/fire,
-/turf/closed/wall/r_wall,
-/area/space)
 "wQy" = (
 /obj/machinery/light_switch{
 	dir = 8;
@@ -55663,6 +55643,13 @@
 /obj/structure/chair/sofa/left,
 /turf/open/floor/carpet,
 /area/medical/psychology)
+"wQE" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 5
+	},
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating/airless,
+/area/engineering/atmos)
 "wQU" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/cable,
@@ -55885,11 +55872,11 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "wYi" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "wYr" = (
@@ -56014,10 +56001,12 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "xca" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/turf/open/floor/plating,
 /area/engineering/atmos)
 "xdc" = (
 /obj/structure/table/reinforced,
@@ -56040,6 +56029,11 @@
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"xdQ" = (
+/obj/structure/lattice,
+/obj/structure/grille/broken,
+/turf/open/space/basic,
+/area/space/nearstation)
 "xdY" = (
 /obj/machinery/door/window/eastright{
 	name = "Danger: Conveyor Access";
@@ -56477,13 +56471,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"xvT" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/disposal/incinerator)
 "xvV" = (
 /obj/effect/turf_decal/caution{
 	dir = 8
@@ -56649,6 +56636,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/library)
+"xCh" = (
+/obj/machinery/door/poddoor/incinerator_atmos_main,
+/turf/open/floor/engine/vacuum,
+/area/maintenance/disposal/incinerator)
 "xDj" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
@@ -56771,6 +56762,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/paramedic)
+"xJb" = (
+/obj/effect/turf_decal/box/white{
+	color = "#52B4E9"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "xJy" = (
 /obj/structure/chair/comfy/black,
 /obj/structure/sign/plaques/kiddie{
@@ -56847,7 +56844,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "xMQ" = (
@@ -57235,6 +57231,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/engineering/lobby)
 "yhR" = (
@@ -57275,6 +57272,14 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"yjt" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/light,
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "yjF" = (
 /obj/machinery/button/flasher{
 	id = "Cell 1";
@@ -90112,11 +90117,11 @@ bAl
 bIu
 bmD
 bKK
-bLV
+bmD
 bMT
 bOc
 cCU
-bmD
+bLb
 bmD
 bmD
 dpA
@@ -90369,11 +90374,11 @@ bHp
 bIx
 bJD
 qOx
-qXH
-qXH
-jez
-jez
 qOx
+qXH
+qXH
+jez
+jez
 qOx
 qzm
 xGi
@@ -91143,7 +91148,7 @@ qzm
 bLT
 rnQ
 fUc
-mYW
+bKS
 mYW
 mYW
 xLH
@@ -91655,9 +91660,9 @@ bIx
 bJE
 qOx
 qOx
-bMX
-bOf
 qOx
+bOf
+bKT
 qOx
 qzm
 bRr
@@ -91919,7 +91924,7 @@ bPN
 bRs
 mlD
 gur
-bSj
+bSS
 vzg
 bUp
 bVe
@@ -91929,13 +91934,13 @@ bXr
 nrD
 uwI
 bZK
-vRY
+gig
 eTt
 eTt
 eTt
 eTt
 ndP
-oXr
+igC
 adR
 aaa
 gBb
@@ -92171,7 +92176,7 @@ bKP
 bLX
 bMZ
 bOh
-bKS
+bKV
 faY
 faY
 vWp
@@ -92183,7 +92188,7 @@ bVf
 syt
 bWJ
 bXs
-nSc
+pln
 fBp
 abI
 bJP
@@ -92436,7 +92441,7 @@ bSd
 gEv
 kPP
 urG
-feh
+fuR
 bWO
 bWO
 qbv
@@ -92444,7 +92449,7 @@ mkS
 tvq
 bZL
 caC
-qyg
+jOk
 cbs
 cbs
 bJP
@@ -92685,25 +92690,25 @@ fBp
 fBp
 fBp
 bOj
-bKT
+bKY
 fBp
 fBp
 fBp
 fBp
 fBp
 fBp
-bVn
-feh
+bWP
+fuR
 bWO
 bWO
 bXx
-pln
+pEh
 vzg
 abI
 mkf
 cbt
 ccm
-wPf
+qIT
 bJP
 aaa
 aaa
@@ -92943,22 +92948,22 @@ bLY
 rud
 ksv
 bOS
-bKV
+bLc
 bPQ
 bRv
 bSe
-bSS
+bSU
 bPQ
-bWP
-feh
+bXB
+fuR
 bWO
 eVD
 qsH
-pEh
+qFJ
 rGo
 fda
 caB
-vqY
+oOo
 cbs
 cbs
 bJP
@@ -93201,17 +93206,17 @@ vap
 wVQ
 sBV
 bPR
-bNb
+bNj
 hXC
 hXC
 hXC
-bTO
+bTP
 eKY
 wUN
 bOk
 wCz
 bXx
-qFJ
+qIz
 vzg
 abI
 bJP
@@ -93458,26 +93463,26 @@ wSR
 lyB
 bOV
 bWO
-bNj
+bNk
 bIG
 bWO
 bWO
-bTP
+bTQ
 ksv
 sGc
 eUb
 wCz
-mrv
+mvA
 mkS
 tvq
 bZL
 caC
-pCJ
+cRY
 cbu
 cbu
 bJP
 abI
-jRv
+cPd
 fon
 fon
 fon
@@ -93714,24 +93719,24 @@ bMb
 axl
 bXA
 bOV
-bKY
+bLd
 bPQ
 bRx
 bQJ
 bRx
 bPQ
-bXB
+bXC
 sGc
 bWO
 wCz
 bXx
-qIz
+sEx
 vzg
 abI
 mkf
 cbv
 ccn
-nqQ
+svD
 bJP
 mZE
 abI
@@ -93971,13 +93976,13 @@ qux
 bNg
 bWO
 bOW
-bLb
+bLV
 bPQ
 bPQ
 bPQ
 bPQ
 bPQ
-bXC
+bZT
 sGc
 bVY
 shs
@@ -93986,7 +93991,7 @@ dHc
 vJD
 eYd
 caE
-tNz
+egk
 cbu
 cbu
 bJP
@@ -94228,19 +94233,19 @@ bMd
 aAK
 bIG
 bOX
-bLc
+bMk
 bPQ
 bQK
 bQK
 bQK
 bPQ
-bZT
+dsR
 sGc
 vtD
 wCz
 pyH
 qkk
-wjT
+wwr
 abI
 bJP
 bJP
@@ -94248,11 +94253,11 @@ bJP
 bJP
 bJP
 auI
-vTl
+hnV
 ayY
 ayY
 ayY
-kZM
+ssU
 auI
 aaa
 aaa
@@ -94486,30 +94491,30 @@ feN
 vsJ
 fIA
 bST
-bNk
+bOn
 bST
 bSf
 bSR
 hfi
 nUq
-fuR
+fDm
 vtD
 lRh
 bXA
 frC
-wwr
+wYi
 fda
 caF
-kGY
+gGn
 cby
 cby
 bJP
 auI
 bUp
 azi
-eMs
+xJb
 rsy
-wGa
+uWA
 auI
 aaa
 aaa
@@ -94745,28 +94750,28 @@ wCz
 bSf
 bWO
 bWO
-bSg
+bSj
 bWO
 bTR
 gbu
-fDm
+fJw
 vtD
-jMl
+keN
 bWO
-sEx
+taw
 xgG
 abI
 mkf
 cbx
 cco
-pMJ
+lag
 bJP
 auI
 bUp
 azm
 azN
-rBT
-wGa
+evU
+uWA
 auI
 aaa
 aaa
@@ -95000,30 +95005,30 @@ bWO
 bWO
 wCz
 bST
-bOn
+bOo
 bST
 bSf
 bST
 bTS
 nEp
 xXv
-iQR
+jty
 bMe
 pHb
 gQj
-wYi
+xca
 fda
 caH
-aRu
+oCb
 cby
 cby
 bJP
 auI
 bUp
 rsy
-nNe
+rjl
 azi
-wGa
+uWA
 auI
 aaa
 aaa
@@ -95256,19 +95261,19 @@ eDR
 eUb
 bWO
 wCz
-bLd
+bMX
 bWO
 bQM
 bQM
 bQM
 bTT
 bUv
-fJw
+iBq
 vtD
 bWO
 bWO
 bYs
-xca
+qKG
 fBp
 bJP
 bJP
@@ -95276,11 +95281,11 @@ bJP
 bJP
 bJP
 fBp
-kMq
+njg
 bWO
 bWO
 bWO
-kTL
+mNv
 auI
 aaa
 aaa
@@ -95513,33 +95518,33 @@ iJc
 bWO
 bOp
 bPc
-bMk
+bNb
 vsJ
 vsJ
 vsJ
-bSU
+bTK
 bMe
 bMe
 qQx
-jty
+jMl
 bWO
 bWO
 bYt
 bZf
 jOl
-gwQ
+mrH
 wMm
 wMm
 wMm
 wMm
 tlU
 ayG
-pdS
+fQy
 bWO
 bWO
 hCg
 sxs
-mcS
+fsP
 aaa
 aaa
 aaa
@@ -95772,9 +95777,9 @@ bOq
 nbE
 wYC
 eNC
-bQH
+bRz
 eNC
-bTK
+bTO
 eNC
 jaS
 xbZ
@@ -95784,17 +95789,17 @@ bXz
 bYu
 tiG
 dej
-lDk
+dFK
 yeD
 yeD
 yeD
 yeD
-hrR
+iVT
 bUp
 bWO
 bWO
 bWO
-wGa
+uWA
 auI
 aaa
 aaa
@@ -96028,20 +96033,20 @@ bNl
 bXF
 bPe
 bPX
-bOo
+bPg
 bXF
 bSh
 bSV
-bTQ
+bUx
 bXF
 bVk
 bWb
-keN
+lQQ
 bXF
-taw
+tvr
 fBp
-cIR
-lDk
+bRn
+dFK
 yeD
 yeD
 yeD
@@ -96051,7 +96056,7 @@ ayJ
 azt
 aAu
 aBR
-lDS
+ryS
 auI
 aaa
 aaa
@@ -96291,15 +96296,15 @@ rGo
 pFG
 rGo
 eGT
-iBq
+iQR
 pFG
 rGo
 eGT
-tvr
+vLx
 fBp
 fBp
 rfm
-kWy
+wQE
 mkf
 fBp
 fBp
@@ -96551,7 +96556,7 @@ mDo
 wLU
 oln
 cAO
-mvA
+mOH
 tSV
 aor
 bZh
@@ -96562,7 +96567,7 @@ fbC
 auW
 axx
 hMa
-jOx
+kJU
 aaa
 aaa
 aaa
@@ -96809,16 +96814,16 @@ bJP
 bMi
 mkf
 bIH
-vLx
+wfp
 bYw
 apV
 pxE
-iXz
+kqc
 usl
 usl
 usl
 tQj
-xvT
+mPP
 bYw
 aaa
 aaa
@@ -97057,25 +97062,25 @@ bII
 bJP
 bPZ
 bQP
-bRz
+bSc
 bJP
 bSW
 bTV
-dsR
+feh
 bJP
 bWe
 bWT
-mOH
-vLx
+mZO
+wfp
 bYw
 yby
 rGD
-vDa
+rFv
 usl
 usl
 usl
 oib
-gMt
+yjt
 bYw
 aaa
 aaa
@@ -97323,16 +97328,16 @@ bJP
 bWg
 bVo
 bWg
-vLx
+wfp
 bYw
-nTh
+udE
 pxE
-tuu
+ibw
 usl
-mwG
+mYX
 usl
 oib
-xvT
+mPP
 bYw
 aaa
 aaa
@@ -97570,28 +97575,28 @@ bzy
 bLe
 bJP
 bQb
-bPg
+bQH
 bQb
 bJP
 bSY
-bUx
+bVn
 bSY
 bJP
 bWg
-lQQ
+mrv
 bWg
-vLx
+wfp
 bYw
-drU
+lnh
 pxE
-tuu
+ibw
 usl
 atF
 faU
 fsO
 ayP
-eOS
-sxH
+pGV
+jKs
 aaa
 aaa
 aaa
@@ -97837,7 +97842,7 @@ bJP
 bJP
 bJP
 bJP
-vLx
+wfp
 bYw
 bYw
 bZU
@@ -97846,7 +97851,7 @@ cbF
 cEJ
 ccs
 axO
-qPa
+uhR
 bYw
 aaa
 gYo
@@ -98100,9 +98105,9 @@ bYw
 aqx
 caP
 foz
-pHj
+cBd
 bYw
-lMl
+klp
 azC
 bYw
 aht
@@ -98342,7 +98347,7 @@ aaa
 aby
 aaa
 aaa
-bSc
+bSg
 aby
 aby
 aby
@@ -98351,7 +98356,7 @@ aby
 aby
 aby
 aby
-wfp
+wjT
 aaa
 rLJ
 aqB
@@ -98359,11 +98364,11 @@ caQ
 asY
 xTb
 azC
-nWv
+woV
 azC
-sxH
+jKs
 aaa
-ldG
+xdQ
 aaa
 aaa
 aaa
@@ -98613,10 +98618,10 @@ aht
 rLJ
 bYw
 wit
-omN
-pHj
+rQM
+cBd
 bYw
-rlb
+tlJ
 lTW
 abI
 aht
@@ -98864,7 +98869,7 @@ aby
 aaa
 acO
 aby
-mZO
+nSc
 aaa
 aaa
 rLJ
@@ -98872,7 +98877,7 @@ bYw
 arv
 atf
 atJ
-iMK
+cRm
 cdm
 cdm
 aaa
@@ -99127,7 +99132,7 @@ aaa
 rLJ
 bYw
 bYw
-koA
+ttA
 bYw
 lTW
 aaa
@@ -99382,9 +99387,9 @@ aaa
 aaa
 aaa
 aaa
-vFe
+tna
 bYw
-bLp
+eHK
 lTW
 aht
 fon
@@ -99641,8 +99646,8 @@ aaa
 abI
 arl
 asA
-gqp
-wQc
+xCh
+kHY
 aaa
 aaa
 aaa

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -78,14 +78,10 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
-"aaj" = (
-/turf/closed/wall/r_wall,
-/area/science/nanite)
 "aak" = (
-/obj/machinery/nanite_program_hub,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/engine,
-/area/science/nanite)
+/area/science/explab)
 "aal" = (
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -97,58 +93,65 @@
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "aam" = (
-/obj/machinery/computer/nanite_cloud_controller,
-/turf/open/floor/engine,
-/area/science/nanite)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "aan" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/effect/landmark/blobstart,
 /turf/open/floor/engine,
-/area/science/nanite)
+/area/science/explab)
 "aao" = (
-/obj/machinery/nanite_chamber,
+/obj/structure/table/reinforced,
+/obj/item/pen,
+/obj/item/paper_bin,
 /turf/open/floor/engine,
-/area/science/nanite)
+/area/science/explab)
 "aap" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "telelab";
+	name = "test chamber blast door"
+	},
 /turf/open/floor/engine,
-/area/science/nanite)
+/area/science/explab)
 "aaq" = (
-/obj/machinery/nanite_programmer,
-/obj/machinery/power/apc/auto_name/west,
-/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
-/area/science/nanite)
-"aar" = (
-/obj/machinery/computer/nanite_chamber_control{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/science/nanite)
+/area/science/explab)
 "aas" = (
-/obj/machinery/door/airlock/research{
-	name = "Nanite Lab";
-	req_access_txt = "7"
-	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/door/poddoor/preopen{
+	id = "telelab";
+	name = "test chamber blast door"
+	},
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/engine,
 /area/science/explab)
 "aat" = (
 /obj/structure/sign/warning,
 /turf/closed/wall/r_wall,
-/area/science/nanite)
+/area/science/explab)
 "aau" = (
 /obj/machinery/firealarm/directional/north,
+/obj/machinery/rnd/experimentor,
 /turf/open/floor/engine,
-/area/science/nanite)
+/area/science/explab)
 "aav" = (
 /obj/machinery/firealarm/directional/west,
 /obj/structure/cable,
@@ -159,35 +162,36 @@
 	dir = 1;
 	light_color = "#d1dfff"
 	},
-/obj/structure/table,
-/obj/item/nanite_remote,
 /obj/machinery/requests_console/directional/north{
 	department = "Nanite Lab";
 	name = "Nanite Lab Requests Console"
 	},
 /turf/open/floor/engine,
-/area/science/nanite)
+/area/science/explab)
 "aax" = (
 /obj/structure/chair/office/light{
 	dir = 4
 	},
 /obj/effect/landmark/start/scientist,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
-/area/science/nanite)
+/area/science/explab)
 "aay" = (
-/obj/structure/table,
-/obj/item/nanite_scanner,
+/obj/machinery/camera{
+	c_tag = "Experimentation Lab Chamber";
+	network = list("ss13","rd")
+	},
 /turf/open/floor/engine,
-/area/science/nanite)
+/area/science/explab)
 "aaz" = (
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "aaA" = (
-/obj/structure/table,
-/obj/item/storage/box/disks_nanite,
+/obj/structure/table/reinforced,
+/obj/item/relic,
 /turf/open/floor/engine,
-/area/science/nanite)
+/area/science/explab)
 "aaB" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -7184,6 +7188,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/tank_holder/extinguisher,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "awh" = (
@@ -7223,7 +7228,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -7232,13 +7237,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
+/obj/structure/tank_holder/extinguisher,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "awn" = (
@@ -7695,6 +7697,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/structure/tank_holder/extinguisher,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "axN" = (
@@ -9323,6 +9326,7 @@
 	department = "Dormitories";
 	name = "Dorms Requests Console"
 	},
+/obj/structure/tank_holder/extinguisher,
 /turf/open/floor/iron/white/corner{
 	dir = 8
 	},
@@ -17202,6 +17206,7 @@
 /area/commons/vacant_room/commissary)
 "bhJ" = (
 /obj/effect/turf_decal/bot,
+/obj/structure/tank_holder/extinguisher,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "bhK" = (
@@ -17426,6 +17431,13 @@
 /obj/effect/decal/cleanable/robot_debris{
 	icon_state = "gib3"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "biy" = (
@@ -17950,19 +17962,34 @@
 /turf/open/floor/engine,
 /area/science/explab)
 "bkz" = (
-/obj/machinery/camera{
-	c_tag = "Experimentation Lab Chamber";
-	network = list("ss13","rd")
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/turf/open/floor/engine,
-/area/science/explab)
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/iron,
+/area/science/breakroom)
 "bkA" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#d1dfff"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/turf/open/floor/engine,
-/area/science/explab)
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/light/directional/north,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/science/breakroom)
 "bkD" = (
 /obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/delivery,
@@ -18383,16 +18410,35 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "blP" = (
-/obj/machinery/light{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/engine,
-/area/science/explab)
+/obj/effect/spawner/randomcolavend,
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron,
+/area/science/breakroom)
 "blR" = (
-/obj/item/beacon,
-/obj/effect/landmark/blobstart,
-/turf/open/floor/engine,
-/area/science/explab)
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/chair/stool/bar/directional/west,
+/turf/open/floor/iron,
+/area/science/breakroom)
 "blS" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -18628,9 +18674,20 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/science/server)
 "bmV" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on,
-/turf/open/floor/engine,
-/area/science/explab)
+/obj/machinery/vending/coffee,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/science/breakroom)
 "bnb" = (
 /obj/machinery/restaurant_portal/restaurant,
 /turf/open/floor/iron/dark,
@@ -18821,29 +18878,57 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/science/server)
 "bnW" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "testlab";
-	name = "test chamber blast door"
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/engine,
-/area/science/explab)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/science/breakroom)
 "bnX" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/poddoor/preopen{
-	id = "telelab";
-	name = "test chamber blast door"
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/soda_cans/dr_gibb,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
-/turf/open/floor/engine,
-/area/science/explab)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/science/breakroom)
 "bnY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "testlab";
-	name = "test chamber blast door"
+/obj/structure/table/wood,
+/obj/item/folder,
+/obj/item/clipboard,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
-/turf/open/floor/engine,
-/area/science/explab)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/science/breakroom)
 "boc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
 	dir = 1
@@ -19096,40 +19181,21 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/iron/dark,
 /area/science/server)
-"bpd" = (
-/obj/machinery/button/door{
-	id = "testlab";
-	name = "Window Blast Doors";
-	pixel_x = -6
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/button/door{
-	id = "telelab";
-	name = "Test Chamber Blast Door";
-	pixel_x = 6
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
-/turf/open/floor/iron/dark,
-/area/science/explab)
 "bpe" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/door/airlock/research{
+	name = "Break Room";
+	req_access_txt = "47"
 	},
-/turf/open/floor/iron/dark,
-/area/science/explab)
-"bpg" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/relic,
-/turf/open/floor/iron/dark,
-/area/science/explab)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/science/breakroom)
 "bpi" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/disposalpipe/segment,
@@ -19456,9 +19522,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1
-	},
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/white,
 /area/science/explab)
@@ -19469,7 +19532,13 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/structure/chair/stool/bar/directional/south,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/science/explab)
 "bqq" = (
@@ -20015,10 +20084,6 @@
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1;
-	name = "Connector Port (Air Supply)"
 	},
 /turf/open/floor/iron/white,
 /area/science/explab)
@@ -21620,10 +21685,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/machinery/door/airlock/research{
-	name = "Research Division Access";
-	req_access_txt = "47"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -21634,6 +21695,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/door/airlock/research{
+	name = "Research Division Access";
+	req_access_txt = "47"
 	},
 /turf/open/floor/iron/dark,
 /area/science/explab)
@@ -22990,6 +23055,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/structure/tank_holder/extinguisher,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "bBP" = (
@@ -23684,7 +23750,9 @@
 /obj/item/storage/bag/ore,
 /obj/item/pickaxe,
 /obj/structure/closet/crate,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "bEk" = (
@@ -24444,11 +24512,13 @@
 /area/science/mixing)
 "bGw" = (
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/machinery/door/airlock/research{
 	name = "Toxins Launch Room";
 	req_access_txt = "8"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
@@ -25934,6 +26004,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/structure/tank_holder/extinguisher,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "bMN" = (
@@ -31352,9 +31423,7 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
 "ciK" = (
-/obj/structure/table,
-/obj/item/crowbar,
-/obj/item/clothing/mask/gas,
+/obj/structure/tank_holder/extinguisher,
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
 "ciN" = (
@@ -32564,7 +32633,6 @@
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "cpf" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -34593,16 +34661,19 @@
 /turf/open/floor/plating,
 /area/service/chapel/office)
 "cBN" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron,
+/area/science/breakroom)
 "cBT" = (
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
@@ -36019,6 +36090,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/science/explab)
 "edJ" = (
@@ -36795,9 +36869,8 @@
 	},
 /area/maintenance/department/security/brig)
 "eSL" = (
-/obj/item/beacon,
-/turf/open/floor/iron/dark,
-/area/science/explab)
+/turf/closed/wall/r_wall,
+/area/science/breakroom)
 "eSW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/chair/stool/bar/directional/west,
@@ -36989,6 +37062,18 @@
 	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "telelab";
+	name = "Test Chamber Blast Door";
+	pixel_x = 6;
+	pixel_y = 26
+	},
+/obj/machinery/button/door{
+	id = "testlab";
+	name = "Window Blast Doors";
+	pixel_x = -6;
+	pixel_y = 26
 	},
 /turf/open/floor/iron/white,
 /area/science/explab)
@@ -37427,13 +37512,6 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "fqJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -37778,10 +37856,19 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "fGH" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/rnd/experimentor,
-/turf/open/floor/engine,
-/area/science/explab)
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron,
+/area/science/breakroom)
 "fIc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -38355,7 +38442,9 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "gmH" = (
@@ -40009,8 +40098,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
-/area/science/nanite)
+/area/science/explab)
 "hTr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40979,13 +41069,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "jaS" = (
@@ -41148,9 +41231,9 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "jnp" = (
-/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
-/area/science/nanite)
+/area/science/explab)
 "jnG" = (
 /obj/machinery/door/airlock/virology{
 	autoclose = 0;
@@ -41414,6 +41497,14 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"jBx" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "telelab";
+	name = "test chamber blast door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/engine,
+/area/science/explab)
 "jCr" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -41727,7 +41818,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -42220,6 +42310,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"kxI" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/science/breakroom)
 "kxJ" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
 	dir = 4
@@ -43240,6 +43349,13 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/carpet,
 /area/service/chapel/office)
+"lzP" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1;
+	name = "Connector Port (Air Supply)"
+	},
+/turf/open/floor/iron/white,
+/area/science/explab)
 "lAf" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -43907,6 +44023,25 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
+"moh" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/chair/stool/bar/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/landmark/start/scientist,
+/obj/machinery/holopad,
+/turf/open/floor/iron,
+/area/science/breakroom)
 "mpd" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
@@ -44202,14 +44337,21 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "mAQ" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "testlab";
-	name = "test chamber blast door"
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/engine,
-/area/science/explab)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/science/breakroom)
 "mBz" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/yellow,
@@ -47496,8 +47638,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/item/beacon,
 /turf/open/floor/engine,
-/area/science/nanite)
+/area/science/explab)
 "pKd" = (
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
@@ -47577,7 +47720,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "pOc" = (
@@ -47671,7 +47816,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "pTG" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -47679,7 +47823,7 @@
 	dir = 8
 	},
 /turf/open/floor/engine,
-/area/science/nanite)
+/area/science/explab)
 "pTJ" = (
 /obj/machinery/newscaster/security_unit/directional/south,
 /turf/open/floor/iron,
@@ -47756,9 +47900,19 @@
 /obj/item/clothing/head/beret/sec/navyofficer,
 /obj/item/clothing/head/beret/sec/navyofficer,
 /obj/item/clothing/head/beret/sec/navywarden,
-/obj/item/clothing/head/beret/sec/navyhos,
+/obj/item/clothing/head/hos/beret/navyhos,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"pWK" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/science/explab)
 "pWT" = (
 /obj/effect/landmark/start/botanist,
 /obj/effect/turf_decal/tile/green,
@@ -48060,6 +48214,15 @@
 	},
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
+"qkf" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/obj/machinery/door/poddoor/preopen{
+	id = "telelab";
+	name = "test chamber blast door"
+	},
+/turf/open/floor/engine,
+/area/science/explab)
 "qkk" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -49816,7 +49979,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "rLn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/closed/wall/r_wall,
 /area/science/mixing)
 "rLJ" = (
@@ -50468,7 +50633,9 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "svm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/genetics)
@@ -51548,6 +51715,12 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/security/brig)
+"tpf" = (
+/obj/structure/table,
+/obj/item/crowbar,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/iron/dark,
+/area/service/chapel/main/monastery)
 "tpC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -51946,6 +52119,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/bar)
+"tEc" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/tank_holder/extinguisher,
+/turf/open/floor/iron,
+/area/engineering/main)
 "tEB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -52606,6 +52788,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"ukz" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "telelab";
+	name = "test chamber blast door"
+	},
+/turf/open/floor/engine,
+/area/science/breakroom)
 "ukM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -53122,6 +53312,16 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"uDS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/item/beacon,
+/turf/open/floor/iron/white,
+/area/science/explab)
 "uEr" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -53747,7 +53947,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "veM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "vfp" = (
@@ -54613,6 +54815,22 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"vXd" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/science/breakroom)
 "vXt" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -54631,6 +54849,35 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
+"vYH" = (
+/obj/structure/table/wood,
+/obj/machinery/camera{
+	c_tag = "Science - Break Room";
+	dir = 8;
+	name = "science camera";
+	network = list("ss13","rd")
+	},
+/obj/structure/sign/poster/official/report_crimes{
+	pixel_y = 32
+	},
+/obj/machinery/microwave{
+	desc = "Cooks and boils stuff, somehow.";
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/iron,
+/area/science/breakroom)
 "vYN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -55335,6 +55582,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"wDf" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "telelab";
+	name = "test chamber blast door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/engine,
+/area/science/breakroom)
 "wDm" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -56998,6 +57253,21 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/medbay/lobby)
+"xQM" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/donkpockets,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/science/breakroom)
 "xQO" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner/north,
@@ -67612,7 +67882,7 @@ bWV
 chC
 chV
 bWV
-bWV
+tpf
 cvq
 ykY
 bWV
@@ -90979,7 +91249,7 @@ iok
 doP
 doP
 pyA
-cdY
+tEc
 nZX
 lXk
 nZX
@@ -96329,7 +96599,7 @@ mdx
 mdx
 mdx
 fGd
-aFi
+aam
 bix
 aFi
 pKd
@@ -96587,13 +96857,13 @@ bbI
 bbI
 fqJ
 aFi
-aFi
-bjw
-bjw
-bjw
-bjw
-bjw
-bjw
+aam
+eSL
+eSL
+eSL
+eSL
+eSL
+eSL
 bjw
 bjw
 bjw
@@ -96843,14 +97113,14 @@ amb
 bfB
 bbI
 jaJ
-cBN
+xba
 dSK
-bjw
-bky
+eSL
+cBN
 blP
 bmV
 mAQ
-bpd
+eSL
 bqo
 brG
 btg
@@ -97102,14 +97372,14 @@ bbI
 nts
 bbI
 lru
-bjw
+eSL
 bkz
 fGH
-bky
+kxI
 bnW
 bpe
 bqp
-bqs
+pWK
 vfp
 dGN
 dha
@@ -97359,10 +97629,10 @@ bbI
 fQD
 aNT
 lru
-bjw
+eSL
 bkA
 blR
-bky
+moh
 bnX
 eSL
 bqq
@@ -97616,12 +97886,12 @@ bbI
 bhr
 bbI
 lru
-bjw
-bky
-bky
-bky
+eSL
+vYH
+xQM
+vXd
 bnY
-bpg
+eSL
 bqr
 bqs
 vfp
@@ -97873,12 +98143,12 @@ cqI
 bhs
 bbI
 lru
-bjw
-aaj
-aaj
-aaj
-aaj
-bjw
+eSL
+eSL
+wDf
+ukz
+ukz
+eSL
 eYr
 bqs
 vfp
@@ -98131,13 +98401,13 @@ bht
 bbI
 biC
 dSK
-aaj
+bjw
 aak
-aam
+bky
 aaq
-aap
+qkf
 edl
-bqs
+lzP
 vfp
 twS
 bqs
@@ -98388,11 +98658,11 @@ bhu
 bbI
 aFi
 lru
-aaj
+bjw
 aau
 aan
 jnp
-aap
+jBx
 bqt
 mAo
 vfp
@@ -98645,7 +98915,7 @@ bhv
 bbI
 aEj
 lru
-aaj
+bjw
 aaw
 pJU
 pTG
@@ -98907,7 +99177,7 @@ aay
 hTq
 aax
 aap
-bqt
+uDS
 bqs
 vfp
 cKA
@@ -99159,10 +99429,10 @@ aaa
 aEj
 pKd
 lru
-aaj
+bjw
 aaA
 aao
-aar
+jnp
 aap
 nBL
 bqs

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -24476,9 +24476,6 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
-	name = "Outlet Injector"
-	},
 /turf/open/floor/plating/airless,
 /area/service/chapel/dock)
 "bGH" = (
@@ -35469,14 +35466,6 @@
 	},
 /turf/open/floor/iron/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
-"dvU" = (
-/obj/item/flashlight/lantern{
-	icon_state = "lantern-on"
-	},
-/obj/machinery/power/apc/auto_name/south,
-/obj/structure/cable,
-/turf/open/floor/plating/asteroid,
-/area/service/chapel/asteroid/monastery)
 "dvY" = (
 /turf/open/floor/iron/dark/side{
 	dir = 4
@@ -36039,13 +36028,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/cargo/office)
-"eed" = (
-/obj/item/flashlight/lantern{
-	icon_state = "lantern-on"
-	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/plating/asteroid,
-/area/service/chapel/asteroid/monastery)
 "eeF" = (
 /obj/structure/chair{
 	dir = 8
@@ -71704,7 +71686,7 @@ bQe
 bOw
 bOw
 bOw
-eed
+bQe
 bWV
 csS
 csS
@@ -72475,7 +72457,7 @@ bQe
 bOw
 bOw
 bOw
-dvU
+bQe
 bWV
 csS
 csS

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -5080,17 +5080,15 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/command/nuke_storage)
 "apV" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/computer/atmos_control/incinerator,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/stack/sheet/iron/fifty{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/stack/sheet/glass/fifty{
-	pixel_x = 3;
-	pixel_y = -4
+	dir = 5
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
@@ -5152,14 +5150,13 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "aqp" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/door/airlock/atmos{
+	name = "Incinerator";
+	req_access_txt = "24"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -5196,10 +5193,16 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "aqx" = (
+/obj/machinery/power/smes,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "aqy" = (
 /obj/structure/disposalpipe/segment,
@@ -5235,7 +5238,7 @@
 /area/security/brig)
 "aqB" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 10
+	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
@@ -5388,31 +5391,19 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "arl" = (
-/obj/structure/lattice,
-/turf/open/space,
-/area/maintenance/disposal/incinerator)
-"arm" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Incinerator";
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/table/glass,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/structure/cable,
+/obj/structure/table/wood/fancy,
+/obj/effect/spawner/lootdrop/prison_contraband,
 /turf/open/floor/iron/dark,
+/area/security/prison)
+"arm" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 5
+	},
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating/airless,
 /area/maintenance/disposal/incinerator)
 "arn" = (
 /obj/structure/disposalpipe/segment{
@@ -5462,10 +5453,10 @@
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "arv" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/incinerator_input{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 4
 	},
-/turf/open/floor/engine/vacuum,
+/turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "arx" = (
 /obj/item/flashlight/lamp,
@@ -5886,9 +5877,11 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "asA" = (
-/obj/structure/sign/warning/fire,
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
+/obj/item/bedsheet,
+/obj/structure/bed,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "asB" = (
 /obj/machinery/light,
 /obj/machinery/door_timer{
@@ -6010,7 +6003,12 @@
 	},
 /area/ai_monitored/command/nuke_storage)
 "asY" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/public/glass/incinerator/atmos_interior,
+/obj/machinery/embedded_controller/radio/airlock_controller/incinerator_atmos{
+	pixel_x = -6;
+	pixel_y = -26
+	},
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
@@ -6047,13 +6045,10 @@
 /turf/open/floor/iron/dark,
 /area/command/gateway)
 "atf" = (
-/obj/machinery/igniter/incinerator_atmos,
-/obj/machinery/air_sensor/atmos/incinerator_tank{
-	pixel_x = 32;
-	pixel_y = -32
-	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/public/glass/incinerator/atmos_exterior,
 /obj/structure/cable,
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "atg" = (
 /obj/effect/turf_decal/tile/blue{
@@ -6208,10 +6203,7 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "atF" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 6
-	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "atG" = (
@@ -6238,12 +6230,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/security/brig)
-"atJ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/engine/vacuum,
-/area/maintenance/disposal/incinerator)
 "atK" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/command{
@@ -6702,22 +6688,16 @@
 /turf/open/floor/plating,
 /area/command/bridge)
 "auW" = (
+/obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
-	dir = 8
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the turbine vent.";
-	dir = 4;
-	name = "turbine vent monitor";
-	network = list("turbine");
-	pixel_x = -29
-	},
-/obj/structure/closet/radiation,
-/turf/open/floor/iron/dark,
-/area/maintenance/disposal/incinerator)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "auX" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -7650,20 +7630,14 @@
 /turf/open/floor/plating,
 /area/commons/fitness/recreation)
 "axx" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/machinery/door/airlock/atmos{
+	name = "Incinerator";
+	req_access_txt = "24"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron/dark,
-/area/maintenance/disposal/incinerator)
+/obj/machinery/door/firedoor,
+/obj/machinery/navbeacon/wayfinding/incinerator,
+/turf/open/space/basic,
+/area/engineering/atmos)
 "axy" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Holodeck Door"
@@ -7728,10 +7702,7 @@
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/captain)
 "axO" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/components/trinary/filter,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "axP" = (
@@ -7946,13 +7917,15 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "ayG" = (
+/obj/machinery/light{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ayI" = (
@@ -7972,16 +7945,12 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "ayJ" = (
-/obj/structure/closet/radiation,
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/machinery/requests_console/directional/east{
+	department = "Atmospherics";
+	departmentType = 2;
+	name = "Atmos RC"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "ayN" = (
 /obj/machinery/holopad,
@@ -8012,14 +7981,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"ayP" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/turf/open/floor/iron/dark,
-/area/maintenance/disposal/incinerator)
 "ayQ" = (
 /obj/item/beacon,
 /turf/open/floor/iron,
@@ -8058,14 +8019,11 @@
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
 "ayY" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/machinery/computer/turbine_computer{
+	id = "incineratorturbine"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "ayZ" = (
 /obj/machinery/door/window{
 	dir = 8;
@@ -8147,10 +8105,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"azi" = (
-/obj/effect/turf_decal/bot/right,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "azj" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue,
@@ -8191,9 +8145,7 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "azm" = (
-/obj/effect/turf_decal/box/white{
-	color = "#9FED58"
-	},
+/obj/effect/turf_decal/bot/right,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "azo" = (
@@ -8235,22 +8187,10 @@
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "azt" = (
-/obj/structure/rack,
-/obj/item/hfr_box/body/fuel_input,
-/obj/item/hfr_box/body/interface,
-/obj/item/hfr_box/body/moderator_input,
-/obj/item/hfr_box/body/waste_output,
-/obj/item/hfr_box/core,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "azu" = (
 /obj/machinery/door/airlock{
@@ -8305,7 +8245,9 @@
 /turf/open/space,
 /area/solars/port)
 "azN" = (
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/box/white{
+	color = "#52B4E9"
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "azR" = (
@@ -8460,20 +8402,18 @@
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
 "aAu" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
-	dir = 4
+	dir = 1
 	},
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/camera{
-	c_tag = "HFR Room";
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "aAv" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -8953,23 +8893,13 @@
 /turf/open/floor/iron/grimy,
 /area/commons/dorms)
 "aBR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
-/obj/structure/table/reinforced,
-/obj/item/stack/cable_coil{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/stack/sheet/plasteel/fifty,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "aBS" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -27169,11 +27099,7 @@
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "bRn" = (
-/obj/machinery/requests_console/directional/east{
-	department = "Atmospherics";
-	departmentType = 2;
-	name = "Atmos RC"
-	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "bRp" = (
@@ -28521,6 +28447,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bVn" = (
@@ -28783,6 +28710,7 @@
 	dir = 8;
 	name = "CO2 Outlet Pump"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bWe" = (
@@ -29051,10 +28979,11 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bWQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "bWT" = (
 /obj/machinery/air_sensor/atmos/carbon_tank,
 /turf/open/floor/engine/co2,
@@ -29222,7 +29151,6 @@
 /obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bXA" = (
@@ -29435,7 +29363,6 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bYw" = (
@@ -29677,21 +29604,15 @@
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
 	},
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "bZh" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/computer/atmos_control/incinerator,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 5
-	},
 /turf/open/floor/iron/dark,
-/area/maintenance/disposal/incinerator)
+/area/engineering/atmos)
 "bZl" = (
 /obj/structure/chair/wood,
 /turf/open/floor/iron/chapel{
@@ -29798,15 +29719,9 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bZU" = (
-/obj/machinery/power/smes,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "bZY" = (
@@ -29970,24 +29885,33 @@
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "caP" = (
+/obj/machinery/button/door/incinerator_vent_atmos_main{
+	pixel_x = 24;
+	pixel_y = 6
+	},
+/obj/machinery/button/door/incinerator_vent_atmos_aux{
+	pixel_x = 24;
+	pixel_y = -6
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
+"caQ" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
-"caQ" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/airlock_sensor/incinerator_atmos{
-	pixel_y = 22
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/hidden,
-/turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "caS" = (
 /turf/closed/wall,
@@ -30136,27 +30060,14 @@
 /turf/open/floor/engine/air,
 /area/engineering/atmos)
 "cbC" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/tank/toxins{
-	dir = 4;
-	initialize_directions = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating/airless,
 /area/maintenance/disposal/incinerator)
 "cbF" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/incinerator_input{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "cbK" = (
 /obj/structure/chair/wood{
@@ -30340,11 +30251,7 @@
 /turf/open/floor/engine/air,
 /area/engineering/atmos)
 "ccs" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/airalarm/directional/east,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "ccu" = (
@@ -34513,10 +34420,18 @@
 /turf/open/floor/iron/dark,
 /area/service/library)
 "cBd" = (
+/obj/machinery/button/ignition/incinerator/atmos{
+	pixel_x = 26;
+	pixel_y = -6
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "cBk" = (
 /obj/machinery/vending/boozeomat,
@@ -34773,16 +34688,9 @@
 	},
 /area/maintenance/department/science)
 "cEJ" = (
-/obj/machinery/button/ignition/incinerator/atmos{
-	pixel_x = 26;
-	pixel_y = -6
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
+	dir = 6
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
@@ -34910,6 +34818,13 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/maintenance/disposal)
+"cMZ" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
+	dir = 1
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/engineering/atmos)
 "cOv" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
@@ -34923,9 +34838,9 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "cPd" = (
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
+/obj/structure/sign/warning/fire,
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "cPy" = (
 /obj/machinery/light{
 	dir = 8
@@ -35016,9 +34931,9 @@
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "cRm" = (
-/obj/machinery/door/poddoor/incinerator_atmos_aux,
-/turf/open/floor/engine/vacuum,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "cRA" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -35148,7 +35063,9 @@
 /turf/open/floor/iron,
 /area/command/gateway)
 "dej" = (
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 10
+	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "dfm" = (
@@ -36459,11 +36376,7 @@
 /turf/open/floor/iron/white,
 /area/security/prison)
 "evU" = (
-/obj/effect/turf_decal/box/white,
-/obj/effect/turf_decal/arrows/white{
-	color = "#0000FF";
-	pixel_y = 15
-	},
+/obj/effect/turf_decal/bot/left,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ewb" = (
@@ -36693,9 +36606,14 @@
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "eHK" = (
-/obj/machinery/power/turbine{
-	dir = 4;
+/obj/machinery/power/compressor{
+	comp_id = "incineratorturbine";
+	dir = 8;
 	luminosity = 2
+	},
+/obj/machinery/camera{
+	c_tag = "Turbine Chamber";
+	network = list("turbine")
 	},
 /obj/structure/cable,
 /turf/open/floor/engine/vacuum,
@@ -37144,7 +37062,18 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "faU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/tank/toxins{
+	dir = 4;
+	initialize_directions = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "faY" = (
@@ -37170,16 +37099,8 @@
 /turf/open/floor/iron/dark,
 /area/medical/abandoned)
 "fbC" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/closet/radiation,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/west,
-/turf/open/floor/iron/dark,
+/obj/machinery/door/poddoor/incinerator_atmos_main,
+/turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "fcK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -37501,14 +37422,12 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
 "foz" = (
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/public/glass/incinerator/atmos_interior,
-/obj/machinery/embedded_controller/radio/airlock_controller/incinerator_atmos{
-	pixel_x = -6;
-	pixel_y = -26
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable,
-/turf/open/floor/engine,
+/turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "fqJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -37555,16 +37474,25 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "fsO" = (
-/obj/machinery/atmospherics/components/trinary/filter,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/closet/radiation,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "fsP" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
-	dir = 1
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engineering/atmos)
+/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/hidden,
+/turf/open/floor/engine,
+/area/maintenance/disposal/incinerator)
 "ftb" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
@@ -38037,11 +37965,11 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "fQy" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/turf/open/floor/engine/vacuum,
+/area/maintenance/disposal/incinerator)
 "fQD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39475,11 +39403,16 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching the turbine vent.";
+	dir = 4;
+	name = "turbine vent monitor";
+	network = list("turbine");
+	pixel_x = -29
 	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/obj/structure/closet/radiation,
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "hnY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
@@ -39527,13 +39460,13 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "hqI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "htK" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -39693,7 +39626,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "hCj" = (
@@ -39890,15 +39825,8 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "hMa" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/structure/closet/secure_closet/atmospherics,
-/turf/open/floor/iron/dark,
+/obj/machinery/door/poddoor/incinerator_atmos_aux,
+/turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "hMc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -40385,27 +40313,13 @@
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
 "iiP" = (
-/obj/machinery/button/door/incinerator_vent_atmos_main{
-	pixel_x = 24;
-	pixel_y = 6
+/obj/machinery/door/airlock/atmos{
+	name = "HFR";
+	req_access_txt = "24"
 	},
-/obj/machinery/button/door/incinerator_vent_atmos_aux{
-	pixel_x = 24;
-	pixel_y = -6
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
-/obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
-/area/maintenance/disposal/incinerator)
+/area/engineering/atmos)
 "ijU" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/memeorgans,
@@ -40953,12 +40867,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/plating,
 /area/engineering/atmos)
-"iRa" = (
-/obj/item/bedsheet,
-/obj/structure/bed,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/turf/open/floor/iron,
-/area/security/prison/safe)
 "iRs" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -41004,12 +40912,9 @@
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "iVT" = (
-/obj/machinery/door/airlock/atmos{
-	name = "HFR";
-	req_access_txt = "24"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/turf/open/floor/plating/airless,
 /area/engineering/atmos)
 "iWV" = (
 /obj/machinery/light{
@@ -41587,12 +41492,10 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "jKs" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 1;
-	frequency = 1441;
-	id = "inc_in"
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "jKE" = (
 /obj/effect/turf_decal/trimline/blue/line{
@@ -41670,11 +41573,10 @@
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
 "jOl" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/open/floor/iron/dark,
+/turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "jOw" = (
 /obj/structure/table/wood/fancy,
@@ -42060,14 +41962,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "klp" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/door/airlock/external{
-	name = "Atmospherics External Access";
-	req_access_txt = "24"
-	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "klB" = (
 /obj/effect/turf_decal/tile/purple,
@@ -42131,9 +42030,26 @@
 /turf/open/floor/iron/stairs/left,
 /area/service/abandoned_gambling_den)
 "kqc" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/camera{
+	c_tag = "Incinerator";
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/table/glass,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "kqH" = (
@@ -42513,9 +42429,15 @@
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "kHY" = (
-/obj/structure/sign/warning/fire,
-/turf/closed/wall/r_wall,
-/area/space)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "Atmospherics External Access";
+	req_access_txt = "24"
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal/incinerator)
 "kIo" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -42539,9 +42461,17 @@
 	},
 /area/maintenance/department/security/brig)
 "kJU" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/disposal/incinerator)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "kKz" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -43086,8 +43016,10 @@
 /turf/open/floor/iron/dark,
 /area/service/library/lounge)
 "lnh" = (
-/obj/machinery/computer/turbine_computer{
-	id = "incineratorturbine"
+/obj/structure/table,
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -7
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
@@ -43576,6 +43508,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "lRh" = (
@@ -44034,10 +43967,14 @@
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
 "mrH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 8
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "mrR" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -44422,11 +44359,13 @@
 /turf/open/floor/grass,
 /area/medical/psychology)
 "mNv" = (
+/obj/structure/closet/radiation,
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
-	dir = 8
+	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -44492,10 +44431,14 @@
 /turf/open/space,
 /area/space/nearstation)
 "mPP" = (
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/closet/secure_closet/atmospherics,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "mQc" = (
@@ -44647,7 +44590,11 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "mYX" = (
-/obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/light,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "mZi" = (
@@ -44913,17 +44860,18 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "njg" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "njH" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -47471,10 +47419,11 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "pGV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/disposal/incinerator)
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "pGZ" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lantern{
@@ -48996,16 +48945,22 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "rfm" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Incinerator";
-	req_access_txt = "24"
+/obj/structure/rack,
+/obj/item/hfr_box/body/fuel_input,
+/obj/item/hfr_box/body/interface,
+/obj/item/hfr_box/body/moderator_input,
+/obj/item/hfr_box/body/waste_output,
+/obj/item/hfr_box/core,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "rgs" = (
 /obj/structure/table,
@@ -49045,9 +49000,7 @@
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "rjl" = (
-/obj/effect/turf_decal/box/white{
-	color = "#EFB341"
-	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "rka" = (
@@ -49291,7 +49244,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "rsy" = (
-/obj/effect/turf_decal/bot/left,
+/obj/effect/turf_decal/box/white{
+	color = "#9FED58"
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "rsK" = (
@@ -49513,15 +49468,9 @@
 /turf/open/floor/iron,
 /area/medical/cryo)
 "ryS" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/maintenance/disposal/incinerator)
 "rzp" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
@@ -49699,8 +49648,8 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "rFv" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 5
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
@@ -49710,12 +49659,9 @@
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "rGD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
 /area/maintenance/disposal/incinerator)
 "rHh" = (
 /obj/structure/flora/ausbushes/fernybush,
@@ -49852,8 +49798,12 @@
 /turf/closed/wall/r_wall,
 /area/science/mixing)
 "rLJ" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1;
+	frequency = 1441;
+	id = "inc_in"
+	},
+/turf/open/floor/plating/airless,
 /area/maintenance/disposal/incinerator)
 "rLQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -49960,8 +49910,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "rQM" = (
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/public/glass/incinerator/atmos_exterior,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos,
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
@@ -50436,12 +50385,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "ssU" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/effect/turf_decal/box/white{
+	color = "#EFB341"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -50557,9 +50502,19 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "sxs" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
-/turf/open/floor/plating,
+/obj/structure/rack,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/camera{
+	c_tag = "HFR Room";
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "sxT" = (
 /obj/structure/cable,
@@ -51427,17 +51382,10 @@
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
 "tiG" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Incinerator";
-	req_access_txt = "24"
-	},
-/obj/machinery/navbeacon/wayfinding/incinerator,
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 9
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "tiI" = (
 /obj/structure/cable,
@@ -51490,13 +51438,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "tlJ" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/machinery/door/airlock/external{
-	name = "Atmospherics External Access";
-	req_access_txt = "24"
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = 32
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "tlN" = (
@@ -51511,13 +51459,31 @@
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
 "tlU" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/open/floor/plating/airless,
+/obj/effect/turf_decal/box/white,
+/obj/effect/turf_decal/arrows/white{
+	color = "#0000FF";
+	pixel_y = 15
+	},
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "tna" = (
-/turf/open/space/basic,
-/area/maintenance/disposal/incinerator)
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
+/obj/structure/table/reinforced,
+/obj/item/stack/cable_coil{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "tnY" = (
 /obj/machinery/button/door{
 	id = "aux_base_shutters";
@@ -51626,14 +51592,10 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "ttA" = (
-/obj/machinery/power/compressor{
-	comp_id = "incineratorturbine";
-	dir = 8;
-	luminosity = 2
-	},
-/obj/machinery/camera{
-	c_tag = "Turbine Chamber";
-	network = list("turbine")
+/obj/machinery/igniter/incinerator_atmos,
+/obj/machinery/air_sensor/atmos/incinerator_tank{
+	pixel_x = 32;
+	pixel_y = -32
 	},
 /obj/structure/cable,
 /turf/open/floor/engine/vacuum,
@@ -51694,6 +51656,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "tvy" = (
@@ -51892,14 +51855,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"tCe" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/structure/table/wood/fancy,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "tCi" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/machinery/disposal/bin,
@@ -52102,9 +52057,18 @@
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "tQj" = (
-/obj/machinery/atmospherics/components/binary/pump{
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "tQJ" = (
@@ -52169,9 +52133,9 @@
 /area/engineering/supermatter/room)
 "tSV" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
-/turf/open/space,
-/area/maintenance/disposal/incinerator)
+/obj/structure/grille/broken,
+/turf/open/space/basic,
+/area/space/nearstation)
 "tTq" = (
 /obj/structure/closet/crate,
 /obj/item/food/breadslice/plain,
@@ -52399,6 +52363,9 @@
 /area/service/chapel/main/monastery)
 "udE" = (
 /obj/structure/table,
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 10
+	},
 /obj/item/stack/cable_coil{
 	pixel_x = 3;
 	pixel_y = -7
@@ -52525,12 +52492,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "uib" = (
@@ -54780,9 +54742,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "wfp" = (
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "wfr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -54869,10 +54837,17 @@
 	},
 /area/maintenance/department/security/brig)
 "wit" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/airlock_sensor/incinerator_atmos{
+	pixel_y = 22
+	},
+/obj/machinery/atmospherics/components/binary/pump{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/hidden,
+/turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "wiy" = (
 /obj/structure/table,
@@ -55022,13 +54997,13 @@
 /turf/open/floor/iron/freezer,
 /area/security/prison/toilet)
 "woV" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
 	},
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
+/obj/machinery/door/airlock/external{
+	name = "Atmospherics External Access";
+	req_access_txt = "24"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "woX" = (
@@ -55574,8 +55549,12 @@
 /turf/open/space,
 /area/space/nearstation)
 "wMm" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "wMn" = (
 /obj/structure/window/reinforced/spawner/east,
@@ -55685,11 +55664,14 @@
 /turf/open/floor/carpet,
 /area/medical/psychology)
 "wQE" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 5
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating/airless,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "wQU" = (
 /obj/effect/spawner/lootdrop/maintenance,
@@ -56071,10 +56053,10 @@
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "xdQ" = (
-/obj/structure/lattice,
-/obj/structure/grille/broken,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
+/turf/open/floor/plating,
+/area/engineering/atmos)
 "xdY" = (
 /obj/machinery/door/window/eastright{
 	name = "Danger: Conveyor Access";
@@ -56678,7 +56660,11 @@
 /turf/open/floor/iron/dark,
 /area/service/library)
 "xCh" = (
-/obj/machinery/door/poddoor/incinerator_atmos_main,
+/obj/machinery/power/turbine{
+	dir = 4;
+	luminosity = 2
+	},
+/obj/structure/cable,
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "xDj" = (
@@ -56804,8 +56790,11 @@
 /turf/open/floor/iron/white,
 /area/medical/paramedic)
 "xJb" = (
-/obj/effect/turf_decal/box/white{
-	color = "#52B4E9"
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -56998,12 +56987,10 @@
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "xTb" = (
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/hidden,
-/turf/open/floor/engine,
+/turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "xTe" = (
 /obj/structure/cable,
@@ -57108,13 +57095,17 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "yby" = (
-/obj/structure/table,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 10
+	dir = 4
 	},
-/obj/item/stack/cable_coil{
+/obj/structure/table,
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/stack/sheet/glass/fifty{
 	pixel_x = 3;
-	pixel_y = -7
+	pixel_y = -4
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
@@ -57314,7 +57305,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/light,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "yjF" = (
@@ -76431,7 +76421,7 @@ aaa
 aaa
 aaa
 adE
-tCe
+arl
 aij
 lGp
 aij
@@ -79535,7 +79525,7 @@ agd
 agp
 ahp
 agM
-iRa
+asA
 ahC
 ahL
 ahL
@@ -93261,7 +93251,7 @@ bJP
 bJP
 bJP
 bJP
-mZE
+aaa
 bBW
 aaa
 aaa
@@ -93519,7 +93509,7 @@ cbu
 cbu
 bJP
 abI
-cPd
+abI
 fon
 fon
 fon
@@ -93775,7 +93765,7 @@ cbv
 ccn
 svD
 bJP
-mZE
+aaa
 abI
 fon
 aaa
@@ -94032,13 +94022,13 @@ egk
 cbu
 cbu
 bJP
-fBp
-auI
-auI
-auI
-auI
-auI
-fBp
+aaa
+aht
+aaa
+aaa
+aht
+aaa
+aht
 aaa
 aaa
 pDW
@@ -94289,13 +94279,13 @@ bJP
 bJP
 bJP
 bJP
+fBp
 auI
-hnV
-ayY
-ayY
-ayY
-ssU
 auI
+auI
+auI
+auI
+fBp
 aaa
 aaa
 aaa
@@ -94547,11 +94537,11 @@ cby
 cby
 bJP
 auI
-bUp
-azi
+kJU
 xJb
-rsy
-uWA
+xJb
+xJb
+wfp
 auI
 aaa
 aaa
@@ -95064,7 +95054,7 @@ auI
 bUp
 rsy
 rjl
-azi
+tlU
 uWA
 auI
 aaa
@@ -95311,18 +95301,18 @@ bWO
 bWO
 bYs
 qKG
-fBp
+abI
 bJP
 bJP
 bJP
 bJP
 bJP
-fBp
-njg
-bWO
-bWO
-bWO
-mNv
+auI
+bUp
+evU
+ssU
+azm
+uWA
 auI
 aaa
 aaa
@@ -95569,19 +95559,19 @@ bWO
 bYt
 bZf
 jOl
-mrH
-wMm
-wMm
-wMm
-wMm
-tlU
+fBp
+fBp
+fBp
+fBp
+fBp
+fBp
 ayG
-fQy
+bWO
 bWO
 bWO
 hCg
-sxs
-fsP
+auI
+aaa
 aaa
 aaa
 aaa
@@ -95820,25 +95810,25 @@ bTO
 eNC
 jaS
 xbZ
-hqI
-bWQ
+bTO
+eNC
 bXz
 bYu
 tiG
 dej
-dFK
-yeD
-yeD
-yeD
-yeD
+azt
+bZh
+cRm
+cRm
+cRm
 iVT
-bUp
+mrH
+pGV
 bWO
 bWO
-bWO
-uWA
-auI
-aaa
+wMm
+xdQ
+cMZ
 aaa
 aaa
 aaa
@@ -96079,21 +96069,21 @@ bXF
 bVk
 bWb
 lQQ
-bXF
+auW
 tvr
-fBp
+axx
 bRn
 dFK
 yeD
 yeD
 yeD
 yeD
-mkf
-ayJ
-azt
-aAu
-aBR
-ryS
+iiP
+bUp
+bWO
+bWO
+bWO
+uWA
 auI
 aaa
 aaa
@@ -96339,19 +96329,19 @@ rGo
 eGT
 vLx
 fBp
-fBp
-rfm
-wQE
+ayJ
+dFK
+yeD
+yeD
+yeD
+yeD
 mkf
-fBp
-fBp
-fBp
-fBp
-fBp
-fBp
-fBp
-fBp
-fBp
+mNv
+rfm
+sxs
+tna
+wQE
+auI
 aaa
 aaa
 aaa
@@ -96594,21 +96584,21 @@ wLU
 oln
 cAO
 mOH
-tSV
+cAO
 aor
-bZh
+bYw
 aqp
 arm
 cbC
-fbC
-auW
-axx
-hMa
-kJU
-aaa
-aaa
-aaa
-aaa
+bYw
+bYw
+bYw
+bYw
+bYw
+fBp
+fBp
+fBp
+fBp
 aaa
 aaa
 aaa
@@ -96851,17 +96841,17 @@ bJP
 bMi
 mkf
 bIH
-wfp
+bJP
 bYw
 apV
-pxE
+aAu
 kqc
-usl
-usl
-usl
+faU
+fsO
+hnV
 tQj
 mPP
-bYw
+ryS
 aaa
 aaa
 aaa
@@ -97108,15 +97098,15 @@ bJP
 bWe
 bWT
 mZO
-wfp
+bJP
 bYw
 yby
-rGD
+pxE
 rFv
 usl
 usl
 usl
-oib
+jKs
 yjt
 bYw
 aaa
@@ -97365,16 +97355,16 @@ bJP
 bWg
 bVo
 bWg
-wfp
+bJP
 bYw
 udE
-pxE
-ibw
+aBR
+bZU
 usl
-mYX
+usl
 usl
 oib
-mPP
+mYX
 bYw
 aaa
 aaa
@@ -97622,18 +97612,18 @@ bJP
 bWg
 mrv
 bWg
-wfp
+bJP
 bYw
 lnh
 pxE
 ibw
 usl
 atF
-faU
-fsO
-ayP
-pGV
-jKs
+usl
+oib
+yjt
+bYw
+aaa
 aaa
 aaa
 aaa
@@ -97879,19 +97869,19 @@ bJP
 bJP
 bJP
 bJP
-wfp
+bJP
 bYw
-bYw
-bZU
-iiP
-cbF
+ayY
+pxE
+ibw
+usl
 cEJ
 ccs
 axO
 uhR
-bYw
+rGD
+rLJ
 aaa
-gYo
 aaa
 aaa
 aaa
@@ -98137,18 +98127,18 @@ aaa
 aaa
 aaa
 abI
-rLJ
+bYw
 bYw
 aqx
 caP
 foz
 cBd
-bYw
+hqI
 klp
-azC
+njg
 bYw
-aht
-fon
+aaa
+gYo
 aaa
 aaa
 aaa
@@ -98395,17 +98385,17 @@ aby
 aby
 wjT
 aaa
-rLJ
+bYw
 aqB
 caQ
 asY
 xTb
-azC
+bYw
 woV
 azC
-jKs
-aaa
-xdQ
+bYw
+aht
+fon
 aaa
 aaa
 aaa
@@ -98652,17 +98642,17 @@ abI
 aaa
 aht
 aht
-rLJ
-bYw
+aht
+bWQ
 wit
 rQM
-cBd
-bYw
+fsP
+azC
 tlJ
-lTW
-abI
-aht
-fon
+azC
+rLJ
+aaa
+tSV
 aaa
 aaa
 aaa
@@ -98909,17 +98899,17 @@ aby
 nSc
 aaa
 aaa
-rLJ
+aht
 bYw
 arv
 atf
-atJ
-cRm
-cdm
-cdm
-aaa
+xTb
+bYw
+kHY
+bYw
+abI
 aht
-aaa
+fon
 aaa
 aaa
 aaa
@@ -99166,16 +99156,16 @@ aaa
 aaa
 aaa
 aaa
-rLJ
+aht
 bYw
-bYw
+cbF
 ttA
-bYw
-lTW
+fQy
+hMa
+cdm
+cdm
 aaa
-aaa
-aaa
-fon
+aht
 aaa
 aaa
 aaa
@@ -99423,15 +99413,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-tna
+aht
+bYw
 bYw
 eHK
-lTW
-aht
-fon
-fon
-fon
+bYw
+bYw
+aaa
+aaa
+aaa
 fon
 aaa
 aaa
@@ -99680,16 +99670,16 @@ aaa
 aaa
 aaa
 aaa
-abI
-arl
-asA
+mZE
+aaa
+bYw
 xCh
-kHY
-aaa
-aaa
-aaa
-aaa
-aaa
+bYw
+aht
+fon
+fon
+fon
+fon
 aaa
 aaa
 aaa
@@ -99937,11 +99927,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abI
+abI
+cPd
+fbC
+cPd
 aaa
 aaa
 aaa

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -34818,13 +34818,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/maintenance/disposal)
-"cMZ" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
-	dir = 1
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engineering/atmos)
 "cOv" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
@@ -36264,6 +36257,13 @@
 	icon_state = "wood-broken"
 	},
 /area/service/abandoned_gambling_den)
+"eru" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
+	dir = 1
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/engineering/atmos)
 "ery" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -38387,6 +38387,10 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
+	},
+/obj/machinery/shower{
+	dir = 4;
+	name = "emergency shower"
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
@@ -95828,7 +95832,7 @@ bWO
 bWO
 wMm
 xdQ
-cMZ
+eru
 aaa
 aaa
 aaa

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -16618,7 +16618,6 @@
 	name = "bar shutters"
 	},
 /obj/effect/turf_decal/bot,
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/service/bar/atrium)
 "bft" = (
@@ -16898,6 +16897,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Bar"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/service/bar/atrium)
 "bgu" = (
@@ -16909,6 +16909,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/service/bar/atrium)
 "bgv" = (
@@ -17355,7 +17356,6 @@
 	name = "AI Core";
 	req_access_txt = "65"
 	},
-/obj/machinery/door/firedoor,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/ai_monitored/turret_protected/ai)
@@ -30847,11 +30847,10 @@
 /turf/closed/wall/mineral/iron,
 /area/service/chapel/main/monastery)
 "cfr" = (
-/obj/structure/transit_tube_pod,
-/obj/structure/transit_tube/station/reverse{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/transit_tube/station/dispenser{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -31924,10 +31923,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "clP" = (
-/obj/structure/transit_tube/station/reverse/flipped{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/transit_tube/station/dispenser{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -39816,12 +39815,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"hHu" = (
-/obj/item/bedsheet,
-/obj/structure/bed,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/turf/open/floor/iron,
-/area/security/prison/safe)
 "hHG" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
@@ -40960,6 +40953,12 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/plating,
 /area/engineering/atmos)
+"iRa" = (
+/obj/item/bedsheet,
+/obj/structure/bed,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "iRs" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -40987,14 +40986,6 @@
 /obj/effect/turf_decal/trimline/yellow/line,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"iTR" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/structure/table/wood/fancy,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "iUX" = (
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
@@ -50362,7 +50353,6 @@
 	name = "bar shutters"
 	},
 /obj/effect/turf_decal/bot,
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -51902,6 +51892,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"tCe" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/structure/table/wood/fancy,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "tCi" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/machinery/disposal/bin,
@@ -76433,7 +76431,7 @@ aaa
 aaa
 aaa
 adE
-iTR
+tCe
 aij
 lGp
 aij
@@ -79537,7 +79535,7 @@ agd
 agp
 ahp
 agM
-hHu
+iRa
 ahC
 ahL
 ahL

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -7636,7 +7636,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/navbeacon/wayfinding/incinerator,
-/turf/open/space/basic,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "axy" = (
 /obj/machinery/door/airlock/public/glass{
@@ -33054,10 +33054,6 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "crh" = (
-/obj/machinery/button/crematorium{
-	id = "foo";
-	pixel_x = 25
-	},
 /obj/structure/bodycontainer/crematorium{
 	id = "foo"
 	},
@@ -54605,6 +54601,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /turf/closed/wall,
 /area/maintenance/department/engine)
+"vWg" = (
+/obj/machinery/button/crematorium{
+	id = "foo";
+	pixel_x = 25
+	},
+/turf/open/floor/iron/dark,
+/area/service/chapel/office)
 "vWp" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -68104,7 +68107,7 @@ cfN
 cfN
 bZY
 crh
-crv
+vWg
 crv
 bZY
 crU

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -26674,6 +26674,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bPP" = (
@@ -27150,7 +27151,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -19060,7 +19060,7 @@
 "bou" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Morgue";
-	req_one_access_txt = "6;5"
+	req_access_txt = "6;5"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51220,7 +51220,7 @@
 "tbS" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Morgue";
-	req_one_access_txt = "6;5"
+	req_access_txt = "6"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -53259,7 +53259,7 @@
 "uPG" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Morgue";
-	req_one_access_txt = "6;5"
+	req_access_txt = "6"
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -8326,6 +8326,10 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/east,
+/obj/machinery/camera{
+	c_tag = "HFR Room";
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "azu" = (
@@ -9041,13 +9045,12 @@
 /turf/open/floor/iron/grimy,
 /area/commons/dorms)
 "aBR" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/camera{
-	c_tag = "HFR Room";
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -19057,8 +19060,7 @@
 "bou" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Morgue";
-	req_access = null;
-	req_access_txt = "6;5"
+	req_one_access_txt = "6;5"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23331,7 +23333,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/medical/glass{
 	name = "Pharmacy";
-	req_access_txt = "5; 69"
+	req_one_access_txt = "5; 69"
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -39935,12 +39937,9 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/department/engine)
 "hCg" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
+/turf/open/floor/plating,
 /area/engineering/atmos)
 "hCj" = (
 /obj/structure/cable,
@@ -40996,6 +40995,7 @@
 	},
 /obj/structure/table/glass,
 /obj/item/stack/medical/gauze,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "iIB" = (
@@ -42586,6 +42586,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/trunk,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "kDY" = (
@@ -44454,12 +44455,25 @@
 /turf/open/space,
 /area/space/nearstation)
 "mDN" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/item/reagent_containers/glass/bottle/epinephrine,
+/obj/item/reagent_containers/glass/bottle/multiver{
+	pixel_x = 6
+	},
+/obj/item/reagent_containers/syringe,
+/obj/structure/table/glass,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/medical/medbay/central)
 "mDW" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -44796,8 +44810,8 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -49343,9 +49357,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "rsK" = (
@@ -50561,9 +50572,11 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "sxs" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
+	dir = 1
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
 /area/engineering/atmos)
 "sxT" = (
 /obj/structure/cable,
@@ -51161,11 +51174,14 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "taw" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
-	dir = 1
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "taA" = (
 /obj/structure/chair/office/light,
@@ -51204,8 +51220,7 @@
 "tbS" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Morgue";
-	req_access = null;
-	req_access_txt = "6;5"
+	req_one_access_txt = "6;5"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -53244,8 +53259,7 @@
 "uPG" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Morgue";
-	req_access = null;
-	req_access_txt = "6;5"
+	req_one_access_txt = "6;5"
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -55934,9 +55948,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "xdc" = (
@@ -78089,8 +78101,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-pDW
+fon
+aht
 aht
 aem
 czK
@@ -80662,16 +80674,16 @@ aaa
 aaa
 aaa
 aaa
-pDW
-pDW
-aht
-aht
-aht
-aht
-aht
-aht
-aht
 aaa
+pDW
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+fon
 aaa
 aaa
 aaa
@@ -80920,7 +80932,7 @@ aaa
 aaa
 aaa
 aaa
-pDW
+aaa
 pDW
 pDW
 pDW
@@ -83314,7 +83326,7 @@ bjc
 bjR
 blc
 tgT
-bny
+mDN
 boB
 bpF
 xUU
@@ -93898,8 +93910,8 @@ auI
 auI
 auI
 auI
-auI
 fBp
+aaa
 aaa
 aaa
 pDW
@@ -94154,9 +94166,9 @@ awr
 ayY
 ayY
 ayY
-ayY
-rsy
+mZO
 auI
+aaa
 aaa
 aaa
 aaa
@@ -94411,9 +94423,9 @@ cqG
 ayc
 azi
 ayC
-bWO
-mDN
+rsy
 auI
+aaa
 aaa
 aaa
 aaa
@@ -94668,9 +94680,9 @@ cqG
 ayy
 azm
 azN
-bWO
-mDN
+rsy
 auI
+aaa
 aaa
 aaa
 aaa
@@ -94925,9 +94937,9 @@ cqG
 ayC
 azn
 ayc
-bWO
-mDN
+rsy
 auI
+aaa
 aaa
 aaa
 aaa
@@ -95182,9 +95194,9 @@ axl
 bWO
 bWO
 bWO
-bWO
-mZO
+taw
 auI
+aaa
 aaa
 aaa
 aaa
@@ -95439,10 +95451,10 @@ tlU
 ayG
 bWO
 bWO
-bWO
+xca
 hCg
 sxs
-taw
+aaa
 aaa
 aaa
 aaa
@@ -95696,9 +95708,9 @@ cqG
 bWO
 bWO
 bWO
-bWO
-mDN
+rsy
 auI
+aaa
 aaa
 aaa
 aaa
@@ -95954,8 +95966,8 @@ ayJ
 azt
 aAu
 aBR
-xca
 auI
+aaa
 aaa
 aaa
 aaa
@@ -96212,7 +96224,7 @@ fBp
 fBp
 fBp
 fBp
-fBp
+aaa
 aaa
 aaa
 aaa

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -16779,7 +16779,13 @@
 /area/cargo/miningdock)
 "bfC" = (
 /obj/structure/table,
-/obj/item/stack/sheet/cardboard,
+/obj/item/clothing/gloves/cargo_gauntlet{
+	pixel_y = -7
+	},
+/obj/item/clothing/gloves/cargo_gauntlet,
+/obj/item/clothing/gloves/cargo_gauntlet{
+	pixel_y = 7
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -260,6 +260,9 @@
 /area/cargo/warehouse/upper)
 "aaN" = (
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "aaQ" = (
@@ -622,15 +625,18 @@
 /area/ai_monitored/turret_protected/ai)
 "acB" = (
 /obj/machinery/door/firedoor/heavy,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
-"acC" = (
-/obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
+"acC" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "acD" = (
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat AI Chamber South";
@@ -647,6 +653,10 @@
 	pixel_y = 37
 	},
 /obj/machinery/holopad/secure,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "acF" = (
@@ -691,6 +701,10 @@
 	uses = 8
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/ai_monitored/turret_protected/ai)
 "acM" = (
@@ -736,6 +750,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "add" = (
@@ -797,11 +815,19 @@
 "adk" = (
 /obj/structure/table,
 /obj/machinery/recharger,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "adl" = (
 /obj/structure/chair/office{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -809,12 +835,20 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "ado" = (
 /obj/structure/table,
 /obj/item/pen,
 /obj/item/paper_bin,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "adq" = (
@@ -844,6 +878,7 @@
 	network = list("minisat")
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
 "adu" = (
@@ -861,6 +896,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
 "adx" = (
@@ -894,6 +933,10 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
 "adC" = (
@@ -910,6 +953,10 @@
 	network = list("minisat")
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
 "adE" = (
@@ -976,6 +1023,10 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "adO" = (
@@ -989,6 +1040,10 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
 "adR" = (
@@ -997,11 +1052,9 @@
 /turf/open/space,
 /area/space/nearstation)
 "adT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "adU" = (
 /turf/open/space/basic,
 /area/cargo/warehouse/upper)
@@ -1231,6 +1284,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "aeR" = (
@@ -1250,6 +1307,10 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
 "aeT" = (
@@ -1283,11 +1344,9 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "aeY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
-	dir = 6
-	},
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
 "aeZ" = (
@@ -1304,6 +1363,10 @@
 	},
 /obj/structure/cable,
 /obj/item/radio/intercom/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
 "afb" = (
@@ -1325,6 +1388,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
 "afd" = (
@@ -1350,6 +1417,10 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "aff" = (
@@ -1360,6 +1431,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "afg" = (
@@ -1375,6 +1450,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "afh" = (
@@ -1396,6 +1475,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
 "afj" = (
@@ -1420,6 +1503,10 @@
 	},
 /obj/structure/cable,
 /obj/item/radio/intercom/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
 "afl" = (
@@ -1498,6 +1585,7 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "afx" = (
@@ -1526,6 +1614,9 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "afB" = (
@@ -4737,6 +4828,13 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/security/brig)
+"aoN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/brig)
 "aoO" = (
 /obj/machinery/camera{
 	c_tag = "Brig Gulag Teleporter";
@@ -6033,9 +6131,16 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/command/bridge)
 "asO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/bridge)
 "asQ" = (
@@ -6342,6 +6447,10 @@
 	},
 /obj/machinery/navbeacon/wayfinding/minisat_access_ai,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "atN" = (
@@ -7417,6 +7526,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "awz" = (
@@ -7607,6 +7719,16 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/paramedic)
+"awX" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "awY" = (
 /obj/machinery/light{
 	dir = 8;
@@ -7832,7 +7954,6 @@
 	},
 /obj/item/clothing/suit/armor/riot/knight/blue,
 /obj/item/clothing/head/helmet/knight/blue,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/captain)
 "axQ" = (
@@ -7978,13 +8099,6 @@
 /obj/item/storage/backpack,
 /turf/open/floor/carpet,
 /area/commons/dorms)
-"ayr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "ayu" = (
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
@@ -8160,6 +8274,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
@@ -8554,6 +8671,9 @@
 /obj/structure/chair/comfy/brown{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/captain)
 "aAs" = (
@@ -8661,6 +8781,13 @@
 	dir = 8
 	},
 /obj/machinery/navbeacon/wayfinding/aiupload,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aAD" = (
@@ -8725,6 +8852,9 @@
 /obj/structure/chair/comfy{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "aAQ" = (
@@ -8732,6 +8862,9 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/assistant,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "aAS" = (
@@ -9481,10 +9614,6 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/commons/toilet/restrooms)
 "aDm" = (
@@ -9664,7 +9793,14 @@
 	network = list("aiupload")
 	},
 /obj/machinery/holopad/secure,
-/obj/machinery/airalarm/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "aDN" = (
@@ -9775,6 +9911,10 @@
 "aEb" = (
 /obj/machinery/newscaster/directional/north,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "aEc" = (
@@ -10371,19 +10511,11 @@
 /obj/machinery/door/airlock{
 	name = "Unisex Showers"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
 "aFL" = (
 /obj/machinery/light{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
@@ -11564,7 +11696,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aLx" = (
@@ -11866,12 +11998,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/cargo/warehouse)
-"aMB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/commons/storage/primary)
 "aMD" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -14537,6 +14663,12 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/service)
+"aXg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/construction/mining/aux_base)
 "aXh" = (
 /obj/effect/landmark/start/bartender,
 /turf/open/floor/iron/dark,
@@ -14866,13 +14998,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/kitchen)
-"aYc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "aYf" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/barman_recipes,
@@ -17544,9 +17669,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "biy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
-/area/service/abandoned_gambling_den)
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "biC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -18764,13 +18890,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"bnp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/freezer,
-/area/commons/toilet/restrooms)
 "bnq" = (
 /obj/item/beacon,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -19259,11 +19378,6 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"bps" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "bpu" = (
 /obj/structure/table,
 /obj/item/storage/belt/fannypack/red,
@@ -19652,6 +19766,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/explab)
+"bqy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/service/bar/atrium)
 "bqA" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "9;55"
@@ -20315,15 +20436,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"bsC" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/service/bar/atrium)
 "bsD" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -23269,16 +23381,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/rd)
-"bCJ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
 "bCK" = (
 /obj/structure/table,
 /obj/machinery/camera{
@@ -28881,13 +28983,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"bWd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/department/engine)
 "bWe" = (
 /obj/machinery/air_sensor/atmos/carbon_tank,
 /turf/open/floor/engine/co2,
@@ -31031,15 +31126,6 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/transit_tube)
-"cft" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/science/xenobiology)
 "cfu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -32113,6 +32199,7 @@
 "clU" = (
 /obj/item/wrench,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "clV" = (
@@ -32122,6 +32209,8 @@
 /area/tcommsat/computer)
 "clY" = (
 /obj/item/beacon,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "cma" = (
@@ -32129,11 +32218,14 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "cmb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "cmc" = (
 /obj/item/stack/cable_coil,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "cmf" = (
@@ -32151,6 +32243,7 @@
 	},
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "cmg" = (
@@ -32168,6 +32261,7 @@
 	pixel_y = 30
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "cmh" = (
@@ -32177,6 +32271,8 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "cmj" = (
@@ -32191,6 +32287,8 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "cml" = (
@@ -32240,6 +32338,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "cms" = (
@@ -32627,6 +32726,16 @@
 	},
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
+"coc" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "cod" = (
 /obj/structure/table,
 /obj/item/clothing/under/color/grey,
@@ -32652,6 +32761,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/assistant,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "com" = (
@@ -33579,15 +33689,6 @@
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
-"ctd" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "cth" = (
 /obj/structure/table/wood/fancy,
 /obj/item/storage/fancy/candle_box,
@@ -34806,6 +34907,17 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/service/chapel/office)
+"cBN" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "cBT" = (
 /obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/iron,
@@ -34896,10 +35008,6 @@
 "cDa" = (
 /turf/closed/wall,
 /area/cargo/warehouse)
-"cDw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/closed/wall/r_wall,
-/area/engineering/lobby)
 "cDy" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -34950,6 +35058,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"cHR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/commons/dorms)
 "cHS" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Firing Range"
@@ -35025,6 +35139,14 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/service/library/lounge)
+"cOG" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/main)
 "cPy" = (
 /obj/machinery/light{
 	dir = 8
@@ -35075,6 +35197,10 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/genetics)
+"cQs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "cQy" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -35370,6 +35496,13 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"doe" = (
+/obj/effect/turf_decal/bot/right,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/engineering/gravity_generator)
 "dok" = (
 /obj/effect/turf_decal/trimline/green/line{
 	dir = 4
@@ -35426,6 +35559,11 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"dpV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/tcommsat/computer)
 "dqw" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -35465,12 +35603,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
-"dsm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/cargo/sorting)
 "dsv" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -35517,6 +35649,13 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"duC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/commons/fitness/recreation)
 "duF" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -35624,6 +35763,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
+"dDZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/command/bridge)
 "dEd" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/bot,
@@ -35875,6 +36021,19 @@
 /obj/item/hemostat,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"dSK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "dTR" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -36124,14 +36283,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse/upper)
-"ekB" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "ekU" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/loot_site_spawner,
@@ -36179,6 +36330,9 @@
 /area/security/brig)
 "emV" = (
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "enI" = (
@@ -36275,19 +36429,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"esM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "eta" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Supplies";
@@ -36346,6 +36487,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"ewb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "eyL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
@@ -36369,6 +36514,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
 "ezx" = (
@@ -36383,15 +36529,6 @@
 /obj/item/pen/red,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"eAI" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white/corner,
-/area/hallway/secondary/exit/departure_lounge)
 "eAP" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
@@ -36495,10 +36632,11 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
-"eHl" = (
-/obj/item/wrench,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+"eHb" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/maintenance/department/engine)
 "eHq" = (
 /obj/effect/landmark/start/hangover,
@@ -36710,6 +36848,16 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"eTZ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "eUa" = (
 /obj/machinery/requests_console/directional/south{
 	department = "Mining";
@@ -36767,6 +36915,12 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/storage_shared)
+"eXa" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/tcommsat/computer)
 "eXo" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/engine,
@@ -36843,19 +36997,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"eZE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ai_monitored/command/storage/eva)
-"eZJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "eZM" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay Storage";
@@ -36897,6 +37038,14 @@
 /obj/machinery/atmospherics/components/trinary/filter,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
+"faY" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "fby" = (
 /obj/structure/bed,
 /obj/item/bedsheet/cmo,
@@ -37172,18 +37321,6 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark,
 /area/science/explab)
-"fkQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "flQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37244,18 +37381,19 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"frb" = (
-/obj/structure/window/reinforced,
-/obj/structure/rack,
-/obj/item/circuitboard/machine/exoscanner{
-	pixel_y = 3
+"fqJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/item/circuitboard/machine/exoscanner,
-/obj/item/circuitboard/machine/exoscanner{
-	pixel_y = -3
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/cargo/warehouse/upper)
+/obj/structure/cable,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "frn" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -37457,11 +37595,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"fAU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/turf/closed/wall,
-/area/maintenance/department/engine)
 "fBp" = (
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
@@ -37497,6 +37630,19 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
+"fEj" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/door/airlock/research{
+	name = "Toxins Launch Room";
+	req_access_txt = "8"
+	},
+/turf/open/floor/iron,
+/area/science/mixing)
 "fEo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -37560,6 +37706,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"fGo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/department/engine)
 "fGz" = (
 /obj/machinery/door/airlock/medical{
 	name = "Surgical Theatres";
@@ -37576,6 +37731,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
+"fIc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/main)
 "fIA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/iron,
@@ -37645,13 +37806,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
-"fMk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen)
 "fMm" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -37700,16 +37854,22 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/plating/asteroid,
 /area/service/chapel/asteroid/monastery)
-"fOw" = (
-/obj/structure/cable,
+"fOP" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/ai_upload)
 "fQd" = (
 /obj/machinery/conveyor{
 	id = "CargoLoad"
@@ -37780,6 +37940,11 @@
 /obj/machinery/navbeacon/wayfinding/dockarrival,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"fUc" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "fUA" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -37789,12 +37954,31 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
+"fVi" = (
+/obj/machinery/space_heater,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
+"fVJ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/commons/fitness/recreation)
 "fWl" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"fWq" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/engineering/gravity_generator)
 "fWv" = (
 /obj/structure/bookcase/random/religion,
 /turf/open/floor/iron/dark,
@@ -37813,14 +37997,6 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"fXu" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/service/hydroponics)
 "fYY" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -37830,14 +38006,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"fZv" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/lobby)
 "fZV" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/blue,
@@ -37876,10 +38044,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"gbz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "gbK" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -37985,6 +38149,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/security)
+"gif" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/command/bridge)
 "gii" = (
 /obj/structure/chair,
 /obj/machinery/newscaster/directional/east,
@@ -38101,12 +38271,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
-"gmE" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/cargo/warehouse/upper)
+"gmH" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/tcommsat/computer)
 "gmO" = (
 /obj/structure/chair{
 	dir = 1
@@ -38130,6 +38300,14 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
+"gnQ" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "gpu" = (
 /obj/structure/sign/directions/medical{
 	pixel_x = 32;
@@ -38165,6 +38343,14 @@
 /mob/living/simple_animal/pet/dog/corgi,
 /turf/open/floor/grass,
 /area/medical/psychology)
+"gta" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/brig)
 "gtl" = (
 /obj/item/toy/crayon/black,
 /obj/item/toy/crayon/white{
@@ -38188,6 +38374,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"gtW" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/science/xenobiology)
 "gue" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -38212,6 +38408,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/psychology)
+"gur" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "guE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -38243,6 +38450,12 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"gvp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/commons/storage/primary)
 "gvu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -38295,12 +38508,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
-"gzf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/main)
 "gzy" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
@@ -38339,6 +38546,10 @@
 /area/commons/storage/emergency/starboard)
 "gAY" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "gBb" = (
@@ -38408,6 +38619,16 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/storage)
+"gEg" = (
+/obj/structure/chair/comfy{
+	dir = 8
+	},
+/obj/effect/landmark/start/assistant,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "gEh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -38703,6 +38924,13 @@
 /obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"gTR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/service/hydroponics)
 "gUb" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -38861,12 +39089,6 @@
 /obj/machinery/vending/wardrobe/gene_wardrobe,
 /turf/open/floor/iron/dark,
 /area/science/genetics)
-"hgf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "hgV" = (
 /turf/open/floor/iron,
 /area/cargo/miningdock)
@@ -39019,13 +39241,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/virology)
-"hol" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/engineering/gravity_generator)
 "hoP" = (
 /obj/structure/chair/wood,
 /obj/effect/landmark/start/hangover,
@@ -39156,27 +39371,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
-"hxp" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/science/storage)
-"hxx" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "hxB" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -39215,14 +39409,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
-"hBf" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "hBn" = (
 /obj/structure/table/glass,
 /obj/item/folder/white,
@@ -39274,12 +39460,10 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "hCS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/service/abandoned_gambling_den)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/ai_monitored/turret_protected/ai_sat_ext_ap)
 "hDG" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Auxiliary Base Construction";
@@ -39354,27 +39538,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
-"hHp" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/department/engine)
 "hHr" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"hHw" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "misclab";
-	name = "test chamber blast door"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/science/xenobiology)
 "hHG" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
@@ -39424,16 +39593,6 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
-"hJV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen)
 "hKU" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark/telecomms,
@@ -39594,12 +39753,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"hRQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/command/heads_quarters/rd)
 "hSM" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -39673,6 +39826,15 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"hVS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/grimy,
+/area/command/heads_quarters/captain)
 "hVW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -39732,6 +39894,9 @@
 /area/medical/virology)
 "ibD" = (
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "icy" = (
@@ -39747,6 +39912,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
+"icK" = (
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/commons/fitness/recreation)
 "icY" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -39809,6 +39979,10 @@
 /area/command/heads_quarters/captain)
 "ieU" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "igj" = (
@@ -39917,21 +40091,6 @@
 /obj/structure/closet/secure_closet/medical2,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"ikY" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "ilD" = (
 /obj/machinery/processor/slime,
 /turf/open/floor/iron/white,
@@ -39949,6 +40108,10 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engineering/supermatter/room)
+"int" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall,
+/area/maintenance/department/engine)
 "inG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/landmark/start/hangover,
@@ -39963,7 +40126,7 @@
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
-"ioK" = (
+"iok" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -39994,20 +40157,6 @@
 "iqc" = (
 /turf/open/floor/iron/stairs/right,
 /area/service/abandoned_gambling_den)
-"iqg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/psychology)
-"iqp" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/main)
 "iqI" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/camera{
@@ -40095,11 +40244,11 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/library/lounge)
-"iww" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/supply/visible,
-/obj/machinery/atmospherics/pipe/layer_manifold/supply,
-/turf/closed/wall/r_wall,
-/area/science/mixing/chamber)
+"ixd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/turf/closed/wall,
+/area/maintenance/department/engine)
 "ixN" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8
@@ -40243,6 +40392,13 @@
 /obj/item/clothing/suit/apron/chef,
 /turf/open/floor/plating,
 /area/service/abandoned_gambling_den)
+"iFA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "iFI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -40300,6 +40456,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"iJN" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/supply,
+/turf/closed/wall/r_wall,
+/area/engineering/atmos)
 "iKb" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westleft{
@@ -40485,6 +40645,20 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
+"jat" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/exit/departure_lounge)
 "jaJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -40550,6 +40724,10 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
+"jez" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/closed/wall/r_wall,
+/area/engineering/lobby)
 "jgr" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Library"
@@ -40600,16 +40778,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/service/abandoned_gambling_den)
-"jhH" = (
-/obj/structure/mineral_door/wood{
-	name = "The Roosterdome"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "jiD" = (
 /turf/closed/wall,
 /area/science/genetics)
@@ -40640,12 +40808,23 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"jks" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen)
 "jlb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/storage_shared)
+"jlc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/turf/closed/wall/r_wall,
+/area/tcommsat/computer)
 "jng" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -40685,6 +40864,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"jos" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/service/bar/atrium)
 "jpa" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/virology{
@@ -40725,6 +40913,15 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
+"jsa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "jsf" = (
 /obj/item/toy/katana,
 /turf/open/floor/plating,
@@ -40978,25 +41175,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/disposal)
-"jJK" = (
-/obj/structure/window/reinforced,
-/obj/structure/table,
-/obj/item/stock_parts/scanning_module{
-	pixel_x = 5;
-	pixel_y = 7
-	},
-/obj/item/stock_parts/scanning_module{
-	pixel_x = 5
-	},
-/obj/item/stock_parts/scanning_module{
-	pixel_x = -5;
-	pixel_y = 7
-	},
-/obj/item/stock_parts/scanning_module{
-	pixel_x = -5
-	},
-/turf/open/floor/iron,
-/area/cargo/warehouse/upper)
 "jJN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -41214,6 +41392,13 @@
 /obj/item/stack/ore/iron,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"jXJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/freezer,
+/area/commons/toilet/restrooms)
 "jYh" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -41234,11 +41419,13 @@
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "kbV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/security/armory)
+/turf/open/floor/plating,
+/area/ai_monitored/turret_protected/ai_sat_ext_ap)
 "kdb" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -41322,6 +41509,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"kjI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/engine)
 "kjK" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "MiniSat Maintenance";
@@ -41413,6 +41607,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
+"koW" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "kpu" = (
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/stairs/left,
@@ -41535,16 +41743,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/maintenance/department/engine)
-"kvr" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/commons/storage/primary)
 "kvB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -41554,6 +41752,12 @@
 	},
 /turf/open/floor/iron,
 /area/science/robotics)
+"kww" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/engine)
 "kxj" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -41627,12 +41831,6 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/engineering/break_room)
-"kAv" = (
-/obj/structure/window/reinforced,
-/obj/item/fuel_pellet,
-/obj/structure/rack,
-/turf/open/floor/iron,
-/area/cargo/warehouse/upper)
 "kAD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41839,16 +42037,6 @@
 /obj/machinery/holopad/secure,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
-"kNK" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "kOF" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/chapel,
@@ -41970,6 +42158,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "kUH" = (
@@ -42061,6 +42253,22 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/cargo/warehouse/upper)
+"laB" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "lba" = (
 /obj/structure/flora/junglebush,
 /obj/structure/flora/ausbushes/brflowers,
@@ -42087,6 +42295,25 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
+"lcz" = (
+/obj/structure/window/reinforced,
+/obj/structure/table,
+/obj/item/stock_parts/scanning_module{
+	pixel_x = 5;
+	pixel_y = 7
+	},
+/obj/item/stock_parts/scanning_module{
+	pixel_x = 5
+	},
+/obj/item/stock_parts/scanning_module{
+	pixel_x = -5;
+	pixel_y = 7
+	},
+/obj/item/stock_parts/scanning_module{
+	pixel_x = -5
+	},
+/turf/open/floor/iron,
+/area/cargo/warehouse/upper)
 "lcA" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
 /turf/closed/wall/r_wall,
@@ -42144,6 +42371,14 @@
 	},
 /turf/open/floor/grass,
 /area/science/genetics)
+"lfS" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "lgj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -42153,10 +42388,6 @@
 "lgR" = (
 /obj/machinery/shower{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
@@ -42196,6 +42427,14 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"ljs" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "ljT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -42262,6 +42501,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"loc" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Recreation Room"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/commons/fitness/recreation)
 "lor" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -42324,13 +42573,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"lrw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/service/hydroponics)
 "lrI" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -42375,6 +42617,15 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"ltk" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "misclab";
+	name = "test chamber blast door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "ltl" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
@@ -42386,10 +42637,25 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/engine,
 /area/science/storage)
+"ltE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ai_monitored/command/storage/eva)
 "ltJ" = (
 /obj/structure/statue/petrified,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"lug" = (
+/obj/effect/decal/cleanable/ash,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "lwT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -42414,6 +42680,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron,
 /area/security)
+"lyB" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "lzJ" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/carpet,
@@ -42464,16 +42739,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/gateway)
-"lCe" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/command/bridge)
 "lDw" = (
 /obj/structure/flora/grass/jungle,
 /mob/living/carbon/human/species/monkey,
@@ -42514,10 +42779,23 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/engine)
+"lFK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/commons/fitness/recreation)
 "lGp" = (
 /obj/structure/weightmachine/weightlifter,
 /turf/open/floor/iron/dark,
 /area/security/prison)
+"lGq" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/service/bar/atrium)
 "lGv" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Maintenance";
@@ -42527,6 +42805,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"lGJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/cargo/miningdock)
 "lGS" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -42545,6 +42832,11 @@
 /obj/item/wrench,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"lJM" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/commons/fitness/recreation)
 "lKL" = (
 /obj/machinery/door/airlock{
 	name = "Starboard Emergency Storage"
@@ -42599,14 +42891,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"lQb" = (
+"lPe" = (
+/obj/structure/grille/broken,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
+/turf/open/floor/plating,
 /area/maintenance/department/engine)
 "lQn" = (
 /obj/machinery/light/small{
@@ -42621,6 +42909,11 @@
 	},
 /turf/closed/wall,
 /area/cargo/sorting)
+"lQv" = (
+/obj/machinery/atmospherics/pipe/bridge_pipe/supply/visible,
+/obj/machinery/atmospherics/pipe/layer_manifold/supply,
+/turf/closed/wall/r_wall,
+/area/science/mixing/chamber)
 "lQQ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -42660,21 +42953,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"lTD" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/exit/departure_lounge)
 "lTW" = (
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
@@ -42765,17 +43043,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
-"lXV" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "lYE" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -42830,6 +43097,15 @@
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
 /area/engineering/storage_shared)
+"mcp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "mcy" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -42848,6 +43124,17 @@
 	},
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
+"mdx" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "mdL" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -42860,6 +43147,21 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/lab)
+"meu" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/exit/departure_lounge)
 "mew" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -42882,12 +43184,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/science/xenobiology)
-"mfZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/commons/dorms)
 "mgW" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/blue{
@@ -43058,19 +43354,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/plating/airless,
 /area/engineering/atmos)
-"mrA" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/door/airlock/research{
-	name = "Toxins Launch Room";
-	req_access_txt = "8"
-	},
-/turf/open/floor/iron,
-/area/science/mixing)
 "mse" = (
 /turf/open/floor/wood,
 /area/cargo/qm)
@@ -43149,6 +43432,12 @@
 /obj/item/gun/ballistic/shotgun/toy,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"mxg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/commons/storage/primary)
 "mxy" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -43245,6 +43534,21 @@
 /obj/item/blood_filter,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
+"mAu" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "mAQ" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "testlab";
@@ -43306,6 +43610,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
+"mEo" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/cryo)
 "mES" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Surgical Room"
@@ -43481,13 +43793,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"mRO" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engineering/lobby)
 "mSc" = (
 /obj/machinery/computer/scan_consolenew{
 	dir = 4
@@ -43504,17 +43809,6 @@
 /obj/item/clothing/head/mailman,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"mTF" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "mUt" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43664,6 +43958,12 @@
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"ndd" = (
+/obj/structure/window/reinforced,
+/obj/item/fuel_pellet,
+/obj/structure/rack,
+/turf/open/floor/iron,
+/area/cargo/warehouse/upper)
 "ndt" = (
 /obj/structure/chair{
 	dir = 8
@@ -43673,6 +43973,13 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"ndy" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Atmos Supermatter Mix"
+	},
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "ndF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -43809,6 +44116,18 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
+"nkE" = (
+/obj/structure/window/reinforced,
+/obj/structure/rack,
+/obj/item/circuitboard/machine/exoscanner{
+	pixel_y = 3
+	},
+/obj/item/circuitboard/machine/exoscanner,
+/obj/item/circuitboard/machine/exoscanner{
+	pixel_y = -3
+	},
+/turf/open/floor/iron,
+/area/cargo/warehouse/upper)
 "nkK" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/grunge{
@@ -43998,6 +44317,7 @@
 	name = "Recreation Room"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "nwg" = (
@@ -44120,12 +44440,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
-"nBT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/storage_shared)
 "nCe" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -44261,6 +44575,17 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/art)
+"nJB" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "nJI" = (
 /obj/structure/sign/plaques/kiddie/perfect_drone{
 	pixel_y = 32
@@ -44290,6 +44615,8 @@
 	},
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "nNk" = (
@@ -44387,6 +44714,18 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
+"nTt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "nTv" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron{
@@ -44604,12 +44943,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"ocg" = (
+"odh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/engine,
-/area/science/storage)
+/turf/open/floor/iron,
+/area/cargo/sorting)
 "odF" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Chapel"
@@ -44653,16 +44992,6 @@
 	},
 /turf/open/floor/wood,
 /area/cargo/qm)
-"ofG" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/science/nanite)
 "ofN" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -44687,6 +45016,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
+"ofR" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/cargo/warehouse/upper)
 "ofX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -44742,6 +45077,18 @@
 /obj/machinery/light,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
+"ojJ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/security/brig)
+"ojN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/captain)
 "okX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -44775,6 +45122,21 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
+"olV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/command/teleporter)
+"olY" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "omu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/brown,
@@ -44961,6 +45323,11 @@
 	},
 /turf/open/floor/plating/airless,
 /area/maintenance/department/engine)
+"ovf" = (
+/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/cargo/warehouse/upper)
 "ovv" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -45067,13 +45434,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
-"ozZ" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Atmos Supermatter Mix"
-	},
-/turf/open/floor/engine,
-/area/engineering/supermatter/room)
 "oAk" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/lizard/wags_his_tail,
@@ -45103,6 +45463,13 @@
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"oAY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/commons/fitness/recreation)
 "oBP" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -45521,6 +45888,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"oWL" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/engine)
 "oXe" = (
 /obj/structure/table/glass,
 /obj/item/mmi,
@@ -45553,16 +45926,6 @@
 	},
 /turf/closed/wall,
 /area/cargo/sorting)
-"oZN" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "oZX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -45625,15 +45988,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/server)
-"pdI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/cargo/miningdock)
 "pec" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45666,6 +46020,12 @@
 /obj/effect/turf_decal/trimline/blue/line,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"pfF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/commons/fitness/recreation)
 "pfP" = (
 /obj/structure/table,
 /obj/item/storage/box/syringes{
@@ -45691,6 +46051,15 @@
 	},
 /turf/closed/wall,
 /area/maintenance/department/science)
+"pgv" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white/corner,
+/area/hallway/secondary/exit/departure_lounge)
 "php" = (
 /obj/machinery/conveyor{
 	id = "CrateReturn";
@@ -45812,15 +46181,6 @@
 	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
-"pos" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/cargo/warehouse/upper)
 "pps" = (
 /turf/closed/wall,
 /area/engineering/break_room)
@@ -45911,7 +46271,7 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"puU" = (
+"puW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
@@ -45941,6 +46301,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"pwI" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen)
 "pwS" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/segment{
@@ -46135,16 +46503,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"pIu" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "pIy" = (
 /obj/structure/sign/painting/library{
 	pixel_y = 32
@@ -46313,6 +46671,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"pTG" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/science/nanite)
 "pTJ" = (
 /obj/machinery/newscaster/security_unit/directional/south,
 /turf/open/floor/iron,
@@ -46427,13 +46795,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/department/engine)
-"pZM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/service/bar/atrium)
 "pZT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46528,6 +46889,26 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"qfa" = (
+/obj/structure/window/reinforced,
+/obj/structure/table,
+/obj/item/stock_parts/micro_laser{
+	pixel_x = 6;
+	pixel_y = -2
+	},
+/obj/item/stock_parts/micro_laser{
+	pixel_x = 2
+	},
+/obj/item/stock_parts/micro_laser{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/stock_parts/micro_laser{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/turf/open/floor/iron,
+/area/cargo/warehouse/upper)
 "qfI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -46647,6 +47028,13 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
+"qkS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "qlk" = (
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
@@ -46711,6 +47099,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
+"qnQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/science/storage)
 "qnT" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/plating,
@@ -46778,6 +47172,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
+"qqz" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "qqQ" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -46811,6 +47213,16 @@
 /obj/item/clothing/glasses/science,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"qqZ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/science/storage)
 "qrl" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -46844,12 +47256,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"qsJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/construction/mining/aux_base)
 "qtA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron,
@@ -46947,6 +47353,13 @@
 	},
 /turf/open/floor/plating,
 /area/tcommsat/computer)
+"qxE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/service/abandoned_gambling_den)
 "qyR" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -47180,6 +47593,12 @@
 "qOx" = (
 /turf/closed/wall/r_wall,
 /area/engineering/lobby)
+"qOD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/rd)
 "qOE" = (
 /turf/open/floor/iron/dark,
 /area/service/library/lounge)
@@ -47193,6 +47612,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "qPB" = (
@@ -47314,6 +47734,16 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"qXx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "qXD" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -47336,12 +47766,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/chapel/main/monastery)
-"qZE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/command/heads_quarters/captain)
 "rax" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -47354,16 +47778,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/processing/cremation)
-"raH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "raI" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = 32
@@ -47383,6 +47797,12 @@
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/grass,
 /area/medical/medbay/central)
+"rbu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "rbx" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
@@ -47393,6 +47813,7 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse/upper)
 "rcF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/open/floor/plating/airless,
 /area/tcommsat/computer)
 "reH" = (
@@ -47471,10 +47892,11 @@
 /turf/open/floor/grass,
 /area/science/genetics)
 "rlR" = (
-/obj/structure/grille/broken,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "rlT" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -47510,15 +47932,6 @@
 	},
 /turf/open/space/basic,
 /area/cargo/storage)
-"rny" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/service/lawoffice)
 "rnE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -47566,26 +47979,6 @@
 "roy" = (
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
-"roA" = (
-/obj/structure/window/reinforced,
-/obj/structure/table,
-/obj/item/stock_parts/micro_laser{
-	pixel_x = 6;
-	pixel_y = -2
-	},
-/obj/item/stock_parts/micro_laser{
-	pixel_x = 2
-	},
-/obj/item/stock_parts/micro_laser{
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/stock_parts/micro_laser{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/turf/open/floor/iron,
-/area/cargo/warehouse/upper)
 "rpa" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -47594,6 +47987,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"rpc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/storage_shared)
 "rpm" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -47902,14 +48301,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/engine)
-"rzz" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen)
 "rzT" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -47979,19 +48370,6 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/cargo/office)
-"rCf" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/command/bridge)
 "rCg" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -48055,6 +48433,12 @@
 /obj/item/reagent_containers/blood/random,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"rEZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/security/armory)
 "rFq" = (
 /obj/effect/turf_decal/trimline/yellow/corner{
 	dir = 4
@@ -48198,22 +48582,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
 /turf/closed/wall/r_wall,
 /area/science/mixing)
-"rLF" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "rLJ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 10
@@ -48397,17 +48765,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"rWG" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/entry)
 "rWM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -48454,21 +48811,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"rYS" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "rYY" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
@@ -48673,6 +49015,13 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"sli" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/main)
 "slC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -48735,14 +49084,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"soL" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "spo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -48753,13 +49094,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
-"spP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/commons/dorms)
 "sqh" = (
 /obj/structure/chair{
 	dir = 8
@@ -48795,24 +49129,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
-"ssa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/command/bridge)
 "ssx" = (
 /obj/item/shard,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"ssL" = (
-/obj/effect/turf_decal/bot/right,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/engineering/gravity_generator)
 "stc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/iron/white,
@@ -48867,6 +49187,11 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"svm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/science/genetics)
 "svN" = (
 /obj/structure/sign/departments/restroom{
 	pixel_y = 32
@@ -48893,6 +49218,16 @@
 	},
 /turf/open/floor/carpet,
 /area/service/library/lounge)
+"swO" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "sxe" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -49048,6 +49383,21 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
+"sDk" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "sDQ" = (
 /obj/structure/transit_tube/curved/flipped{
 	dir = 8
@@ -49092,12 +49442,9 @@
 /area/maintenance/department/crew_quarters/dorms)
 "sFL" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/brig)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/grimy,
+/area/ai_monitored/turret_protected/aisat_interior)
 "sGc" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron,
@@ -49173,11 +49520,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"sLg" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron,
-/area/engineering/lobby)
 "sLv" = (
 /obj/item/stack/medical/mesh,
 /obj/item/stack/medical/suture,
@@ -49226,6 +49568,18 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
+"sQx" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "bridgespace";
+	name = "bridge external shutters"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/command/bridge)
 "sQP" = (
 /turf/closed/wall/r_wall,
 /area/space)
@@ -49271,12 +49625,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"sTf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/service/lawoffice)
 "sTi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49290,6 +49638,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/explab)
+"sTY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen)
 "sUg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49367,6 +49725,10 @@
 /area/maintenance/department/security/brig)
 "sYY" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "sZh" = (
@@ -49555,6 +49917,7 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "ten" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "teJ" = (
@@ -49692,12 +50055,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/bar)
-"tkl" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/cargo/office)
 "tko" = (
 /turf/closed/wall,
 /area/cargo/warehouse/upper)
@@ -49716,6 +50073,16 @@
 "tlw" = (
 /turf/open/floor/iron,
 /area/tcommsat/computer)
+"tlB" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/security/brig)
 "tlN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49843,12 +50210,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"tuG" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/department/engine)
 "tuL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49910,15 +50271,6 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/iron/white,
 /area/science/explab)
-"txa" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/service/bar/atrium)
 "txu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -49976,20 +50328,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"tyU" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/exit/departure_lounge)
 "tzm" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -50078,6 +50416,13 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/iron,
 /area/medical/medbay/central)
+"tCk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ai_monitored/command/storage/eva)
 "tCP" = (
 /obj/docking_port/stationary/public_mining_dock,
 /turf/open/floor/plating,
@@ -50144,6 +50489,11 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"tGl" = (
+/obj/item/wrench,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "tGQ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
@@ -50177,28 +50527,6 @@
 /obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"tKl" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/medical/medbay/lobby)
-"tLm" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "tLA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -50221,17 +50549,6 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
-"tMU" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "tNf" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -50299,16 +50616,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/engine)
-"tRk" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
 "tSm" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 4
@@ -50492,11 +50799,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"uca" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/science/genetics)
 "ucd" = (
 /obj/machinery/light/dim{
 	dir = 8
@@ -50551,14 +50853,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"udZ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/cryo)
 "uek" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -50631,6 +50925,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"uhd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/psychology)
 "uhn" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
@@ -51037,19 +51337,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"uyp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "uyY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
@@ -51062,6 +51349,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "uzr" = (
@@ -51109,6 +51398,18 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"uAq" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/medical/medbay/lobby)
 "uAs" = (
 /turf/open/floor/iron/freezer,
 /area/medical/virology)
@@ -51283,10 +51584,6 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
-"uMh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet,
-/area/commons/dorms)
 "uMo" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/loading_area{
@@ -51309,12 +51606,6 @@
 /obj/effect/turf_decal/plaque,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"uMU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "uMY" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -51351,17 +51642,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/psychology)
-"uOR" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "uPz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51534,6 +51814,14 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"uWC" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "uXp" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -51586,6 +51874,16 @@
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"uXX" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "uYF" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -51702,6 +52000,13 @@
 /obj/structure/cable,
 /turf/open/space,
 /area/solars/starboard)
+"ver" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "veM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
 /turf/open/floor/iron/dark,
@@ -51818,14 +52123,6 @@
 /obj/structure/lattice,
 /turf/closed/wall,
 /area/maintenance/department/science)
-"vld" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "vlv" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 10
@@ -52020,14 +52317,6 @@
 "vtT" = (
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
-"vtV" = (
-/obj/machinery/space_heater,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "vtX" = (
 /obj/machinery/atmospherics/components/binary/thermomachine/freezer{
 	dir = 8
@@ -52166,6 +52455,15 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"vCE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/science/xenobiology)
 "vDh" = (
 /obj/item/target,
 /obj/structure/training_machine,
@@ -52193,16 +52491,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
-"vGC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ai_monitored/command/storage/eva)
 "vHj" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance{
@@ -52284,6 +52572,19 @@
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
 /area/engineering/storage_shared)
+"vLp" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/command/bridge)
 "vLx" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 4
@@ -52343,6 +52644,11 @@
 "vNl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
+"vNu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "vNA" = (
@@ -52465,6 +52771,16 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
+"vRq" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/commons/storage/primary)
 "vRw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -52567,6 +52883,15 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/medical/medbay/central)
+"vZJ" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/cargo/warehouse/upper)
 "vZP" = (
 /obj/machinery/door/window/westleft{
 	dir = 1;
@@ -52584,28 +52909,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"waa" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "was" = (
 /obj/machinery/vending/boozeomat,
 /turf/closed/wall,
 /area/service/bar)
-"waK" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/supply,
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "wbs" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -52678,6 +52985,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"wdW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/ai_upload)
 "weL" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -52686,6 +53003,12 @@
 /obj/structure/ore_box,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"wfr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/service/bar/atrium)
 "wfs" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/latex{
@@ -52801,6 +53124,15 @@
 /obj/item/stack/cable_coil,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"wjw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "wjT" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
@@ -52808,11 +53140,12 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "wkA" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/security/brig)
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "wkM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52913,12 +53246,6 @@
 /obj/item/pestle,
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
-"wpn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/service/bar/atrium)
 "wpI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -52957,6 +53284,16 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"wsA" = (
+/obj/structure/mineral_door/wood{
+	name = "The Roosterdome"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "wsC" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
@@ -52981,6 +53318,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
+"wuO" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -53044,6 +53392,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
+"wxO" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/service/hydroponics)
 "wyP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -53134,6 +53490,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"wDb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "wDm" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -53230,6 +53592,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"wFZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "wGM" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -53314,6 +53682,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"wLx" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/commons/dorms)
 "wLU" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
@@ -53388,12 +53763,11 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
 "wPr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/security/brig)
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "wPw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53539,11 +53913,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"wVt" = (
-/obj/effect/decal/cleanable/ash,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "wVC" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Sci";
@@ -53610,6 +53979,10 @@
 	},
 /turf/open/floor/plating,
 /area/medical/storage)
+"wXr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/engine)
 "wXu" = (
 /obj/machinery/disposal/bin,
 /obj/structure/window/reinforced{
@@ -53628,15 +54001,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
-"wYb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "wYi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
@@ -53644,6 +54008,11 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"wYr" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/turf/open/floor/iron,
+/area/tcommsat/computer)
 "wYu" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "shootshut"
@@ -53906,18 +54275,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "xjl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/brig)
-"xjq" = (
-/obj/structure/window/reinforced,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/cargo/warehouse/upper)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/service/abandoned_gambling_den)
 "xjK" = (
 /obj/machinery/requests_console/directional/west{
 	department = "Detective";
@@ -54050,17 +54410,15 @@
 /area/medical/medbay/central)
 "xnm" = (
 /obj/machinery/power/port_gen/pacman,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
-"xnS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
+"xnp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "xog" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -54114,10 +54472,6 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/hangover,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
 "xqq" = (
@@ -54152,14 +54506,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/service/bar/atrium)
-"xst" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "xsO" = (
 /obj/item/ectoplasm,
 /turf/open/floor/plating{
@@ -54211,10 +54557,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron/dark,
 /area/security/prison)
-"xvu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall,
-/area/maintenance/department/engine)
 "xvx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -54261,6 +54603,17 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
+"xxo" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "xxw" = (
 /obj/machinery/atmospherics/components/binary/pump,
 /turf/open/floor/iron/dark,
@@ -54376,13 +54729,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/library)
-"xBF" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/main)
 "xDj" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
@@ -54405,6 +54751,10 @@
 /area/cargo/storage)
 "xEA" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
 "xEI" = (
@@ -54448,13 +54798,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"xGL" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/commons/dorms)
 "xGN" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -54521,12 +54864,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/lawoffice)
-"xJC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/commons/storage/primary)
 "xKc" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/r_wall,
@@ -54542,13 +54879,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/engine)
-"xKY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/command/teleporter)
 "xLi" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -54577,6 +54907,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/lawoffice)
+"xLF" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/cargo/office)
 "xLH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -54750,6 +55086,14 @@
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"xWN" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/brig)
 "xWR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54773,14 +55117,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
-"xZO" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "yat" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -54825,6 +55161,16 @@
 	icon_state = "wood-broken5"
 	},
 /area/maintenance/department/engine)
+"ycQ" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/command/bridge)
 "ycT" = (
 /obj/machinery/conveyor_switch/oneway{
 	dir = 8;
@@ -54892,20 +55238,6 @@
 	},
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
-"yfT" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
-"yfV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/department/engine)
 "ygx" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -54942,6 +55274,13 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"yhO" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engineering/lobby)
 "yhR" = (
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 1
@@ -54959,6 +55298,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
+"yiL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "yiR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -54969,10 +55316,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"ykC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/engine)
 "ykY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -73604,12 +73947,12 @@ aaa
 aaa
 aiu
 nyO
-tRk
-tRk
-tRk
-tRk
-tRk
-tRk
+tlB
+tlB
+tlB
+tlB
+tlB
+tlB
 aiu
 gxq
 jeq
@@ -73861,12 +74204,12 @@ aaa
 aaa
 aiu
 awE
-tRk
+tlB
 eOZ
 kQZ
 nih
 kxs
-tRk
+tlB
 aiu
 rgs
 jeq
@@ -73883,7 +74226,7 @@ aQt
 sYE
 aie
 aYG
-rWG
+nJB
 vvo
 bbQ
 bcX
@@ -74140,7 +74483,7 @@ aQu
 aOf
 duQ
 aYG
-rWG
+nJB
 bop
 aZx
 aZx
@@ -74185,11 +74528,11 @@ amB
 aht
 bva
 bHP
-ykC
-ykC
-ykC
-ykC
-hHp
+wXr
+wXr
+wXr
+wXr
+oWL
 bHQ
 bPp
 bva
@@ -74387,7 +74730,7 @@ aKD
 gmO
 aQt
 aOh
-eAI
+pgv
 aRE
 aSw
 aTL
@@ -74441,7 +74784,7 @@ aaa
 amB
 bva
 bva
-ykC
+wXr
 bJc
 bKh
 bLu
@@ -74632,7 +74975,7 @@ aaa
 aaa
 ebD
 aCe
-rny
+mcp
 xHe
 elk
 mXq
@@ -74640,11 +74983,11 @@ gSH
 jhk
 aiu
 gxq
-lTD
+meu
 pGe
 aQu
 aOg
-eAI
+pgv
 aRF
 aSx
 aTM
@@ -74698,7 +75041,7 @@ aaa
 amB
 bva
 bGK
-ykC
+wXr
 bJd
 bKi
 bLv
@@ -74889,15 +75232,15 @@ aiu
 aiu
 gSH
 xJy
-rny
-sTf
+mcp
+wFZ
 oYc
 sJr
 gSH
 jhk
 aiu
 niy
-tyU
+jat
 pGe
 aQt
 aOf
@@ -74911,7 +75254,7 @@ aQt
 aOf
 bxH
 aYG
-rWG
+nJB
 bop
 bbS
 bda
@@ -74955,7 +75298,7 @@ aaa
 amB
 bva
 bGL
-ykC
+wXr
 bJe
 bKj
 bLv
@@ -75113,9 +75456,9 @@ aen
 aep
 aeD
 fJd
-acC
-acC
-adT
+wkA
+wkA
+wPr
 wbB
 agz
 agM
@@ -75146,7 +75489,7 @@ ayE
 aAb
 ebD
 jjC
-rny
+mcp
 vhk
 gAG
 kxj
@@ -75154,7 +75497,7 @@ gSH
 oTp
 aiu
 kAa
-tyU
+jat
 gvf
 xUX
 xUX
@@ -75182,7 +75525,7 @@ aaa
 aZx
 aZx
 aZx
-xnS
+jsa
 fLM
 aZx
 aaa
@@ -75439,7 +75782,7 @@ aaa
 bbQ
 bcX
 bdV
-xnS
+jsa
 bon
 aZx
 aaa
@@ -75469,12 +75812,12 @@ lsq
 aht
 bva
 bHQ
-bWd
+kjI
 bJg
 bKl
-yfV
+kww
 bMC
-tuG
+eHb
 bHQ
 bPq
 bva
@@ -75649,7 +75992,7 @@ avB
 avB
 avB
 lUY
-wkA
+ojJ
 asu
 apE
 auy
@@ -75696,7 +76039,7 @@ aaa
 jzz
 aZx
 jzz
-xnS
+jsa
 bon
 aZx
 aZx
@@ -75726,7 +76069,7 @@ bva
 bva
 oTJ
 bHQ
-bWd
+kjI
 bJh
 bHQ
 bKm
@@ -75899,7 +76242,7 @@ aen
 ajL
 ark
 ark
-sFL
+xWN
 oGx
 hdB
 hdB
@@ -75907,9 +76250,9 @@ hdB
 hdB
 hdB
 hdB
-wPr
+aoN
 atw
-xjl
+gta
 avt
 uUY
 oZX
@@ -75953,7 +76296,7 @@ aaa
 aYG
 bbR
 bbR
-xnS
+jsa
 bop
 bbR
 bbR
@@ -75970,20 +76313,20 @@ bBX
 bBX
 bva
 xtI
-hBf
-hBf
-hBf
+olY
+olY
+olY
 xtI
-hBf
+olY
 pZT
 xKD
 pZT
-hBf
+olY
 xtI
-hBf
+olY
 bva
 bLy
-jhH
+wsA
 bva
 bva
 bva
@@ -76226,7 +76569,7 @@ bDg
 bXy
 bFF
 bva
-hBf
+olY
 bva
 bHT
 bJi
@@ -76240,7 +76583,7 @@ bNQ
 xtI
 xtI
 xtI
-hBf
+olY
 bDi
 mpU
 bIZ
@@ -76467,7 +76810,7 @@ cBT
 bdX
 bop
 bop
-xnS
+jsa
 bop
 bop
 bop
@@ -76712,25 +77055,25 @@ kAa
 aYG
 oPg
 iWV
-xnS
-xnS
-xnS
-xnS
-xnS
+jsa
+jsa
+jsa
+jsa
+jsa
 hGq
 iWV
 tfS
-xnS
+jsa
 uxF
 bkT
-xnS
+jsa
 xjZ
-xnS
-xnS
+jsa
+jsa
 hGq
 bsm
-xnS
-xnS
+jsa
+jsa
 bwr
 bya
 bzB
@@ -76754,7 +77097,7 @@ bNL
 bOD
 aht
 bIZ
-hBf
+olY
 bDi
 ccN
 bva
@@ -76935,7 +77278,7 @@ aoS
 amh
 aqq
 wbs
-wPr
+aoN
 atA
 auA
 avw
@@ -76997,7 +77340,7 @@ bva
 bEm
 bva
 bTl
-hBf
+olY
 bEr
 erQ
 oat
@@ -77011,7 +77354,7 @@ bNM
 bOD
 aht
 bIZ
-hBf
+olY
 bDi
 ftp
 bva
@@ -77216,7 +77559,7 @@ uoS
 uoS
 aPt
 uos
-qsJ
+aXg
 qjx
 uCS
 aML
@@ -77228,7 +77571,7 @@ aZF
 baQ
 aXH
 bdd
-xnS
+jsa
 ejn
 bfb
 bgU
@@ -77243,18 +77586,18 @@ aYG
 aYG
 eUe
 bva
-eZJ
+rbu
 bsn
 bws
 byb
 bzC
 bzC
 bBY
-hBf
+olY
 xtI
-hBf
-hBf
-hBf
+olY
+olY
+olY
 bEr
 qIl
 sEN
@@ -77270,7 +77613,7 @@ aht
 bva
 tAh
 bWZ
-vtV
+fVi
 bva
 bTc
 dRB
@@ -77485,8 +77828,8 @@ aZI
 baR
 aXI
 bde
-xnS
-fOw
+jsa
+coc
 bga
 bgV
 qIf
@@ -77501,12 +77844,12 @@ bpu
 uHJ
 uPG
 xtI
-hBf
+olY
 tAh
 kkF
 bzD
 bAM
-hBf
+olY
 bDj
 bEr
 bEr
@@ -77788,11 +78131,11 @@ wwp
 oKD
 fwg
 qvM
-aYc
-aYc
-aYc
+iFA
+iFA
+iFA
 bWZ
-aYc
+iFA
 bDi
 bZr
 caa
@@ -77963,7 +78306,7 @@ aoW
 apM
 aqy
 arn
-wPr
+aoN
 atC
 auA
 avz
@@ -77999,7 +78342,7 @@ tdj
 baT
 aXI
 bop
-xnS
+jsa
 jVo
 bjK
 bgX
@@ -78049,7 +78392,7 @@ bva
 bva
 bva
 bDi
-aYc
+iFA
 bva
 bva
 bva
@@ -78208,10 +78551,10 @@ abI
 ahL
 ail
 quw
-kbV
-kbV
-kbV
-kbV
+rEZ
+rEZ
+rEZ
+rEZ
 amk
 piI
 piI
@@ -78297,8 +78640,8 @@ aaa
 aaa
 bva
 eNy
-bps
-fAU
+vNu
+ixd
 sUP
 bTf
 isF
@@ -78553,17 +78896,17 @@ bEr
 aaa
 aaa
 bva
-raH
+qXx
 bDi
 bva
 rXJ
 bTg
-eHl
+tGl
 jYh
 bVv
 bva
 nQc
-lQb
+fGo
 bva
 bOB
 bva
@@ -78820,7 +79163,7 @@ dAG
 bVw
 bva
 iEQ
-lQb
+fGo
 ccN
 lFx
 bva
@@ -79052,7 +79395,7 @@ bCa
 tqC
 ulf
 cKQ
-xZO
+uWC
 boN
 sOB
 uYF
@@ -79072,12 +79415,12 @@ bDi
 bva
 bva
 bva
-xvu
+int
 bva
 bva
 bva
 bva
-aYc
+iFA
 bDi
 bZt
 bva
@@ -79324,7 +79667,7 @@ mKz
 bSs
 aht
 bIZ
-raH
+qXx
 bNQ
 bva
 bSu
@@ -79566,12 +79909,12 @@ bCc
 tqC
 pBm
 uyg
-xZO
+uWC
 sAF
 sOB
 rtk
 bsu
-iqg
+uhd
 bss
 piR
 lba
@@ -79581,12 +79924,12 @@ gkS
 bSs
 aht
 bIZ
-raH
+qXx
 bDi
 bRF
 bDi
 bPC
-gbz
+ewb
 bva
 bPA
 bSw
@@ -79812,11 +80155,11 @@ nyl
 bjL
 bvc
 bqY
-udZ
-udZ
+mEo
+mEo
 rtd
-waa
-waa
+koW
+koW
 bzK
 btV
 btV
@@ -79839,11 +80182,11 @@ sOB
 aht
 bva
 xbD
-gbz
-rlR
-wVt
+ewb
+lPe
+lug
 bTj
-gbz
+ewb
 bva
 tRc
 bVz
@@ -80030,13 +80373,13 @@ aAn
 aBi
 aCs
 ktv
-kvr
-kvr
-kvr
+vRq
+vRq
+vRq
 aGY
-pIu
+eTZ
 ygW
-pIu
+eTZ
 aKL
 nJc
 aMW
@@ -80287,7 +80630,7 @@ aAm
 aBi
 aCt
 aDy
-aMB
+mxg
 aDA
 aGf
 aGX
@@ -80362,7 +80705,7 @@ bva
 bDi
 bDi
 bDi
-aYc
+iFA
 bDi
 nWP
 bva
@@ -80544,7 +80887,7 @@ aAo
 aBi
 aCu
 aDz
-aMB
+mxg
 aDA
 aGg
 aBi
@@ -80609,7 +80952,7 @@ sOB
 sOB
 bva
 bva
-fkQ
+nTt
 bDi
 bva
 bva
@@ -80619,7 +80962,7 @@ bva
 bDi
 bDi
 bDi
-ekB
+ljs
 bva
 bva
 bva
@@ -80801,7 +81144,7 @@ awR
 aBj
 aCv
 aDz
-aMB
+mxg
 qDb
 aGh
 aBi
@@ -80874,8 +81217,8 @@ bDi
 bDi
 bOB
 ygZ
-aYc
-aYc
+iFA
+iFA
 cad
 eYM
 bQl
@@ -81057,7 +81400,7 @@ ayS
 aAp
 aBj
 aCw
-xJC
+gvp
 xfm
 aDA
 aGi
@@ -81118,7 +81461,7 @@ xtI
 omS
 xtI
 xtI
-hBf
+olY
 bva
 gcn
 bDi
@@ -81567,7 +81910,7 @@ auH
 avK
 auH
 axP
-qmQ
+hVS
 aAr
 aBj
 aCx
@@ -81824,7 +82167,7 @@ auH
 auH
 auH
 axQ
-qmQ
+hVS
 aAs
 aBj
 gkR
@@ -81903,7 +82246,7 @@ acN
 bZx
 eQN
 tcY
-nBT
+rpc
 xiw
 cdI
 cri
@@ -82107,7 +82450,7 @@ aRL
 aWT
 aZW
 uwY
-lrw
+gTR
 aZW
 bca
 aZW
@@ -82335,7 +82678,7 @@ fvq
 fvq
 atK
 auJ
-mTF
+xxo
 awT
 axR
 ohu
@@ -82349,7 +82692,7 @@ awR
 aHb
 xyp
 ygW
-xst
+qqz
 aKR
 aLF
 aNd
@@ -82364,7 +82707,7 @@ aRL
 aaX
 aaY
 vPa
-fXu
+wxO
 bbd
 aRL
 bdm
@@ -82621,7 +82964,7 @@ afu
 afu
 aXZ
 aZW
-fXu
+wxO
 pWT
 bcb
 nQn
@@ -82657,10 +83000,10 @@ bSw
 bSw
 bDi
 bNU
-hBf
+olY
 bPB
 pQm
-ssL
+doe
 cCF
 cCH
 bTp
@@ -82849,7 +83192,7 @@ arB
 asM
 atN
 aaZ
-ssa
+dDZ
 awR
 axT
 ayZ
@@ -82878,7 +83221,7 @@ aVW
 afu
 aXY
 aZW
-fXu
+wxO
 pWT
 bcc
 inG
@@ -82914,10 +83257,10 @@ bpY
 bpY
 bpY
 dVv
-hBf
+olY
 bPB
 bQo
-hol
+fWq
 bRa
 bSy
 bTo
@@ -83105,14 +83448,14 @@ aqG
 arC
 asO
 atM
-auK
+sQx
 avO
 awR
 axU
 kfZ
 aAw
 aBn
-qZE
+ojN
 aDE
 aEz
 aFx
@@ -83135,7 +83478,7 @@ iNR
 afu
 hwo
 aYQ
-fXu
+wxO
 bbe
 bcd
 jcT
@@ -83171,7 +83514,7 @@ uik
 txK
 bMK
 dVv
-hBf
+olY
 bPB
 bQp
 ptK
@@ -83360,7 +83703,7 @@ ahi
 ahi
 aqG
 arD
-asO
+gif
 atN
 hmL
 avP
@@ -83428,7 +83771,7 @@ rFq
 bsK
 ygx
 cBL
-hBf
+olY
 bPB
 bQq
 bRG
@@ -83442,9 +83785,9 @@ caj
 cnX
 bXY
 bYK
-iqp
-iqp
-iqp
+cOG
+cOG
+cOG
 vAE
 vAE
 cdL
@@ -83482,9 +83825,9 @@ teJ
 clA
 clD
 clJ
-kCI
+wYr
 clY
-kCI
+gmH
 cmh
 uzn
 cmp
@@ -83649,11 +83992,11 @@ iNR
 aWU
 afu
 aYR
-rzz
+pwI
 ftU
 cpq
 cpu
-hJV
+sTY
 bfp
 bgk
 jcT
@@ -83685,7 +84028,7 @@ bKA
 bwV
 bMM
 dVv
-hBf
+olY
 bPB
 bPB
 bPB
@@ -83701,7 +84044,7 @@ bXY
 bYK
 cbW
 cbW
-gzf
+fIc
 pBN
 cbW
 cdM
@@ -83740,7 +84083,7 @@ clw
 hQz
 clw
 jCr
-tlw
+dpV
 kCI
 clw
 nMG
@@ -83908,9 +84251,9 @@ aYa
 gHR
 gHR
 bbg
-fMk
-fMk
-hJV
+jks
+jks
+sTY
 cpy
 bgk
 jcT
@@ -83942,7 +84285,7 @@ bKA
 prD
 dVv
 dVv
-hBf
+olY
 bPC
 bPB
 bRd
@@ -83997,7 +84340,7 @@ clw
 clw
 clw
 clL
-clG
+eXa
 ugv
 clw
 cmj
@@ -84134,7 +84477,7 @@ arA
 arA
 atQ
 auO
-lCe
+ycQ
 awY
 axX
 azd
@@ -84199,7 +84542,7 @@ bKA
 vcC
 dVv
 bNV
-hBf
+olY
 bPD
 bPB
 bRe
@@ -84250,7 +84593,7 @@ aaa
 aaa
 aaa
 rcF
-clw
+jlc
 xnm
 clM
 clU
@@ -84391,7 +84734,7 @@ arH
 asQ
 atR
 auP
-puU
+puW
 ayg
 ayg
 wyP
@@ -84474,7 +84817,7 @@ cbW
 cak
 cbg
 mjt
-xBF
+sli
 xSs
 rYY
 eHY
@@ -84649,7 +84992,7 @@ asR
 atS
 syK
 syK
-rCf
+vLp
 aDO
 wyP
 aAB
@@ -84713,7 +85056,7 @@ bKA
 anH
 dVv
 bNX
-hBf
+olY
 bPE
 bQs
 bRg
@@ -84970,7 +85313,7 @@ bKA
 prD
 dVv
 dVv
-hBf
+olY
 bPF
 bTu
 bTu
@@ -85204,7 +85547,7 @@ jcT
 cQN
 bkf
 bys
-yfT
+gnQ
 dBC
 boK
 bpU
@@ -85227,7 +85570,7 @@ bKA
 bLM
 bMN
 dVv
-hBf
+olY
 bPE
 bQu
 bRi
@@ -85484,7 +85827,7 @@ bKA
 bsK
 bAg
 dVv
-hBf
+olY
 bPE
 bQv
 bRj
@@ -85681,8 +86024,8 @@ axb
 yeL
 azj
 aAC
-aBu
-aCK
+fOP
+wdW
 aDM
 aEG
 aAB
@@ -85714,8 +86057,8 @@ cpC
 bgp
 jcT
 bhN
-ayr
-tKl
+ver
+uAq
 cpY
 cqa
 bmy
@@ -85741,7 +86084,7 @@ jSW
 bLO
 bAh
 dVv
-hBf
+olY
 bPE
 bQw
 bRj
@@ -85998,7 +86341,7 @@ nnf
 byz
 ooh
 dVv
-hBf
+olY
 bPE
 bQx
 bRj
@@ -86012,7 +86355,7 @@ bWw
 bXm
 bYg
 bYW
-gzf
+fIc
 fgv
 uUh
 cce
@@ -86255,7 +86598,7 @@ bKG
 byA
 bAi
 dVv
-hBf
+olY
 bPE
 bQy
 bRk
@@ -86412,7 +86755,7 @@ abO
 acP
 acW
 aee
-olO
+hCS
 adH
 olO
 olO
@@ -86512,7 +86855,7 @@ dVv
 dVv
 dVv
 dVv
-hBf
+olY
 bPE
 bQz
 bRl
@@ -86734,7 +87077,7 @@ beB
 aYg
 qmm
 liQ
-bsC
+lGq
 bbr
 udo
 bez
@@ -86768,8 +87111,8 @@ vNl
 vNl
 vNl
 vNl
-hBf
-hBf
+olY
+olY
 bPE
 bQA
 bRm
@@ -86917,16 +87260,16 @@ ace
 ace
 ace
 amd
-acl
-acl
-acl
-acl
+acC
+acC
+acC
+acC
 acd
 acw
 acP
 acY
 sPa
-olO
+kbV
 acP
 adV
 adV
@@ -86934,7 +87277,7 @@ cnD
 adV
 adV
 acP
-olO
+kbV
 acP
 acP
 acP
@@ -87177,8 +87520,8 @@ abO
 bhU
 abO
 abO
-acl
-acl
+acC
+acC
 cCO
 acP
 acP
@@ -87248,7 +87591,7 @@ beB
 aYg
 qmm
 aBH
-txa
+jos
 bbp
 udo
 liQ
@@ -87504,11 +87847,11 @@ naX
 aXh
 aYg
 aZd
-pZM
-pZM
-pZM
-pZM
-pZM
+bqy
+bqy
+bqy
+bqy
+bqy
 snD
 bgu
 aDm
@@ -87750,7 +88093,7 @@ fei
 aKZ
 aLS
 daO
-eZE
+tCk
 aPJ
 aRa
 aRX
@@ -87764,7 +88107,7 @@ aZd
 liQ
 lTf
 bbr
-wpn
+wfr
 liQ
 bfs
 bgt
@@ -87954,7 +88297,7 @@ acL
 sYY
 adb
 ieU
-ieU
+sFL
 adM
 kUt
 gAY
@@ -88003,11 +88346,11 @@ aGu
 aHh
 aHV
 xPQ
-tMU
+wuO
 aLb
-vGC
-eZE
-eZE
+ltE
+tCk
+tCk
 aPK
 aRb
 aKY
@@ -88021,7 +88364,7 @@ aZd
 liQ
 bbs
 bcq
-wpn
+wfr
 beC
 ajX
 ajX
@@ -88053,8 +88396,8 @@ bJD
 qOx
 qXH
 qXH
-cDw
-cDw
+jez
+jez
 qOx
 qOx
 qzm
@@ -88078,7 +88421,7 @@ dsM
 aUG
 mUJ
 gsB
-ozZ
+ndy
 wza
 lWQ
 nZX
@@ -88206,7 +88549,7 @@ acs
 abO
 abO
 abO
-ace
+adT
 abY
 acT
 add
@@ -88278,7 +88621,7 @@ cpk
 liQ
 xsr
 bbp
-wpn
+wfr
 beD
 cpC
 bgv
@@ -88463,7 +88806,7 @@ act
 abO
 abO
 abO
-acB
+biy
 rlV
 abO
 add
@@ -88583,7 +88926,7 @@ bXp
 bYn
 bZa
 gZx
-ioK
+iok
 eSW
 eSW
 pyA
@@ -88719,8 +89062,8 @@ abO
 act
 abO
 abO
-ace
-ace
+adT
+adT
 sWM
 acU
 acU
@@ -88824,7 +89167,7 @@ cqz
 qzm
 bLT
 rnQ
-sLg
+fUc
 mYW
 mYW
 mYW
@@ -88973,10 +89316,10 @@ ace
 ace
 ace
 aFc
-ace
-ace
-ace
-ace
+adT
+adT
+adT
+adT
 acd
 acw
 acU
@@ -89072,7 +89415,7 @@ byH
 bAo
 bBs
 bCG
-hRQ
+qOD
 bET
 bBp
 bHj
@@ -89086,7 +89429,7 @@ bOM
 bPM
 bRq
 pwa
-fZv
+lfS
 bSP
 pps
 bUo
@@ -89288,9 +89631,9 @@ aGx
 aHl
 aHV
 xPQ
-tMU
+wuO
 aLd
-xKY
+olV
 aNw
 aOG
 aPO
@@ -89343,7 +89686,7 @@ qOx
 qOx
 qzm
 bRr
-mRO
+yhO
 qOx
 fBp
 fBp
@@ -89600,7 +89943,7 @@ bOO
 bPN
 bRs
 mlD
-lXV
+gur
 bYq
 cqG
 bUp
@@ -89853,8 +90196,8 @@ bKP
 bLX
 bMZ
 bOh
-vld
-vld
+faY
+faY
 vWp
 vWp
 bSc
@@ -90360,7 +90703,7 @@ bCL
 bDH
 bEX
 bGb
-rLF
+laB
 xbB
 bJH
 fBp
@@ -91137,7 +91480,7 @@ bJK
 fBp
 bMa
 wSR
-ctd
+lyB
 bWO
 fJw
 eUb
@@ -91383,18 +91726,18 @@ bvE
 vvn
 byM
 bAw
-tLm
-tLm
-tLm
-tLm
-tLm
+swO
+swO
+swO
+swO
+swO
 bHr
 bID
 bJL
-waK
+iJN
 bMb
 wSR
-ctd
+lyB
 bOV
 bPQ
 bQJ
@@ -91908,7 +92251,7 @@ fBp
 fBp
 bMd
 wSR
-ctd
+lyB
 bOX
 bPQ
 bQK
@@ -92128,12 +92471,12 @@ aOT
 uZJ
 php
 vZP
-dsm
+odh
 aZn
 bav
 cuL
 pvZ
-oZN
+uXX
 beI
 bfv
 bgE
@@ -92342,7 +92685,7 @@ aju
 ajt
 alQ
 mnG
-biy
+xjl
 otM
 aJc
 anY
@@ -92390,7 +92733,7 @@ aZn
 baw
 bbA
 pvZ
-oZN
+uXX
 beI
 bfw
 bgF
@@ -92422,7 +92765,7 @@ fBp
 bKT
 bWO
 wYi
-ctd
+lyB
 wCz
 bWO
 bWO
@@ -92599,7 +92942,7 @@ akh
 alc
 alR
 amF
-hCS
+qxE
 stG
 anm
 sFK
@@ -92647,7 +92990,7 @@ aZn
 bat
 syO
 pvZ
-oZN
+uXX
 beI
 bfx
 bgG
@@ -92875,7 +93218,7 @@ avg
 awp
 apX
 ayl
-spP
+qkS
 apX
 aBO
 aDd
@@ -92904,7 +93247,7 @@ hNd
 tYn
 nBt
 pvZ
-oZN
+uXX
 beI
 bfy
 bgI
@@ -93152,7 +93495,7 @@ lAs
 bdS
 edZ
 hFV
-tkl
+xLF
 cay
 pvZ
 abc
@@ -93161,7 +93504,7 @@ rJT
 rJT
 sLD
 vQo
-uyp
+dSK
 beI
 bfz
 bgI
@@ -93389,10 +93732,10 @@ avh
 pec
 axo
 aym
-xGL
+wLx
 aav
 aQC
-mfZ
+cHR
 apX
 aET
 bPd
@@ -93698,8 +94041,8 @@ byV
 bAA
 bBG
 bCR
-ocg
-ocg
+qnQ
+qnQ
 rPu
 bCR
 bII
@@ -93901,10 +94244,10 @@ apX
 apX
 avj
 awv
-uMh
-azv
-azv
 ten
+azv
+azv
+rlR
 com
 aXV
 apX
@@ -93933,9 +94276,9 @@ baz
 uwF
 oYq
 set
-uOR
-uOR
-uOR
+mdx
+mdx
+mdx
 fGd
 aFi
 bix
@@ -93955,7 +94298,7 @@ byW
 bAA
 bBG
 bCR
-hxp
+qqZ
 tct
 bGi
 bHv
@@ -94171,9 +94514,9 @@ eZv
 jcT
 jcT
 ame
-pIu
+eTZ
 pez
-oZN
+uXX
 wDZ
 wDZ
 wDZ
@@ -94193,7 +94536,7 @@ bbI
 bbI
 bbI
 bbI
-esM
+fqJ
 aFi
 aFi
 bjw
@@ -94430,7 +94773,7 @@ aIj
 aJm
 aKg
 aEj
-oZN
+uXX
 wDZ
 aUm
 bcN
@@ -94451,8 +94794,8 @@ amb
 bfB
 bbI
 jaJ
-hxx
-uyp
+cBN
+dSK
 bjw
 bky
 blP
@@ -94672,9 +95015,9 @@ atk
 izB
 com
 nzR
-uMh
+ten
 cok
-cok
+gEg
 ibD
 bdJ
 aDi
@@ -94687,7 +95030,7 @@ aEd
 nSz
 aEd
 aEd
-oZN
+uXX
 wDZ
 abh
 mse
@@ -94930,8 +95273,8 @@ aum
 uFi
 awv
 com
-com
-com
+cQs
+cHR
 com
 com
 aDj
@@ -94944,7 +95287,7 @@ aGF
 rtC
 aKh
 aEd
-oZN
+uXX
 aNO
 ofj
 ofj
@@ -95187,21 +95530,21 @@ atn
 jNg
 awv
 com
-com
-com
+cQs
+cHR
 com
 com
 aDk
 aEd
 aFb
-bnp
-bnp
+jXJ
+jXJ
 aFe
 beh
 sPU
 aGF
 aEd
-oZN
+uXX
 wDZ
 aPa
 aRp
@@ -95218,7 +95561,7 @@ tCS
 qXb
 udR
 dma
-pdI
+lGJ
 eUa
 bbI
 bhr
@@ -95445,7 +95788,7 @@ atn
 aww
 axv
 nvX
-nvX
+loc
 axv
 axv
 atn
@@ -95458,7 +95801,7 @@ aEd
 aEd
 aKi
 aEd
-oZN
+uXX
 wDZ
 aPb
 bcS
@@ -95696,19 +96039,19 @@ aiS
 aiS
 atn
 low
-fCX
-ayu
+icK
+pfF
 emV
 awy
-ayu
-ayu
-ayu
-ayu
+oAY
+oAY
+pfF
+pfF
 aBT
 atn
 aEf
 aGF
-bnp
+jXJ
 aGF
 aHp
 aIl
@@ -95738,7 +96081,7 @@ pXH
 bht
 bbI
 biC
-uyp
+dSK
 aaj
 aak
 aam
@@ -95953,26 +96296,26 @@ sFK
 sFK
 atn
 enI
-ayu
-ayu
-emV
-awy
-ayu
+fVJ
+lFK
+lJM
+duC
+lFK
 pcg
 ayu
-ayu
+pfF
 aBU
 atn
 aEg
 aFd
-bnp
+jXJ
 qLU
 aEd
 aEd
 aEd
 aEd
 aEd
-oZN
+uXX
 aQk
 bbG
 bgy
@@ -96217,19 +96560,19 @@ awz
 ayu
 ayv
 azD
-ayu
+pfF
 aBV
 atn
 aEg
 ycl
-bnp
+aGF
 aGF
 aHq
 aIl
 aEd
 aKk
-oZN
-oZN
+uXX
+uXX
 aNQ
 bbG
 aQg
@@ -96256,7 +96599,7 @@ lru
 aaj
 aaw
 pJU
-ofG
+pTG
 aas
 jWq
 cpf
@@ -96474,7 +96817,7 @@ awA
 fCX
 ayu
 wzh
-ayu
+pfF
 aBW
 atn
 aEd
@@ -96484,7 +96827,7 @@ aEd
 aEd
 aEd
 aEd
-oZN
+uXX
 cDa
 aPg
 cDa
@@ -96740,8 +97083,8 @@ aFL
 aGI
 aHr
 aEd
-oZN
-oZN
+uXX
+uXX
 cDa
 aMw
 aQo
@@ -96997,7 +97340,7 @@ lgR
 xqh
 lgR
 aDl
-oZN
+uXX
 cDa
 cDa
 hhJ
@@ -97511,7 +97854,7 @@ aFN
 aGK
 aHs
 aEj
-oZN
+uXX
 cDa
 aOP
 aMy
@@ -98071,7 +98414,7 @@ rLn
 rLn
 bGw
 rLn
-iww
+lQv
 tLN
 iUX
 iUX
@@ -98325,7 +98668,7 @@ mSc
 sci
 jiD
 glf
-mrA
+fEj
 qtA
 khk
 bIN
@@ -98813,15 +99156,15 @@ bbG
 nTv
 kSG
 kXZ
-oZN
-oZN
+uXX
+uXX
 tfz
-uOR
+mdx
 kjA
-uOR
-uyp
+mdx
+dSK
 tfz
-uOR
+mdx
 fGd
 aKq
 aFi
@@ -98834,8 +99177,8 @@ roa
 buK
 dqw
 kmq
-wYb
-uMU
+wjw
+wDb
 wFT
 lRW
 veM
@@ -99051,14 +99394,14 @@ aur
 atn
 odG
 aFi
-soL
-soL
+yiL
+yiL
 set
 aRs
-uOR
-uOR
-uOR
-uOR
+mdx
+mdx
+mdx
+mdx
 dWw
 mXc
 saR
@@ -99067,10 +99410,10 @@ eCB
 eCB
 ahW
 vHj
-uOR
+mdx
 ajS
-uOR
-uOR
+mdx
+mdx
 vaa
 mri
 aEj
@@ -99091,10 +99434,10 @@ ume
 bkF
 bkF
 lUC
-wYb
-hgf
+wjw
+xnp
 nev
-uca
+svm
 bEf
 bFu
 noM
@@ -99348,7 +99691,7 @@ vMx
 xzp
 bkF
 iLl
-ikY
+mAu
 uuN
 xlA
 jiD
@@ -99563,9 +99906,9 @@ atn
 atn
 atn
 atn
-soL
-soL
-soL
+yiL
+yiL
+yiL
 aFi
 aMH
 aNV
@@ -99598,7 +99941,7 @@ bkH
 mql
 hEX
 nNW
-bCJ
+gtW
 bzg
 jwD
 csu
@@ -99606,7 +99949,7 @@ ofN
 bkF
 gdJ
 uAx
-hgf
+xnp
 xgt
 oKI
 skj
@@ -99820,7 +100163,7 @@ atn
 aFi
 aFi
 aFi
-soL
+yiL
 aEj
 aFi
 aFi
@@ -99862,11 +100205,11 @@ uel
 xpr
 bkF
 pXg
-rYS
-uMU
-uMU
-uMU
-kNK
+sDk
+wDb
+wDb
+wDb
+awX
 mJm
 gOV
 jiD
@@ -100074,10 +100417,10 @@ lhO
 cgB
 hju
 oqY
-soL
-soL
-soL
-soL
+yiL
+yiL
+yiL
+yiL
 aEj
 aFi
 aIq
@@ -100343,8 +100686,8 @@ aEj
 tko
 aaM
 wPc
-pos
-jJK
+vZJ
+lcz
 ktQ
 rWE
 aht
@@ -100600,8 +100943,8 @@ cdm
 rlU
 wmE
 wmE
-gmE
-roA
+ofR
+qfa
 sZh
 sut
 aTx
@@ -100858,7 +101201,7 @@ rlU
 aaQ
 aco
 lao
-kAv
+ndd
 sZh
 sut
 aTy
@@ -101115,7 +101458,7 @@ rlU
 aco
 aco
 adO
-frb
+nkE
 sZh
 sut
 bcK
@@ -101372,7 +101715,7 @@ rlU
 uOe
 uOe
 uOe
-xjq
+ovf
 sZh
 sut
 aTz
@@ -104998,7 +105341,7 @@ bkF
 pIW
 cPy
 eIL
-cft
+vCE
 gyj
 oNE
 sXR
@@ -106281,7 +106624,7 @@ bbP
 aaa
 bkF
 dmT
-hHw
+ltk
 nEb
 pWm
 uvo

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -2,13 +2,6 @@
 "aaa" = (
 /turf/open/space/basic,
 /area/space)
-"aab" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "aac" = (
 /obj/machinery/computer/cargo/request{
 	dir = 8
@@ -95,10 +88,10 @@
 /area/science/nanite)
 "aal" = (
 /obj/machinery/firealarm/directional/north,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -140,8 +133,12 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/engine,
 /area/science/explab)
 "aat" = (
@@ -219,6 +216,7 @@
 /area/cargo/warehouse/upper)
 "aaG" = (
 /obj/machinery/computer/exoscanner_control,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/cargo/warehouse/upper)
 "aaH" = (
@@ -264,25 +262,10 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
-"aaP" = (
-/obj/structure/rack,
-/obj/item/fuel_pellet,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
-/area/cargo/warehouse/upper)
 "aaQ" = (
-/obj/structure/rack,
-/obj/item/circuitboard/machine/exoscanner{
-	pixel_y = 3
-	},
-/obj/item/circuitboard/machine/exoscanner,
-/obj/item/circuitboard/machine/exoscanner{
-	pixel_y = -3
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/item/exodrone,
+/obj/machinery/exodrone_launcher,
+/turf/open/floor/plating,
 /area/cargo/warehouse/upper)
 "aaR" = (
 /obj/effect/landmark/start/chief_medical_officer,
@@ -300,11 +283,11 @@
 "aaT" = (
 /obj/effect/mapping_helpers/iannewyear,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
@@ -544,9 +527,6 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "aco" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /turf/open/floor/plating,
 /area/cargo/warehouse/upper)
 "acq" = (
@@ -645,10 +625,12 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "acC" = (
-/obj/item/exodrone,
-/obj/machinery/exodrone_launcher,
-/turf/open/floor/plating,
-/area/cargo/warehouse/upper)
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "acD" = (
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat AI Chamber South";
@@ -689,6 +671,9 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/cargo/warehouse/upper)
 "acK" = (
@@ -696,8 +681,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse/upper)
@@ -706,20 +691,11 @@
 	uses = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /turf/open/floor/iron/white,
 /area/ai_monitored/turret_protected/ai)
 "acM" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/ai_monitored/turret_protected/ai)
 "acN" = (
@@ -760,8 +736,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "add" = (
@@ -813,35 +787,21 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
 "adj" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/turf/open/floor/circuit/green{
+	luminosity = 2
+	},
+/area/ai_monitored/command/nuke_storage)
 "adk" = (
 /obj/structure/table,
 /obj/machinery/recharger,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "adl" = (
 /obj/structure/chair/office{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -849,24 +809,12 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "ado" = (
 /obj/structure/table,
 /obj/item/pen,
 /obj/item/paper_bin,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "adq" = (
@@ -875,9 +823,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
-"adr" = (
-/turf/open/floor/plating,
-/area/cargo/warehouse/upper)
 "ads" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/light{
@@ -898,9 +843,6 @@
 	dir = 1;
 	network = list("minisat")
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
@@ -917,12 +859,6 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -957,12 +893,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
@@ -979,12 +909,6 @@
 	dir = 1;
 	network = list("minisat")
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
@@ -996,18 +920,23 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/warehouse/upper)
 "adG" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/iron/grimy,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/command/bridge)
 "adH" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "MiniSat Maintenance";
@@ -1034,7 +963,9 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/west,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/security)
 "adM" = (
@@ -1048,9 +979,7 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "adO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/cargo/warehouse/upper)
 "adQ" = (
@@ -1059,8 +988,6 @@
 	req_access_txt = "65"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
@@ -1070,13 +997,13 @@
 /turf/open/space,
 /area/space/nearstation)
 "adT" = (
-/obj/machinery/exodrone_launcher,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/cargo/warehouse/upper)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "adU" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
+/turf/open/space/basic,
 /area/cargo/warehouse/upper)
 "adV" = (
 /turf/open/space,
@@ -1202,6 +1129,12 @@
 	dir = 4
 	},
 /obj/machinery/firealarm/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/warehouse/upper)
 "aeu" = (
@@ -1221,8 +1154,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/warehouse/upper)
 "aex" = (
@@ -1251,8 +1182,7 @@
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
 "aeB" = (
 /obj/structure/window/reinforced,
-/obj/structure/tank_holder/extinguisher,
-/turf/open/floor/iron,
+/turf/open/space/basic,
 /area/cargo/warehouse/upper)
 "aeC" = (
 /obj/machinery/hydroponics/constructable,
@@ -1308,9 +1238,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "aeS" = (
@@ -1321,8 +1249,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
@@ -1377,12 +1303,6 @@
 	network = list("minisat")
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
@@ -1405,12 +1325,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
 "afd" = (
@@ -1436,12 +1350,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "aff" = (
@@ -1452,12 +1360,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "afg" = (
@@ -1473,12 +1375,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "afh" = (
@@ -1491,12 +1387,6 @@
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/cargo/warehouse/upper)
 "afi" = (
@@ -1506,12 +1396,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
 "afj" = (
@@ -1521,11 +1405,11 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse/upper)
@@ -1535,43 +1419,15 @@
 	network = list("minisat")
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
 "afl" = (
-/obj/structure/table,
-/obj/item/stock_parts/micro_laser{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/item/stock_parts/micro_laser{
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/stock_parts/micro_laser{
-	pixel_x = 2
-	},
-/obj/item/stock_parts/micro_laser{
-	pixel_x = 6;
-	pixel_y = -2
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse/upper)
@@ -1632,9 +1488,6 @@
 /area/service/kitchen/coldroom)
 "afv" = (
 /obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
@@ -1644,7 +1497,6 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -1674,7 +1526,6 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/east,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "afB" = (
@@ -1759,6 +1610,12 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/warehouse/upper)
 "afP" = (
@@ -1769,12 +1626,6 @@
 "afQ" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "afR" = (
@@ -1939,12 +1790,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "agy" = (
@@ -1960,9 +1809,9 @@
 	name = "Cell 2"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
@@ -1976,9 +1825,9 @@
 	name = "Cell 1"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
@@ -2006,8 +1855,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
@@ -2058,8 +1907,8 @@
 "agM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/prisoner,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -2104,20 +1953,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"agV" = (
-/obj/machinery/door/airlock/security{
-	aiControlDisabled = 1;
-	name = "Solutions Room";
-	req_access_txt = "2"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/security/execution/transfer)
 "agW" = (
 /obj/machinery/flasher{
 	id = "PCell 2";
@@ -2131,11 +1966,9 @@
 /area/security/prison)
 "agX" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/security/prison)
@@ -2158,23 +1991,9 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "aha" = (
-/obj/structure/table,
-/obj/item/stock_parts/scanning_module{
-	pixel_x = -5;
-	pixel_y = 7
-	},
-/obj/item/stock_parts/scanning_module{
-	pixel_x = 5;
-	pixel_y = 7
-	},
-/obj/item/stock_parts/scanning_module{
-	pixel_x = -5
-	},
-/obj/item/stock_parts/scanning_module{
-	pixel_x = 5
-	},
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
+/obj/structure/tank_holder/extinguisher,
 /turf/open/floor/iron,
 /area/cargo/warehouse/upper)
 "ahd" = (
@@ -2182,21 +2001,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/showroomfloor,
 /area/security)
-"ahg" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/exit/departure_lounge)
 "ahh" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/showcase/cyborg/old{
@@ -2256,10 +2060,10 @@
 	},
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "ahm" = (
@@ -2272,9 +2076,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/security/prison)
@@ -2288,9 +2092,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/security/prison)
@@ -2358,20 +2162,18 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "ahB" = (
 /obj/item/chair,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
@@ -2428,6 +2230,12 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/warehouse/upper)
 "ahK" = (
@@ -2448,7 +2256,7 @@
 	departmentType = 5;
 	name = "Security Lockers Requests Console"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
@@ -2501,8 +2309,12 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "ahX" = (
@@ -2525,11 +2337,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
@@ -2642,7 +2452,9 @@
 	dir = 9;
 	pixel_x = -22
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/security)
 "aio" = (
@@ -2870,10 +2682,10 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "ajb" = (
@@ -2988,7 +2800,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/security)
 "ajl" = (
@@ -3076,9 +2890,7 @@
 	dir = 8
 	},
 /obj/structure/reagent_dispensers/peppertank/directional/east,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron,
 /area/security)
 "ajr" = (
@@ -3174,10 +2986,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron/dark,
 /area/security/processing/cremation)
 "ajL" = (
@@ -3276,6 +3088,12 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "ajT" = (
@@ -3311,10 +3129,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 1
-	},
 /obj/item/radio/intercom/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron,
 /area/security)
 "aka" = (
@@ -3389,11 +3205,9 @@
 	},
 /obj/item/cigbutt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
@@ -3402,10 +3216,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -3421,10 +3233,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -3434,10 +3244,8 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -3451,6 +3259,9 @@
 	light_color = "#e8eaff"
 	},
 /obj/machinery/firealarm/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "akp" = (
@@ -3464,10 +3275,8 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -3477,11 +3286,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
@@ -3507,14 +3314,8 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"aku" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
 "akv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "akw" = (
@@ -3522,9 +3323,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "akx" = (
@@ -3616,12 +3415,6 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
 	},
 /turf/open/floor/iron,
 /area/security/brig)
@@ -3731,8 +3524,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/security)
@@ -3744,9 +3537,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron,
 /area/security)
 "akT" = (
@@ -3799,11 +3590,9 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "alb" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/service/abandoned_gambling_den)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/bar)
 "alc" = (
 /obj/structure/table,
 /obj/item/storage/fancy/cigarettes/cigars,
@@ -3857,9 +3646,7 @@
 /area/maintenance/department/security/brig)
 "alj" = (
 /obj/item/wrench,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "alk" = (
@@ -3870,16 +3657,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "all" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
 /obj/item/radio/intercom/directional/south{
 	desc = "A station intercom. It looks like it has been modified to not broadcast.";
 	name = "prison intercom";
 	prison_radio = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
@@ -4036,18 +3821,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"alP" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/department/crew_quarters/dorms)
 "alQ" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/wood{
@@ -4065,10 +3838,14 @@
 /area/service/abandoned_gambling_den)
 "alT" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "alY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron/dark,
 /area/security/processing/cremation)
 "alZ" = (
@@ -4120,13 +3897,13 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "ame" = (
-/obj/machinery/requests_console/directional/south{
-	department = "Mining";
-	departmentType = 2;
-	name = "Mining Bay Requests Console"
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/cargo/miningdock)
+/area/hallway/primary/central)
 "amf" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -4153,7 +3930,9 @@
 	req_access_txt = "3"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/security/warden)
 "amm" = (
@@ -4178,12 +3957,10 @@
 /area/security)
 "amp" = (
 /obj/machinery/holopad/secure,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron,
 /area/security)
 "amq" = (
@@ -4194,12 +3971,10 @@
 	dir = 6
 	},
 /obj/effect/landmark/start/security_officer,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron,
 /area/security)
 "amr" = (
@@ -4211,12 +3986,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron,
 /area/security)
 "ams" = (
@@ -4224,12 +3997,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron/dark,
 /area/security)
 "amt" = (
@@ -4242,12 +4013,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "amu" = (
@@ -4255,12 +4024,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "amv" = (
@@ -4269,12 +4036,10 @@
 	},
 /obj/effect/landmark/start/head_of_security,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
 "amw" = (
@@ -4285,12 +4050,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
 "amx" = (
@@ -4362,10 +4125,10 @@
 	req_one_access_txt = "3;27"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "amK" = (
@@ -4398,10 +4161,10 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron/white,
 /area/security/brig)
 "amN" = (
@@ -4409,10 +4172,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron/white,
 /area/security/brig)
 "amO" = (
@@ -4430,12 +4193,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron/white,
 /area/security/brig)
 "amS" = (
@@ -4537,8 +4298,10 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/service/abandoned_gambling_den)
 "anp" = (
@@ -4546,8 +4309,10 @@
 	icon_state = "gib6"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "anq" = (
@@ -4568,12 +4333,10 @@
 /obj/item/wirecutters,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "anw" = (
@@ -4586,8 +4349,10 @@
 	req_access_txt = "63"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "any" = (
@@ -4634,8 +4399,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "anH" = (
@@ -4783,6 +4550,10 @@
 /obj/structure/closet/emcloset,
 /obj/item/camera,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "aod" = (
@@ -4804,8 +4575,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
@@ -4868,12 +4639,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "aot" = (
@@ -4883,24 +4652,20 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron,
 /area/security)
 "aov" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron,
 /area/security)
 "aow" = (
@@ -5042,10 +4807,10 @@
 	dir = 10
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "aoX" = (
@@ -5096,12 +4861,10 @@
 	sortType = 7
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron,
 /area/security)
 "apd" = (
@@ -5110,7 +4873,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -5149,7 +4912,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -5163,7 +4926,7 @@
 	req_access_txt = "1"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -5173,7 +4936,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -5186,7 +4949,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -5196,8 +4959,8 @@
 	dir = 10
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -5303,7 +5066,7 @@
 	},
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -5343,10 +5106,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "apP" = (
@@ -5358,10 +5121,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron,
 /area/security)
 "apQ" = (
@@ -5370,7 +5133,9 @@
 	pixel_x = 32
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "apR" = (
@@ -5443,11 +5208,6 @@
 /area/maintenance/disposal/incinerator)
 "aqn" = (
 /obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -5526,10 +5286,10 @@
 "aqy" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron,
 /area/security/brig)
 "aqz" = (
@@ -5572,17 +5332,11 @@
 /obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
-"aqE" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "aqF" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/fore)
@@ -5636,11 +5390,11 @@
 /area/ai_monitored/command/nuke_storage)
 "aqR" = (
 /obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/command/gateway)
 "aqS" = (
@@ -5746,21 +5500,10 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden/layer4,
-/turf/open/floor/iron,
-/area/security/brig)
-"arp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron,
 /area/security/brig)
 "arq" = (
@@ -5768,12 +5511,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron,
 /area/security/brig)
 "arr" = (
@@ -5781,20 +5522,10 @@
 	dir = 9
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden/layer4,
-/turf/open/floor/iron,
-/area/security/brig)
-"art" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron,
 /area/security/brig)
 "aru" = (
@@ -5804,12 +5535,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "arv" = (
@@ -6049,8 +5778,12 @@
 	pixel_x = -32
 	},
 /obj/machinery/computer/gateway_control,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/command/gateway)
 "arY" = (
@@ -6122,8 +5855,9 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
@@ -6136,13 +5870,11 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/cafeteria,
 /area/commons/dorms)
 "asf" = (
@@ -6195,10 +5927,8 @@
 	},
 /obj/item/cigbutt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -6269,7 +5999,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "asE" = (
@@ -6379,9 +6109,11 @@
 /obj/machinery/light_switch{
 	pixel_x = -20
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/command/gateway)
@@ -6430,9 +6162,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/cafeteria,
 /area/commons/dorms)
@@ -6447,11 +6179,9 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/cafeteria,
 /area/commons/dorms)
@@ -6481,16 +6211,6 @@
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plating,
 /area/commons/dorms)
-"atm" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
 "atn" = (
 /turf/closed/wall,
 /area/commons/fitness/recreation)
@@ -6517,6 +6237,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "atA" = (
@@ -6528,6 +6252,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "atC" = (
@@ -6537,6 +6265,10 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -6574,7 +6306,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "atH" = (
@@ -6598,7 +6330,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "atM" = (
@@ -6730,9 +6464,6 @@
 "aub" = (
 /obj/machinery/light,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
 "auc" = (
@@ -6746,8 +6477,8 @@
 	network = list("vault")
 	},
 /obj/machinery/light,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
@@ -6767,10 +6498,12 @@
 	name = "Gateway Requests Console"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/command/gateway)
 "aug" = (
@@ -6818,7 +6551,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/cafeteria,
 /area/commons/dorms)
 "aul" = (
@@ -6835,16 +6571,6 @@
 	},
 /turf/open/floor/plating,
 /area/commons/dorms)
-"aun" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
 "auq" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
@@ -6870,6 +6596,9 @@
 /area/maintenance/department/security/brig)
 "auy" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "auz" = (
@@ -6877,11 +6606,18 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "auA" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "auB" = (
@@ -6906,7 +6642,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "auD" = (
@@ -6969,8 +6705,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/item/radio/intercom/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "auK" = (
@@ -7001,9 +6739,6 @@
 "auP" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
@@ -7072,8 +6807,12 @@
 	},
 /obj/machinery/navbeacon/wayfinding/vault,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
 "auZ" = (
@@ -7088,8 +6827,12 @@
 /obj/machinery/navbeacon/wayfinding/gateway,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/command/gateway)
 "avb" = (
@@ -7153,11 +6896,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
@@ -7174,12 +6915,6 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
@@ -7423,11 +7158,9 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -7441,20 +7174,18 @@
 	dir = 1
 	},
 /obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "avP" = (
 /obj/machinery/firealarm/directional/south,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "avQ" = (
@@ -7466,11 +7197,9 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
@@ -7482,11 +7211,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
@@ -7568,10 +7295,10 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -7590,7 +7317,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -7599,7 +7326,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -7622,10 +7349,8 @@
 /turf/open/floor/wood,
 /area/commons/dorms)
 "awp" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/wood{
@@ -7637,10 +7362,8 @@
 	id_tag = "Dorm3";
 	name = "Dorm 3"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -7659,10 +7382,7 @@
 /area/engineering/atmos)
 "aws" = (
 /obj/structure/disposalpipe/junction/flip,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -7790,7 +7510,7 @@
 	},
 /obj/machinery/navbeacon/wayfinding/sec,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "awO" = (
@@ -7864,8 +7584,12 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/command/heads_quarters/captain)
 "awW" = (
@@ -7881,7 +7605,6 @@
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/west,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/paramedic)
 "awY" = (
@@ -7896,9 +7619,8 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/west,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
@@ -7914,6 +7636,9 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
@@ -7940,8 +7665,9 @@
 "axg" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -7978,22 +7704,19 @@
 	pixel_x = -32
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "axq" = (
 /obj/effect/landmark/start/assistant,
 /obj/structure/chair/comfy,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "axr" = (
 /obj/structure/chair/comfy,
 /obj/effect/landmark/start/assistant,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "axu" = (
@@ -8072,7 +7795,7 @@
 /area/hallway/primary/fore)
 "axL" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "axM" = (
@@ -8126,8 +7849,12 @@
 	},
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
 "axT" = (
@@ -8160,8 +7887,9 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "ayb" = (
@@ -8188,8 +7916,12 @@
 /area/command/bridge)
 "ayh" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/stairs,
 /area/hallway/primary/central)
 "ayi" = (
@@ -8247,11 +7979,12 @@
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "ayr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/carpet,
-/area/commons/dorms)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "ayu" = (
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
@@ -8314,11 +8047,11 @@
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
@@ -8336,11 +8069,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
@@ -8362,18 +8095,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"ayL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "ayN" = (
 /obj/machinery/holopad,
 /obj/structure/disposalpipe/segment{
@@ -8383,11 +8104,11 @@
 	codes_txt = "patrol;next_patrol=BrigP";
 	location = "BrigS1"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
@@ -8395,10 +8116,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "ayP" = (
@@ -8435,10 +8158,7 @@
 	req_access_txt = "20"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -8466,7 +8186,6 @@
 "azb" = (
 /obj/structure/chair/comfy/black,
 /obj/effect/landmark/start/captain,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "azc" = (
@@ -8474,6 +8193,7 @@
 	pixel_x = 35;
 	pixel_y = 5
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "azd" = (
@@ -8488,11 +8208,11 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
@@ -8508,10 +8228,10 @@
 	pixel_y = -32
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -8521,10 +8241,10 @@
 	light_color = "#e8eaff"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -8541,11 +8261,11 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
@@ -8560,22 +8280,18 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/command/bridge)
-"azl" = (
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "azm" = (
@@ -8621,8 +8337,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
@@ -8642,10 +8358,8 @@
 	id_tag = "Dorm2";
 	name = "Dorm 2"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -8717,6 +8431,7 @@
 	name = "Port Solar Access";
 	req_access_txt = "10"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
 "azY" = (
@@ -8747,18 +8462,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"aAc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "aAd" = (
 /obj/machinery/light,
 /obj/structure/disposalpipe/segment{
@@ -8772,8 +8475,12 @@
 	sortType = 29
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "aAf" = (
@@ -8791,8 +8498,12 @@
 	codes_txt = "patrol;next_patrol=Tool";
 	location = "BrigS2"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "aAm" = (
@@ -8804,7 +8515,7 @@
 	c_tag = "Fore Primary Hallway Starboard";
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -8883,12 +8594,13 @@
 /obj/item/paper_bin{
 	layer = 2.9
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "aAx" = (
 /obj/structure/table/wood,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "aAy" = (
@@ -8901,6 +8613,9 @@
 /obj/machinery/keycard_auth{
 	pixel_x = 28;
 	pixel_y = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
@@ -8919,8 +8634,12 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "aAB" = (
@@ -8942,8 +8661,6 @@
 	dir = 8
 	},
 /obj/machinery/navbeacon/wayfinding/aiupload,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aAD" = (
@@ -8953,6 +8670,12 @@
 	},
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "aAE" = (
@@ -8968,6 +8691,12 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "aAH" = (
@@ -8996,9 +8725,6 @@
 /obj/structure/chair/comfy{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "aAQ" = (
@@ -9006,9 +8732,6 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/assistant,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "aAS" = (
@@ -9023,7 +8746,6 @@
 /obj/structure/rack,
 /obj/item/clothing/mask/gas,
 /obj/item/multitool,
-/obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
@@ -9063,8 +8785,12 @@
 	},
 /obj/machinery/navbeacon/wayfinding/det,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/security/detectives_office)
 "aBg" = (
@@ -9095,6 +8821,12 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
 "aBl" = (
@@ -9102,8 +8834,12 @@
 	dir = 10
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
 "aBm" = (
@@ -9111,18 +8847,22 @@
 /area/command/heads_quarters/captain)
 "aBn" = (
 /obj/machinery/holopad/secure,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
 "aBo" = (
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
 "aBp" = (
 /obj/machinery/firealarm/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
 "aBs" = (
@@ -9364,16 +9104,6 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white/corner,
 /area/commons/fitness/recreation)
-"aBZ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
 "aCc" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -9527,6 +9257,9 @@
 /obj/machinery/light_switch{
 	pixel_x = 25
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
 "aCD" = (
@@ -9635,10 +9368,10 @@
 	dir = 6
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -9654,10 +9387,10 @@
 /obj/machinery/navbeacon/wayfinding/hop,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -9669,10 +9402,10 @@
 	},
 /obj/effect/landmark/start/assistant,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -9696,16 +9429,14 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/grimy,
 /area/commons/dorms)
 "aDd" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/grimy,
@@ -9715,10 +9446,8 @@
 	id_tag = "Dorm1";
 	name = "Dorm 1"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -9752,17 +9481,19 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/commons/toilet/restrooms)
 "aDm" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/engineering/gravity_generator)
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "aDq" = (
 /obj/structure/chair,
 /turf/open/floor/iron/grimy,
@@ -9782,14 +9513,14 @@
 /area/commons/storage/primary)
 "aDy" = (
 /obj/effect/landmark/start/assistant,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "aDz" = (
 /obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -9801,6 +9532,12 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/airalarm/directional/west,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
 "aDC" = (
@@ -9814,11 +9551,11 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
@@ -9828,10 +9565,12 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "aDF" = (
@@ -9839,8 +9578,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -9850,10 +9591,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -9868,10 +9609,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -9884,7 +9625,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -9921,12 +9665,6 @@
 	},
 /obj/machinery/holopad/secure,
 /obj/machinery/airalarm/directional/south,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "aDN" = (
@@ -9944,6 +9682,12 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "aDO" = (
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "aDP" = (
@@ -9954,10 +9698,10 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -9972,10 +9716,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -9986,10 +9730,10 @@
 	sortType = 15
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -9998,10 +9742,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -10010,10 +9754,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
 "aDX" = (
@@ -10029,12 +9775,6 @@
 "aEb" = (
 /obj/machinery/newscaster/directional/north,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "aEc" = (
@@ -10092,8 +9832,12 @@
 /obj/structure/table/wood,
 /obj/item/storage/fancy/cigarettes,
 /obj/item/lighter,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "aEp" = (
@@ -10180,8 +9924,12 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "aEC" = (
@@ -10293,8 +10041,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "aEK" = (
@@ -10303,6 +10049,9 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "aEL" = (
@@ -10374,6 +10123,9 @@
 	dir = 4
 	},
 /obj/machinery/firealarm/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aET" = (
@@ -10433,6 +10185,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
 "aFf" = (
@@ -10448,6 +10204,7 @@
 	name = "Starboard Solar Access";
 	req_access_txt = "10"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
 "aFi" = (
@@ -10460,8 +10217,12 @@
 /obj/effect/spawner/lootdrop/minor/bowler_or_that,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -10483,19 +10244,21 @@
 	},
 /obj/effect/landmark/start/detective,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "aFp" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/security/detectives_office)
@@ -10608,11 +10371,9 @@
 /obj/machinery/door/airlock{
 	name = "Unisex Showers"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
@@ -10620,11 +10381,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
@@ -10664,11 +10423,11 @@
 	sortType = 30
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -10683,11 +10442,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
@@ -10696,11 +10455,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
@@ -10771,8 +10530,6 @@
 /area/commons/storage/primary)
 "aGj" = (
 /obj/structure/disposalpipe/junction/flip,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "aGk" = (
@@ -10889,8 +10646,10 @@
 	pixel_x = -32
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aGF" = (
@@ -10912,18 +10671,6 @@
 	},
 /obj/structure/sign/poster/official/no_erp{
 	pixel_x = -32
-	},
-/turf/open/floor/iron/freezer,
-/area/commons/toilet/restrooms)
-"aGJ" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
@@ -10956,26 +10703,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"aGR" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/entry)
-"aGT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "aGX" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -10994,8 +10721,12 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "aHb" = (
@@ -11023,8 +10754,12 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "aHe" = (
@@ -11041,8 +10776,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "aHg" = (
@@ -11062,6 +10795,9 @@
 /obj/machinery/navbeacon/wayfinding/bridge,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "aHh" = (
@@ -11145,11 +10881,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
@@ -11158,11 +10894,11 @@
 	codes_txt = "patrol;next_patrol=Dorms";
 	location = "Tool"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -11220,8 +10956,12 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aHV" = (
@@ -11245,6 +10985,9 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aIb" = (
@@ -11264,6 +11007,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aId" = (
@@ -11309,31 +11053,19 @@
 /area/maintenance/department/cargo)
 "aIX" = (
 /obj/effect/landmark/observer_start,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aJa" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"aJb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "aJc" = (
 /turf/closed/wall,
 /area/service/abandoned_gambling_den)
@@ -11342,13 +11074,11 @@
 	codes_txt = "patrol;next_patrol=Robo";
 	location = "HoP"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aJk" = (
@@ -11356,24 +11086,20 @@
 	codes_txt = "patrol;next_patrol=HoP";
 	location = "Dorms"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aJm" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
@@ -11441,12 +11167,13 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aJN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/hallway/primary/central)
 "aJR" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/blue{
@@ -11514,13 +11241,11 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Dormitory"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aKe" = (
@@ -11565,11 +11290,11 @@
 "aKk" = (
 /obj/effect/loot_site_spawner,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -11577,8 +11302,8 @@
 /area/maintenance/department/cargo)
 "aKl" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/space/basic,
 /area/space/nearstation)
 "aKp" = (
@@ -11636,11 +11361,11 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/white/corner{
 	dir = 1
@@ -11663,8 +11388,12 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/commons/storage/art)
 "aKM" = (
@@ -11677,8 +11406,12 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/service/cafeteria)
 "aKP" = (
@@ -11693,8 +11426,10 @@
 	name = "Unisex Restrooms"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/auxiliary)
 "aKS" = (
@@ -11715,8 +11450,10 @@
 	req_access_txt = "12"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aKY" = (
@@ -11742,8 +11479,10 @@
 	},
 /obj/machinery/navbeacon/wayfinding/eva,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "aLc" = (
@@ -11757,8 +11496,10 @@
 	},
 /obj/machinery/navbeacon/wayfinding/teleporter,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/command/teleporter)
 "aLe" = (
@@ -11768,25 +11509,21 @@
 "aLf" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/cargo/office)
-"aLi" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "aLk" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/cargo/warehouse)
 "aLl" = (
@@ -11894,11 +11631,11 @@
 /area/commons/toilet/auxiliary)
 "aLF" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/auxiliary)
 "aLG" = (
@@ -12091,7 +11828,6 @@
 "aMr" = (
 /obj/structure/chair/stool,
 /obj/item/cigbutt/cigarbutt,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
 "aMs" = (
@@ -12110,10 +11846,10 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -12130,6 +11866,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/cargo/warehouse)
+"aMB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/commons/storage/primary)
 "aMD" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -12246,8 +11988,12 @@
 /area/service/cafeteria)
 "aNa" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/cafeteria,
 /area/service/cafeteria)
 "aNb" = (
@@ -12266,10 +12012,10 @@
 "aNd" = (
 /obj/machinery/light/small,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/auxiliary)
 "aNe" = (
@@ -12304,8 +12050,10 @@
 /obj/structure/grille/broken,
 /obj/item/crowbar,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -12367,11 +12115,9 @@
 "aNw" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/command/teleporter)
@@ -12415,8 +12161,12 @@
 	req_access_txt = "41"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/cargo/qm)
 "aNQ" = (
@@ -12424,19 +12174,23 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aNT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/cargo/miningdock)
 "aNU" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Cargo Bay Warehouse Maintenance";
 	req_access_txt = "31"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/cargo/warehouse)
 "aNV" = (
@@ -12460,12 +12214,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"aNZ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/science/explab)
 "aOf" = (
 /obj/structure/chair,
 /turf/open/floor/iron{
@@ -12493,16 +12241,14 @@
 /obj/item/wrench,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
-"aOr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/security/brig)
 "aOs" = (
 /obj/structure/sign/departments/evac,
 /turf/closed/wall,
@@ -12581,12 +12327,6 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/maintenance/department/crew_quarters/bar)
-"aOx" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aOD" = (
 /obj/machinery/suit_storage_unit/standard_unit,
@@ -12692,15 +12432,13 @@
 	pixel_y = -3
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/item/radio/intercom/directional/east{
 	pixel_x = 32;
 	pixel_y = 3
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
@@ -12761,9 +12499,11 @@
 /area/cargo/warehouse)
 "aPi" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -12775,7 +12515,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/white/corner{
@@ -12786,7 +12526,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/cafeteria,
@@ -12813,11 +12553,11 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Departure Lounge"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
@@ -12874,10 +12614,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "aPK" = (
@@ -12984,8 +12724,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "aQg" = (
@@ -13076,11 +12818,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
@@ -13088,8 +12830,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aQC" = (
@@ -13104,23 +12850,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/hallway/primary/central)
-"aQE" = (
-/obj/structure/grille/broken,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
 "aQH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -13132,11 +12869,9 @@
 	},
 /obj/effect/landmark/blobstart,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -13149,11 +12884,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -13164,13 +12897,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aQM" = (
@@ -13178,22 +12909,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
-"aQN" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aQQ" = (
@@ -13201,11 +12921,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -13216,8 +12934,9 @@
 	dir = 9
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
@@ -13267,8 +12986,10 @@
 "aRa" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "aRb" = (
@@ -13304,19 +13025,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"aRe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "aRf" = (
 /obj/item/banner/cargo/mundane,
 /obj/machinery/light{
@@ -13337,19 +13045,6 @@
 "aRl" = (
 /turf/closed/wall,
 /area/cargo/office)
-"aRm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "aRp" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
@@ -13363,8 +13058,12 @@
 /obj/structure/disposalpipe/segment,
 /obj/item/shard,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aRB" = (
@@ -13456,8 +13155,6 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aRL" = (
@@ -13471,8 +13168,10 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aRN" = (
@@ -13484,11 +13183,13 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/maintenance{
 	name = "Kitchen Maintenance";
 	req_access_txt = "28"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/service/kitchen/coldroom)
@@ -13512,13 +13213,11 @@
 /obj/structure/chair/wood{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/wood{
 	icon_state = "wood-broken"
 	},
@@ -13528,13 +13227,11 @@
 	name = "Bar Storage Maintenance";
 	req_access_txt = "25"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aRX" = (
@@ -13544,8 +13241,10 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aRY" = (
@@ -13582,10 +13281,10 @@
 /area/cargo/office)
 "aSj" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/wood{
@@ -13599,19 +13298,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/medical/virology)
-"aSt" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
 "aSu" = (
 /obj/item/wirecutters,
 /turf/open/floor/plating,
@@ -13688,8 +13377,10 @@
 "aSH" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen/coldroom)
 "aSI" = (
@@ -13728,16 +13419,6 @@
 	icon_state = "wood-broken6"
 	},
 /area/service/bar)
-"aSP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/service/bar)
 "aSQ" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/item/storage/box/beanbag,
@@ -13751,11 +13432,9 @@
 "aSR" = (
 /obj/item/weldingtool,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
@@ -13764,8 +13443,10 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aSV" = (
@@ -13773,11 +13454,9 @@
 	dir = 10
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
@@ -13796,28 +13475,17 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/cargo/office)
-"aTa" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/cargo/warehouse)
 "aTc" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay";
 	req_one_access_txt = "31;48"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/cargo/office)
@@ -13831,11 +13499,6 @@
 	icon_state = "wood-broken6"
 	},
 /area/cargo/qm)
-"aTl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "aTm" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/wood,
@@ -13897,10 +13560,10 @@
 /obj/machinery/light{
 	light_color = "#cee5d2"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -13951,7 +13614,9 @@
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
 "aTN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/service/library)
 "aTO" = (
@@ -13974,11 +13639,9 @@
 	dir = 10
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
@@ -14019,11 +13682,11 @@
 /area/maintenance/department/crew_quarters/bar)
 "aUd" = (
 /obj/machinery/firealarm/directional/west,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/service/bar)
 "aUe" = (
@@ -14041,8 +13704,7 @@
 	req_access_txt = "25"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aUi" = (
@@ -14130,9 +13792,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "aUJ" = (
@@ -14147,11 +13807,9 @@
 "aUO" = (
 /obj/machinery/light/small,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
@@ -14241,8 +13899,11 @@
 	req_access_txt = "25"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/service)
 "aVg" = (
@@ -14362,8 +14023,10 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aVo" = (
@@ -14396,23 +14059,23 @@
 	light_color = "#cee5d2"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/office)
 "aVw" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/cargo/office)
@@ -14422,11 +14085,11 @@
 	pixel_y = -25
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
@@ -14435,11 +14098,11 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
@@ -14449,10 +14112,10 @@
 	sortType = 3
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -14466,11 +14129,11 @@
 /area/cargo/storage)
 "aVM" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
@@ -14479,8 +14142,12 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "aVQ" = (
@@ -14488,11 +14155,11 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -14539,8 +14206,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "aVW" = (
@@ -14554,14 +14223,12 @@
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen/coldroom)
 "aWb" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/service)
 "aWd" = (
@@ -14569,13 +14236,11 @@
 	pixel_y = 28
 	},
 /mob/living/carbon/human/species/monkey/punpun,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/service)
 "aWf" = (
@@ -14584,22 +14249,7 @@
 	},
 /obj/machinery/airalarm/directional/north,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/hallway/secondary/service)
-"aWg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/service)
 "aWh" = (
@@ -14609,12 +14259,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "aWm" = (
@@ -14690,8 +14335,10 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/service/theater)
 "aWs" = (
@@ -14830,8 +14477,10 @@
 	sortType = 21
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "aWT" = (
@@ -14856,11 +14505,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen/coldroom)
-"aWV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
-/area/service/kitchen/coldroom)
 "aWW" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/open/floor/iron/showroomfloor,
@@ -14869,9 +14513,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/service)
 "aWY" = (
@@ -14909,11 +14555,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/service/theater)
@@ -14939,10 +14583,10 @@
 	department = "Theatre";
 	name = "Theatre Requests Console"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/service/theater)
 "aXm" = (
@@ -14960,9 +14604,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/service/theater)
@@ -14981,11 +14625,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/service/theater)
@@ -15009,11 +14651,9 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/service/theater)
@@ -15114,6 +14754,9 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aXN" = (
@@ -15126,10 +14769,6 @@
 "aXO" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/service/janitor)
 "aXP" = (
@@ -15163,8 +14802,10 @@
 /area/hallway/primary/fore)
 "aXU" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "aXV" = (
@@ -15204,9 +14845,11 @@
 	req_access_txt = "28"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen/coldroom)
 "aYb" = (
@@ -15216,11 +14859,20 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/service/kitchen)
+"aYc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "aYf" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/barman_recipes,
@@ -15280,8 +14932,10 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/service/theater)
 "aYk" = (
@@ -15309,31 +14963,11 @@
 /area/service/theater)
 "aYr" = (
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
-"aYu" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/office)
 "aYv" = (
 /obj/machinery/autolathe,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -15347,11 +14981,11 @@
 	req_one_access_txt = "31;48"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
@@ -15450,8 +15084,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/service/janitor)
 "aYN" = (
@@ -15475,10 +15107,8 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -15493,12 +15123,6 @@
 "aYR" = (
 /obj/machinery/vending/dinnerware,
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen)
-"aYS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "aYT" = (
@@ -15557,12 +15181,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/restaurant_portal/bar,
 /turf/open/floor/iron/dark,
@@ -15583,13 +15201,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
 /obj/structure/chair/stool/bar/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/service/bar/atrium)
 "aZf" = (
@@ -15605,11 +15221,9 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/east,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/service/bar/atrium)
@@ -15705,11 +15319,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
@@ -15730,11 +15344,11 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
@@ -15830,6 +15444,9 @@
 	},
 /obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bat" = (
@@ -16012,10 +15629,10 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -16044,12 +15661,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /turf/open/floor/iron,
 /area/service/janitor)
 "baZ" = (
@@ -16070,22 +15681,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
-"bbc" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/service/hydroponics)
 "bbd" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-10"
@@ -16103,8 +15698,10 @@
 /area/service/hydroponics)
 "bbg" = (
 /obj/effect/landmark/start/cook,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "bbi" = (
@@ -16129,7 +15726,7 @@
 /area/service/kitchen)
 "bbo" = (
 /obj/structure/table/wood/fancy,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -16150,9 +15747,7 @@
 /obj/item/cane,
 /obj/item/clothing/head/that,
 /obj/structure/table/wood/fancy,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/service/bar/atrium)
 "bbt" = (
@@ -16308,10 +15903,6 @@
 /obj/structure/janitorialcart,
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/service/janitor)
 "bbY" = (
@@ -16518,19 +16109,6 @@
 /obj/item/toy/plush/lizard_plushie,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"bcM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "bcN" = (
 /obj/structure/table,
 /obj/item/cartridge/quartermaster{
@@ -16599,6 +16177,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "bde" = (
@@ -16642,8 +16221,8 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -16698,6 +16277,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/cargo/miningdock)
+"bdJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/commons/dorms)
 "bdM" = (
 /obj/machinery/light{
 	dir = 4;
@@ -16706,13 +16291,6 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"bdO" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/cargo/storage)
 "bdR" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -16753,12 +16331,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"bec" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/service/janitor)
 "bed" = (
 /obj/structure/table,
 /obj/item/restraints/legcuffs/beartrap,
@@ -16789,27 +16361,19 @@
 /area/security/detectives_office)
 "beh" = (
 /obj/machinery/airalarm/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
 "bei" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/service/hydroponics)
-"bej" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
@@ -16826,11 +16390,9 @@
 	},
 /obj/machinery/navbeacon/wayfinding/hydro,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
@@ -16841,10 +16403,10 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bem" = (
@@ -16852,9 +16414,9 @@
 	dir = 4
 	},
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -16883,11 +16445,9 @@
 	},
 /obj/machinery/navbeacon/wayfinding/kitchen,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/service/kitchen)
@@ -16896,7 +16456,7 @@
 	dir = 4;
 	sortType = 20
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "ber" = (
@@ -16907,9 +16467,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "beu" = (
@@ -17064,8 +16622,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/navbeacon/wayfinding/janitor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/service/janitor)
@@ -17137,6 +16693,9 @@
 	pixel_y = -25
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bfu" = (
@@ -17251,11 +16810,9 @@
 /area/maintenance/department/cargo)
 "bfQ" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
 	},
 /turf/open/floor/iron/white,
 /area/engineering/gravity_generator)
@@ -17266,8 +16823,12 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "bgc" = (
@@ -17308,8 +16869,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bgh" = (
@@ -17369,22 +16928,20 @@
 "bgq" = (
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/cafeteria,
 /area/service/cafeteria)
 "bgr" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
@@ -17404,8 +16961,10 @@
 	name = "Bar"
 	},
 /obj/machinery/navbeacon/wayfinding/bar,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/service/bar/atrium)
 "bgv" = (
@@ -17522,9 +17081,11 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
@@ -17578,14 +17139,19 @@
 	dir = 1;
 	sortType = 22
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bhb" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bhf" = (
@@ -17616,19 +17182,23 @@
 	codes_txt = "patrol;next_patrol=Bar1";
 	location = "Robo"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bhl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
@@ -17640,10 +17210,12 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "bhn" = (
@@ -17651,11 +17223,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
@@ -17668,11 +17240,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/science/robotics/mechbay)
@@ -17680,12 +17252,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/closet/secure_closet/miner,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/door/airlock/maintenance{
+	name = "Mining Maintenance";
+	req_access_txt = "48"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
@@ -17693,7 +17269,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/closet/secure_closet/miner,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "bht" = (
@@ -17718,14 +17300,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"bhE" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "bhF" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -17754,11 +17328,11 @@
 	codes_txt = "patrol;next_patrol=BrigS1";
 	location = "Lounge"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -17767,11 +17341,11 @@
 	codes_txt = "patrol;next_patrol=Lounge";
 	location = "Kitchen"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -17779,8 +17353,12 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "L7"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bhP" = (
@@ -17815,14 +17393,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/science/robotics/mechbay)
-"bhS" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -17912,8 +17482,12 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "L8"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "biq" = (
@@ -17944,9 +17518,18 @@
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "biv" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/cryo)
 "biw" = (
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/bot,
@@ -17958,28 +17541,12 @@
 /obj/effect/decal/cleanable/robot_debris{
 	icon_state = "gib3"
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "biy" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/service/abandoned_gambling_den)
 "biC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -17988,11 +17555,11 @@
 	icon_state = "small"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
@@ -18173,6 +17740,10 @@
 "bjL" = (
 /turf/closed/wall,
 /area/medical/cryo)
+"bjM" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "bjQ" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner/north,
@@ -18405,10 +17976,8 @@
 	codes_txt = "patrol;next_patrol=Sci3";
 	location = "Sci2"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -18477,8 +18046,12 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/science/robotics)
 "bkx" = (
@@ -18544,8 +18117,12 @@
 /area/hallway/secondary/entry)
 "bkT" = (
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "bkW" = (
@@ -18648,9 +18225,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "bli" = (
@@ -18659,9 +18233,6 @@
 	dir = 1
 	},
 /obj/machinery/newscaster/directional/west,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /turf/open/floor/iron/white,
 /area/medical/paramedic)
 "bll" = (
@@ -18716,10 +18287,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"blt" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "blu" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -18819,11 +18386,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/science/robotics)
@@ -18835,11 +18402,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/science/robotics)
@@ -18859,11 +18426,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/science/robotics)
@@ -18879,11 +18446,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/science/robotics)
@@ -18970,12 +18537,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"bmd" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/service/bar)
 "bmh" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/beaker/cryoxadone{
@@ -19048,21 +18609,20 @@
 	codes_txt = "patrol;next_patrol=Kitchen";
 	location = "Med"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "bmz" = (
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
@@ -19098,10 +18658,8 @@
 	codes_txt = "patrol;next_patrol=Sci2";
 	location = "Sci"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -19206,12 +18764,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"bnp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/freezer,
+/area/commons/toilet/restrooms)
 "bnq" = (
 /obj/item/beacon,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -19262,10 +18827,7 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/paramedic)
 "bnC" = (
@@ -19276,9 +18838,7 @@
 /obj/structure/sign/poster/official/cleanliness{
 	pixel_y = -30
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/paramedic)
 "bnD" = (
@@ -19286,9 +18846,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/paramedic)
 "bnG" = (
@@ -19312,14 +18870,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
-"bnN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "bnO" = (
@@ -19376,9 +18926,7 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/science/server)
 "bnU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/iron/dark/telecomms,
 /area/science/server)
 "bnW" = (
@@ -19416,8 +18964,6 @@
 /area/science/explab)
 "bof" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/engine{
 	name = "Holodeck Projector Floor"
 	},
@@ -19476,6 +19022,10 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "boz" = (
@@ -19500,8 +19050,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/paramedic)
 "boH" = (
@@ -19531,8 +19080,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "boL" = (
@@ -19668,7 +19216,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/iron/dark,
 /area/science/explab)
 "bpe" = (
@@ -19691,8 +19239,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bpo" = (
@@ -19713,6 +19259,11 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"bps" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "bpu" = (
 /obj/structure/table,
 /obj/item/storage/belt/fannypack/red,
@@ -19814,8 +19365,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/medical/glass,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "bpV" = (
@@ -19905,8 +19455,10 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "bqf" = (
@@ -19940,9 +19492,11 @@
 	dir = 6
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/science/robotics)
@@ -19950,7 +19504,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -20072,8 +19626,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/explab)
 "bqx" = (
@@ -20107,8 +19659,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "bqC" = (
@@ -20200,19 +19753,13 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"bqS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/science/xenobiology)
 "bqV" = (
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
@@ -20448,8 +19995,12 @@
 "brx" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/science/robotics)
 "bry" = (
@@ -20535,9 +20086,6 @@
 /obj/structure/table,
 /obj/item/folder/white,
 /obj/item/pen,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/science/server)
 "brG" = (
@@ -20609,8 +20157,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "brW" = (
@@ -20674,16 +20223,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
-"bsg" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/brig)
 "bsl" = (
 /obj/structure/sign/warning/vacuum/external,
 /obj/effect/spawner/structure/window/reinforced,
@@ -20697,8 +20236,12 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "bsn" = (
@@ -20737,6 +20280,10 @@
 /area/medical/morgue)
 "bsr" = (
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "bss" = (
@@ -20753,12 +20300,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bsB" = (
@@ -20770,14 +20312,18 @@
 	light_color = "#cee5d2"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"bsC" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/service/bar/atrium)
 "bsD" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -20790,12 +20336,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bsG" = (
@@ -20841,8 +20382,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "bsJ" = (
@@ -20853,12 +20393,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "bsK" = (
@@ -20918,8 +20453,12 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/science/robotics)
 "bsY" = (
@@ -21002,8 +20541,12 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/science/server)
 "btg" = (
@@ -21027,8 +20570,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/explab)
 "btt" = (
@@ -21041,8 +20582,11 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
@@ -21063,9 +20607,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
@@ -21116,8 +20662,10 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "btW" = (
@@ -21134,12 +20682,7 @@
 "btZ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "bua" = (
@@ -21228,9 +20771,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "bun" = (
@@ -21311,8 +20851,12 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/science/robotics)
 "buw" = (
@@ -21327,9 +20871,6 @@
 	},
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /turf/open/floor/iron/dark,
 /area/science/explab)
 "buy" = (
@@ -21349,12 +20890,7 @@
 "buD" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/service)
 "buH" = (
@@ -21375,8 +20911,12 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "bva" = (
@@ -21410,8 +20950,6 @@
 	req_access_txt = "5"
 	},
 /obj/effect/mapping_helpers/airlock/unres,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bvi" = (
@@ -21450,12 +20988,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "bvm" = (
@@ -21463,12 +20996,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bvn" = (
@@ -21480,12 +21008,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bvo" = (
@@ -21511,12 +21034,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "bvp" = (
@@ -21543,13 +21061,8 @@
 	network = list("ss13","medbay")
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /obj/machinery/power/apc/auto_name/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "bvw" = (
@@ -21563,8 +21076,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/start/scientist,
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/science/lab)
 "bvy" = (
@@ -21580,11 +21095,9 @@
 /area/hallway/primary/aft)
 "bvC" = (
 /obj/machinery/newscaster/directional/south,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
@@ -21612,8 +21125,12 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "bvF" = (
@@ -21663,10 +21180,13 @@
 /turf/open/floor/iron/white,
 /area/science/explab)
 "bvL" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/medical/cryo)
 "bvM" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -21720,8 +21240,6 @@
 /area/science/explab)
 "bvV" = (
 /obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/explab)
 "bvW" = (
@@ -21776,8 +21294,12 @@
 	},
 /obj/machinery/navbeacon/wayfinding/minisat_access_chapel_library,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "bws" = (
@@ -21920,24 +21442,12 @@
 /obj/item/book/manual/wiki/research_and_development,
 /obj/item/disk/tech_disk,
 /obj/item/disk/design_disk,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
 /area/science/lab)
 "bxc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/science/lab)
@@ -21950,11 +21460,11 @@
 	sortType = 13
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/science/lab)
@@ -21967,8 +21477,12 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/lab)
 "bxf" = (
@@ -21979,11 +21493,11 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/science/lab)
@@ -21992,11 +21506,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/science/lab)
@@ -22011,11 +21525,11 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/science/lab)
@@ -22030,11 +21544,11 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
@@ -22046,8 +21560,12 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "bxm" = (
@@ -22056,11 +21574,11 @@
 	location = "Sci7"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
@@ -22076,11 +21594,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
@@ -22095,11 +21613,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/hallway/primary/aft)
@@ -22117,11 +21635,11 @@
 /obj/machinery/navbeacon/wayfinding/research,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/science/explab)
@@ -22138,24 +21656,11 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/science/explab)
-"bxz" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/science/explab)
@@ -22164,10 +21669,10 @@
 	dir = 10
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -22201,10 +21706,10 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/north,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/white/corner{
@@ -22338,10 +21843,12 @@
 /area/hallway/secondary/entry)
 "bya" = (
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/entry)
 "byb" = (
@@ -22372,12 +21879,6 @@
 "bye" = (
 /turf/open/floor/iron/white,
 /area/medical/storage)
-"byg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "byh" = (
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
@@ -22398,12 +21899,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
 "byp" = (
@@ -22463,16 +21959,6 @@
 /obj/machinery/door/firedoor,
 /turf/closed/wall,
 /area/medical/chemistry)
-"byv" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/iron/dark,
-/area/security/execution/transfer)
 "byw" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -22519,16 +22005,6 @@
 	},
 /turf/open/floor/engine,
 /area/medical/chemistry)
-"byC" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "byD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -22538,9 +22014,13 @@
 	pixel_x = -11
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/item/radio/intercom/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/science/lab)
 "byE" = (
@@ -22552,6 +22032,12 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/lab)
 "byF" = (
@@ -22568,8 +22054,12 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/lab)
 "byH" = (
@@ -22581,9 +22071,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/science/lab)
 "byI" = (
@@ -22593,9 +22080,6 @@
 /obj/item/stock_parts/cell/high/plus,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
@@ -22630,8 +22114,12 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "byN" = (
@@ -22772,8 +22260,12 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "bzh" = (
@@ -22916,11 +22408,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -22931,10 +22421,10 @@
 	dir = 6
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "bzG" = (
@@ -22942,10 +22432,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -22958,10 +22446,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -22986,10 +22472,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -22999,7 +22483,6 @@
 	dir = 4;
 	light_color = "#e8eaff"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bzX" = (
@@ -23089,8 +22572,12 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bAo" = (
@@ -23114,8 +22601,12 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/rd)
 "bAt" = (
@@ -23138,8 +22629,12 @@
 "bAw" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "bAx" = (
@@ -23175,12 +22670,6 @@
 /area/science/mixing)
 "bAG" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 9
-	},
 /turf/open/floor/iron/dark,
 /area/security/processing/cremation)
 "bAH" = (
@@ -23215,6 +22704,10 @@
 "bAM" = (
 /obj/item/extinguisher,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -23288,8 +22781,7 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bBg" = (
@@ -23349,9 +22841,11 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/rd)
@@ -23359,7 +22853,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -23682,7 +23176,7 @@
 	dir = 10
 	},
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "bCl" = (
@@ -23694,8 +23188,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
 "bCn" = (
@@ -23706,8 +23198,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "bCp" = (
@@ -23778,6 +23269,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/rd)
+"bCJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/science/xenobiology)
 "bCK" = (
 /obj/structure/table,
 /obj/machinery/camera{
@@ -23800,8 +23301,8 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
@@ -23854,8 +23355,12 @@
 "bCU" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/science/explab)
 "bCV" = (
@@ -23897,7 +23402,7 @@
 	dir = 4
 	},
 /obj/item/wrench,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "bDe" = (
@@ -23927,6 +23432,10 @@
 "bDj" = (
 /obj/item/trash/candy,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bDs" = (
@@ -23949,12 +23458,7 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "bDv" = (
@@ -24013,8 +23517,8 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/rd)
@@ -24053,8 +23557,10 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
 "bDH" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
 "bDI" = (
@@ -24101,10 +23607,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -24114,8 +23620,12 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/science/explab)
 "bDT" = (
@@ -24127,10 +23637,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -24148,10 +23655,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -24161,31 +23665,10 @@
 	dir = 10
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/science/mixing)
-"bEa" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
-	dir = 10
-	},
-/turf/open/floor/iron/white,
-/area/science/mixing)
-"bEb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
 /area/science/mixing)
 "bEc" = (
 /obj/machinery/atmospherics/components/binary/valve{
@@ -24202,18 +23685,14 @@
 	},
 /obj/machinery/meter,
 /obj/machinery/firealarm/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "bEf" = (
 /obj/item/storage/bag/ore,
 /obj/item/pickaxe,
 /obj/structure/closet/crate,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible/layer4{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "bEk" = (
@@ -24476,9 +23955,13 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
 "bEY" = (
@@ -24575,7 +24058,7 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "bFq" = (
@@ -24583,8 +24066,6 @@
 	req_access_txt = "12"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bFr" = (
@@ -24657,19 +24138,21 @@
 /turf/open/floor/iron/freezer,
 /area/medical/virology)
 "bFJ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/iron/white,
+/area/medical/cryo)
 "bFK" = (
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bFL" = (
@@ -24685,10 +24168,8 @@
 	dir = 9
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -24702,15 +24183,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/newscaster/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"bFT" = (
-/obj/effect/landmark/start/security_officer,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security)
 "bFU" = (
 /turf/closed/wall,
 /area/medical/surgery)
@@ -24734,9 +24209,13 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
 "bGd" = (
@@ -24782,7 +24261,9 @@
 	},
 /obj/machinery/firealarm/directional/east,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/engine,
 /area/science/storage)
 "bGj" = (
@@ -24948,7 +24429,7 @@
 /obj/machinery/computer/atmos_control/toxinsmix{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/mixing/chamber)
 "bGt" = (
@@ -24956,7 +24437,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "bGv" = (
@@ -24970,14 +24451,8 @@
 /area/science/mixing)
 "bGw" = (
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/door/airlock/research{
-	name = "Toxins Launch Room";
-	req_access_txt = "8"
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron,
 /area/science/mixing)
 "bGB" = (
@@ -25036,19 +24511,12 @@
 "bGO" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"bGS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
 "bGT" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -25142,8 +24610,12 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "bHs" = (
@@ -25260,6 +24732,7 @@
 /area/space/nearstation)
 "bHP" = (
 /obj/effect/decal/cleanable/cobweb,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/maintenance/department/engine)
 "bHQ" = (
@@ -25267,6 +24740,7 @@
 /area/maintenance/department/engine)
 "bHR" = (
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/maintenance/department/engine)
 "bHS" = (
@@ -25292,8 +24766,10 @@
 /obj/effect/turf_decal/trimline/blue/line,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bHY" = (
@@ -25366,11 +24842,9 @@
 	codes_txt = "patrol;next_patrol=Eng2";
 	location = "Eng"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
@@ -25382,11 +24856,9 @@
 	codes_txt = "patrol;next_patrol=Sci6";
 	location = "Eng3"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
@@ -25394,32 +24866,26 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "bIy" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron/freezer,
-/area/commons/toilet/restrooms)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "bIC" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Sci7";
 	location = "Sci6"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -25429,11 +24895,11 @@
 	codes_txt = "patrol;next_patrol=Eng";
 	location = "Sci5"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
@@ -25527,12 +24993,10 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/department/engine)
 "bJb" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "bJc" = (
 /obj/structure/chair/comfy/black,
 /obj/item/trash/pistachios,
@@ -25554,6 +25018,9 @@
 /area/maintenance/department/engine)
 "bJg" = (
 /obj/item/trash/popcorn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/maintenance/department/engine)
 "bJh" = (
@@ -25580,8 +25047,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/psychology)
 "bJD" = (
@@ -25648,7 +25117,9 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "bJM" = (
@@ -25672,8 +25143,12 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bJO" = (
@@ -25697,7 +25172,7 @@
 	pixel_x = -24
 	},
 /obj/machinery/atmospherics/components/binary/pump/on,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -25715,7 +25190,7 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
+/obj/machinery/atmospherics/pipe/bridge_pipe/supply/visible{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -25725,7 +25200,7 @@
 /obj/machinery/door/airlock/external{
 	req_access_txt = "8"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/plating,
 /area/science/mixing)
 "bJV" = (
@@ -25808,6 +25283,9 @@
 /area/maintenance/department/engine)
 "bKl" = (
 /obj/item/stack/medical/gauze,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/maintenance/department/engine)
 "bKm" = (
@@ -25883,10 +25361,10 @@
 	sortType = 27
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bKK" = (
@@ -25923,7 +25401,7 @@
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "bKR" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "bKS" = (
@@ -26028,23 +25506,14 @@
 	},
 /turf/open/floor/plating,
 /area/science/mixing)
-"bLp" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/dock)
 "bLq" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Monastery Transit"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -26126,26 +25595,8 @@
 /obj/structure/girder,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"bLJ" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "bLL" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -26375,7 +25826,7 @@
 /obj/machinery/door/airlock/external{
 	req_access_txt = "8"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/plating,
 /area/science/mixing)
 "bMq" = (
@@ -26429,6 +25880,9 @@
 /area/maintenance/department/engine)
 "bMC" = (
 /obj/item/stack/spacecash/c10,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/maintenance/department/engine)
 "bMD" = (
@@ -26448,6 +25902,7 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "bMM" = (
@@ -26490,24 +25945,18 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "bMW" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/rnd/production/circuit_imprinter,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "bMX" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/closed/wall/r_wall,
 /area/engineering/lobby)
 "bMY" = (
@@ -26784,15 +26233,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"bOa" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
 "bOc" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/tile/blue{
@@ -26820,18 +26260,18 @@
 /obj/structure/chair/stool,
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "bOe" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/rnd/production/protolathe/department/engineering,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "bOf" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/closed/wall/r_wall,
 /area/engineering/lobby)
 "bOg" = (
@@ -26853,6 +26293,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bOj" = (
@@ -26865,6 +26308,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bOk" = (
@@ -26875,6 +26321,9 @@
 /area/engineering/atmos)
 "bOn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bOo" = (
@@ -26883,6 +26332,9 @@
 	},
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Mix to Port"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -26972,10 +26424,8 @@
 "bOH" = (
 /obj/effect/landmark/blobstart,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -27104,20 +26554,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"bOZ" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"bPa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "bPb" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -27135,13 +26571,11 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/commons/storage/emergency/starboard)
 "bPe" = (
@@ -27216,8 +26650,10 @@
 	req_access_txt = "23"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
 "bPG" = (
@@ -27232,8 +26668,10 @@
 "bPH" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "bPI" = (
@@ -27283,7 +26721,9 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/west,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bPP" = (
@@ -27578,8 +27018,10 @@
 	codes_txt = "patrol;next_patrol=Eng3";
 	location = "Eng2"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "bQG" = (
@@ -27650,9 +27092,8 @@
 	dir = 8;
 	network = list("ss13","medbay")
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/iron/freezer,
 /area/medical/virology)
 "bQZ" = (
@@ -27662,9 +27103,6 @@
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "bRa" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/engineering/gravity_generator)
 "bRd" = (
@@ -27773,21 +27211,29 @@
 /obj/machinery/navbeacon/wayfinding/atmos,
 /obj/machinery/door/firedoor/heavy,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "bRs" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bRt" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "bRu" = (
 /obj/machinery/light{
 	dir = 4
@@ -27821,14 +27267,6 @@
 /area/engineering/atmos)
 "bRz" = (
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"bRA" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bRB" = (
@@ -27873,11 +27311,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
@@ -27885,11 +27321,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
@@ -27898,11 +27332,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
 	},
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
@@ -27916,11 +27348,9 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
@@ -27929,11 +27359,9 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
@@ -27941,10 +27369,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "bRO" = (
@@ -27960,11 +27388,9 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
@@ -27981,11 +27407,9 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
@@ -28002,11 +27426,9 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
@@ -28015,11 +27437,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
@@ -28030,11 +27450,9 @@
 	},
 /obj/machinery/navbeacon/wayfinding/techstorage,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
@@ -28047,6 +27465,7 @@
 "bSa" = (
 /obj/structure/table,
 /obj/item/toy/cards/deck,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "bSc" = (
@@ -28059,12 +27478,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bSd" = (
@@ -28076,9 +27490,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bSe" = (
@@ -28087,9 +27499,7 @@
 /area/engineering/atmos)
 "bSf" = (
 /obj/item/wrench,
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bSg" = (
@@ -28156,9 +27566,7 @@
 /area/medical/psychology)
 "bSt" = (
 /obj/machinery/meter/atmos/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bSu" = (
@@ -28217,10 +27625,10 @@
 /area/engineering/storage/tech)
 "bSF" = (
 /obj/item/beacon,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "bSG" = (
@@ -28280,7 +27688,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bSR" = (
@@ -28295,14 +27702,11 @@
 /area/engineering/atmos)
 "bSS" = (
 /obj/item/beacon,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bST" = (
 /obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bSU" = (
@@ -28366,7 +27770,6 @@
 /obj/machinery/atmospherics/components/binary/pump/on/layer2{
 	name = "Virology Waste to Space"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -28390,7 +27793,7 @@
 /area/maintenance/department/engine)
 "bTj" = (
 /obj/structure/bonfire,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bTk" = (
@@ -28456,8 +27859,10 @@
 /area/engineering/storage/tech)
 "bTu" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "bTv" = (
@@ -28604,8 +28009,10 @@
 	req_one_access_txt = "10;24"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "bTI" = (
@@ -28620,9 +28027,6 @@
 	dir = 6
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bTK" = (
@@ -28645,9 +28049,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bTO" = (
@@ -28659,9 +28060,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -28680,9 +28078,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bTQ" = (
@@ -28699,18 +28094,12 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bTR" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
 	name = "Port to Filter"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -28754,9 +28143,7 @@
 "bUb" = (
 /obj/structure/grille/broken,
 /obj/structure/musician/piano,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bUc" = (
@@ -28783,8 +28170,10 @@
 	name = "Secure Tech Storage";
 	req_access_txt = "19;23"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "bUh" = (
@@ -28847,8 +28236,10 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "bUn" = (
@@ -28876,22 +28267,16 @@
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "bUp" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bUq" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bUv" = (
@@ -29104,10 +28489,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "bUX" = (
@@ -29115,13 +28500,11 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "bUY" = (
@@ -29139,26 +28522,22 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "bUZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "bVa" = (
@@ -29166,10 +28545,8 @@
 	dir = 6
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/goonplaque,
@@ -29210,8 +28587,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bVf" = (
@@ -29259,9 +28636,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bVu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bVv" = (
@@ -29433,7 +28808,9 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "bVP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "bVQ" = (
@@ -29457,11 +28834,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/break_room)
@@ -29469,16 +28844,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "bVV" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Waste to Space"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bVY" = (
@@ -29508,6 +28881,13 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"bWd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/engine)
 "bWe" = (
 /obj/machinery/air_sensor/atmos/carbon_tank,
 /turf/open/floor/engine/co2,
@@ -29660,14 +29040,18 @@
 "bWx" = (
 /obj/effect/landmark/start/station_engineer,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
 "bWy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
@@ -29755,8 +29139,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "bWG" = (
@@ -29769,8 +29155,8 @@
 /area/engineering/break_room)
 "bWI" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bWJ" = (
@@ -29813,6 +29199,10 @@
 /turf/closed/wall,
 /area/service/chapel/main/monastery)
 "bWZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -29858,6 +29248,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "bXj" = (
@@ -29898,7 +29289,10 @@
 /area/engineering/engine_smes)
 "bXn" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
 "bXo" = (
@@ -29922,8 +29316,10 @@
 	req_one_access_txt = "10;24"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "bXr" = (
@@ -29932,8 +29328,8 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bXs" = (
@@ -30056,7 +29452,8 @@
 /area/service/chapel/asteroid/monastery)
 "bXU" = (
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/plating{
@@ -30067,7 +29464,8 @@
 /obj/item/shard{
 	icon_state = "small"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -30088,6 +29486,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "bYb" = (
@@ -30122,15 +29521,12 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/engineering/engine_smes)
-"bYi" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/security/brig)
+/turf/open/floor/iron/dark,
+/area/engineering/engine_smes)
 "bYj" = (
 /obj/machinery/vending/engivend,
 /turf/open/floor/iron/dark,
@@ -30155,8 +29551,10 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/main)
 "bYq" = (
@@ -30243,6 +29641,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/main)
 "bYL" = (
@@ -30257,6 +29659,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/main)
 "bYN" = (
@@ -30277,6 +29683,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/main)
 "bYR" = (
@@ -30294,6 +29704,10 @@
 	},
 /obj/structure/cable,
 /obj/machinery/newscaster/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/main)
 "bYV" = (
@@ -30302,6 +29716,10 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
@@ -30316,6 +29734,10 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -30335,6 +29757,10 @@
 	},
 /obj/machinery/airalarm/directional/north,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/main)
 "bYY" = (
@@ -30351,6 +29777,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/main)
 "bYZ" = (
@@ -30359,6 +29789,10 @@
 	sortType = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/main)
 "bZa" = (
@@ -30366,16 +29800,12 @@
 	dir = 9
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/main)
-"bZb" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "bZc" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hazardvest,
@@ -30465,21 +29895,11 @@
 "bZE" = (
 /obj/machinery/holopad,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/engineering/main)
 "bZG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
@@ -30500,7 +29920,7 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
 /turf/open/floor/plating/airless,
 /area/engineering/atmos)
 "bZL" = (
@@ -30574,8 +29994,9 @@
 /area/maintenance/department/engine)
 "cad" = (
 /obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
@@ -30596,10 +30017,11 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "caj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/cargo/office)
+/area/command/heads_quarters/ce)
 "cak" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -30662,7 +30084,6 @@
 /area/engineering/main)
 "caw" = (
 /obj/structure/table,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
 "cax" = (
@@ -30752,14 +30173,14 @@
 "caV" = (
 /obj/machinery/holopad,
 /obj/item/flashlight/lantern,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/chapel,
 /area/service/chapel/main/monastery)
 "caW" = (
 /obj/item/flashlight/lantern,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/chapel{
@@ -30793,11 +30214,8 @@
 	layer = 2.9
 	},
 /obj/structure/table/glass,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
@@ -30808,11 +30226,8 @@
 	},
 /obj/item/book/manual/wiki/engineering_construction,
 /obj/structure/table/glass,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
@@ -30823,22 +30238,14 @@
 	},
 /obj/item/book/manual/wiki/engineering_guide,
 /obj/structure/table/glass,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
 "cbh" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
 "cbi" = (
@@ -30869,7 +30276,6 @@
 "cbn" = (
 /obj/structure/table,
 /obj/item/storage/belt/utility,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
 "cbo" = (
@@ -30951,8 +30357,12 @@
 	pixel_y = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/carpet,
 /area/service/chapel/main/monastery)
 "cbP" = (
@@ -30965,9 +30375,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "cbS" = (
@@ -31082,7 +30490,6 @@
 /obj/item/storage/toolbox/mechanical{
 	pixel_x = -2
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
 "cck" = (
@@ -31122,11 +30529,11 @@
 "ccF" = (
 /obj/effect/landmark/start/chaplain,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/carpet,
 /area/service/chapel/main/monastery)
@@ -31307,8 +30714,10 @@
 "cdP" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "cdQ" = (
@@ -31414,10 +30823,10 @@
 	},
 /obj/effect/turf_decal/sand,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -31425,10 +30834,10 @@
 "cef" = (
 /obj/effect/turf_decal/sand,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -31443,10 +30852,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -31589,9 +30998,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "cfg" = (
@@ -31601,9 +31008,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "cfl" = (
@@ -31626,6 +31031,15 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/transit_tube)
+"cft" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/science/xenobiology)
 "cfu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -31707,9 +31121,7 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "cfU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "cfV" = (
@@ -31733,9 +31145,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "cgb" = (
@@ -31788,8 +31200,8 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "cgw" = (
@@ -31805,9 +31217,11 @@
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "cgF" = (
@@ -31923,11 +31337,11 @@
 /area/service/chapel/main/monastery)
 "chd" = (
 /obj/item/clothing/suit/apron/chef,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/service/chapel/main/monastery)
@@ -31951,10 +31365,10 @@
 	id_tag = "Cell1";
 	name = "Cell 1"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/grimy,
@@ -31963,17 +31377,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/grimy,
 /area/service/chapel/main/monastery)
-"chs" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "cht" = (
 /obj/machinery/door/airlock{
 	name = "Bathroom"
@@ -32008,9 +31416,7 @@
 /area/service/library)
 "chA" = (
 /obj/effect/turf_decal/stripes/corner,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "chB" = (
@@ -32153,8 +31559,8 @@
 /turf/open/floor/iron/showroomfloor,
 /area/service/chapel/main/monastery)
 "cis" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /obj/effect/landmark/xeno_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "cit" = (
@@ -32182,18 +31588,14 @@
 	id_tag = "Cell2";
 	name = "Cell 2"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/grimy,
 /area/service/chapel/main/monastery)
-"ciG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
-/turf/open/floor/engine,
-/area/engineering/supermatter/room)
 "ciH" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/engineering/glass/critical{
@@ -32203,10 +31605,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)
-"ciI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/orange/visible,
-/turf/open/floor/engine,
-/area/engineering/supermatter/room)
 "ciJ" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/cobweb,
@@ -32285,10 +31683,10 @@
 	name = "Monastery Cemetary"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -32319,9 +31717,7 @@
 /area/service/hydroponics/garden/monastery)
 "cjt" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold/orange/visible{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "cju" = (
@@ -32368,10 +31764,10 @@
 	name = "Chapel Garden"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -32385,13 +31781,15 @@
 	amount = 20;
 	layer = 3.1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/chapel/monastery)
 "cjQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/carpet,
 /area/service/library)
 "cjV" = (
@@ -32518,8 +31916,8 @@
 /area/service/chapel/main/monastery)
 "ckO" = (
 /obj/structure/closet/emcloset,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/chapel/monastery)
@@ -32561,13 +31959,6 @@
 /obj/structure/bookcase/random/fiction,
 /turf/open/floor/iron/dark,
 /area/service/library/lounge)
-"ckZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
 "clb" = (
 /obj/machinery/door/poddoor/massdriver_chapel,
 /turf/open/floor/plating,
@@ -32577,7 +31968,7 @@
 	dir = 1
 	},
 /obj/item/storage/box/lights/bulbs,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -32722,7 +32113,6 @@
 "clU" = (
 /obj/item/wrench,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "clV" = (
@@ -32732,39 +32122,18 @@
 /area/tcommsat/computer)
 "clY" = (
 /obj/item/beacon,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "cma" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/tcommsat/computer)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/command/heads_quarters/ce)
 "cmb" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "cmc" = (
 /obj/item/stack/cable_coil,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "cmf" = (
@@ -32782,9 +32151,6 @@
 	},
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "cmg" = (
@@ -32802,9 +32168,6 @@
 	pixel_y = 30
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "cmh" = (
@@ -32814,8 +32177,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "cmj" = (
@@ -32830,12 +32191,6 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "cml" = (
@@ -32884,9 +32239,6 @@
 /obj/structure/chair/office,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
 	},
 /turf/open/floor/iron,
 /area/tcommsat/computer)
@@ -33266,11 +32618,15 @@
 /turf/open/floor/iron/showroomfloor,
 /area/security)
 "cnX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/command/heads_quarters/ce)
 "cod" = (
 /obj/structure/table,
 /obj/item/clothing/under/color/grey,
@@ -33301,14 +32657,6 @@
 "com" = (
 /turf/open/floor/iron,
 /area/commons/dorms)
-"con" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/commons/dorms)
 "cop" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock{
@@ -33317,8 +32665,10 @@
 /obj/machinery/navbeacon/wayfinding/dorms,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/commons/dorms)
 "cor" = (
@@ -33340,8 +32690,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -33358,11 +32706,9 @@
 /area/hallway/primary/central)
 "coF" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -33374,11 +32720,9 @@
 /area/maintenance/department/security/brig)
 "coH" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -33397,6 +32741,13 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"coP" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "coV" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron/dark,
@@ -33439,54 +32790,41 @@
 /area/service/bar)
 "cpf" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/science/explab)
 "cpg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /turf/open/floor/iron/dark,
 /area/service/bar/atrium)
-"cpj" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "cpk" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4;
 	sortType = 19
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/structure/chair/stool/bar/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/iron/dark,
 /area/service/bar/atrium)
 "cpl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "cpm" = (
@@ -33589,11 +32927,11 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "L1"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -33601,11 +32939,11 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "L3"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -33613,11 +32951,11 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "L5"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -33625,10 +32963,10 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "L9"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -33637,10 +32975,10 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "L11"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -33649,10 +32987,10 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "L13"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -33716,6 +33054,10 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "cpZ" = (
@@ -33732,16 +33074,18 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "cqc" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -33759,11 +33103,9 @@
 	codes_txt = "patrol;next_patrol=Med";
 	location = "Sci9"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
@@ -33875,7 +33217,13 @@
 /area/service/chapel/dock)
 "cqI" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/start/shaft_miner,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "cqS" = (
@@ -33923,12 +33271,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "cre" = (
@@ -34149,8 +33492,12 @@
 	dir = 6
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "csv" = (
@@ -34202,10 +33549,10 @@
 	},
 /obj/effect/turf_decal/sand,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -34232,6 +33579,15 @@
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
+"ctd" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "cth" = (
 /obj/structure/table/wood/fancy,
 /obj/item/storage/fancy/candle_box,
@@ -34253,8 +33609,8 @@
 /area/service/chapel/office)
 "ctF" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "ctJ" = (
@@ -34396,7 +33752,9 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
 "cuw" = (
@@ -34449,7 +33807,9 @@
 /area/service/chapel/main/monastery)
 "cuJ" = (
 /obj/item/shovel/spade,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/service/chapel/main/monastery)
 "cuK" = (
@@ -34501,10 +33861,10 @@
 	name = "Kitchen"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -34514,10 +33874,10 @@
 	name = "Dining Room"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -34531,7 +33891,7 @@
 /area/service/chapel/main/monastery)
 "cuZ" = (
 /obj/item/wrench,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -34623,15 +33983,15 @@
 /area/service/chapel/main/monastery)
 "cvy" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/power/apc/highcap/five_k{
 	name = "Chapel APC";
 	pixel_y = -26
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
@@ -34687,8 +34047,12 @@
 	req_one_access_txt = "22;24;10;11;37"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/chapel/monastery)
 "cwe" = (
@@ -34699,7 +34063,9 @@
 	name = "Library"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/service/library/lounge)
 "cwj" = (
@@ -34722,8 +34088,8 @@
 "cwm" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/chapel/monastery)
@@ -34733,7 +34099,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -34864,10 +34230,10 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
 "cxq" = (
@@ -34885,27 +34251,21 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"cxu" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "cxC" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/service/library/lounge)
 "cxD" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/service/library/lounge)
 "cxJ" = (
@@ -34929,7 +34289,9 @@
 	dir = 4;
 	network = list("ss13","monastery")
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/service/library/lounge)
 "cxY" = (
@@ -34940,15 +34302,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/service/library/lounge)
-"cyi" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/cargo/sorting)
+/turf/open/floor/iron/dark,
+/area/service/library/lounge)
 "cyl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -34956,7 +34314,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/service/library/lounge)
 "cym" = (
@@ -34964,7 +34324,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -34973,8 +34333,10 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/service/library/lounge)
 "cyA" = (
@@ -34982,7 +34344,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/service/library/lounge)
 "cyB" = (
@@ -35097,10 +34461,10 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron,
 /area/security/brig)
 "czB" = (
@@ -35383,10 +34747,8 @@
 	pixel_y = 27
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -35401,10 +34763,8 @@
 	pixel_y = 27
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -35412,11 +34772,9 @@
 "cBA" = (
 /obj/structure/grille/broken,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
@@ -35426,8 +34784,10 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -35439,8 +34799,7 @@
 	req_one_access_txt = ""
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "cBM" = (
@@ -35489,9 +34848,6 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /turf/open/floor/iron/white{
 	heat_capacity = 1e+006
 	},
@@ -35540,11 +34896,15 @@
 "cDa" = (
 /turf/closed/wall,
 /area/cargo/warehouse)
+"cDw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/closed/wall/r_wall,
+/area/engineering/lobby)
 "cDy" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "cDB" = (
@@ -35569,8 +34929,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "cFX" = (
@@ -35604,11 +34967,6 @@
 /obj/item/reagent_containers/pill/morphine,
 /turf/open/floor/iron/dark,
 /area/medical/abandoned)
-"cIn" = (
-/obj/effect/landmark/start/security_officer,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden/layer4,
-/turf/open/floor/iron,
-/area/security)
 "cIt" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor6"
@@ -35622,15 +34980,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/cargo)
-"cJv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "cKA" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -35672,19 +35021,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/maintenance/disposal)
-"cND" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "cOv" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
@@ -35745,11 +35081,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/science/explab)
@@ -35779,7 +35115,9 @@
 /area/maintenance/solars/port)
 "cRE" = (
 /obj/structure/chair/wood,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
 "cSf" = (
@@ -35813,24 +35151,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/lab)
-"cTq" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/carpet,
-/area/service/library/artgallery)
 "cTr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
-"cTx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/grimy,
-/area/command/heads_quarters/captain)
 "cTC" = (
 /obj/machinery/door/airlock/security{
 	name = "Equipment Room";
@@ -35838,9 +35163,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron,
 /area/security)
 "cUb" = (
@@ -35848,45 +35171,10 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
-"cUj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/ai_sat_ext_ap)
-"cXx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/service/kitchen/coldroom)
-"cZm" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/security/execution/transfer)
 "daO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
-"daV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "dbI" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -35916,12 +35204,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security)
-"dcx" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/medical/cryo)
 "dcL" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
@@ -35959,7 +35241,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "dgz" = (
@@ -35969,21 +35251,19 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "dgI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "dha" = (
@@ -35994,31 +35274,32 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/science/explab)
-"diu" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/science/explab)
+"dhy" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/engineering/main)
+/area/hallway/primary/central)
 "diw" = (
 /obj/machinery/light{
 	light_color = "#e8eaff"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/item/radio/intercom/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "diM" = (
@@ -36033,12 +35314,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "djD" = (
@@ -36066,11 +35342,12 @@
 /turf/open/floor/iron/white,
 /area/medical/psychology)
 "dma" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "dmI" = (
@@ -36093,22 +35370,15 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"dnd" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/command/heads_quarters/captain)
-"dnE" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/engineering/main)
 "dok" = (
 /obj/effect/turf_decal/trimline/green/line{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "doo" = (
@@ -36148,21 +35418,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
-"dpo" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/engineering/main)
 "dpA" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"dqj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/closed/wall,
-/area/maintenance/department/engine)
 "dqw" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -36173,8 +35436,12 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/science/genetics)
 "dqG" = (
@@ -36192,22 +35459,18 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse)
-"drJ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
 "drR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
+"dsm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/cargo/sorting)
 "dsv" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -36220,7 +35483,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
 "dsR" = (
@@ -36240,12 +35503,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron,
 /area/security/brig)
 "duu" = (
@@ -36294,12 +35555,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/asteroid,
 /area/service/chapel/asteroid/monastery)
-"dwj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/science/mixing)
 "dxo" = (
 /obj/machinery/igniter/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
@@ -36323,12 +35578,6 @@
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"dyt" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/engine,
-/area/science/storage)
 "dAF" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external,
@@ -36336,9 +35585,7 @@
 /area/science/mixing)
 "dAG" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -36358,21 +35605,7 @@
 /area/maintenance/disposal)
 "dBC" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
-"dBN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "dBQ" = (
@@ -36404,15 +35637,11 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/service/library/lounge)
-"dEB" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "dES" = (
 /obj/structure/flora/grass/jungle,
 /mob/living/simple_animal/pet/dog/corgi,
@@ -36428,13 +35657,15 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/service/library/lounge)
 "dGd" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
 "dGH" = (
@@ -36451,8 +35682,12 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/explab)
 "dGO" = (
@@ -36461,48 +35696,15 @@
 	},
 /turf/open/floor/wood,
 /area/service/bar)
-"dGQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
 "dGY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/security/prison)
-"dHa" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ai_monitored/command/storage/eva)
 "dHc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /turf/open/floor/plating,
 /area/engineering/atmos)
-"dHN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
-"dIl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/service/lawoffice)
 "dJm" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Research Pit";
@@ -36511,8 +35713,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "dJP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/security)
@@ -36562,9 +35764,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "dNr" = (
@@ -36585,8 +35785,10 @@
 	req_access_txt = "5"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "dPO" = (
@@ -36594,39 +35796,23 @@
 	dir = 9
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"dPX" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/commons/storage/primary)
 "dQg" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/chapel/dock)
-"dQm" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
 "dQq" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "dQr" = (
@@ -36636,9 +35822,7 @@
 /area/service/abandoned_gambling_den)
 "dRB" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/hidden/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible/layer2,
 /turf/open/floor/plating/airless,
 /area/maintenance/department/engine)
 "dRU" = (
@@ -36691,16 +35875,6 @@
 /obj/item/hemostat,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"dTg" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/iron/white,
-/area/medical/cryo)
 "dTR" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -36709,23 +35883,15 @@
 "dTT" = (
 /turf/open/floor/iron,
 /area/cargo/office)
-"dTV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
 "dUh" = (
 /obj/effect/turf_decal/sand,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/service/chapel/asteroid/monastery)
 "dUZ" = (
@@ -36749,15 +35915,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/sorting)
-"dVU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "dWk" = (
 /obj/item/food/meat/slab/monkey,
 /turf/open/floor/plating,
@@ -36772,24 +35929,21 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/cargo/warehouse/upper)
 "dWO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"dXR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/science/mixing)
 "dXU" = (
 /obj/machinery/light{
 	dir = 1
@@ -36804,33 +35958,13 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
-"dZh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen)
 "dZj" = (
 /obj/machinery/atmospherics/components/binary/pump,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"eaw" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
 "eaB" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -36849,12 +35983,6 @@
 /obj/structure/table,
 /turf/open/floor/iron,
 /area/engineering/break_room)
-"eaM" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "ebp" = (
 /obj/structure/sign/plaques/kiddie{
 	desc = "It reads: PRIVATE EXHIBIT -  Please inquire with library staff for guided tours.";
@@ -36879,45 +36007,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"ecs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"ecv" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"ecB" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/engineering/main)
 "ecR" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/cargo/warehouse/upper)
-"ecX" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/main)
+/area/cargo/warehouse/upper)
 "edl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -36966,12 +36065,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
-"efJ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "efU" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -36983,16 +36076,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/security/brig)
-"ehe" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/science/explab)
 "ehr" = (
 /obj/structure/table/glass,
 /obj/item/clothing/gloves/color/latex,
@@ -37036,22 +36119,19 @@
 /area/hallway/secondary/entry)
 "ejp" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse/upper)
-"ekI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+"ekB" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/iron/showroomfloor,
-/area/service/kitchen/coldroom)
-"ekM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/general/visible,
-/turf/open/floor/iron/dark,
-/area/science/xenobiology)
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "ekU" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/loot_site_spawner,
@@ -37083,17 +36163,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
-"elJ" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/ai_upload)
 "ema" = (
 /obj/structure/plasticflaps/opaque,
 /turf/open/floor/plating,
@@ -37108,22 +36177,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
-"emJ" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/chemistry)
 "emV" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -37143,25 +36196,10 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"eoQ" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/command/glass{
-	name = "Bridge";
-	req_access_txt = "19"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/command/bridge)
 "eoS" = (
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
-"epl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "epJ" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
@@ -37187,12 +36225,6 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"eqy" = (
-/obj/effect/turf_decal/trimline/blue/line,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "eqD" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -32
@@ -37237,14 +36269,25 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"esM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "eta" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Supplies";
@@ -37256,11 +36299,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage_shared)
@@ -37280,8 +36321,10 @@
 "euT" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "evg" = (
@@ -37299,24 +36342,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "eyL" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"eyY" = (
-/obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/department/engine)
 "ezk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37350,11 +36383,24 @@
 /obj/item/pen/red,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"eAI" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white/corner,
+/area/hallway/secondary/exit/departure_lounge)
 "eAP" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/dock)
 "eBf" = (
@@ -37377,19 +36423,13 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
-"eBO" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "eCB" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -37412,16 +36452,6 @@
 /obj/machinery/suit_storage_unit/engine,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
-"eEc" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/iron/dark,
-/area/command/bridge)
 "eER" = (
 /obj/machinery/light{
 	dir = 8
@@ -37443,7 +36473,6 @@
 	pixel_x = -25
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
 "eFj" = (
@@ -37458,28 +36487,31 @@
 	sortType = 10
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
-"eFz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "eGT" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 9
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
+"eHl" = (
+/obj/item/wrench,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
+"eHq" = (
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "eHY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
@@ -37506,79 +36538,35 @@
 /area/cargo/storage)
 "eJq" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
-"eJt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/security)
-"eKx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/main)
+/area/hallway/primary/central)
 "eKI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "eKY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"eLo" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/science/robotics)
 "eLt" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"eMg" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/commons/dorms)
 "eNo" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 9
@@ -37599,6 +36587,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -37623,15 +36616,19 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "eOJ" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
@@ -37659,8 +36656,12 @@
 "eQZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -37671,12 +36672,12 @@
 /area/science/explab)
 "eSW" = (
 /obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
 "eTt" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
 /turf/open/space,
 /area/space/nearstation)
 "eTw" = (
@@ -37703,16 +36704,18 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal)
 "eTW" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/security/prison)
 "eUa" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/machinery/requests_console/directional/south{
+	department = "Mining";
+	departmentType = 2;
+	name = "Mining Bay Requests Console"
+	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "eUb" = (
@@ -37742,9 +36745,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/iron/dark,
 /area/science/server)
 "eVy" = (
@@ -37768,8 +36769,6 @@
 /area/engineering/storage_shared)
 "eXo" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/science/explab)
 "eXv" = (
@@ -37782,7 +36781,9 @@
 "eXy" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/service/library/lounge)
 "eYd" = (
@@ -37825,9 +36826,11 @@
 "eZj" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "eZv" = (
@@ -37840,6 +36843,19 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"eZE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ai_monitored/command/storage/eva)
+"eZJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "eZM" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay Storage";
@@ -37850,32 +36866,19 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/medical/storage)
-"eZX" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "faA" = (
 /obj/effect/landmark/blobstart,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -37908,15 +36911,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/abandoned)
-"fbz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "fbC" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -37934,18 +36928,6 @@
 /obj/structure/closet/radiation,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
-"fct" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/cargo/office)
-"fcJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/ai_monitored/command/storage/eva)
 "fcK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -37967,8 +36949,12 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
 "fdN" = (
@@ -38013,9 +36999,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "fei" = (
@@ -38040,12 +37023,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"feS" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/medical/psychology)
 "feU" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/o2{
@@ -38066,16 +37043,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/storage)
-"ffx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "ffJ" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -38129,9 +37096,8 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/item/radio/intercom/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "fhE" = (
@@ -38159,6 +37125,7 @@
 	},
 /obj/structure/cable,
 /obj/item/radio/intercom/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "fhM" = (
@@ -38166,11 +37133,11 @@
 	pixel_x = -22
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
@@ -38205,6 +37172,18 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark,
 /area/science/explab)
+"fkQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "flQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38254,8 +37233,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
@@ -38265,12 +37244,18 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"fpG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+"frb" = (
+/obj/structure/window/reinforced,
+/obj/structure/rack,
+/obj/item/circuitboard/machine/exoscanner{
+	pixel_y = 3
 	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/dock)
+/obj/item/circuitboard/machine/exoscanner,
+/obj/item/circuitboard/machine/exoscanner{
+	pixel_y = -3
+	},
+/turf/open/floor/iron,
+/area/cargo/warehouse/upper)
 "frn" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -38298,10 +37283,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "fsO" = (
@@ -38314,7 +37297,7 @@
 /area/maintenance/disposal/incinerator)
 "ftb" = (
 /obj/effect/turf_decal/stripes/corner,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "ftp" = (
@@ -38326,11 +37309,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
@@ -38347,12 +37328,6 @@
 	},
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "ftY" = (
@@ -38380,30 +37355,17 @@
 "fvq" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"fvN" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "fwe" = (
 /obj/machinery/firealarm/directional/west,
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron/dark,
 /area/science/server)
 "fwg" = (
@@ -38414,7 +37376,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "fwi" = (
@@ -38425,7 +37391,7 @@
 	c_tag = "Engineering Supermatter Port Fore";
 	network = list("ss13","engine")
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -38450,11 +37416,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
+"fyK" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "fyO" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
 "fzu" = (
@@ -38484,6 +37457,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"fAU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/turf/closed/wall,
+/area/maintenance/department/engine)
 "fBp" = (
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
@@ -38503,28 +37481,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/mixing)
-"fBJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
-/turf/open/space/basic,
-/area/space)
 "fCX" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
-"fDa" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
 "fDf" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -38542,12 +37506,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"fEL" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "fER" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -38572,8 +37530,12 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "fFL" = (
@@ -38581,10 +37543,8 @@
 /turf/open/floor/plating,
 /area/commons/storage/emergency/starboard)
 "fGa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 6
-	},
 /turf/open/floor/iron/dark,
 /area/science/server)
 "fGd" = (
@@ -38592,20 +37552,14 @@
 	dir = 9
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"fGt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/service/library/lounge)
 "fGz" = (
 /obj/machinery/door/airlock/medical{
 	name = "Surgical Theatres";
@@ -38616,24 +37570,14 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
-"fHB" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "fIA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "fIH" = (
@@ -38659,16 +37603,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/security/prison)
-"fJv" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
-/area/service/kitchen/coldroom)
 "fJw" = (
 /obj/machinery/shower{
 	dir = 8
@@ -38680,24 +37614,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"fJy" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/command/heads_quarters/captain)
-"fJT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
-"fJY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen)
 "fKj" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Mineral Room"
@@ -38705,21 +37621,6 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"fKI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/service/library/artgallery)
-"fKK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/ai_monitored/command/storage/eva)
 "fLG" = (
 /obj/effect/decal/remains/xeno,
 /turf/open/floor/plating,
@@ -38744,24 +37645,22 @@
 	},
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
+"fMk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen)
 "fMm" = (
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/closed/wall,
 /area/space/nearstation)
 "fMw" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"fMR" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "fNg" = (
 /turf/open/floor/plating,
 /area/service/abandoned_gambling_den)
@@ -38801,6 +37700,16 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/plating/asteroid,
 /area/service/chapel/asteroid/monastery)
+"fOw" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "fQd" = (
 /obj/machinery/conveyor{
 	id = "CargoLoad"
@@ -38818,13 +37727,13 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/cargo/miningdock)
 "fQN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -38832,15 +37741,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/security)
-"fQS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "fRs" = (
 /turf/closed/wall,
 /area/command/heads_quarters/rd)
@@ -38849,23 +37749,17 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "fSx" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"fSz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
 "fTp" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/ai_monitored/turret_protected/ai)
 "fTY" = (
@@ -38886,24 +37780,6 @@
 /obj/machinery/navbeacon/wayfinding/dockarrival,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"fUl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/main)
-"fUy" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
 "fUA" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -38937,16 +37813,14 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"fYg" = (
+"fXu" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/service/hydroponics)
 "fYY" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -38956,13 +37830,14 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"fZP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
+"fZv" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "fZV" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/blue,
@@ -38986,13 +37861,11 @@
 	name = "kitchen shutters"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/service/kitchen)
 "gbu" = (
@@ -39003,11 +37876,8 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"gbA" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+"gbz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "gbK" = (
@@ -39028,12 +37898,18 @@
 	dir = 9
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "gda" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
 "gdJ" = (
@@ -39059,9 +37935,7 @@
 /area/hallway/primary/central)
 "geP" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "gfi" = (
@@ -39072,7 +37946,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "gfB" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/general/visible,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
 "gfC" = (
@@ -39102,8 +37976,8 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "ggW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/effect/spawner/structure/window,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /turf/open/floor/plating,
 /area/medical/virology)
 "ghx" = (
@@ -39116,13 +37990,6 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"giF" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/commons/fitness/recreation)
 "giI" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -39150,11 +38017,11 @@
 	dir = 9
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
@@ -39185,12 +38052,6 @@
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
-"gkD" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/service/library/artgallery)
 "gkQ" = (
 /obj/structure/table/wood,
 /turf/open/floor/iron/dark,
@@ -39229,6 +38090,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "glf" = (
@@ -39236,23 +38098,15 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
-"glx" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
+"gmE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/department/security/brig)
+/turf/open/floor/plating,
+/area/cargo/warehouse/upper)
 "gmO" = (
 /obj/structure/chair{
 	dir = 1
@@ -39276,20 +38130,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
-"goz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
-"goJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/dock)
 "gpu" = (
 /obj/structure/sign/directions/medical{
 	pixel_x = 32;
@@ -39313,24 +38153,6 @@
 	heat_capacity = 1e+006
 	},
 /area/hallway/secondary/exit/departure_lounge)
-"gqS" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/prison)
-"gsr" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/command/bridge)
 "gsB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39343,17 +38165,6 @@
 /mob/living/simple_animal/pet/dog/corgi,
 /turf/open/floor/grass,
 /area/medical/psychology)
-"gtk" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "gtl" = (
 /obj/item/toy/crayon/black,
 /obj/item/toy/crayon/white{
@@ -39371,8 +38182,10 @@
 "gtn" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "gue" = (
@@ -39380,11 +38193,11 @@
 	dir = 6
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
@@ -39412,15 +38225,13 @@
 	heat_capacity = 1e+006
 	},
 /area/commons/fitness/recreation)
-"guZ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "gvf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron{
 	heat_capacity = 1e+006
 	},
@@ -39447,11 +38258,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"gwt" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/chemistry)
 "gxe" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -32
@@ -39470,16 +38276,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"gxV" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
 "gyj" = (
 /obj/structure/sink{
 	dir = 4;
@@ -39499,6 +38295,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
+"gzf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/main)
 "gzy" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
@@ -39518,24 +38320,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"gzU" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/wood,
-/area/service/lawoffice)
 "gAG" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -39543,13 +38330,11 @@
 /area/service/lawoffice)
 "gAV" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/commons/storage/emergency/starboard)
 "gAY" = (
@@ -39623,16 +38408,6 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/storage)
-"gDZ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/science/explab)
 "gEh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -39654,6 +38429,13 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"gEZ" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "gFf" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -39729,13 +38511,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "gHR" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "gIC" = (
@@ -39760,10 +38540,10 @@
 /area/science/xenobiology)
 "gJN" = (
 /obj/structure/chair/wood,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -39789,17 +38569,17 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "gLn" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -39815,8 +38595,11 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "gMA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "gMG" = (
@@ -39862,9 +38645,11 @@
 /area/science/genetics)
 "gQa" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -39888,24 +38673,14 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"gRh" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
 "gRJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
@@ -39939,8 +38714,10 @@
 	dir = 6
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "gVc" = (
@@ -39950,8 +38727,12 @@
 /area/maintenance/department/engine)
 "gVk" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "gVy" = (
@@ -40006,24 +38787,12 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/sorting)
-"gZq" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/carpet,
-/area/service/chapel/main/monastery)
 "gZx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -40036,9 +38805,9 @@
 "hae" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron{
 	heat_capacity = 1e+006
@@ -40053,35 +38822,25 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)
-"hdh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "hdk" = (
 /obj/structure/flora/junglebush,
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/grass,
 /area/medical/psychology)
 "hdB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "hdK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "hfi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "hfC" = (
@@ -40092,17 +38851,21 @@
 "hfX" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "hfZ" = (
 /obj/machinery/vending/wardrobe/gene_wardrobe,
 /turf/open/floor/iron/dark,
+/area/science/genetics)
+"hgf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/science/genetics)
 "hgV" = (
 /turf/open/floor/iron,
@@ -40112,14 +38875,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
-"hia" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/commons/storage/primary)
 "hiw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -40159,10 +38914,10 @@
 /area/hallway/primary/aft)
 "hju" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "hjy" = (
@@ -40198,14 +38953,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"hko" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "hkQ" = (
 /obj/machinery/light{
 	dir = 4
@@ -40221,8 +38968,12 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "hmv" = (
@@ -40250,7 +39001,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -40263,20 +39014,18 @@
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
 "hnY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /turf/open/floor/plating,
 /area/medical/virology)
-"hoN" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
+"hol" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/commons/storage/primary)
+/turf/open/floor/iron/white,
+/area/engineering/gravity_generator)
 "hoP" = (
 /obj/structure/chair/wood,
 /obj/effect/landmark/start/hangover,
@@ -40292,16 +39041,18 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "hqc" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/chapel/monastery)
 "hqo" = (
@@ -40320,14 +39071,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"hsw" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
 "htK" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
@@ -40358,9 +39101,7 @@
 /area/cargo/storage)
 "hvS" = (
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "hvW" = (
@@ -40400,15 +39141,42 @@
 "hwx" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "hwY" = (
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
+"hxp" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/science/storage)
+"hxx" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "hxB" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -40423,10 +39191,6 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/service/theater)
-"hyf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "hzc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -40446,15 +39210,19 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
 "hAF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
-"hAL" = (
+"hBf" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/science/explab)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "hBn" = (
 /obj/structure/table/glass,
 /obj/item/folder/white,
@@ -40492,11 +39260,11 @@
 /area/engineering/atmos)
 "hCj" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/dock)
@@ -40506,37 +39274,22 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "hCS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
-"hCZ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
-"hDu" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/cargo/office)
+/turf/open/floor/wood,
+/area/service/abandoned_gambling_den)
 "hDG" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Auxiliary Base Construction";
 	req_one_access_txt = "32;47;48"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "hDQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/grimy,
@@ -40555,8 +39308,8 @@
 /turf/closed/wall,
 /area/medical/abandoned)
 "hEX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
@@ -40579,30 +39332,49 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "hFV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/cargo/office)
 "hGq" = (
 /obj/machinery/firealarm/directional/east,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "hGQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
+"hHp" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/engine)
 "hHr" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"hHw" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "misclab";
+	name = "test chamber blast door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "hHG" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
@@ -40618,31 +39390,15 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
 "hID" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/iron/freezer,
 /area/medical/virology)
-"hIF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/commons/dorms)
 "hIQ" = (
 /obj/machinery/light,
 /obj/machinery/airalarm/directional/south,
@@ -40668,6 +39424,16 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
+"hJV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen)
 "hKU" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark/telecomms,
@@ -40712,23 +39478,9 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"hMY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
 "hNd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40737,10 +39489,7 @@
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "hNB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
@@ -40754,15 +39503,6 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark,
 /area/command/gateway)
-"hPg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
 "hPG" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -40813,12 +39553,7 @@
 	sortType = 11
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "hQz" = (
@@ -40829,9 +39564,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "hQV" = (
@@ -40861,6 +39594,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"hRQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/rd)
 "hSM" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -40870,16 +39609,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"hSP" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "hTl" = (
 /obj/structure/sink{
 	dir = 8;
@@ -40913,7 +39642,7 @@
 /area/service/chapel/main/monastery)
 "hUx" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -40935,6 +39664,15 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"hVJ" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "hVW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -40957,25 +39695,12 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron,
 /area/security/brig)
-"hWI" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/iron/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/entry)
 "hXt" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
@@ -40988,15 +39713,6 @@
 "hXW" = (
 /turf/closed/wall,
 /area/hallway/secondary/entry)
-"hXX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 10
-	},
-/turf/open/floor/engine,
-/area/engineering/supermatter/room)
 "hZL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -41005,15 +39721,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"hZQ" = (
-/obj/structure/window/plasma/reinforced/spawner/west,
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/engineering/supermatter)
 "iab" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -41023,47 +39730,21 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"iaC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "ibD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet,
 /area/commons/dorms)
-"ibI" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
-"ibP" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/ai_sat_ext_ap)
 "icy" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Art Storage"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
 "icY" = (
@@ -41080,9 +39761,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "idj" = (
@@ -41099,9 +39778,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "idl" = (
@@ -41121,7 +39798,9 @@
 /area/maintenance/department/chapel/monastery)
 "idZ" = (
 /obj/effect/landmark/start/security_officer,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/security)
 "iea" = (
@@ -41132,19 +39811,9 @@
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
-"ife" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "igj" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "igu" = (
@@ -41155,21 +39824,9 @@
 	c_tag = "Engineering Supermatter Starboard Fore";
 	network = list("ss13","engine")
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"igC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/cargo/sorting)
 "igE" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -41216,6 +39873,18 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/medical/abandoned)
+"ihM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/exit/departure_lounge)
 "iiy" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -41237,17 +39906,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
-"iiU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/service/janitor)
 "ijU" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/memeorgans,
@@ -41259,20 +39917,30 @@
 /obj/structure/closet/secure_closet/medical2,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"ikU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+"ikY" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/command/bridge)
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "ilD" = (
 /obj/machinery/processor/slime,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "imd" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/stairs,
 /area/engineering/storage/tech)
 "imB" = (
@@ -41281,14 +39949,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engineering/supermatter/room)
-"inA" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "inG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/landmark/start/hangover,
@@ -41303,12 +39963,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
-"ioG" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+"ioK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/engineering/main)
 "ioZ" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -41325,17 +39986,28 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "iqc" = (
 /turf/open/floor/iron/stairs/right,
 /area/service/abandoned_gambling_den)
+"iqg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/psychology)
+"iqp" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/main)
 "iqI" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/camera{
@@ -41357,8 +40029,12 @@
 	req_access_txt = "12"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "irZ" = (
@@ -41377,27 +40053,19 @@
 	location = "Tool"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"isE" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "isF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/brown/hidden/layer2{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "iuM" = (
@@ -41414,14 +40082,7 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
-"ivi" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/commons/dorms)
 "ivy" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
@@ -41434,36 +40095,27 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/library/lounge)
-"iwn" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+"iww" = (
+/obj/machinery/atmospherics/pipe/bridge_pipe/supply/visible,
+/obj/machinery/atmospherics/pipe/layer_manifold/supply,
+/turf/closed/wall/r_wall,
+/area/science/mixing/chamber)
 "ixN" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"ixV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/commons/storage/primary)
 "iyg" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_x = 32
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "iyJ" = (
@@ -41507,17 +40159,17 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "iBp" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -41536,12 +40188,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"iBS" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
 "iCe" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
 	dir = 4;
@@ -41561,15 +40207,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"iDQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
 "iDT" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -41631,25 +40268,8 @@
 	},
 /obj/structure/table/glass,
 /obj/item/stack/medical/gauze,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/medical/medbay/central)
-"iHs" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/security/processing/cremation)
-"iHY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/service/library)
 "iIB" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -41661,8 +40281,12 @@
 /area/space)
 "iJb" = (
 /obj/structure/chair,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "iJI" = (
@@ -41676,19 +40300,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"iJV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "iKb" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westleft{
@@ -41703,12 +40314,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
-"iKj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/science/xenobiology)
 "iLl" = (
 /obj/structure/sink{
 	pixel_y = 29
@@ -41737,12 +40342,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"iLS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/command/bridge)
 "iMH" = (
 /obj/machinery/door/window/southleft{
 	base_state = "right";
@@ -41752,19 +40351,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron/dark,
 /area/security/warden)
-"iNd" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "iNg" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/green{
@@ -41786,10 +40375,10 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "iNR" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen/coldroom)
 "iOj" = (
@@ -41801,15 +40390,12 @@
 "iOl" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"iOE" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/ai_upload)
 "iPj" = (
 /obj/machinery/igniter{
 	id = "xenoigniter";
@@ -41835,47 +40421,15 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
-"iRX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen)
 "iSi" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/cargo)
-"iSx" = (
-/obj/item/reagent_containers/glass/bottle/epinephrine,
-/obj/item/reagent_containers/glass/bottle/multiver{
-	pixel_x = 6
-	},
-/obj/item/reagent_containers/syringe,
-/obj/structure/table/glass,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/medical/medbay/central)
 "iTa" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -41888,27 +40442,6 @@
 /obj/effect/turf_decal/trimline/yellow/line,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"iUg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"iUV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "iUX" = (
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
@@ -41918,6 +40451,18 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
+"iWV" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "iYH" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay";
@@ -41925,11 +40470,11 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
@@ -41940,24 +40485,17 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
-"jap" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "jaJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "jaS" = (
@@ -42020,7 +40558,9 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/service/library)
 "jhk" = (
@@ -42028,11 +40568,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
@@ -42060,21 +40600,19 @@
 	icon_state = "platingdmg3"
 	},
 /area/service/abandoned_gambling_den)
+"jhH" = (
+/obj/structure/mineral_door/wood{
+	name = "The Roosterdome"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "jiD" = (
 /turf/closed/wall,
 /area/science/genetics)
-"jiZ" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron/dark,
-/area/command/bridge)
 "jjC" = (
 /obj/structure/rack,
 /obj/item/storage/briefcase{
@@ -42087,12 +40625,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/lawoffice)
-"jjV" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/command/bridge)
 "jkf" = (
 /obj/effect/turf_decal/caution{
 	dir = 8
@@ -42116,10 +40648,10 @@
 /area/engineering/storage_shared)
 "jng" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
 "jnp" = (
@@ -42147,29 +40679,12 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/virology)
-"jom" = (
-/obj/effect/landmark/start/shaft_miner,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/cargo/miningdock)
-"joz" = (
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/iron/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/exit/departure_lounge)
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "jpa" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/virology{
@@ -42231,15 +40746,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
-"jsr" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/medical/psychology)
 "jsD" = (
 /obj/structure/sign/plaques/deempisi{
 	pixel_y = 28
@@ -42274,14 +40780,14 @@
 /area/service/kitchen/coldroom)
 "juf" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -42294,11 +40800,9 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/medical/storage)
@@ -42309,19 +40813,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"jvZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "jwq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42342,8 +40833,12 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "jxl" = (
@@ -42356,13 +40851,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
-"jyI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/medical/psychology)
 "jze" = (
 /turf/closed/wall,
 /area/medical/paramedic)
@@ -42374,9 +40862,7 @@
 	dir = 4;
 	light_color = "#e8eaff"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "jzz" = (
@@ -42404,10 +40890,6 @@
 	},
 /turf/closed/wall,
 /area/cargo/warehouse)
-"jBi" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/turf/open/floor/engine,
-/area/engineering/supermatter/room)
 "jBn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42415,12 +40897,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"jBI" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/wood,
-/area/cargo/qm)
 "jCr" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -42481,11 +40957,6 @@
 	},
 /turf/closed/wall,
 /area/maintenance/department/cargo)
-"jIy" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "jII" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -42507,6 +40978,25 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/disposal)
+"jJK" = (
+/obj/structure/window/reinforced,
+/obj/structure/table,
+/obj/item/stock_parts/scanning_module{
+	pixel_x = 5;
+	pixel_y = 7
+	},
+/obj/item/stock_parts/scanning_module{
+	pixel_x = 5
+	},
+/obj/item/stock_parts/scanning_module{
+	pixel_x = -5;
+	pixel_y = 7
+	},
+/obj/item/stock_parts/scanning_module{
+	pixel_x = -5
+	},
+/turf/open/floor/iron,
+/area/cargo/warehouse/upper)
 "jJN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -42520,20 +41010,12 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/psychology)
-"jKL" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/command/bridge)
 "jMl" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 6
@@ -42547,9 +41029,7 @@
 /obj/machinery/airalarm/engine{
 	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "jMD" = (
@@ -42562,22 +41042,15 @@
 /area/medical/morgue)
 "jMS" = (
 /obj/effect/spawner/xmastree,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/carpet,
 /area/service/library)
 "jNg" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/closed/wall,
 /area/commons/fitness/recreation)
-"jNv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "jOe" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -42664,23 +41137,15 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"jTU" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/commons/storage/primary)
 "jVo" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "jVK" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -42695,19 +41160,13 @@
 /area/medical/virology)
 "jWj" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/item/radio/intercom/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
-"jWn" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "jWq" = (
@@ -42718,8 +41177,12 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/science/explab)
 "jWH" = (
@@ -42728,16 +41191,22 @@
 /area/medical/medbay/lobby)
 "jXw" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "jXz" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/dock)
 "jXA" = (
@@ -42760,26 +41229,16 @@
 	},
 /turf/closed/wall,
 /area/maintenance/department/cargo)
-"kaV" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/engine,
-/area/science/nanite)
 "kbi" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "kbV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/engineering/supermatter/room)
+/turf/open/floor/iron/dark,
+/area/ai_monitored/security/armory)
 "kdb" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -42791,12 +41250,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"kdN" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "keN" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/structure/cable,
@@ -42861,8 +41314,12 @@
 	sortType = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "kjK" = (
@@ -42885,8 +41342,10 @@
 /area/service/abandoned_gambling_den)
 "kkF" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -42902,8 +41361,8 @@
 /turf/open/floor/iron/dark,
 /area/science/genetics)
 "kkU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/service/library/artgallery)
@@ -42940,32 +41399,20 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
-"kni" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/service/bar/atrium)
 "knx" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
-"knA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "kpu" = (
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/stairs/left,
@@ -42982,11 +41429,11 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
@@ -43002,12 +41449,7 @@
 	dir = 6
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
 "krC" = (
@@ -43045,32 +41487,18 @@
 /obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/iron,
 /area/engineering/main)
-"ksq" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/cargo/warehouse/upper)
 "ksv" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ktv" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/commons/storage/primary)
-"ktz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall,
-/area/tcommsat/computer)
 "ktQ" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -43087,12 +41515,7 @@
 "kvj" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "kvq" = (
@@ -43112,20 +41535,25 @@
 	},
 /turf/open/floor/iron/white,
 /area/maintenance/department/engine)
+"kvr" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/commons/storage/primary)
 "kvB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/science/robotics)
-"kwh" = (
-/obj/effect/turf_decal/bot/right,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/engineering/gravity_generator)
 "kxj" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -43145,23 +41573,11 @@
 	},
 /turf/closed/wall,
 /area/medical/medbay/central)
-"kxK" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
 "kya" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "kyv" = (
@@ -43184,11 +41600,11 @@
 /area/engineering/storage_shared)
 "kzj" = (
 /obj/structure/chair/wood,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
@@ -43211,31 +41627,19 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/engineering/break_room)
+"kAv" = (
+/obj/structure/window/reinforced,
+/obj/item/fuel_pellet,
+/obj/structure/rack,
+/turf/open/floor/iron,
+/area/cargo/warehouse/upper)
 "kAD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"kAF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/cargo/storage)
-"kBt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "kCc" = (
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/conveyor{
@@ -43252,11 +41656,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/carpet/black,
 /area/service/chapel/office)
-"kDB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/command/bridge)
 "kDJ" = (
 /obj/machinery/light{
 	dir = 8
@@ -43282,9 +41681,6 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/trunk,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "kDY" = (
@@ -43330,29 +41726,14 @@
 	req_access_txt = "38"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"kFP" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
-"kGd" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "kGl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43364,19 +41745,6 @@
 /obj/machinery/newscaster/security_unit/directional/south,
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
-"kHv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/engineering/storage_shared)
 "kHO" = (
 /obj/structure/bed/dogbed/renault,
 /mob/living/simple_animal/pet/fox/renault,
@@ -43428,22 +41796,13 @@
 	},
 /turf/open/space/basic,
 /area/cargo/storage)
-"kMf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/service/bar/atrium)
 "kMt" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/chapel/monastery)
@@ -43457,18 +41816,14 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
-	dir = 1
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "kMX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
@@ -43484,6 +41839,16 @@
 /obj/machinery/holopad/secure,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
+"kNK" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "kOF" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/chapel,
@@ -43499,26 +41864,8 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"kPQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
-"kPZ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
 "kQy" = (
 /obj/machinery/computer/med_data,
 /obj/effect/turf_decal/tile/blue{
@@ -43564,19 +41911,6 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
-"kSj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "kSD" = (
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
@@ -43593,38 +41927,15 @@
 	},
 /turf/open/floor/plating,
 /area/medical/cryo)
-"kTi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engineering/supermatter/room)
-"kTk" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
 "kTn" = (
 /obj/structure/grille/broken,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"kTJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "kTU" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/effect/turf_decal/tile/green{
@@ -43651,9 +41962,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "kUt" = (
@@ -43669,25 +41978,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
-"kUR" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/grimy,
-/area/ai_monitored/turret_protected/aisat_interior)
 "kVc" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -43707,12 +42006,7 @@
 "kVN" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "kVO" = (
@@ -43728,15 +42022,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/explab)
-"kWW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/service/bar/atrium)
 "kXe" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -43745,30 +42030,15 @@
 	name = "Engineering External Access";
 	req_one_access_txt = "10;24"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
-"kXr" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white/corner,
-/area/hallway/secondary/exit/departure_lounge)
 "kXZ" = (
 /obj/structure/easel,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "kYt" = (
 /obj/structure/flora/ausbushes/sparsegrass,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/grass,
 /area/medical/psychology)
 "kZU" = (
@@ -43787,13 +42057,9 @@
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
 "lao" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/machinery/exodrone_launcher,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
 /area/cargo/warehouse/upper)
 "lba" = (
 /obj/structure/flora/junglebush,
@@ -43801,16 +42067,6 @@
 /obj/structure/window/reinforced/spawner/north,
 /turf/open/floor/grass,
 /area/medical/psychology)
-"lbk" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
 "lbC" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -43823,11 +42079,11 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
@@ -43889,7 +42145,7 @@
 /turf/open/floor/grass,
 /area/science/genetics)
 "lgj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -43898,8 +42154,10 @@
 /obj/machinery/shower{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
 "lhf" = (
@@ -43917,24 +42175,16 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/storage_shared)
-"lhy" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/cargo/office)
 "lhO" = (
 /obj/structure/chair/office/light{
 	dir = 8
 	},
 /obj/effect/landmark/start/assistant,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "liQ" = (
@@ -43946,11 +42196,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"lji" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/command/teleporter)
 "ljT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -43981,10 +42226,10 @@
 "lkK" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/iron/freezer,
 /area/medical/virology)
 "llS" = (
@@ -43995,21 +42240,8 @@
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/science/genetics)
-"lmh" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/command/glass{
-	name = "Bridge";
-	req_access_txt = "19"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/command/bridge)
 "lmU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "lmV" = (
@@ -44027,17 +42259,12 @@
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "lor" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/ywflowers,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/grass,
 /area/medical/psychology)
 "lot" = (
@@ -44057,8 +42284,7 @@
 /area/commons/fitness/recreation)
 "lpW" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "lpX" = (
@@ -44080,7 +42306,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/service/library/lounge)
 "lru" = (
@@ -44088,34 +42316,26 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"lrB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+"lrw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
+/area/service/hydroponics)
 "lrI" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"lrT" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "lsq" = (
 /obj/structure/transit_tube/curved{
 	dir = 1
@@ -44157,9 +42377,7 @@
 /area/hallway/primary/aft)
 "ltl" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/space,
 /area/space/nearstation)
 "ltu" = (
@@ -44172,34 +42390,12 @@
 /obj/structure/statue/petrified,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"lve" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
-"lvE" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/command/heads_quarters/captain)
 "lwT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/service/library/lounge)
-"lxl" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "lxx" = (
 /obj/item/stack/medical/gauze{
 	pixel_x = 2
@@ -44215,9 +42411,7 @@
 /area/medical/paramedic)
 "lyd" = (
 /obj/effect/landmark/start/security_officer,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron,
 /area/security)
 "lzJ" = (
@@ -44231,25 +42425,9 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
-"lAq" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/commons/dorms)
 "lAs" = (
 /turf/closed/wall,
 /area/security/checkpoint/supply)
-"lAD" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/cargo/storage)
 "lAR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -44281,20 +42459,21 @@
 /area/maintenance/department/engine)
 "lCb" = (
 /obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/command/gateway)
-"lCw" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+"lCe" = (
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/command/bridge)
 "lDw" = (
 /obj/structure/flora/grass/jungle,
 /mob/living/carbon/human/species/monkey,
@@ -44314,12 +42493,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/paramedic)
-"lEU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/command/heads_quarters/rd)
 "lFb" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -44328,6 +42501,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "lFh" = (
@@ -44350,9 +42524,7 @@
 	req_access_txt = "12;24"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "lGS" = (
@@ -44369,17 +42541,6 @@
 /obj/item/bedsheet/orange,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"lIG" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "lJr" = (
 /obj/item/wrench,
 /turf/open/floor/plating,
@@ -44420,13 +42581,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"lNy" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/iron/white,
-/area/medical/virology)
 "lNW" = (
 /obj/machinery/computer/scan_consolenew{
 	dir = 4
@@ -44445,6 +42599,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"lQb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/department/engine)
 "lQn" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -44477,30 +42640,17 @@
 "lRC" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/service/janitor)
 "lRW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/genetics)
-"lTe" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "lTf" = (
 /obj/structure/chair/wood{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/service/bar/atrium)
 "lTC" = (
@@ -44510,15 +42660,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"lTD" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/exit/departure_lounge)
 "lTW" = (
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
-"lUd" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/commons/storage/primary)
 "lUC" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -44533,12 +42692,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/genetics)
-"lUD" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "lUY" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -44547,40 +42700,25 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "lVR" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/dock)
-"lWd" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/commons/dorms)
 "lWv" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "lWy" = (
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"lWz" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Chapel"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
 "lWH" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/winterboots,
@@ -44595,22 +42733,20 @@
 /area/engineering/storage_shared)
 "lWQ" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "lWU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "lXc" = (
@@ -44618,13 +42754,6 @@
 /obj/item/clothing/head/beret,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"lXe" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "lXk" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -44633,11 +42762,20 @@
 	name = "Engineering External Access";
 	req_one_access_txt = "10;24"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
+"lXV" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "lYE" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -44685,14 +42823,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"mcf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/cargo/miningdock)
 "mci" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -44733,8 +42863,12 @@
 "mew" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "mfu" = (
@@ -44748,6 +42882,12 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"mfZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/commons/dorms)
 "mgW" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/blue{
@@ -44765,13 +42905,13 @@
 /area/medical/cryo)
 "mhL" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "mjt" = (
@@ -44780,14 +42920,11 @@
 	},
 /obj/effect/landmark/start/station_engineer,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/main)
-"mjG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/science/mixing)
 "mkf" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
@@ -44806,8 +42943,10 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "mlI" = (
@@ -44831,20 +42970,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/engineering/storage_shared)
-"mmI" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"mnc" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "mnw" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -44860,9 +42985,7 @@
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "mnR" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
 "mpd" = (
@@ -44922,8 +43045,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "mrv" = (
@@ -44931,6 +43058,19 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/plating/airless,
 /area/engineering/atmos)
+"mrA" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/door/airlock/research{
+	name = "Toxins Launch Room";
+	req_access_txt = "8"
+	},
+/turf/open/floor/iron,
+/area/science/mixing)
 "mse" = (
 /turf/open/floor/wood,
 /area/cargo/qm)
@@ -44968,16 +43108,14 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"mtT" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
 "muO" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -44993,11 +43131,11 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -45028,21 +43166,19 @@
 /area/medical/virology)
 "myc" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "myk" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -45114,15 +43250,10 @@
 	id = "testlab";
 	name = "test chamber blast door"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible,
 /turf/open/floor/engine,
 /area/science/explab)
-"mAU" = (
-/obj/effect/decal/cleanable/ash,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "mBz" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/yellow,
@@ -45130,7 +43261,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
 "mBN" = (
@@ -45146,10 +43277,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"mBW" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/service/library)
 "mCe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -45187,9 +43314,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "mEW" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen/coldroom)
 "mFu" = (
@@ -45240,21 +43369,6 @@
 "mKE" = (
 /turf/closed/wall,
 /area/medical/medbay/lobby)
-"mLs" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "mMc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -45274,13 +43388,21 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "mOt" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "mOx" = (
@@ -45295,6 +43417,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "mOH" = (
@@ -45335,11 +43458,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
-"mQS" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/carpet,
-/area/service/library/lounge)
 "mQV" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -45348,6 +43466,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "mRD" = (
@@ -45360,6 +43481,13 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"mRO" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engineering/lobby)
 "mSc" = (
 /obj/machinery/computer/scan_consolenew{
 	dir = 4
@@ -45376,42 +43504,32 @@
 /obj/item/clothing/head/mailman,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"mTL" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+"mTF" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/service/library/artgallery)
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "mUt" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "mUJ" = (
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"mVC" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "mVM" = (
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"mVV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/service/bar/atrium)
 "mWI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -45425,11 +43543,11 @@
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "mWQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/security)
@@ -45440,11 +43558,11 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse/upper)
@@ -45472,12 +43590,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "mZE" = (
@@ -45518,21 +43631,8 @@
 /area/science/xenobiology)
 "naX" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/service/bar)
-"nbb" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/exit/departure_lounge)
 "nbw" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -45547,15 +43647,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"ncU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/service/lawoffice)
 "ndc" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -45595,9 +43686,7 @@
 	},
 /area/maintenance/department/science)
 "ndP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/space/basic,
 /area/space)
 "ndU" = (
@@ -45614,7 +43703,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "new" = (
@@ -45636,10 +43727,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -45656,13 +43747,6 @@
 /obj/structure/lattice,
 /turf/open/space,
 /area/space/nearstation)
-"ngn" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "ngp" = (
 /obj/item/chair/stool,
 /turf/open/floor/carpet,
@@ -45683,12 +43767,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
-"nhr" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/science/explab)
 "nih" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/costume,
@@ -45714,8 +43792,10 @@
 /area/engineering/supermatter/room)
 "njH" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "njS" = (
@@ -45729,23 +43809,16 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
-"nkH" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/exit/departure_lounge)
 "nkK" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/grunge{
 	name = "Chapel"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
@@ -45753,10 +43826,8 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "nlm" = (
@@ -45767,10 +43838,10 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -45790,15 +43861,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
-"nmS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security)
 "nnf" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -45821,16 +43883,14 @@
 /obj/item/reagent_containers/food/drinks/soda_cans/lemon_lime,
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"now" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
-/area/service/library)
 "nox" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/science/robotics)
 "noF" = (
@@ -45872,27 +43932,21 @@
 	dir = 9
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "nqV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "nrD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
-"nsm" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "nsy" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
@@ -45910,18 +43964,15 @@
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "nsD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
 /area/science/mixing)
 "nta" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
@@ -45929,39 +43980,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Mining Maintenance";
-	req_access_txt = "48"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/cargo/miningdock)
-"ntC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/engineering/storage_shared)
-"ntI" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
 "ntO" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -45969,16 +43989,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"nuX" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "nvG" = (
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/iron/dark,
@@ -45998,16 +44008,16 @@
 /area/engineering/supermatter/room)
 "nww" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/chapel/monastery)
 "nwK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -46054,13 +44064,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"nzD" = (
-/obj/structure/chair/wood,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
 "nzP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -46068,41 +44071,12 @@
 /turf/open/floor/iron,
 /area/command/teleporter)
 "nzR" = (
-/obj/structure/cable,
-/turf/closed/wall,
-/area/maintenance/solars/port)
-"nAj" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
-"nAx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
-/area/hallway/primary/aft)
-"nAJ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/brig)
-"nBi" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/engineering/main)
+/area/commons/dorms)
 "nBt" = (
 /obj/structure/disposaloutlet{
 	dir = 8
@@ -46141,9 +44115,17 @@
 /obj/machinery/light/dim{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
+"nBT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/storage_shared)
 "nCe" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -46158,21 +44140,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"nCm" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"nCn" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/medical/psychology)
 "nCW" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -46190,7 +44157,6 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "nEb" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "misclab";
 	name = "test chamber blast door"
@@ -46198,11 +44164,13 @@
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "nEp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "nES" = (
@@ -46265,6 +44233,12 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/lab)
 "nJc" = (
@@ -46279,42 +44253,30 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/commons/storage/art)
-"nJf" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 6
-	},
-/turf/open/space,
-/area/space/nearstation)
 "nJI" = (
 /obj/structure/sign/plaques/kiddie/perfect_drone{
 	pixel_y = 32
 	},
 /turf/open/floor/engine,
 /area/science/explab)
-"nKh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
+"nLS" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
-"nLc" = (
-/obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/lobby)
+/area/hallway/primary/central)
 "nMG" = (
 /obj/machinery/camera/motion{
 	c_tag = "Telecomms Monitoring";
@@ -46327,21 +44289,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
-"nMI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/commons/storage/primary)
 "nNk" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
@@ -46359,7 +44309,9 @@
 /area/space/nearstation)
 "nNW" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "nOt" = (
@@ -46368,14 +44320,6 @@
 /obj/structure/window/reinforced/spawner/north,
 /turf/open/floor/grass,
 /area/medical/storage)
-"nOG" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/tcommsat/computer)
 "nOY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -46401,18 +44345,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
-"nPn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "nPA" = (
 /obj/item/chair,
 /turf/open/floor/plating,
@@ -46443,36 +44375,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
-"nSs" = (
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/chemistry)
 "nSz" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
-"nSZ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/engineering/lobby)
 "nTv" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron{
@@ -46485,36 +44399,26 @@
 	icon_state = "small"
 	},
 /obj/item/light/bulb,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "nTx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "nTH" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/service/hydroponics)
-"nTO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/secondary/entry)
+/area/service/hydroponics)
 "nTU" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay";
@@ -46523,8 +44427,12 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "nUb" = (
@@ -46542,12 +44450,7 @@
 	pixel_y = 32
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "nUq" = (
@@ -46564,22 +44467,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"nUU" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/service/chapel/main/monastery)
-"nUW" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "nVz" = (
 /obj/structure/sign/directions/evac{
 	dir = 8;
@@ -46627,22 +44514,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "nWX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
-"nXu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/science/explab)
 "nXC" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Slime Pen #1";
@@ -46651,18 +44525,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"nXG" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/command/bridge)
 "nYb" = (
 /obj/structure/table_frame/wood,
 /turf/open/floor/wood,
@@ -46711,8 +44573,12 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "oaM" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
 "obj" = (
@@ -46724,21 +44590,37 @@
 	sortType = 24
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"ocd" = (
+/obj/structure/cable,
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
+"ocg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/science/storage)
 "odF" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Chapel"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/dock)
 "odG" = (
@@ -46763,20 +44645,24 @@
 /area/engineering/atmos)
 "ofj" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
-/area/cargo/qm)
-"ofy" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/service/bar)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/cargo/qm)
+"ofG" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/science/nanite)
 "ofN" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -46806,11 +44692,11 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
@@ -46836,8 +44722,12 @@
 "ohu" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
 "ohR" = (
@@ -46908,8 +44798,10 @@
 /obj/effect/decal/cleanable/ash,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "onX" = (
@@ -46923,8 +44815,6 @@
 	},
 /obj/machinery/navbeacon/wayfinding/tools,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "ooh" = (
@@ -46966,8 +44856,10 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/commons/fitness/recreation)
 "orc" = (
@@ -46991,10 +44883,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
-"orW" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/engine,
-/area/science/storage)
 "orZ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/segment{
@@ -47030,19 +44918,17 @@
 /area/maintenance/disposal)
 "osQ" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/medical/psychology)
 "oto" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
 	},
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
@@ -47092,7 +44978,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/white/corner{
@@ -47101,8 +44987,12 @@
 /area/hallway/secondary/entry)
 "ovT" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "owS" = (
@@ -47125,11 +45015,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
@@ -47139,28 +45029,18 @@
 	dir = 8;
 	network = list("ss13","monastery")
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/carpet,
-/area/service/library/artgallery)
-"oyy" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
+/turf/open/floor/carpet,
+/area/service/library/artgallery)
 "oyF" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "oyH" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "ozc" = (
@@ -47187,6 +45067,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
+"ozZ" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Atmos Supermatter Mix"
+	},
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "oAk" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/lizard/wags_his_tail,
@@ -47225,9 +45112,6 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -47300,9 +45184,7 @@
 	id = "xenoigniter";
 	pixel_y = 7
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "oFf" = (
@@ -47338,25 +45220,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/department/engine)
-"oFK" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "oFO" = (
 /obj/effect/landmark/start/security_officer,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron,
 /area/security)
 "oGm" = (
@@ -47369,41 +45238,22 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "oGx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
-"oHO" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/entry)
-"oJw" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+"oGZ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
-/area/cargo/office)
+/area/hallway/primary/central)
 "oKD" = (
 /obj/structure/disposalpipe/junction,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -47415,14 +45265,16 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "oLR" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/cafeteria,
@@ -47441,16 +45293,6 @@
 "oMN" = (
 /turf/open/floor/iron/stairs/left,
 /area/service/abandoned_gambling_den)
-"oNA" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
 "oNE" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -47474,10 +45316,8 @@
 "oNY" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -47493,11 +45333,11 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/white/corner{
 	dir = 1
@@ -47520,11 +45360,11 @@
 /turf/open/floor/plating,
 /area/cargo/miningdock)
 "oPV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
@@ -47533,11 +45373,11 @@
 	dir = 9
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
@@ -47562,12 +45402,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "oSc" = (
@@ -47598,11 +45433,11 @@
 	sortType = 28
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
@@ -47614,11 +45449,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
@@ -47647,17 +45482,12 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/main)
-"oTY" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/surgery)
 "oUa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -47666,34 +45496,27 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "oUl" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
-"oVY" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/command/bridge)
 "oWw" = (
 /obj/item/flashlight,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -47711,16 +45534,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/execution/transfer)
-"oXE" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "oYc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -47740,8 +45553,18 @@
 	},
 /turf/closed/wall,
 /area/cargo/sorting)
+"oZN" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "oZX" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "pbm" = (
@@ -47779,17 +45602,6 @@
 	},
 /turf/open/floor/carpet,
 /area/medical/psychology)
-"pcM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/science/genetics)
-"pcO" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
 "pdf" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
 	dir = 4
@@ -47803,56 +45615,57 @@
 "pds" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /mob/living/simple_animal/pet/dog/corgi/puppy,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
 /turf/open/floor/grass,
 /area/medical/psychology)
 "pdv" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/science/server)
-"pec" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+"pdI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/turf/open/floor/iron,
+/area/cargo/miningdock)
+"pec" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
-"peq" = (
+"pel" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/cargo/miningdock)
+/area/hallway/primary/central)
 "pez" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "peY" = (
 /obj/effect/turf_decal/trimline/blue/line,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"pfD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/iron/dark,
-/area/science/xenobiology)
 "pfP" = (
 /obj/structure/table,
 /obj/item/storage/box/syringes{
@@ -47878,12 +45691,6 @@
 	},
 /turf/closed/wall,
 /area/maintenance/department/science)
-"pgH" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "php" = (
 /obj/machinery/conveyor{
 	id = "CrateReturn";
@@ -47898,19 +45705,9 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/medical/abandoned)
-"piz" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "piI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
@@ -47973,7 +45770,6 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/east,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "plA" = (
@@ -48016,16 +45812,15 @@
 	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
-"pom" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
+"pos" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/grimy,
-/area/ai_monitored/turret_protected/aisat_interior)
+/turf/open/floor/iron,
+/area/cargo/warehouse/upper)
 "pps" = (
 /turf/closed/wall,
 /area/engineering/break_room)
@@ -48049,23 +45844,21 @@
 /turf/open/floor/iron/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
 "pqw" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "pqS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/grimy,
 /area/service/chapel/main/monastery)
-"prl" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/security/execution/transfer)
 "prD" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -48088,12 +45881,10 @@
 /area/hallway/primary/central)
 "psT" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "pth" = (
@@ -48108,28 +45899,22 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"ptI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/science/explab)
 "ptK" = (
 /obj/effect/turf_decal/bot/left,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/engineering/gravity_generator)
 "ptL" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"puU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/command/bridge)
 "pvc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -48139,8 +45924,12 @@
 /area/maintenance/department/cargo)
 "pvK" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "pvZ" = (
@@ -48149,6 +45938,7 @@
 "pwa" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "pwS" = (
@@ -48158,15 +45948,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"pxn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen)
 "pxE" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 4
@@ -48174,12 +45955,7 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "pyA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
 "pyH" = (
@@ -48208,9 +45984,8 @@
 /turf/open/floor/plating,
 /area/engineering/storage_shared)
 "pAo" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "pBm" = (
@@ -48231,15 +46006,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
-"pCm" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
 "pDf" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -48264,34 +46030,21 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"pEs" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/ai_sat_ext_as)
 "pEv" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
-"pEG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/commons/dorms)
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "pEK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "pFy" = (
@@ -48300,6 +46053,9 @@
 	},
 /obj/structure/sign/departments/lawyer{
 	pixel_y = -32
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
@@ -48333,18 +46089,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"pGK" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "pGZ" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lantern{
 	pixel_y = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/service/library)
 "pHb" = (
@@ -48359,10 +46111,10 @@
 /area/engineering/atmos)
 "pHo" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -48383,6 +46135,16 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"pIu" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "pIy" = (
 /obj/structure/sign/painting/library{
 	pixel_y = 32
@@ -48396,18 +46158,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
-"pJH" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "pJU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/science/nanite)
@@ -48476,18 +46232,16 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible/layer4{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "pOc" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/medical/virology)
 "pOt" = (
@@ -48502,15 +46256,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"pQd" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "pQm" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -48519,20 +46264,14 @@
 "pQA" = (
 /turf/open/floor/carpet,
 /area/service/library/artgallery)
-"pRj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/iron/grimy,
-/area/command/heads_quarters/captain)
 "pRR" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "pRU" = (
@@ -48540,10 +46279,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/wood{
 	icon_state = "wood-broken7"
 	},
@@ -48554,19 +46293,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
-"pTc" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "pTy" = (
 /obj/machinery/door/window/eastleft{
 	dir = 1;
 	name = "Petting Garden"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/grass,
 /area/medical/psychology)
 "pTF" = (
@@ -48574,10 +46305,10 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -48586,12 +46317,6 @@
 /obj/machinery/newscaster/security_unit/directional/south,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
-"pUY" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/commons/dorms)
 "pVr" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/red{
@@ -48642,11 +46367,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"pXd" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "pXg" = (
 /obj/structure/table/glass,
 /obj/item/storage/pill_bottle/mutadone{
@@ -48707,8 +46427,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/department/engine)
+"pZM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/service/bar/atrium)
 "pZT" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
@@ -48735,16 +46466,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"qbE" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
 "qbP" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
@@ -48759,8 +46480,12 @@
 	name = "Chapel Access"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
 "qcD" = (
@@ -48773,12 +46498,6 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
-"qcH" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ai_monitored/turret_protected/ai)
 "qcR" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -48806,18 +46525,15 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "qfI" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden/layer4{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "qfV" = (
@@ -48857,9 +46573,7 @@
 /area/cargo/storage)
 "qgX" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "qhW" = (
@@ -48896,9 +46610,18 @@
 	icon_state = "plant-05";
 	pixel_y = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/service/library)
+"qiz" = (
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "qiF" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -48924,11 +46647,6 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
-"qkR" = (
-/obj/structure/grille/broken,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "qlk" = (
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
@@ -48961,41 +46679,28 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/iron/dark,
 /area/service/bar/atrium)
 "qmK" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold/general/visible,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "qmQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/captain)
 "qmR" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/rd)
-"qny" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "qnJ" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Medbay Security Post";
@@ -49003,12 +46708,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "qnT" = (
@@ -49059,13 +46759,15 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "qpT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
@@ -49073,17 +46775,9 @@
 /obj/structure/window/plasma/reinforced/spawner/west,
 /obj/machinery/power/rad_collector/anchored,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
-"qqe" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/command/bridge)
 "qqQ" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -49133,7 +46827,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "qsk" = (
@@ -49150,18 +46844,16 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"qtA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+"qsJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
+/area/construction/mining/aux_base)
+"qtA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/turf/open/floor/iron,
 /area/science/mixing)
-"qtD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/lobby)
 "qtF" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobiomain";
@@ -49170,10 +46862,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -49200,7 +46892,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron,
 /area/science/mixing)
 "qvx" = (
@@ -49214,10 +46906,12 @@
 /area/maintenance/department/engine)
 "qvM" = (
 /obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/brown/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -49228,16 +46922,6 @@
 	},
 /turf/open/floor/plating,
 /area/medical/cryo)
-"qwp" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
 "qwJ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -49245,6 +46929,15 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"qxa" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "qxq" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -49254,37 +46947,13 @@
 	},
 /turf/open/floor/plating,
 /area/tcommsat/computer)
-"qxC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/commons/storage/primary)
-"qxO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron/white,
-/area/science/explab)
-"qyG" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "qyR" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "qzm" = (
@@ -49301,19 +46970,13 @@
 /area/maintenance/department/engine)
 "qCG" = (
 /obj/structure/grille/broken,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
-/area/maintenance/department/engine)
-"qCL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
 /area/maintenance/department/engine)
 "qDb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -49321,22 +46984,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/primary)
-"qDi" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/wood,
-/area/service/abandoned_gambling_den)
-"qDQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
 "qEf" = (
 /obj/structure/flora/junglebush/b,
 /obj/structure/window/reinforced/spawner/north,
@@ -49382,11 +47029,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
-"qGO" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/engineering/main)
 "qHa" = (
 /obj/structure/closet/wardrobe/red,
 /obj/effect/turf_decal/tile/red,
@@ -49404,20 +47046,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"qHg" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/maintenance/department/security/brig)
-"qHl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
 "qHu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -49426,7 +47054,12 @@
 /area/engineering/supermatter)
 "qIf" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "qIl" = (
@@ -49478,20 +47111,14 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
 /area/hallway/secondary/entry)
-"qJt" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "qJB" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -49499,8 +47126,8 @@
 /area/maintenance/department/cargo)
 "qJK" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/service/library/lounge)
@@ -49514,16 +47141,6 @@
 	name = "Holodeck Projector Floor"
 	},
 /area/holodeck/rec_center)
-"qLa" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/science/explab)
 "qLU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -49531,12 +47148,8 @@
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
 "qMX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/iron/freezer,
 /area/medical/virology)
 "qNB" = (
@@ -49544,14 +47157,26 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"qNG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "qOx" = (
 /turf/closed/wall/r_wall,
 /area/engineering/lobby)
@@ -49564,9 +47189,6 @@
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -49600,8 +47222,12 @@
 	sortType = 26
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "qRW" = (
@@ -49643,15 +47269,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"qVs" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/service/bar/atrium)
 "qVP" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobiomain";
@@ -49686,8 +47303,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "qXq" = (
@@ -49697,14 +47316,14 @@
 /area/maintenance/department/engine)
 "qXD" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
 "qXH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/closed/wall/r_wall,
 /area/engineering/lobby)
 "qYn" = (
@@ -49712,11 +47331,17 @@
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "qZa" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/service/chapel/main/monastery)
+"qZE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/captain)
 "rax" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -49729,6 +47354,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/processing/cremation)
+"raH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "raI" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = 32
@@ -49758,18 +47393,8 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse/upper)
 "rcF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /turf/open/floor/plating/airless,
 /area/tcommsat/computer)
-"rcS" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "reH" = (
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
 /obj/structure/disposalpipe/segment{
@@ -49802,15 +47427,6 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"rgx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/security)
 "rgO" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -49842,15 +47458,6 @@
 /obj/effect/spawner/randomarcade,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"rkl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/tcommsat/computer)
 "rli" = (
 /obj/structure/sink{
 	dir = 8;
@@ -49863,6 +47470,11 @@
 /obj/structure/flora/junglebush/large,
 /turf/open/floor/grass,
 /area/science/genetics)
+"rlR" = (
+/obj/structure/grille/broken,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "rlT" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -49874,12 +47486,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/corner,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "rlU" = (
@@ -49887,16 +47493,12 @@
 /area/cargo/warehouse/upper)
 "rlV" = (
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/ai_monitored/turret_protected/ai)
 "rmP" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
@@ -49908,6 +47510,15 @@
 	},
 /turf/open/space/basic,
 /area/cargo/storage)
+"rny" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "rnE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49932,9 +47543,7 @@
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "rnQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "roa" = (
@@ -49942,8 +47551,12 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "rof" = (
@@ -49953,26 +47566,31 @@
 "roy" = (
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
-"roJ" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+"roA" = (
+/obj/structure/window/reinforced,
+/obj/structure/table,
+/obj/item/stock_parts/micro_laser{
+	pixel_x = 6;
+	pixel_y = -2
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
+/obj/item/stock_parts/micro_laser{
+	pixel_x = 2
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
+/obj/item/stock_parts/micro_laser{
+	pixel_x = -2;
+	pixel_y = 2
 	},
-/turf/open/floor/iron/dark,
-/area/command/bridge)
+/obj/item/stock_parts/micro_laser{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/turf/open/floor/iron,
+/area/cargo/warehouse/upper)
 "rpa" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
@@ -49989,8 +47607,10 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "rpu" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "rpB" = (
@@ -49998,11 +47618,9 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -50051,7 +47669,7 @@
 /area/service/chapel/office)
 "rsd" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "rse" = (
@@ -50093,8 +47711,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "rtk" = (
@@ -50111,11 +47731,9 @@
 /area/medical/psychology)
 "rtC" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
@@ -50131,19 +47749,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"rtQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
 "rtR" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -50196,7 +47801,9 @@
 /area/medical/virology)
 "rut" = (
 /obj/structure/chair/wood,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
 "rvA" = (
@@ -50221,25 +47828,15 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/medical/medbay/central)
-"rvL" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
 "rvO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -50300,20 +47897,19 @@
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/rods/fifty,
-/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/atmospherics/pipe/layer_manifold/supply,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/engine)
 "rzz" = (
-/obj/effect/turf_decal/stripes/corner{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
-/area/ai_monitored/turret_protected/ai)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen)
 "rzT" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -50363,10 +47959,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/white/corner{
@@ -50386,9 +47979,22 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/cargo/office)
+"rCf" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/command/bridge)
 "rCg" = (
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -50422,7 +48028,9 @@
 /area/cargo/storage)
 "rCR" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/circuit/green{
 	luminosity = 2
 	},
@@ -50436,14 +48044,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"rDS" = (
-/obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/department/engine)
 "rEh" = (
 /obj/structure/table/glass,
 /obj/item/restraints/handcuffs/cable/zipties,
@@ -50454,8 +48059,6 @@
 /obj/effect/turf_decal/trimline/yellow/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "rGo" = (
@@ -50469,35 +48072,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
-"rGG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/security)
 "rHh" = (
 /obj/structure/flora/ausbushes/fernybush,
 /turf/open/floor/grass,
 /area/medical/psychology)
-"rHm" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
-"rHA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/construction/mining/aux_base)
 "rHF" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "rHG" = (
@@ -50539,31 +48123,23 @@
 	dir = 1;
 	name = "Air Out"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/engine)
-"rJx" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/iron/dark,
-/area/security/processing/cremation)
 "rJT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "rJZ" = (
@@ -50597,12 +48173,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
-"rKI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible/layer4{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/science/mixing)
 "rLd" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -50625,15 +48195,37 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "rLn" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
 /turf/closed/wall/r_wall,
 /area/science/mixing)
+"rLF" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "rLJ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 10
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"rLQ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "rMn" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/disposalpipe/segment{
@@ -50642,9 +48234,7 @@
 /turf/open/floor/plating,
 /area/cargo/sorting)
 "rMN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "rMY" = (
@@ -50680,12 +48270,10 @@
 /area/medical/storage)
 "rNj" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "rNB" = (
@@ -50701,32 +48289,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/grass,
 /area/medical/medbay/central)
-"rNU" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/service/bar/atrium)
 "rPu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/engine,
 /area/science/storage)
-"rPK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "rPY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/service/bar)
 "rQa" = (
@@ -50745,6 +48319,9 @@
 	pixel_y = -8
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "rQV" = (
@@ -50752,24 +48329,14 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"rRI" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/science/storage)
 "rSH" = (
 /obj/item/trash/can,
 /turf/open/floor/wood,
@@ -50783,31 +48350,28 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "rUS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/carpet,
 /area/service/library/artgallery)
 "rUW" = (
 /obj/structure/chair/wood,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/chapel,
 /area/service/chapel/main/monastery)
-"rVm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "rVA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -50833,24 +48397,30 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"rWG" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "rWM" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "rXJ" = (
 /obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -50881,9 +48451,24 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"rYS" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "rYY" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
@@ -50891,20 +48476,26 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
 "sah" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/service)
 "saR" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -50944,11 +48535,9 @@
 	req_one_access_txt = "32;47;48"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
@@ -50980,8 +48569,10 @@
 /area/space/nearstation)
 "sdE" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "sea" = (
@@ -51000,10 +48591,10 @@
 	dir = 10
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -51013,11 +48604,11 @@
 	dir = 6
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
@@ -51050,26 +48641,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"sjA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/service/hydroponics)
-"skg" = (
-/obj/structure/sign/painting/library_private{
-	pixel_x = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/service/library/artgallery)
 "skj" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -51078,8 +48649,10 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/firealarm/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "skw" = (
@@ -51088,14 +48661,18 @@
 /area/maintenance/department/security/brig)
 "skS" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"slb" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "slC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -51104,9 +48681,7 @@
 	id = "Supermatter";
 	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "smW" = (
@@ -51120,24 +48695,17 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/science/xenobiology)
-"snn" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "snD" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "barshutters";
 	name = "bar shutters"
 	},
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/service/bar/atrium)
 "snT" = (
@@ -51161,29 +48729,20 @@
 	name = "Psychology Maintenance";
 	req_access_txt = "70"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "soA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"soD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+"soL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/security/checkpoint/customs)
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "spo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -51194,6 +48753,13 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
+"spP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "sqh" = (
 /obj/structure/chair{
 	dir = 8
@@ -51229,16 +48795,24 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
-"srX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
+"ssa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/carpet,
-/area/service/library/artgallery)
+/turf/open/floor/iron/dark,
+/area/command/bridge)
 "ssx" = (
 /obj/item/shard,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"ssL" = (
+/obj/effect/turf_decal/bot/right,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/engineering/gravity_generator)
 "stc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/iron/white,
@@ -51247,33 +48821,29 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "stG" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "stL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"stN" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
 "stQ" = (
 /obj/structure/sign/departments/science{
 	pixel_y = 32
@@ -51290,22 +48860,13 @@
 /turf/open/space/basic,
 /area/space)
 "suz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
 "suU" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"svw" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "svN" = (
 /obj/structure/sign/departments/restroom{
 	pixel_y = 32
@@ -51322,19 +48883,12 @@
 /obj/item/food/meat/slab/monkey,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"swz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "swE" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/carpet,
@@ -51344,10 +48898,8 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -51359,20 +48911,15 @@
 /area/engineering/atmos)
 "sxT" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "syn" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/plating{
@@ -51385,9 +48932,13 @@
 /area/engineering/atmos)
 "syA" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "syK" = (
@@ -51395,7 +48946,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -51463,11 +49014,11 @@
 	dir = 9
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
@@ -51489,20 +49040,14 @@
 /area/service/library/artgallery)
 "sCQ" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
-"sCW" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "sDQ" = (
 /obj/structure/transit_tube/curved/flipped{
 	dir = 8
@@ -51534,20 +49079,22 @@
 /area/security/detectives_office)
 "sFA" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "sFK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "sFL" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 9
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/security/brig)
@@ -51593,21 +49140,12 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"sIN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/service/library/artgallery)
 "sJp" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "sJr" = (
@@ -51635,6 +49173,11 @@
 /obj/machinery/light/small,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"sLg" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "sLv" = (
 /obj/item/stack/medical/mesh,
 /obj/item/stack/medical/suture,
@@ -51646,35 +49189,14 @@
 "sLD" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/cargo/sorting)
-"sLG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/service/library)
-"sMn" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
-"sNv" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/department/security/brig)
+/area/cargo/sorting)
 "sOB" = (
 /turf/closed/wall,
 /area/medical/psychology)
@@ -51698,18 +49220,12 @@
 "sPU" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
-"sQr" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
 "sQP" = (
 /turf/closed/wall/r_wall,
 /area/space)
@@ -51738,10 +49254,8 @@
 "sSs" = (
 /obj/structure/grille/broken,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -51749,48 +49263,44 @@
 "sSJ" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"sTf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "sTi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/science/explab)
 "sUg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
-"sUk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
 "sUP" = (
 /obj/machinery/meter/atmos/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -51798,8 +49308,6 @@
 "sVp" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -51819,11 +49327,9 @@
 	dir = 6
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
@@ -51848,13 +49354,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
-"sYg" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden/layer4,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "sYE" = (
 /obj/structure/chair,
 /obj/effect/landmark/start/hangover,
@@ -51868,8 +49367,6 @@
 /area/maintenance/department/security/brig)
 "sYY" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "sZh" = (
@@ -51887,10 +49384,6 @@
 /obj/structure/closet,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"tag" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "tak" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -51905,6 +49398,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "tal" = (
@@ -51930,10 +49424,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -51985,7 +49479,9 @@
 /area/medical/medbay/central)
 "tct" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/engine,
 /area/science/storage)
 "tcV" = (
@@ -52002,10 +49498,7 @@
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "tcY" = (
@@ -52013,29 +49506,18 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
-"tcZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "tdj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
@@ -52073,15 +49555,8 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "ten" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"teH" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "teJ" = (
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
@@ -52097,29 +49572,14 @@
 /area/cargo/warehouse/upper)
 "tfc" = (
 /obj/effect/landmark/start/assistant,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
-"tfh" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/entry)
 "tfw" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
@@ -52128,16 +49588,16 @@
 	dir = 6
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "tfG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "tfP" = (
@@ -52148,14 +49608,14 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"tfW" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "tgb" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/landmark/start/hangover,
@@ -52163,16 +49623,9 @@
 /area/hallway/primary/aft)
 "tgd" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"tgK" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/security/brig)
 "tgT" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -52192,7 +49645,7 @@
 "thT" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "tim" = (
@@ -52201,8 +49654,6 @@
 	req_access_txt = "47"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/science/explab)
 "tix" = (
@@ -52229,31 +49680,32 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"tjp" = (
-/obj/item/wrench,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "tki" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/wood,
 /area/service/bar)
+"tkl" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/cargo/office)
 "tko" = (
 /turf/closed/wall,
 /area/cargo/warehouse/upper)
 "tla" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "tlc" = (
@@ -52285,16 +49737,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"tmz" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
 "tnY" = (
 /obj/machinery/button/door{
 	id = "aux_base_shutters";
@@ -52312,30 +49754,11 @@
 	},
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
-"tof" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/ai_sat_ext_as)
 "tpb" = (
 /obj/item/food/donut,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/maintenance/department/security/brig)
-"tpu" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "tpC" = (
 /obj/structure/disposalpipe/segment{
@@ -52351,24 +49774,13 @@
 /obj/structure/window/reinforced,
 /turf/open/space,
 /area/space/nearstation)
-"tqq" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
 "tqC" = (
 /turf/closed/wall,
 /area/medical/storage)
 "tqM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/effect/spawner/structure/window,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/medical/virology)
 "tqO" = (
@@ -52407,20 +49819,16 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "ttN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -52435,6 +49843,12 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"tuG" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/engine)
 "tuL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52467,7 +49881,8 @@
 /area/maintenance/disposal/incinerator)
 "tvP" = (
 /obj/item/storage/toolbox/mechanical,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -52483,15 +49898,6 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
-"twM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/cargo/storage)
 "twQ" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio8";
@@ -52504,21 +49910,21 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/iron/white,
 /area/science/explab)
+"txa" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/service/bar/atrium)
 "txu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
-"txz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/freezer,
-/area/commons/toilet/restrooms)
 "txB" = (
 /obj/structure/bookcase/random/adult,
 /obj/machinery/light/small,
@@ -52535,14 +49941,15 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "txZ" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -52561,11 +49968,28 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"tyU" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/exit/departure_lounge)
 "tzm" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -52593,8 +50017,10 @@
 /area/medical/medbay/lobby)
 "tAh" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -52623,19 +50049,11 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/service/library)
-"tBN" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/turf/open/floor/iron/dark,
+/area/service/library)
 "tBP" = (
 /obj/effect/loot_site_spawner,
 /obj/structure/disposalpipe/segment{
@@ -52670,13 +50088,15 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "tCV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/dock)
@@ -52690,9 +50110,6 @@
 /area/maintenance/department/cargo)
 "tDz" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
@@ -52700,8 +50117,7 @@
 /area/service/bar)
 "tEB" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "tEE" = (
@@ -52722,22 +50138,12 @@
 /area/service/library/artgallery)
 "tGj" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"tGm" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/ai_monitored/command/storage/eva)
 "tGQ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
@@ -52760,34 +50166,48 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "tJe" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
 "tJX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"tLw" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/carpet,
-/area/command/heads_quarters/captain)
-"tLA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 1
+"tKl" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/medical/medbay/lobby)
+"tLm" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
+"tLA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron,
 /area/security)
 "tLN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
 "tMs" = (
@@ -52801,11 +50221,23 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
+"tMU" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "tNf" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/machinery/newscaster/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "tNx" = (
@@ -52825,15 +50257,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
-"tOk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/medical/morgue)
 "tOt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52847,22 +50270,13 @@
 	},
 /turf/closed/wall,
 /area/engineering/storage_shared)
-"tQf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "tQi" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
@@ -52873,15 +50287,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
-"tQw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
 "tQJ" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Cold Loop Bypass"
@@ -52894,20 +50299,25 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/engine)
+"tRk" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/security/brig)
 "tSm" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "tSq" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/plating{
@@ -52937,28 +50347,13 @@
 	dir = 8
 	},
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "tSV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"tTD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/brig)
 "tUr" = (
 /obj/structure/table/optable,
 /obj/machinery/computer/operating,
@@ -52971,16 +50366,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
-"tUw" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/cargo/office)
 "tVb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -53007,12 +50392,6 @@
 /area/hallway/primary/central)
 "tWh" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "tWk" = (
@@ -53025,23 +50404,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"tXl" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/commons/fitness/recreation)
 "tXV" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Art Gallery"
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -53093,23 +50465,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"tZf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/ai_sat_ext_ap)
 "tZU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
-"tZX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "uaC" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -53125,17 +50484,19 @@
 "uaY" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"ubc" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/command/bridge)
+"uca" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/science/genetics)
 "ucd" = (
 /obj/machinery/light/dim{
 	dir = 8
@@ -53159,12 +50520,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
-"ucz" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "ucA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -53172,19 +50527,17 @@
 /turf/open/floor/iron/freezer,
 /area/medical/virology)
 "udo" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/service/bar/atrium)
 "udr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
 "udR" = (
@@ -53192,10 +50545,20 @@
 	dir = 9
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"udZ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/cryo)
 "uek" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -53205,10 +50568,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -53218,26 +50581,10 @@
 /obj/item/stack/sheet/cardboard,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
-"ueC" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "ueJ" = (
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen/coldroom)
-"ueK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/service/library)
 "ueP" = (
 /obj/structure/table/glass,
 /obj/machinery/button/door{
@@ -53257,12 +50604,10 @@
 /area/science/xenobiology)
 "ueU" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "ufa" = (
@@ -53278,10 +50623,10 @@
 /area/tcommsat/computer)
 "ugM" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -53292,8 +50637,12 @@
 /area/engineering/gravity_generator)
 "uhN" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "uib" = (
@@ -53319,6 +50668,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "uiP" = (
@@ -53375,11 +50725,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -53414,18 +50764,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/white,
 /area/medical/paramedic)
-"ulr" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "ulu" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -53456,10 +50794,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -53467,12 +50805,6 @@
 "umh" = (
 /turf/open/floor/iron/white,
 /area/medical/cryo)
-"umG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/paramedic)
 "umO" = (
 /obj/machinery/door/morgue{
 	name = "Private Exhibit";
@@ -53494,11 +50826,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/directional/south,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
 	},
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
@@ -53512,15 +50842,6 @@
 "uoS" = (
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
-"upj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/psychology)
 "upV" = (
 /obj/machinery/atmospherics/components/trinary/filter/critical{
 	dir = 1
@@ -53547,9 +50868,7 @@
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "urG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "urO" = (
@@ -53564,15 +50883,6 @@
 /obj/machinery/light,
 /turf/open/floor/iron/white,
 /area/science/explab)
-"urT" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "usl" = (
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
@@ -53582,7 +50892,7 @@
 /area/security/warden)
 "usI" = (
 /obj/structure/chair/wood,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/chapel{
@@ -53591,12 +50901,6 @@
 /area/service/chapel/main/monastery)
 "ute" = (
 /obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
 	},
 /turf/open/floor/iron/white,
@@ -53617,11 +50921,9 @@
 	dir = 9
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
@@ -53631,16 +50933,12 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "uuN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "uuS" = (
@@ -53697,8 +50995,8 @@
 /area/cargo/sorting)
 "uwI" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/space,
 /area/space/nearstation)
 "uwX" = (
@@ -53711,24 +51009,12 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"uxt" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/chemistry)
 "uxF" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -53745,14 +51031,25 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"uyp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "uyY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
@@ -53765,10 +51062,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "uzr" = (
@@ -53806,6 +51099,16 @@
 	},
 /turf/closed/wall,
 /area/cargo/storage)
+"uAj" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "uAs" = (
 /turf/open/floor/iron/freezer,
 /area/medical/virology)
@@ -53818,6 +51121,12 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
@@ -53847,14 +51156,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
-"uDf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/maintenance/department/engine)
 "uDj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -53876,6 +51177,10 @@
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "uEY" = (
@@ -53896,8 +51201,7 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "uFi" = (
@@ -53905,18 +51209,14 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "uFo" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
 /turf/open/floor/iron/white,
 /area/medical/psychology)
 "uGx" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -53926,11 +51226,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
@@ -53947,43 +51245,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"uIq" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "uIv" = (
 /obj/structure/bookcase/random/adult,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
-"uJM" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
-"uJQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/construction/mining/aux_base)
-"uKf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
 "uKD" = (
 /obj/structure/chair,
 /obj/machinery/light{
@@ -54007,12 +51273,20 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
+"uMh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/carpet,
+/area/commons/dorms)
 "uMo" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/loading_area{
@@ -54035,14 +51309,22 @@
 /obj/effect/turf_decal/plaque,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"uMU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "uMY" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "uNL" = (
@@ -54069,15 +51351,26 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/psychology)
+"uOR" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "uPz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -54099,8 +51392,10 @@
 	req_access_txt = "6;5"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/maintenance/department/engine)
 "uQu" = (
@@ -54113,8 +51408,12 @@
 	dir = 6
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "uQR" = (
@@ -54155,15 +51454,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter/room)
-"uUG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/commons/dorms)
 "uUQ" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Engineering Maintenance";
@@ -54176,11 +51466,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
@@ -54200,14 +51488,6 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/carpet,
 /area/service/lawoffice)
-"uVo" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
 "uVB" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -54223,15 +51503,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "uVN" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -54244,7 +51523,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/service/library/lounge)
 "uVW" = (
@@ -54264,9 +51545,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "uXv" = (
@@ -54277,10 +51555,8 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/cafeteria,
@@ -54302,18 +51578,14 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
-"uXL" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/security/armory)
 "uYF" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -54336,6 +51608,12 @@
 /obj/machinery/light/small,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
+"uYW" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "uZJ" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
@@ -54364,10 +51642,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron,
 /area/security/brig)
 "vap" = (
@@ -54377,12 +51655,7 @@
 /area/engineering/atmos)
 "vaR" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "vbv" = (
@@ -54430,18 +51703,16 @@
 /turf/open/space,
 /area/solars/starboard)
 "veM" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "vfp" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/science/explab)
@@ -54475,10 +51746,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -54490,8 +51761,12 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/qm)
 "vhk" = (
@@ -54503,10 +51778,10 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "vif" = (
@@ -54516,8 +51791,9 @@
 /area/hallway/primary/central)
 "viq" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -54529,15 +51805,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"viH" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/freezer,
-/area/commons/toilet/restrooms)
 "vjH" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/yellow,
@@ -54551,6 +51818,14 @@
 /obj/structure/lattice,
 /turf/closed/wall,
 /area/maintenance/department/science)
+"vld" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "vlv" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 10
@@ -54606,9 +51881,18 @@
 /obj/item/reagent_containers/dropper,
 /obj/item/reagent_containers/syringe,
 /obj/item/reagent_containers/glass/beaker,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/iron/freezer,
 /area/medical/virology)
+"vnR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "voI" = (
 /obj/structure/table/glass,
 /obj/item/circular_saw,
@@ -54626,10 +51910,10 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "voM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -54642,21 +51926,11 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
-"voX" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "vpr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -54669,9 +51943,7 @@
 /area/maintenance/department/science)
 "vrx" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "vrV" = (
@@ -54688,16 +51960,22 @@
 	},
 /obj/machinery/holopad,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "vsm" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "vsn" = (
@@ -54711,25 +51989,19 @@
 	name = "Chapel"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
 "vsJ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"vsS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/service/library)
 "vtl" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -54745,19 +52017,17 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"vtQ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
 "vtT" = (
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
+"vtV" = (
+/obj/machinery/space_heater,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "vtX" = (
 /obj/machinery/atmospherics/components/binary/thermomachine/freezer{
 	dir = 8
@@ -54771,11 +52041,11 @@
 /area/maintenance/department/science)
 "vvn" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
@@ -54787,8 +52057,12 @@
 /area/hallway/secondary/entry)
 "vvY" = (
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
 "vxg" = (
@@ -54820,16 +52094,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "vyx" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
@@ -54848,12 +52120,6 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/medical/medbay/central)
-"vzd" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "vzg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
@@ -54866,11 +52132,9 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
@@ -54893,24 +52157,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
-"vBL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
 "vBZ" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "vDh" = (
@@ -54940,11 +52193,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
-"vGh" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
+"vGC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ai_monitored/command/storage/eva)
 "vHj" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance{
@@ -54952,8 +52210,12 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/cargo/storage)
 "vIa" = (
@@ -54965,23 +52227,14 @@
 	dir = 10
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"vIH" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "vII" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -55013,10 +52266,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -55051,9 +52304,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "vLM" = (
@@ -55081,38 +52332,17 @@
 	dir = 9
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
-"vMN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
-"vNa" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/chemistry)
 "vNl" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "vNA" = (
@@ -55122,8 +52352,8 @@
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "vNF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/service/library)
@@ -55135,8 +52365,6 @@
 "vOW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/service/janitor)
 "vPa" = (
@@ -55172,8 +52400,12 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/cargo/sorting)
 "vQz" = (
@@ -55183,9 +52415,11 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "vRi" = (
@@ -55246,17 +52480,13 @@
 /area/hallway/primary/central)
 "vRN" = (
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "vSB" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/service/library)
 "vSG" = (
@@ -55280,17 +52510,17 @@
 	name = "Toxins Lab";
 	req_access_txt = "8"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "vVk" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
 "vWe" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /turf/closed/wall,
 /area/maintenance/department/engine)
 "vWp" = (
@@ -55354,35 +52584,49 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"waa" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "was" = (
 /obj/machinery/vending/boozeomat,
 /turf/closed/wall,
 /area/service/bar)
+"waK" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/supply,
+/turf/closed/wall/r_wall,
+/area/engineering/atmos)
 "wbs" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron,
 /area/security/brig)
 "wbx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/science/explab)
 "wbB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
@@ -55391,11 +52635,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
@@ -55409,13 +52651,6 @@
 "wcf" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -55440,9 +52675,7 @@
 /area/engineering/supermatter/room)
 "wdx" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "weL" = (
@@ -55486,18 +52719,15 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "wfO" = (
 /mob/living/simple_animal/hostile/retaliate/snake,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"wgQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/freezer,
-/area/commons/toilet/restrooms)
 "wha" = (
 /obj/structure/table/glass,
 /obj/item/folder/white{
@@ -55506,7 +52736,6 @@
 /obj/item/pen/red,
 /obj/machinery/light/small,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/medical/virology)
 "whH" = (
@@ -55525,7 +52754,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/service/library/lounge)
 "wig" = (
@@ -55577,21 +52808,20 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "wkA" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Atmos Supermatter Mix"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/turf/open/floor/engine,
-/area/engineering/supermatter/room)
+/turf/open/floor/iron,
+/area/security/brig)
 "wkM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -55624,9 +52854,7 @@
 /obj/structure/table,
 /obj/item/storage/box/mousetraps,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/hidden/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "wlr" = (
@@ -55645,15 +52873,14 @@
 /turf/open/floor/iron/white,
 /area/science/explab)
 "wmE" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/iron,
-/area/cargo/warehouse/upper)
-"wmY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
+/turf/open/floor/plating,
+/area/cargo/warehouse/upper)
+"wmY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
@@ -55665,15 +52892,6 @@
 /obj/structure/sign/warning,
 /turf/closed/wall,
 /area/science/mixing)
-"wnL" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/carpet,
-/area/command/heads_quarters/captain)
 "woq" = (
 /obj/structure/chair,
 /turf/open/floor/plating,
@@ -55695,6 +52913,12 @@
 /obj/item/pestle,
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
+"wpn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/service/bar/atrium)
 "wpI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -55714,8 +52938,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
@@ -55734,9 +52959,7 @@
 /area/engineering/supermatter/room)
 "wsC" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
 "wsV" = (
@@ -55745,20 +52968,20 @@
 /area/service/kitchen/coldroom)
 "wtj" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron/dark,
 /area/security/processing/cremation)
 "wun" = (
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -55769,21 +52992,22 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
 "wvX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "wwp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "wwr" = (
@@ -55807,7 +53031,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "wxJ" = (
@@ -55820,10 +53046,10 @@
 /area/security/brig)
 "wyP" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -55848,11 +53074,9 @@
 "wzm" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
@@ -55862,20 +53086,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/bar)
-"wzK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/engineering/main)
 "wAr" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/space,
 /area/space/nearstation)
 "wAI" = (
@@ -55890,8 +53103,10 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "wBO" = (
@@ -55916,9 +53131,7 @@
 /area/service/library/artgallery)
 "wCz" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "wDm" = (
@@ -55942,10 +53155,7 @@
 /area/service/chapel/main/monastery)
 "wDA" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -55972,9 +53182,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "wEn" = (
@@ -55990,8 +53199,12 @@
 /area/hallway/secondary/exit/departure_lounge)
 "wEz" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/carpet,
 /area/service/chapel/main/monastery)
 "wEJ" = (
@@ -56001,10 +53214,8 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "wFr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -56019,15 +53230,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
-"wGm" = (
-/obj/structure/window/plasma/reinforced/spawner/east,
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engineering/supermatter)
 "wGM" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -56042,15 +53244,19 @@
 "wHP" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "wIt" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/carpet,
@@ -56059,13 +53265,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/service/library/artgallery)
-"wJG" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "wJL" = (
 /obj/structure/sign/painting/library{
 	pixel_x = 32
@@ -56074,7 +53273,7 @@
 /area/service/library/artgallery)
 "wJT" = (
 /obj/structure/chair/wood,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/carpet,
@@ -56158,12 +53357,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"wOl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
 "wOF" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio8";
@@ -56177,7 +53370,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/plating,
 /area/science/mixing)
 "wPc" = (
@@ -56189,13 +53382,18 @@
 /area/cargo/warehouse/upper)
 "wPl" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
 "wPr" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/cargo/office)
+/area/security/brig)
 "wPw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -56211,27 +53409,6 @@
 /obj/structure/chair/sofa/left,
 /turf/open/floor/carpet,
 /area/medical/psychology)
-"wQI" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/science/lab)
-"wQJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "wQU" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating{
@@ -56240,8 +53417,10 @@
 /area/maintenance/department/cargo)
 "wRg" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/service/library/lounge)
 "wRk" = (
@@ -56252,12 +53431,6 @@
 "wRz" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -56310,8 +53483,10 @@
 /area/service/lawoffice)
 "wTG" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/office)
 "wTO" = (
@@ -56364,15 +53539,20 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"wVt" = (
+/obj/effect/decal/cleanable/ash,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "wVC" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Sci";
 	location = "Bar1"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -56393,22 +53573,16 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "wVV" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /turf/open/floor/plating,
 /area/medical/virology)
-"wWb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/service/library)
 "wWO" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
@@ -56430,11 +53604,9 @@
 	req_access_txt = "5"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/plating,
 /area/medical/storage)
@@ -56453,11 +53625,18 @@
 /obj/structure/window/plasma/reinforced/spawner/east,
 /obj/machinery/power/rad_collector/anchored,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
+"wYb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "wYi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
@@ -56478,20 +53657,12 @@
 "wYH" = (
 /obj/structure/grille/broken,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
-"wZg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "xan" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -56518,17 +53689,14 @@
 	name = "Solutions Room";
 	req_access_txt = "2"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "xba" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "xbu" = (
@@ -56540,20 +53708,13 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/newscaster/directional/west,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
 "xbB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
@@ -56562,8 +53723,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
@@ -56639,9 +53801,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "xea" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
 "xee" = (
@@ -56651,24 +53811,16 @@
 /area/hallway/secondary/exit/departure_lounge)
 "xeB" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
-/area/service/lawoffice)
-"xfi" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/service/hydroponics)
-"xfm" = (
-/obj/effect/landmark/start/assistant,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/turf/open/floor/wood,
+/area/service/lawoffice)
+"xfm" = (
+/obj/effect/landmark/start/assistant,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
@@ -56679,8 +53831,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
@@ -56688,7 +53840,9 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "xgG" = (
@@ -56699,7 +53853,9 @@
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "xhj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/carpet,
 /area/service/library/lounge)
 "xhB" = (
@@ -56707,11 +53863,9 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
@@ -56745,14 +53899,25 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "xjl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/turf/open/floor/engine,
-/area/engineering/supermatter/room)
+/turf/open/floor/iron,
+/area/security/brig)
+"xjq" = (
+/obj/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/cargo/warehouse/upper)
 "xjK" = (
 /obj/machinery/requests_console/directional/west{
 	department = "Detective";
@@ -56762,37 +53927,30 @@
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "xjU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/security)
 "xjZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "xkb" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/carpet,
 /area/service/library/artgallery)
 "xkk" = (
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"xks" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "xkB" = (
 /obj/structure/closet/crate,
 /obj/item/canvas/twentythree_twentythree,
@@ -56813,15 +53971,19 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
 "xlh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -56836,9 +53998,7 @@
 /area/science/genetics)
 "xmg" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "xmp" = (
@@ -56849,15 +54009,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
-"xmC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "xmE" = (
 /obj/structure/chair{
 	dir = 8
@@ -56899,9 +54050,17 @@
 /area/medical/medbay/central)
 "xnm" = (
 /obj/machinery/power/port_gen/pacman,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
+"xnS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "xog" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -56917,12 +54076,10 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "xou" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/security)
 "xoD" = (
@@ -56956,9 +54113,11 @@
 /obj/machinery/shower{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
 "xqq" = (
@@ -56975,44 +54134,32 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "xqI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
 "xrG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"xsp" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
 "xsr" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/service/bar/atrium)
-"xsL" = (
+"xst" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/tcommsat/computer)
+/area/hallway/primary/central)
 "xsO" = (
 /obj/item/ectoplasm,
 /turf/open/floor/plating{
@@ -57023,13 +54170,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "xtI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "xud" = (
@@ -57040,12 +54190,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"xuf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/closed/wall,
-/area/maintenance/department/engine)
 "xur" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -57064,11 +54208,13 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
 "xuy" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron/dark,
 /area/security/prison)
+"xvu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall,
+/area/maintenance/department/engine)
 "xvx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -57081,15 +54227,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"xvP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/service/lawoffice)
 "xvV" = (
 /obj/effect/turf_decal/caution{
 	dir = 8
@@ -57101,17 +54238,9 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"xwG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/ai_sat_ext_as)
 "xwX" = (
 /obj/machinery/door/airlock/security{
 	name = "Equipment Room";
@@ -57119,24 +54248,17 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security)
-"xxc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/ai_sat_ext_as)
-"xxk" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
+/turf/open/floor/iron,
+/area/security)
+"xxk" = (
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
 "xxw" = (
@@ -57147,15 +54269,17 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
 "xxK" = (
 /obj/machinery/firealarm/directional/west,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/security)
 "xxO" = (
@@ -57175,8 +54299,12 @@
 "xxS" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "xyh" = (
@@ -57215,8 +54343,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "xyK" = (
@@ -57245,21 +54371,18 @@
 /turf/closed/wall,
 /area/cargo/storage)
 "xBB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/service/library)
-"xBX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
+"xBF" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/engineering/main)
 "xDj" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
@@ -57282,12 +54405,6 @@
 /area/cargo/storage)
 "xEA" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
 "xEI" = (
@@ -57304,24 +54421,17 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/disposal)
-"xFl" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
 "xFF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "xFS" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/service/lawoffice)
@@ -57332,14 +54442,19 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"xGL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/commons/dorms)
 "xGN" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -57351,7 +54466,9 @@
 /turf/open/floor/iron,
 /area/security)
 "xHe" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "xHk" = (
@@ -57364,12 +54481,22 @@
 "xHq" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "xIM" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/office)
 "xIP" = (
@@ -57394,6 +54521,12 @@
 	},
 /turf/open/floor/wood,
 /area/service/lawoffice)
+"xJC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/commons/storage/primary)
 "xKc" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/r_wall,
@@ -57401,10 +54534,21 @@
 "xKD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/engine)
+"xKY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/command/teleporter)
 "xLi" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -57412,7 +54556,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/white/corner,
@@ -57425,14 +54569,19 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/navbeacon/wayfinding/lawyer,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/service/lawoffice)
 "xLH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "xMQ" = (
@@ -57442,15 +54591,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
-"xNg" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
 "xNx" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/junction/flip,
@@ -57458,12 +54598,9 @@
 /area/space/nearstation)
 "xNH" = (
 /obj/structure/cable,
-/turf/closed/wall,
-/area/maintenance/solars/starboard)
-"xNK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/engineering/storage_shared)
+/obj/machinery/power/apc/auto_name/north,
+/turf/open/floor/plating,
+/area/maintenance/solars/port)
 "xNS" = (
 /obj/machinery/bounty_board{
 	dir = 4;
@@ -57483,10 +54620,8 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -57512,8 +54647,12 @@
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "xPQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "xQr" = (
@@ -57538,20 +54677,16 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/main)
-"xSF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/wood,
-/area/service/lawoffice)
 "xSH" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "xTb" = (
@@ -57562,8 +54697,9 @@
 /area/maintenance/disposal/incinerator)
 "xTe" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "xTf" = (
@@ -57599,11 +54735,11 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "xUX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
@@ -57618,14 +54754,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/service/bar/atrium)
 "xXv" = (
@@ -57636,31 +54770,25 @@
 /area/engineering/atmos)
 "xXQ" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
+"xZO" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "yat" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/medical)
-"ybh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
-"ybo" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/science/explab)
 "ybu" = (
 /obj/effect/turf_decal/plaque,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "yby" = (
@@ -57679,16 +54807,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"ybZ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engineering/lobby)
 "ycl" = (
 /obj/machinery/light{
 	dir = 4
@@ -57745,12 +54863,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "ydA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "ydZ" = (
@@ -57778,26 +54890,37 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
+"yfT" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
+"yfV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/engine)
 "ygx" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "ygW" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -57823,32 +54946,39 @@
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "yiF" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
 "yiR" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"ykC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/engine)
 "ykY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
@@ -68848,7 +65978,7 @@ bZY
 bZY
 lAf
 owS
-aYu
+kqH
 rrU
 ctu
 bZY
@@ -68863,7 +65993,7 @@ chY
 bWV
 ciz
 cvs
-nzD
+rut
 rut
 gEh
 csS
@@ -69105,7 +66235,7 @@ giI
 pkM
 crv
 owS
-aYu
+kqH
 rrU
 gKz
 bZY
@@ -69628,7 +66758,7 @@ bWV
 hGQ
 cuv
 hAF
-ckZ
+ykY
 aBS
 ciN
 bWV
@@ -69885,13 +67015,13 @@ bWV
 cvB
 cuw
 cbK
-fUy
+ykY
 csS
 cvd
 bWV
 ciz
 cvt
-fUy
+ykY
 crk
 csS
 csS
@@ -70142,7 +67272,7 @@ bWV
 cvB
 cux
 cbK
-fUy
+ykY
 cvB
 ciO
 bWV
@@ -70399,13 +67529,13 @@ bWV
 csS
 cve
 cuK
-iDQ
+ykY
 txu
 cve
 bWV
-hMY
+ykY
 fdl
-xNg
+ykY
 bWV
 bWV
 bWV
@@ -70904,7 +68034,7 @@ bWV
 csS
 bYz
 hGQ
-uVo
+yiF
 txu
 cfm
 ctK
@@ -70913,11 +68043,11 @@ csS
 csv
 cuz
 csS
-fUy
+ykY
 csS
 csS
 csv
-fUy
+ykY
 csS
 ctP
 cwa
@@ -71161,21 +68291,21 @@ caT
 vFZ
 bWV
 cds
-oNA
+yiF
 yiF
 xkK
 yiF
-qbE
 yiF
 yiF
 yiF
 yiF
-tqq
 yiF
 yiF
 yiF
-tqq
-lbk
+yiF
+yiF
+yiF
+yiF
 qFp
 cwa
 cwm
@@ -71432,7 +68562,7 @@ bWV
 cgG
 cgG
 bWV
-fUy
+ykY
 qFp
 cwa
 cwn
@@ -71675,7 +68805,7 @@ crK
 tWk
 hTw
 csv
-uKf
+yiF
 bWV
 cfm
 csS
@@ -71689,7 +68819,7 @@ cvb
 ciT
 cvh
 cgG
-fUy
+ykY
 qFp
 cwa
 nww
@@ -71932,11 +69062,11 @@ bZl
 usI
 cbP
 cdu
-uKf
+yiF
 ceK
 cfm
 fnN
-fUy
+ykY
 cgG
 cid
 cuA
@@ -71946,8 +69076,8 @@ cgH
 ciS
 cid
 cgG
-sUk
-hCZ
+ykY
+yiF
 cwc
 kMt
 cwA
@@ -72189,11 +69319,11 @@ bZm
 caV
 cbM
 kOF
-uKf
+yiF
 ceL
 cfm
 ccJ
-fUy
+ykY
 bWV
 cun
 cuB
@@ -72203,7 +69333,7 @@ chG
 ciT
 cjo
 bWV
-fUy
+ykY
 cvI
 cwa
 clf
@@ -72229,7 +69359,7 @@ czr
 czr
 czI
 pcn
-vsS
+xBB
 cjp
 cjp
 cyU
@@ -72425,7 +69555,7 @@ bIV
 bMu
 bMu
 bMu
-fpG
+tCV
 bOx
 bPo
 bQg
@@ -72446,11 +69576,11 @@ cwk
 wIt
 cwk
 cbN
-gZq
+wEz
 csS
 ozR
 csS
-fUy
+ykY
 cgG
 cgk
 cuA
@@ -72460,7 +69590,7 @@ cgH
 cgH
 cvi
 cgG
-fUy
+ykY
 gZW
 cwa
 cjO
@@ -72680,7 +69810,7 @@ bGG
 bHL
 bIW
 bMu
-goJ
+xlh
 eAP
 hCj
 jXz
@@ -72694,20 +69824,20 @@ dUh
 dUh
 dUh
 dUh
-lWz
+vsq
 yiF
 wEz
 wEz
 wEz
 wEz
-nUU
+wEz
 wEz
 cbO
 ccF
 oaM
 nkK
 oaM
-ybh
+ykY
 cgG
 cuo
 ciV
@@ -72717,7 +69847,7 @@ cib
 cvg
 cid
 cgG
-fUy
+ykY
 qFp
 cwe
 cwe
@@ -72937,7 +70067,7 @@ bGH
 bHL
 bIX
 bMu
-bLp
+xlh
 dQg
 bNv
 bNw
@@ -72964,7 +70094,7 @@ csS
 cth
 cfm
 ctN
-fUy
+ykY
 bWV
 cup
 cuE
@@ -72974,7 +70104,7 @@ cgH
 cgj
 cvj
 bWV
-fUy
+ykY
 cvJ
 cwe
 cwr
@@ -73000,9 +70130,9 @@ cAK
 cAK
 cAK
 cAK
-wWb
+xBB
 pGZ
-mBW
+xBB
 syW
 cAS
 cyU
@@ -73221,7 +70351,7 @@ csS
 ceK
 cfm
 csS
-fUy
+ykY
 cgG
 ciV
 cgH
@@ -73238,7 +70368,7 @@ xhj
 xhj
 xhj
 xhj
-fGt
+xhj
 xhj
 xhj
 lqy
@@ -73255,8 +70385,8 @@ cjQ
 cjQ
 cjQ
 jMS
-iHY
-ueK
+vNF
+vNF
 xBB
 cAu
 cAC
@@ -73478,7 +70608,7 @@ csS
 bWV
 cfm
 csS
-fUy
+ykY
 cgG
 cgm
 cuE
@@ -73488,15 +70618,15 @@ ciE
 ciW
 cjr
 cgG
-iDQ
+ykY
 vVk
 whQ
-mQS
-mQS
+qJK
+qJK
 qJK
 wRg
 swE
-mQS
+qJK
 eXy
 dEr
 cxD
@@ -73512,9 +70642,9 @@ aTN
 aTN
 aTN
 aTN
-mBW
+xBB
 iBp
-now
+xBB
 cAv
 cAD
 cAK
@@ -73735,7 +70865,7 @@ cfl
 bWV
 cfm
 csS
-fUy
+ykY
 bWV
 cgG
 cgG
@@ -73745,7 +70875,7 @@ bWV
 cgG
 cgG
 bWV
-fUy
+ykY
 qFp
 cwe
 ivQ
@@ -73770,7 +70900,7 @@ cAK
 cAK
 cAK
 cAK
-sLG
+vNF
 cAK
 cAt
 cAK
@@ -73989,21 +71119,21 @@ bWV
 bWV
 bWV
 vDX
-dHN
+ykY
 qcb
-oaM
-qDQ
-oaM
-oaM
-bGS
-oaM
-oaM
-oaM
-bGS
-oaM
-oaM
-qDQ
-lbk
+ykY
+ykY
+ykY
+ykY
+ykY
+ykY
+ykY
+ykY
+ykY
+ykY
+ykY
+ykY
+yiF
 cwe
 cwe
 fWv
@@ -74028,9 +71158,9 @@ czu
 czD
 czN
 vNF
-iHY
+vNF
 qit
-iHY
+vNF
 cAM
 cjp
 cyU
@@ -74252,15 +71382,15 @@ ctP
 csS
 csS
 crk
-fUy
+ykY
 csS
 csS
 wDx
-fUy
+ykY
 cvk
 csS
 csS
-qwp
+yiF
 cfm
 cwe
 bHH
@@ -74660,18 +71790,18 @@ aiu
 ait
 ait
 aiu
-ntI
-vGh
-vGh
-vGh
-sQr
-qHg
+xTe
+xTe
+xTe
+xTe
+xTe
+tSq
 axg
 viq
-sNv
+viq
 axC
-vtT
-vtT
+xNH
+cRA
 aAY
 axC
 aaa
@@ -74917,7 +72047,7 @@ aiu
 aaa
 aaa
 aiu
-xFl
+xTe
 aiu
 aiu
 aiu
@@ -74929,7 +72059,7 @@ syn
 axC
 axC
 azS
-nzR
+axC
 axC
 aiu
 aiu
@@ -75031,7 +72161,7 @@ pqS
 chL
 cfm
 pIy
-sIN
+voM
 gkQ
 whJ
 elH
@@ -75174,19 +72304,19 @@ aiu
 aiu
 aiu
 aiu
-xFl
+xTe
 aiu
 coG
 cIt
-tpu
+ajD
 atp
 aus
 aiu
 tSq
 axC
 xuv
-vtT
 cRA
+vtT
 gjN
 aiu
 apB
@@ -75288,7 +72418,7 @@ oMn
 ciY
 cfm
 pIy
-sIN
+voM
 rie
 whJ
 roy
@@ -75426,7 +72556,7 @@ uqJ
 afU
 afU
 ajG
-aku
+akv
 alj
 alT
 skw
@@ -75435,11 +72565,10 @@ aof
 aiu
 aqh
 lqc
-xsp
+ajD
 atq
 aut
 aiu
-fYg
 xTe
 xTe
 xTe
@@ -75448,7 +72577,8 @@ xTe
 xTe
 xTe
 xTe
-glx
+xTe
+syn
 wUz
 ait
 aht
@@ -75547,10 +72677,10 @@ cfm
 nPm
 voM
 dGd
-cTq
-cTq
-cTq
-cTq
+kkU
+kkU
+kkU
+kkU
 kkU
 pQA
 iiJ
@@ -75802,13 +72932,13 @@ rli
 ciZ
 cfm
 pIy
-mTL
+voM
 gda
 oya
 rUS
 xkb
 xkb
-srX
+xkb
 pQA
 tqW
 woX
@@ -75944,7 +73074,7 @@ akw
 ajD
 aiH
 aiu
-aSt
+ueU
 apB
 aiu
 aiu
@@ -75962,7 +73092,7 @@ aiu
 aiu
 aiu
 aiu
-dQm
+xTe
 aiu
 aiu
 aiu
@@ -76059,7 +73189,7 @@ cfm
 cfm
 cfm
 pIy
-sIN
+voM
 fdN
 whJ
 roy
@@ -76201,7 +73331,7 @@ ajH
 ajH
 ajH
 ajH
-aSt
+ueU
 aiu
 aiu
 aaa
@@ -76219,7 +73349,7 @@ aiu
 aCd
 hHr
 hHr
-dQm
+xTe
 ezF
 aod
 aqg
@@ -76313,7 +73443,7 @@ gtl
 tBb
 nBO
 hwY
-fZP
+voM
 icy
 vvY
 kzj
@@ -76456,10 +73586,10 @@ aiZ
 ajH
 akx
 alY
-rJx
+wtj
 amI
-drJ
-tmz
+ueU
+ueU
 aiu
 aaa
 aaa
@@ -76474,12 +73604,12 @@ aaa
 aaa
 aiu
 nyO
-vtQ
-xTe
-aBZ
-xTe
-xTe
-kxK
+tRk
+tRk
+tRk
+tRk
+tRk
+tRk
 aiu
 gxq
 jeq
@@ -76510,7 +73640,7 @@ aaa
 jzz
 aZx
 jzz
-knA
+wmY
 pVS
 aZx
 aaa
@@ -76570,7 +73700,7 @@ wCj
 roy
 pYc
 roy
-fKI
+gda
 whJ
 whJ
 whJ
@@ -76702,21 +73832,21 @@ adR
 aht
 afU
 afU
-agV
+xaW
 afU
 afU
 ahk
 ahy
-byv
+rHF
 rHF
 aja
 ajI
 wtj
-iHs
+wtj
 bAG
 ajH
 ajH
-aSt
+ueU
 aiu
 aaa
 aaa
@@ -76731,12 +73861,12 @@ aaa
 aaa
 aiu
 awE
-dQm
+tRk
 eOZ
 kQZ
 nih
 kxs
-dQm
+tRk
 aiu
 rgs
 jeq
@@ -76753,7 +73883,7 @@ aQt
 sYE
 aie
 aYG
-hWI
+rWG
 vvo
 bbQ
 bcX
@@ -76767,7 +73897,7 @@ aaa
 bbQ
 bcX
 bdV
-nTO
+wmY
 bon
 aZx
 aaa
@@ -76833,7 +73963,7 @@ reR
 tFt
 dCh
 dCh
-gkD
+roy
 sBW
 whJ
 cfN
@@ -76960,11 +74090,11 @@ abI
 afX
 agl
 xSH
-cZm
+xSH
 xaW
 ahl
 ahz
-prl
+rHF
 aiz
 ajb
 ajH
@@ -76973,7 +74103,7 @@ alo
 raF
 amK
 anw
-aSt
+ueU
 aiu
 aaa
 aaa
@@ -77004,13 +74134,13 @@ xxy
 aRD
 aSv
 aTK
-nkH
+rBj
 pGe
 aQu
 aOf
 duQ
 aYG
-tfh
+rWG
 bop
 aZx
 aZx
@@ -77024,7 +74154,7 @@ aaa
 aZx
 aZx
 aZx
-nTO
+wmY
 uib
 aZx
 aaa
@@ -77055,11 +74185,11 @@ amB
 aht
 bva
 bHP
-bHQ
-bHQ
-bHQ
-bHQ
-bHQ
+ykC
+ykC
+ykC
+ykC
+hHp
 bHQ
 bPp
 bva
@@ -77090,7 +74220,7 @@ uIv
 kVM
 nWF
 xMQ
-skg
+kVM
 gXh
 whJ
 cfN
@@ -77230,7 +74360,7 @@ akA
 akA
 akA
 akA
-aSt
+ueU
 aiu
 aaa
 aaa
@@ -77257,7 +74387,7 @@ aKD
 gmO
 aQt
 aOh
-kXr
+eAI
 aRE
 aSw
 aTL
@@ -77281,7 +74411,7 @@ aaa
 aZx
 bkQ
 bbR
-nTO
+wmY
 bon
 aZx
 aaa
@@ -77311,7 +74441,7 @@ aaa
 amB
 bva
 bva
-bHQ
+ykC
 bJc
 bKh
 bLu
@@ -77478,7 +74608,7 @@ agy
 agy
 agy
 aiF
-cpj
+sdE
 aiC
 ajc
 agy
@@ -77487,7 +74617,7 @@ alq
 alZ
 psT
 anx
-stN
+ueU
 aiu
 aaa
 aaa
@@ -77502,7 +74632,7 @@ aaa
 aaa
 ebD
 aCe
-xvP
+rny
 xHe
 elk
 mXq
@@ -77510,15 +74640,15 @@ gSH
 jhk
 aiu
 gxq
-ahg
+lTD
 pGe
 aQu
 aOg
-kXr
+eAI
 aRF
 aSx
 aTM
-nkH
+rBj
 pGe
 aQu
 aOf
@@ -77568,7 +74698,7 @@ aaa
 amB
 bva
 bGK
-bHQ
+ykC
 bJd
 bKi
 bLv
@@ -77735,7 +74865,7 @@ agI
 agW
 agy
 ahC
-cpj
+sdE
 aiC
 ajc
 agy
@@ -77759,15 +74889,15 @@ aiu
 aiu
 gSH
 xJy
-ncU
-xSF
+rny
+sTf
 oYc
 sJr
 gSH
 jhk
 aiu
 niy
-rBj
+tyU
 pGe
 aQt
 aOf
@@ -77781,7 +74911,7 @@ aQt
 aOf
 bxH
 aYG
-tfh
+rWG
 bop
 bbS
 bda
@@ -77795,7 +74925,7 @@ aaa
 aZx
 bkS
 bbS
-nTO
+wmY
 boo
 aZx
 aaa
@@ -77825,7 +74955,7 @@ aaa
 amB
 bva
 bGL
-bHQ
+ykC
 bJe
 bKj
 bLv
@@ -77983,10 +75113,10 @@ aen
 aep
 aeD
 fJd
-jIy
-jIy
-mnc
-cJv
+acC
+acC
+adT
+wbB
 agz
 agM
 agX
@@ -78016,7 +75146,7 @@ ayE
 aAb
 ebD
 jjC
-dIl
+rny
 vhk
 gAG
 kxj
@@ -78024,21 +75154,21 @@ gSH
 oTp
 aiu
 kAa
-joz
+tyU
 gvf
-lrB
-lrB
-tQw
-lrB
-lrB
-lrB
-hPg
-lrB
-pCm
+xUX
+xUX
+xUX
+xUX
+xUX
+xUX
+xUX
+xUX
+xUX
 aQs
 gzy
 aYG
-aGR
+oPg
 ejn
 aZx
 aZx
@@ -78052,7 +75182,7 @@ aaa
 aZx
 aZx
 aZx
-wmY
+xnS
 fLM
 aZx
 aaa
@@ -78249,7 +75379,7 @@ agK
 agY
 agy
 adE
-gqS
+sdE
 aiE
 agy
 agy
@@ -78273,7 +75403,7 @@ ayF
 mrk
 xLC
 xeB
-gzU
+xeB
 uuS
 uAU
 oCn
@@ -78295,7 +75425,7 @@ xUX
 mcV
 bcl
 aYG
-oHO
+oPg
 bop
 fTZ
 bcX
@@ -78309,7 +75439,7 @@ aaa
 bbQ
 bcX
 bdV
-lTe
+xnS
 bon
 aZx
 aaa
@@ -78339,12 +75469,12 @@ lsq
 aht
 bva
 bHQ
-bHQ
+bWd
 bJg
 bKl
-bHQ
+yfV
 bMC
-bHQ
+tuG
 bHQ
 bPq
 bva
@@ -78506,7 +75636,7 @@ agy
 agy
 agy
 ahF
-cpj
+sdE
 aiF
 ajf
 ajL
@@ -78519,7 +75649,7 @@ avB
 avB
 avB
 lUY
-ark
+wkA
 asu
 apE
 auy
@@ -78566,7 +75696,7 @@ aaa
 jzz
 aZx
 jzz
-lTe
+xnS
 bon
 aZx
 aZx
@@ -78596,7 +75726,7 @@ bva
 bva
 oTJ
 bHQ
-bHQ
+bWd
 bJh
 bHQ
 bKm
@@ -78763,26 +75893,26 @@ agL
 agZ
 agy
 ahG
-cpj
+sdE
 aiF
 aen
 ajL
 ark
 ark
-ylS
+sFL
 oGx
-ark
-ark
-ark
-ark
-bYi
 hdB
-ark
+hdB
+hdB
+hdB
+hdB
+hdB
+wPr
 atw
-auy
+xjl
 avt
 uUY
-aAm
+oZX
 nTx
 pFy
 gSH
@@ -78809,7 +75939,7 @@ aPv
 fBt
 aHz
 aYG
-oHO
+oPg
 bop
 bbR
 bbR
@@ -78823,7 +75953,7 @@ aaa
 aYG
 bbR
 bbR
-lTe
+xnS
 bop
 bbR
 bbR
@@ -78839,21 +75969,21 @@ bBX
 bBX
 bBX
 bva
-epl
-fSx
-fSx
-fSx
-epl
-fSx
+xtI
+hBf
+hBf
+hBf
+xtI
+hBf
 pZT
 xKD
 pZT
-fSx
-epl
-fSx
+hBf
+xtI
+hBf
 bva
 bLy
-bLy
+jhH
 bva
 bva
 bva
@@ -79014,33 +76144,33 @@ dGY
 xuy
 xuy
 xuy
-svw
+wbB
 agB
 agM
 agX
 ahp
 eTW
 jng
-inA
+jng
 cxn
 czw
 wbs
-art
-art
+hWq
+hWq
 wcf
-art
-art
-art
-art
+wcf
+wcf
+wcf
+wcf
 aqn
-tgK
+wbs
 mJe
 apE
 auz
 avu
 uUY
 aAm
-aAc
+mrk
 aAe
 hlQ
 xxS
@@ -79066,7 +76196,7 @@ xUX
 bcl
 gxq
 aYG
-oHO
+oPg
 bop
 bop
 bop
@@ -79096,7 +76226,7 @@ bDg
 bXy
 bFF
 bva
-fSx
+hBf
 bva
 bHT
 bJi
@@ -79107,10 +76237,10 @@ bva
 qvx
 bHT
 bNQ
-epl
-epl
-epl
-fSx
+xtI
+xtI
+xtI
+hBf
 bDi
 mpU
 bIZ
@@ -79290,7 +76420,7 @@ amg
 amh
 amg
 aqo
-bsg
+wbs
 asx
 ajM
 ajM
@@ -79315,7 +76445,7 @@ oEA
 oEA
 oEA
 ayD
-rtQ
+vIc
 xxS
 hlQ
 uLF
@@ -79323,21 +76453,21 @@ aVO
 bcl
 aXG
 aYG
-oHO
+oPg
 bop
 bop
 bop
 bop
 beY
 bop
-nCW
-bop
+qiz
+slb
 bop
 cBT
 bdX
 bop
 bop
-lTe
+xnS
 bop
 bop
 bop
@@ -79353,7 +76483,7 @@ bDg
 bEk
 bva
 bva
-epl
+xtI
 bEr
 bEr
 bEr
@@ -79367,7 +76497,7 @@ bEr
 bEr
 bAW
 bva
-eyY
+kkF
 bDi
 lrI
 bIZ
@@ -79538,7 +76668,7 @@ aiF
 iTa
 agy
 ajN
-sFL
+ark
 aly
 amg
 amS
@@ -79547,14 +76677,14 @@ aop
 aoR
 amh
 aqz
-bsg
+wbs
 mJe
 apE
 auy
 avv
 uUY
 aAm
-ayL
+qNG
 ioZ
 aBd
 aCi
@@ -79576,31 +76706,31 @@ scp
 oEA
 oEA
 jRZ
-dTV
+ihM
 bcl
 kAa
 aYG
 oPg
-bhE
-kGd
-kGd
-kTJ
-kGd
-kGd
+iWV
+xnS
+xnS
+xnS
+xnS
+xnS
 hGq
-bhE
+iWV
 tfS
-kGd
-ucz
+xnS
+uxF
 bkT
-kGd
-vMN
-kGd
-kGd
+xnS
+xjZ
+xnS
+xnS
 hGq
 bsm
-tcZ
-kGd
+xnS
+xnS
 bwr
 bya
 bzB
@@ -79610,7 +76740,7 @@ bDh
 bEl
 bva
 bVC
-epl
+xtI
 bEr
 doo
 hRH
@@ -79624,7 +76754,7 @@ bNL
 bOD
 aht
 bIZ
-fSx
+hBf
 bDi
 ccN
 bva
@@ -79804,14 +76934,14 @@ anI
 aoS
 amh
 aqq
-bsg
-ark
+wbs
+wPr
 atA
 auA
 avw
 uUY
 aAm
-ayL
+qNG
 ioZ
 aBd
 aCj
@@ -79833,7 +76963,7 @@ oto
 tnY
 uCS
 aML
-dTV
+ihM
 aWI
 aXK
 aXH
@@ -79867,7 +76997,7 @@ bva
 bEm
 bva
 bTl
-fSx
+hBf
 bEr
 erQ
 oat
@@ -79881,7 +77011,7 @@ bNM
 bOD
 aht
 bIZ
-fSx
+hBf
 bDi
 ftp
 bva
@@ -80061,14 +77191,14 @@ piI
 aoT
 apK
 ark
-bsg
+wbs
 mJe
 apE
 auz
 avx
 uUY
 aAm
-ayL
+qNG
 ioZ
 aBe
 aCl
@@ -80086,7 +77216,7 @@ uoS
 uoS
 aPt
 uos
-rHA
+qsJ
 qjx
 uCS
 aML
@@ -80098,8 +77228,8 @@ aZF
 baQ
 aXH
 bdd
-lTe
-bop
+xnS
+ejn
 bfb
 bgU
 bhF
@@ -80113,18 +77243,18 @@ aYG
 aYG
 eUe
 bva
-snn
+eZJ
 bsn
 bws
 byb
 bzC
 bzC
 bBY
-fSx
-epl
-fSx
-fSx
-fSx
+hBf
+xtI
+hBf
+hBf
+hBf
 bEr
 qIl
 sEN
@@ -80138,9 +77268,9 @@ bKn
 bEr
 aht
 bva
-rDS
+tAh
 bWZ
-bTl
+vtV
 bva
 bTc
 dRB
@@ -80318,14 +77448,14 @@ oPV
 aoU
 amh
 aqz
-bsg
+wbs
 asz
 ajM
 ajM
 ajM
 ajM
 axI
-nPn
+qNG
 uhN
 aBf
 pqw
@@ -80343,11 +77473,11 @@ uoS
 tCP
 xOC
 jAy
-uJQ
+ydA
 ffJ
 oEA
 dpa
-dTV
+ihM
 bcl
 aXI
 aYI
@@ -80355,8 +77485,8 @@ aZI
 baR
 aXI
 bde
-swz
-pgH
+xnS
+fOw
 bga
 bgV
 qIf
@@ -80370,13 +77500,13 @@ bnu
 bpu
 uHJ
 uPG
-wQJ
-vNl
+xtI
+hBf
 tAh
 kkF
 bzD
 bAM
-fSx
+hBf
 bDj
 bEr
 bEr
@@ -80385,7 +77515,7 @@ bEr
 bEr
 kTU
 wMn
-lNy
+rsd
 rsd
 rsd
 aSr
@@ -80571,18 +77701,18 @@ geP
 iMH
 vrx
 vrx
-sYg
+tla
 aoV
 amh
 aqz
-bsg
+wbs
 mJe
 apE
 auy
 avy
 uUY
 qAF
-ayL
+qNG
 ioZ
 aBe
 aCm
@@ -80603,12 +77733,12 @@ aQw
 ydA
 yfO
 hDG
-nbb
-dGQ
+aML
+ihM
 bcl
 aXJ
 fow
-soD
+tdj
 baS
 bbV
 bop
@@ -80653,16 +77783,16 @@ hnY
 aKl
 ctF
 cFT
-hCS
+bDi
 wwp
 oKD
 fwg
 qvM
-bDi
-bDi
-bDi
+aYc
+aYc
+aYc
 bWZ
-bDi
+aYc
 bDi
 bZr
 caa
@@ -80833,13 +77963,13 @@ aoW
 apM
 aqy
 arn
-ark
+wPr
 atC
 auA
 avz
 uUY
 aAm
-ayL
+qNG
 ioZ
 aBd
 aCn
@@ -80861,7 +77991,7 @@ aRG
 qWM
 oEA
 aML
-dTV
+ihM
 bcl
 aXI
 aYJ
@@ -80869,7 +77999,7 @@ tdj
 baT
 aXI
 bop
-lTe
+xnS
 jVo
 bjK
 bgX
@@ -80882,7 +78012,7 @@ oRF
 bos
 bor
 uwj
-tOk
+wqC
 bso
 tqC
 wiy
@@ -80909,8 +78039,8 @@ bEr
 bEr
 aht
 bva
-qCL
-fJT
+cFT
+bDi
 bva
 bva
 bva
@@ -80919,7 +78049,7 @@ bva
 bva
 bva
 bDi
-bDi
+aYc
 bva
 bva
 bva
@@ -81078,26 +78208,26 @@ abI
 ahL
 ail
 quw
-uXL
-uXL
-uXL
-uXL
+kbV
+kbV
+kbV
+kbV
 amk
-tfW
-tfW
+piI
+piI
 tla
 aoX
 amh
 aqz
-arp
+vao
 mJe
 apE
 auz
 avA
 uUY
-aAm
-ayL
-ioZ
+oZX
+qNG
+coP
 aBd
 aCo
 aaz
@@ -81167,8 +78297,8 @@ aaa
 aaa
 bva
 eNy
-nKh
-dqj
+bps
+fAU
 sUP
 bTf
 isF
@@ -81342,18 +78472,18 @@ afH
 amh
 amZ
 anJ
-oyy
+tla
 aoY
 amg
 sBA
-tTD
+vao
 asB
 ajM
 ajM
 ajM
 ajM
 axJ
-ayL
+qNG
 jTE
 aBd
 aBd
@@ -81383,7 +78513,7 @@ aZK
 aXI
 aXK
 aKa
-oXE
+yiR
 dNA
 bjK
 bhJ
@@ -81423,17 +78553,17 @@ bEr
 aaa
 aaa
 bva
-qCL
+raH
 bDi
 bva
 rXJ
 bTg
-tjp
+eHl
 jYh
 bVv
 bva
 nQc
-uDf
+lQb
 bva
 bOB
 bva
@@ -81603,14 +78733,14 @@ aos
 amh
 amg
 aqv
-tTD
+vao
 mJe
 atE
 auB
 avB
 awL
 aAm
-ayL
+qNG
 ioZ
 aBg
 aEs
@@ -81624,7 +78754,7 @@ ptL
 ptL
 rvS
 ptL
-ptL
+pel
 ptL
 clO
 ptL
@@ -81632,11 +78762,11 @@ ptL
 ptL
 aTO
 ptL
-kSj
+rQV
 hmv
+pel
 ptL
-ptL
-voX
+ygW
 ptL
 rQa
 ptL
@@ -81690,7 +78820,7 @@ dAG
 bVw
 bva
 iEQ
-uDf
+lQb
 ccN
 lFx
 bva
@@ -81860,7 +78990,7 @@ aot
 apa
 agP
 aqz
-tTD
+vao
 mJe
 apE
 ark
@@ -81869,39 +78999,39 @@ uUY
 aAm
 ayN
 aAk
-kPQ
-kPQ
-kPQ
-kPQ
-kPQ
+nTx
+nTx
+nTx
+nTx
+nTx
 fFF
-kdN
+yiR
 isC
 aHF
 vsm
-bZb
-pXd
-pXd
-pXd
-pXd
+yiR
+xPQ
+xPQ
+xPQ
+xPQ
 aQB
-pTc
-pTc
-pTc
-gtk
+ugM
+ugM
+ugM
+xHq
 wun
-pTc
-pTc
-pTc
+ugM
+ugM
+ugM
 ugM
 syA
-pTc
-pTc
-eZX
-pTc
-pTc
+ugM
+ugM
+syA
+ugM
+ugM
 bgZ
-lrT
+ugM
 pkj
 biP
 bjL
@@ -81910,7 +79040,7 @@ bmh
 xyK
 bjL
 bpy
-bqX
+biv
 bsr
 tqC
 tqC
@@ -81922,7 +79052,7 @@ bCa
 tqC
 ulf
 cKQ
-tgd
+xZO
 boN
 sOB
 uYF
@@ -81937,17 +79067,17 @@ pnF
 sOB
 aht
 bva
-hko
+uuC
 bDi
 bva
 bva
 bva
-xuf
+xvu
 bva
 bva
 bva
 bva
-nsm
+aYc
 bDi
 bZt
 bva
@@ -82108,12 +79238,12 @@ aio
 agP
 ajl
 ajY
-bFT
+idZ
 alC
 amn
 alC
 amn
-nmS
+tLA
 apb
 agP
 avE
@@ -82134,25 +79264,25 @@ aBh
 aGd
 tHk
 ptL
-xmC
+xPQ
 aJG
 aKa
 jcT
-jcT
+rLQ
 jcT
 adY
 xvO
 jcT
 jcT
 rBv
-voX
+ame
 aVR
 gpu
 aXL
 aYL
 jcT
 baW
-jcT
+rLQ
 jcT
 beb
 jcT
@@ -82168,7 +79298,7 @@ wns
 bjL
 mgW
 bCd
-htK
+bvL
 uYT
 tqC
 gDX
@@ -82183,7 +79313,7 @@ bGO
 bHU
 bJk
 jKE
-feS
+osQ
 osQ
 vsn
 fNX
@@ -82194,7 +79324,7 @@ mKz
 bSs
 aht
 bIZ
-qCL
+raH
 bNQ
 bva
 bSu
@@ -82370,7 +79500,7 @@ alD
 anM
 anc
 xGN
-nmS
+tLA
 apb
 agQ
 faT
@@ -82415,8 +79545,8 @@ aVS
 aVS
 bgf
 bhb
-xmC
-jcT
+xPQ
+piM
 bij
 bjL
 bkZ
@@ -82425,7 +79555,7 @@ xyK
 bjL
 mgW
 srf
-umh
+bFJ
 btW
 tqC
 ezx
@@ -82436,12 +79566,12 @@ bCc
 tqC
 pBm
 uyg
-tgd
+xZO
 sAF
 sOB
 rtk
 bsu
-jyI
+iqg
 bss
 piR
 lba
@@ -82451,12 +79581,12 @@ gkS
 bSs
 aht
 bIZ
-qCL
+raH
 bDi
 bRF
 bDi
 bPC
-fJT
+gbz
 bva
 bPA
 bSw
@@ -82626,7 +79756,7 @@ oFO
 tLA
 amp
 tLA
-eJt
+tLA
 aov
 apc
 apP
@@ -82638,7 +79768,7 @@ auE
 aoP
 awO
 aAm
-daV
+nTx
 aAm
 aBi
 aCr
@@ -82648,7 +79778,7 @@ aFs
 aGe
 aGX
 ptL
-xmC
+xPQ
 jcT
 aKK
 aLx
@@ -82667,7 +79797,7 @@ aVS
 aZO
 baX
 bbX
-bec
+lRC
 lRC
 bfi
 bgg
@@ -82682,11 +79812,11 @@ nyl
 bjL
 bvc
 bqY
-dTg
-dcx
+udZ
+udZ
 rtd
-qdO
-qdO
+waa
+waa
 bzK
 btV
 btV
@@ -82698,7 +79828,7 @@ boN
 sOB
 pcH
 vgg
-upj
+uFo
 cSf
 wGM
 nPg
@@ -82709,11 +79839,11 @@ sOB
 aht
 bva
 xbD
-uJM
-qkR
-mAU
+gbz
+rlR
+wVt
 bTj
-qny
+gbz
 bva
 tRc
 bVz
@@ -82879,57 +80009,57 @@ ahd
 agP
 ajo
 ghx
-cIn
+lyd
 alC
-nmS
+tLA
 alC
 okX
 aow
 apd
 agQ
 emB
-nAJ
+wbs
 mJe
 atH
 auF
 auF
 awP
 oZX
-dVU
+nTx
 aAn
 aBi
 aCs
-hoN
-hia
 ktv
-ktv
+kvr
+kvr
+kvr
 aGY
-lUD
-pJH
-lUD
+pIu
+ygW
+pIu
 aKL
 nJc
 aMW
 aOu
 aKJ
 wYH
-iBS
-iBS
-iBS
-gRh
+mUt
+mUt
+mUt
+mUt
 aVS
 aWN
 aXO
 aYM
 vOW
-iiU
+vOW
 oAk
 aZP
 bed
 aVS
 bgh
 jcT
-xmC
+xPQ
 bik
 biT
 bjL
@@ -82956,8 +80086,8 @@ sOB
 bKp
 bpz
 uFo
-nCn
-jsr
+uFo
+wGM
 pTy
 kYt
 pds
@@ -82965,7 +80095,7 @@ rhT
 bSs
 aht
 bIZ
-tBN
+xbD
 bDi
 bva
 nGx
@@ -83157,19 +80287,19 @@ aAm
 aBi
 aCt
 aDy
-lUd
+aMB
 aDA
 aGf
 aGX
-hmv
-xmC
-jcT
+ocd
+xPQ
+piM
 aKK
 aLz
 aMX
 aOv
 aKJ
-kPZ
+mUt
 aLL
 aRL
 aRL
@@ -83186,7 +80316,7 @@ bee
 aVS
 bgi
 jcT
-xmC
+xPQ
 oRl
 bjL
 bjL
@@ -83222,7 +80352,7 @@ rHh
 sOB
 aht
 bva
-tBN
+xbD
 bDi
 bva
 bSx
@@ -83232,7 +80362,7 @@ bva
 bDi
 bDi
 bDi
-nsm
+aYc
 bDi
 nWP
 bva
@@ -83386,9 +80516,9 @@ aby
 aaa
 agQ
 cnP
-rgx
+xou
 xjU
-rGG
+xjU
 xjU
 cTC
 ajq
@@ -83414,19 +80544,19 @@ aAo
 aBi
 aCu
 aDz
-lUd
+aMB
 aDA
 aGg
 aBi
 ptL
-xmC
+xPQ
 jcT
 aKJ
 aKJ
 aKJ
 aKJ
 aKJ
-kPZ
+mUt
 aRL
 aRL
 aRL
@@ -83443,7 +80573,7 @@ aVS
 aVS
 aRL
 qbP
-xmC
+xPQ
 bik
 bjc
 bjc
@@ -83479,7 +80609,7 @@ sOB
 sOB
 bva
 bva
-uuC
+fkQ
 bDi
 bva
 bva
@@ -83489,7 +80619,7 @@ bva
 bDi
 bDi
 bDi
-gbA
+ekB
 bva
 bva
 bva
@@ -83671,19 +80801,19 @@ awR
 aBj
 aCv
 aDz
-ixV
+aMB
 qDb
 aGh
 aBi
 aHK
-xmC
+xPQ
 jcT
 aKM
 aLA
 aMY
 aKP
 aNm
-kPZ
+mUt
 aRL
 aSA
 aTQ
@@ -83700,7 +80830,7 @@ aXQ
 bfj
 bdm
 jcT
-xmC
+xPQ
 ctM
 bjc
 wUf
@@ -83731,12 +80861,12 @@ bNP
 bOE
 dSI
 umd
-tQf
+bDi
 bva
 bsn
 bNX
 bVC
-tBN
+xbD
 bNQ
 bDi
 bDi
@@ -83744,8 +80874,8 @@ bDi
 bDi
 bOB
 ygZ
-vzd
-rHm
+aYc
+aYc
 cad
 eYM
 bQl
@@ -83927,13 +81057,13 @@ ayS
 aAp
 aBj
 aCw
-qxC
+xJC
 xfm
 aDA
 aGi
 aBi
 aHL
-xmC
+xPQ
 jcT
 aKM
 aLB
@@ -83957,47 +81087,47 @@ aZW
 bfk
 bdm
 jcT
-xmC
+xPQ
 bik
 bjc
 bjR
 blc
 tgT
-iSx
+bny
 boB
 bpF
 xUU
-nuX
-eqy
+tgd
+peY
 bvh
-bvL
+cKQ
 ivy
 bzO
-hyf
+cKQ
 bCh
 bjc
 bEu
 rWM
-ibI
-pcO
-oTY
-pcO
+rWM
+rWM
+rWM
+rWM
 iRs
 dOo
 xtI
 omS
 xtI
 xtI
-efJ
+hBf
 bva
 gcn
 bDi
 umd
-tBN
+xbD
 bDi
 bDi
 bDi
-cND
+sWN
 iOl
 iOl
 iOl
@@ -84180,18 +81310,18 @@ auH
 avJ
 awS
 ayV
-pRj
+qmQ
 aAq
 aBj
 vTL
-nMI
-lUd
+aDA
+aDA
 aDA
 aDA
 aGX
 ptL
-cxu
-wJG
+ygW
+eJq
 aKO
 aNa
 bgq
@@ -84200,7 +81330,7 @@ aPy
 aQI
 aRL
 aSC
-bej
+ftu
 aUU
 aRL
 aWQ
@@ -84213,9 +81343,9 @@ bdj
 aZW
 bfl
 bdm
-jcT
-xmC
-fZV
+oGZ
+xPQ
+hVJ
 bjc
 rvH
 uVB
@@ -84250,11 +81380,11 @@ bva
 sZP
 bDi
 bDi
-tBN
+xbD
 bDi
 bDi
 bDi
-jvZ
+xbD
 bBX
 bBX
 bBX
@@ -84442,8 +81572,8 @@ aAr
 aBj
 aCx
 oyF
-dPX
-jTU
+oyF
+oyF
 aGj
 onX
 aRK
@@ -84471,11 +81601,11 @@ lLb
 bfl
 bdm
 jcT
-xmC
+xPQ
 bik
 bjc
 bjS
-qJt
+cKQ
 eyL
 cKQ
 suU
@@ -84511,7 +81641,7 @@ bKH
 iOl
 iyg
 iOl
-iJV
+nqB
 acN
 mbe
 scz
@@ -84694,7 +81824,7 @@ auH
 auH
 auH
 axQ
-cTx
+qmQ
 aAs
 aBj
 gkR
@@ -84704,14 +81834,14 @@ aFv
 ulu
 aGX
 xyp
-xmC
+xPQ
 jcT
 aKQ
 aKQ
 aKQ
 aKQ
 aLL
-aQN
+wbR
 aRL
 aSE
 aTU
@@ -84720,7 +81850,7 @@ aVV
 aWS
 aXU
 aYP
-bbc
+gLd
 gLd
 gLd
 bdl
@@ -84728,12 +81858,12 @@ bei
 bfm
 bdm
 jcT
-xmC
+xPQ
 bik
 bjc
 bjT
-wZg
-aab
+cKQ
+eyL
 pAo
 lpW
 yhR
@@ -84756,10 +81886,10 @@ ehr
 voI
 bFU
 xhT
-cND
+sWN
 iOl
 iOl
-iJV
+nqB
 ccN
 bUe
 bTl
@@ -84772,8 +81902,8 @@ bBX
 acN
 bZx
 eQN
-ntC
-xNK
+tcY
+nBT
 xiw
 cdI
 cri
@@ -84961,7 +82091,7 @@ awR
 awR
 aAN
 gNG
-xmC
+xPQ
 aJM
 aKQ
 aLE
@@ -84977,25 +82107,25 @@ aRL
 aWT
 aZW
 uwY
-xfi
+lrw
 aZW
 bca
 aZW
-bej
+ftu
 bfn
 bdm
 jcT
-xmC
+xPQ
 bik
 bjc
 bjU
-qJt
+cKQ
 eyL
 cKQ
 uQu
 bpJ
 xUU
-ecv
+uFc
 buc
 bvk
 tEE
@@ -85013,7 +82143,7 @@ bFU
 bFU
 bFU
 snT
-jvZ
+xbD
 bPB
 bPB
 bPB
@@ -85200,15 +82330,15 @@ anr
 aiR
 apk
 apQ
-aqE
-aqE
-aqE
+fvq
+fvq
+fvq
 atK
 auJ
-fvq
+mTF
 awT
 axR
-fJy
+ohu
 aDB
 aBk
 aCy
@@ -85218,13 +82348,13 @@ aFw
 awR
 aHb
 xyp
-cxu
-lUD
+ygW
+xst
 aKR
 aLF
 aNd
 wBg
-iBS
+mUt
 aQM
 aRL
 aSG
@@ -85234,7 +82364,7 @@ aRL
 aaX
 aaY
 vPa
-sjA
+fXu
 bbd
 aRL
 bdm
@@ -85252,7 +82382,7 @@ tCi
 xQO
 bpG
 ixN
-ecv
+uFc
 buc
 kQy
 aaR
@@ -85261,15 +82391,15 @@ krb
 eFj
 bCl
 xyI
-uaY
-uaY
+bJb
+bJb
 sVp
-uaY
-uaY
-uaY
+bJb
+bJb
+bJb
 bLG
 bpi
-uaY
+bJb
 nqB
 bPB
 bQm
@@ -85286,7 +82416,7 @@ krU
 acN
 kyv
 lWJ
-kHv
+tcY
 tfG
 dMA
 ous
@@ -85465,8 +82595,8 @@ arA
 avM
 awR
 aza
-wnL
-tLw
+aza
+aza
 aBl
 ohu
 aDD
@@ -85475,14 +82605,14 @@ aza
 awR
 aHc
 aHO
-xmC
+xPQ
 jcT
 aKQ
 aLG
 aNe
 aKQ
 aPA
-aQN
+wbR
 afu
 afu
 afu
@@ -85491,7 +82621,7 @@ afu
 afu
 aXZ
 aZW
-sjA
+fXu
 pWT
 bcb
 nQn
@@ -85499,7 +82629,7 @@ bel
 bdn
 kEM
 eZv
-xmC
+xPQ
 bik
 bjc
 bjW
@@ -85509,7 +82639,7 @@ bny
 boB
 bpF
 xUU
-ecv
+uFc
 buc
 tix
 cSJ
@@ -85527,11 +82657,11 @@ bSw
 bSw
 bDi
 bNU
-lve
+hBf
 bPB
 pQm
-kwh
-aDm
+ssL
+cCF
 cCH
 bTp
 bPB
@@ -85719,7 +82849,7 @@ arB
 asM
 atN
 aaZ
-ikU
+ssa
 awR
 axT
 ayZ
@@ -85731,15 +82861,15 @@ aEy
 aFx
 awR
 awR
-xyp
-xmC
-jhl
+vnR
+xPQ
+gEZ
 aKQ
 aKQ
 aKQ
 aKQ
 aLL
-vBL
+wbR
 afu
 ueJ
 aTX
@@ -85748,14 +82878,14 @@ aVW
 afu
 aXY
 aZW
-sjA
+fXu
 pWT
 bcc
 inG
 bem
-pXd
-bZb
-pXd
+aDm
+aJN
+aDm
 xPQ
 bik
 bjc
@@ -85784,10 +82914,10 @@ bpY
 bpY
 bpY
 dVv
-lve
+hBf
 bPB
 bQo
-cCF
+hol
 bRa
 bSy
 bTo
@@ -85982,14 +83112,14 @@ axU
 kfZ
 aAw
 aBn
-dnd
+qZE
 aDE
 aEz
 aFx
 aGk
 awR
 aHQ
-xmC
+xPQ
 nbw
 aKT
 aLH
@@ -85999,13 +83129,13 @@ aRY
 wbR
 aRO
 aSH
-aWV
-aWV
-cXx
+iNR
+iNR
+iNR
 afu
 hwo
 aYQ
-sjA
+fXu
 bbe
 bcd
 jcT
@@ -86013,7 +83143,7 @@ ttN
 jcT
 aKa
 tWc
-xmC
+xPQ
 bin
 jze
 jze
@@ -86025,7 +83155,7 @@ ftW
 qpu
 bsF
 fhc
-bLJ
+qdO
 qdO
 qdO
 hQh
@@ -86041,7 +83171,7 @@ uik
 txK
 bMK
 dVv
-lve
+hBf
 bPB
 bQp
 ptK
@@ -86239,21 +83369,21 @@ axV
 azb
 aAx
 aBo
-lvE
+aBm
 aDF
 aAt
 aFy
 aGl
 awR
 ezk
-xmC
+xPQ
 psM
 aKT
 aLI
 aNg
 aKT
 aPB
-vBL
+wbR
 afu
 pMM
 aTZ
@@ -86280,7 +83410,7 @@ bnB
 boF
 djh
 xte
-tWt
+bIy
 tWt
 bvm
 tWt
@@ -86290,15 +83420,15 @@ peY
 bCp
 rlT
 tcX
-nSs
+tSm
 tSm
 tcX
-nSs
+tSm
 rFq
-gwt
+bsK
 ygx
 cBL
-nAj
+hBf
 bPB
 bQq
 bRG
@@ -86308,13 +83438,13 @@ bTq
 bPB
 bUJ
 bWp
-bWp
-bXg
+caj
+cnX
 bXY
 bYK
-vAE
-vAE
-xXQ
+iqp
+iqp
+iqp
 vAE
 vAE
 cdL
@@ -86352,9 +83482,9 @@ teJ
 clA
 clD
 clJ
-xsL
+kCI
 clY
-nOG
+kCI
 cmh
 uzn
 cmp
@@ -86503,35 +83633,35 @@ aFz
 aGm
 awR
 aHQ
-xmC
+xPQ
 aJV
 aKT
 aPz
 aLL
 aOw
 aLL
-vBL
+wbR
 afu
 aSI
 aTZ
 aUZ
-ekI
+iNR
 aWU
 afu
 aYR
-gHR
+rzz
 ftU
 cpq
 cpu
-iRX
+hJV
 bfp
 bgk
 jcT
-xmC
+xPQ
 bik
 jze
 bjZ
-umG
+eus
 eus
 bnC
 jze
@@ -86547,7 +83677,7 @@ bIi
 bCp
 tal
 hvS
-vNa
+qwJ
 qwJ
 cbQ
 bum
@@ -86555,7 +83685,7 @@ bKA
 bwV
 bMM
 dVv
-lve
+hBf
 bPB
 bPB
 bPB
@@ -86565,13 +83695,13 @@ uhn
 bPB
 bUK
 bVG
-bWp
+cma
 bXg
 bXY
 bYK
 cbW
 cbW
-fUl
+gzf
 pBN
 cbW
 cdM
@@ -86610,7 +83740,7 @@ clw
 hQz
 clw
 jCr
-rkl
+tlw
 kCI
 clw
 nMG
@@ -86760,35 +83890,35 @@ awR
 awR
 awR
 aHS
-xmC
+xPQ
 aJV
 aKT
 aLK
 aNh
 aKT
 aPC
-vBL
+wbR
 afu
 aSJ
 jtJ
 aVa
-fJv
+mEW
 mEW
 aYa
-aYS
-dZh
+gHR
+gHR
 bbg
-fJY
-fJY
-sUg
+fMk
+fMk
+hJV
 cpy
 bgk
 jcT
-xmC
+xPQ
 bik
 jze
 bka
-umG
+eus
 bmv
 bnD
 jze
@@ -86804,15 +83934,15 @@ bpY
 bpY
 kGl
 tta
-emJ
+xqq
 xqq
 dMR
-uxt
+gFf
 bKA
 prD
 dVv
 dVv
-lve
+hBf
 bPC
 bPB
 bRd
@@ -86867,7 +83997,7 @@ clw
 clw
 clw
 clL
-cma
+clG
 ugv
 clw
 cmj
@@ -87003,14 +84133,14 @@ arA
 arA
 arA
 atQ
-jiZ
-roJ
+auO
+lCe
 awY
 axX
 azd
 aAz
 mNN
-jjV
+wyP
 aDI
 aEB
 aEB
@@ -87041,7 +84171,7 @@ ber
 cpz
 bgk
 jcT
-xmC
+xPQ
 bik
 jze
 boH
@@ -87064,12 +84194,12 @@ tta
 uXp
 xqq
 dMR
-uxt
+gFf
 bKA
 vcC
 dVv
 bNV
-lve
+hBf
 bPD
 bPB
 bRe
@@ -87120,7 +84250,7 @@ aaa
 aaa
 aaa
 rcF
-ktz
+clw
 xnm
 clM
 clU
@@ -87261,8 +84391,8 @@ arH
 asQ
 atR
 auP
+puU
 ayg
-iLS
 ayg
 wyP
 ayg
@@ -87274,13 +84404,13 @@ aDJ
 ayg
 myu
 aHV
-aJb
+ukM
 tiR
 aKU
-aOx
+skS
 aNi
 skS
-aOx
+alb
 aQR
 afu
 aSL
@@ -87294,11 +84424,11 @@ gHR
 cpn
 bch
 bdq
-pxn
+sUg
 cpA
 bgk
 eZv
-xmC
+xPQ
 bik
 jze
 bkc
@@ -87318,10 +84448,10 @@ bsK
 bsK
 kGl
 tta
-emJ
+xqq
 xqq
 dMR
-uxt
+gFf
 bKA
 bLL
 dVv
@@ -87344,7 +84474,7 @@ cbW
 cak
 cbg
 mjt
-qGO
+xBF
 xSs
 rYY
 eHY
@@ -87518,8 +84648,8 @@ arI
 asR
 atS
 syK
-azo
-jKL
+syK
+rCf
 aDO
 wyP
 aAB
@@ -87531,7 +84661,7 @@ aAB
 arA
 arA
 aHV
-xmC
+xPQ
 fei
 kVO
 kVO
@@ -87555,7 +84685,7 @@ bep
 cpB
 bgk
 jcT
-xmC
+xPQ
 bik
 jze
 jze
@@ -87575,7 +84705,7 @@ bBi
 bCt
 bDv
 pKf
-emJ
+xqq
 xqq
 dMR
 rLd
@@ -87583,7 +84713,7 @@ bKA
 anH
 dVv
 bNX
-lve
+hBf
 bPE
 bQs
 bRg
@@ -87597,8 +84727,8 @@ bWs
 bXk
 bYc
 bYK
-cbW
-cbW
+pyA
+pyA
 cbh
 xpw
 vAE
@@ -87788,7 +84918,7 @@ aAB
 aGn
 axi
 aHV
-xmC
+xPQ
 ben
 axi
 aGn
@@ -87800,7 +84930,7 @@ aPE
 aPE
 aPE
 qEN
-aWg
+sah
 aWY
 aRN
 aYU
@@ -87812,7 +84942,7 @@ cpx
 aRN
 aRN
 jcT
-xmC
+xPQ
 fZV
 bje
 bke
@@ -87832,7 +84962,7 @@ bsK
 bsK
 iTx
 prD
-emJ
+xqq
 xqq
 dMR
 gFf
@@ -87840,7 +84970,7 @@ bKA
 prD
 dVv
 dVv
-hSP
+hBf
 bPF
 bTu
 bTu
@@ -87854,9 +84984,9 @@ bWt
 bXk
 bYd
 bYK
-nBi
-dpo
-wzK
+cbW
+cbW
+cbW
 cbW
 vAE
 orZ
@@ -87869,9 +84999,9 @@ igj
 upV
 aJa
 upV
-ciG
+lWv
 dKA
-ciG
+lWv
 hPG
 tSU
 fhE
@@ -88045,7 +85175,7 @@ aAB
 aGo
 awd
 aHV
-xmC
+xPQ
 fei
 awd
 abI
@@ -88069,13 +85199,13 @@ beu
 bgk
 bgn
 jcT
-xmC
+xPQ
 jcT
 cQN
 bkf
 bys
+yfT
 dBC
-chs
 boK
 bpU
 bsI
@@ -88089,7 +85219,7 @@ bsN
 bCv
 iTx
 prD
-emJ
+xqq
 xqq
 dMR
 gFf
@@ -88097,7 +85227,7 @@ bKA
 bLM
 bMN
 dVv
-lve
+hBf
 bPE
 bQu
 bRi
@@ -88111,7 +85241,7 @@ bWu
 bXk
 bYe
 bYK
-diu
+cbW
 can
 cbi
 ccc
@@ -88120,7 +85250,7 @@ cdR
 qFu
 taF
 uTI
-hXX
+vyo
 cgv
 thT
 kUj
@@ -88302,7 +85432,7 @@ aAB
 aGp
 awd
 aHV
-xmC
+xPQ
 fei
 awd
 abI
@@ -88326,7 +85456,7 @@ sbI
 aRN
 bgo
 jcT
-xmC
+xPQ
 jcT
 bjg
 fmD
@@ -88354,7 +85484,7 @@ bKA
 bsK
 bAg
 dVv
-lve
+hBf
 bPE
 bQv
 bRj
@@ -88368,7 +85498,7 @@ bUU
 bUU
 bUT
 bYR
-diu
+cbW
 cao
 cbj
 nZX
@@ -88386,7 +85516,7 @@ mQc
 tbC
 uRk
 tqO
-kTi
+rMN
 sqi
 cCI
 cbj
@@ -88551,8 +85681,8 @@ axb
 yeL
 azj
 aAC
-elJ
-iOE
+aBu
+aCK
 aDM
 aEG
 aAB
@@ -88567,7 +85697,7 @@ kVO
 coH
 aPE
 aQU
-aSP
+rPY
 dGO
 tki
 qaQ
@@ -88584,8 +85714,8 @@ cpC
 bgp
 jcT
 bhN
-jcT
-bjg
+ayr
+tKl
 cpY
 cqa
 bmy
@@ -88611,7 +85741,7 @@ jSW
 bLO
 bAh
 dVv
-lve
+hBf
 bPE
 bQw
 bRj
@@ -88624,8 +85754,8 @@ bVL
 bWv
 bVL
 bYf
-eKx
-diu
+oTM
+cbW
 uco
 nZX
 ccd
@@ -88638,8 +85768,8 @@ tlN
 fsA
 sWj
 tZU
-wGm
-wGm
+wXy
+wXy
 wXy
 uRk
 mZR
@@ -88816,7 +85946,7 @@ aAB
 aGr
 awd
 uNL
-xmC
+xPQ
 fei
 awd
 abI
@@ -88824,7 +85954,7 @@ kVO
 myk
 aPE
 aQV
-aSP
+rPY
 aSQ
 aUe
 qaQ
@@ -88839,9 +85969,9 @@ liQ
 bex
 bfr
 awg
-eZv
-xmC
-jcT
+eHq
+xPQ
+piM
 bjg
 bki
 ufo
@@ -88868,7 +85998,7 @@ nnf
 byz
 ooh
 dVv
-lve
+hBf
 bPE
 bQx
 bRj
@@ -88882,7 +86012,7 @@ bWw
 bXm
 bYg
 bYW
-fUl
+gzf
 fgv
 uUh
 cce
@@ -89073,7 +86203,7 @@ aAB
 aGs
 awd
 aHV
-xmC
+xPQ
 fei
 awd
 abI
@@ -89097,7 +86227,7 @@ bnb
 ajX
 aPT
 jcT
-xmC
+xPQ
 jcT
 cQN
 mKE
@@ -89125,7 +86255,7 @@ bKG
 byA
 bAi
 dVv
-lve
+hBf
 bPE
 bQy
 bRk
@@ -89282,7 +86412,7 @@ abO
 acP
 acW
 aee
-tZf
+olO
 adH
 olO
 olO
@@ -89330,19 +86460,19 @@ aAB
 aGn
 axi
 tNf
-xmC
+xPQ
 bft
 axi
 aGn
 kVO
 wzm
-aQE
-iBS
-fDa
+wYH
+mUt
+mUt
 aSR
 aPE
 ahP
-ofy
+tEB
 rof
 aiy
 qmm
@@ -89354,12 +86484,12 @@ bey
 cpC
 bgs
 jcT
-xmC
+xPQ
 jcT
 bji
 cQN
 blq
-dBN
+wFr
 pGF
 vLM
 yat
@@ -89382,11 +86512,11 @@ dVv
 dVv
 dVv
 dVv
-lve
+hBf
 bPE
 bQz
 bRl
-bOa
+rpu
 bVJ
 bTA
 bUU
@@ -89573,10 +86703,10 @@ aqI
 arQ
 asR
 atV
-nXG
+axc
 axc
 tyJ
-aDJ
+adG
 wyP
 aAB
 aAB
@@ -89587,7 +86717,7 @@ aAB
 arA
 arA
 aHV
-xmC
+xPQ
 aJR
 kVO
 kVO
@@ -89598,13 +86728,13 @@ kVO
 kVO
 ahB
 aUg
-bmd
+tEB
 tEB
 beB
 aYg
 qmm
 liQ
-rNU
+bsC
 bbr
 udo
 bez
@@ -89628,18 +86758,18 @@ cIe
 ihJ
 phx
 azR
-piz
-gVk
-gVk
-gVk
-gVk
-gVk
-gVk
-gVk
-gVk
-gVk
-gVk
-mVC
+vNl
+vNl
+vNl
+vNl
+vNl
+vNl
+vNl
+vNl
+vNl
+vNl
+hBf
+hBf
 bPE
 bQA
 bRm
@@ -89652,8 +86782,8 @@ bVN
 bWz
 bVN
 bYf
-eKx
-diu
+oTM
+cbW
 abb
 nZX
 ccg
@@ -89668,7 +86798,7 @@ sWj
 mnR
 qqa
 qqa
-hZQ
+qqa
 uRk
 sIq
 vRw
@@ -89787,16 +86917,16 @@ ace
 ace
 ace
 amd
-aNT
-aNT
-aNT
-bFJ
+acl
+acl
+acl
+acl
 acd
 acw
 acP
 acY
 sPa
-cUj
+olO
 acP
 adV
 adV
@@ -89804,7 +86934,7 @@ cnD
 adV
 adV
 acP
-ibP
+olO
 acP
 acP
 acP
@@ -89830,20 +86960,20 @@ aqI
 arR
 asT
 atW
-eEc
-gsr
-ubc
-kDB
-oVY
-kDB
-lmh
-qqe
+atW
+atW
+ayg
+ayg
+wyP
+ayg
+aBy
+vRN
 vRN
 aEJ
-qqe
-kDB
+vRN
+ayg
 aHe
-xks
+aHV
 xPQ
 eaB
 aKZ
@@ -89853,10 +86983,10 @@ ads
 aec
 afb
 aKY
-kPZ
+mUt
 aPE
 aVg
-ofy
+tEB
 beB
 aYf
 qmm
@@ -89910,7 +87040,7 @@ bUU
 bUU
 bUT
 bYX
-diu
+cbW
 cau
 cbj
 nZX
@@ -89929,7 +87059,7 @@ oEN
 uRk
 eqg
 dZj
-ciI
+lWv
 cCI
 cbj
 oex
@@ -90047,8 +87177,8 @@ abO
 bhU
 abO
 abO
-bJb
-aNT
+acl
+acl
 cCO
 acP
 acP
@@ -90093,15 +87223,15 @@ axe
 azo
 aAD
 aAE
-eoQ
-azl
+mNN
+wyP
 aDP
 aEK
 aEK
 aEK
 aHg
 aIa
-aRm
+mtC
 fei
 aKZ
 aPK
@@ -90110,7 +87240,7 @@ aPK
 aPK
 aQY
 aKY
-kPZ
+mUt
 aPE
 aVh
 tDz
@@ -90118,7 +87248,7 @@ beB
 aYg
 qmm
 aBH
-qVs
+txa
 bbp
 udo
 liQ
@@ -90130,8 +87260,8 @@ cpP
 jcT
 aKa
 bls
-vIH
-jcT
+aDm
+dhy
 bmB
 bva
 bDi
@@ -90152,7 +87282,7 @@ bEN
 ery
 bEN
 bRV
-bRV
+bRt
 bOK
 bPG
 hjO
@@ -90167,7 +87297,7 @@ bWA
 mCe
 bYj
 bYK
-diu
+cbW
 cav
 cbl
 cch
@@ -90310,7 +87440,7 @@ acM
 abO
 add
 adk
-pom
+ieU
 adX
 adV
 adV
@@ -90318,7 +87448,7 @@ cnD
 adV
 adV
 adX
-adj
+gAY
 afw
 kfl
 agf
@@ -90367,29 +87497,29 @@ adu
 aPI
 aQZ
 aKY
-kPZ
+mUt
 aPE
 aVi
 naX
 aXh
 aYg
 aZd
-kni
-kMf
-kni
-kWW
-kni
+pZM
+pZM
+pZM
+pZM
+pZM
 snD
 bgu
-pXd
+aDm
 bhO
 bio
-pXd
-bZb
+xPQ
+yiR
 vsm
-goz
-rPK
-rPK
+xPQ
+xPQ
+xPQ
 bJN
 mOt
 gVk
@@ -90400,20 +87530,20 @@ gVk
 gVk
 gVk
 uQB
-guZ
-guZ
+bRD
+bRD
 bFq
-fHB
+tWh
 bIt
-eFz
-iaC
-eFz
-eFz
-eFz
-eFz
+xbB
+xbB
+xbB
+xbB
+xbB
+xbB
 bPH
 bQC
-eFz
+xbB
 dpA
 bSM
 bTC
@@ -90424,7 +87554,7 @@ bWB
 mCe
 bYk
 bYK
-xXQ
+vAE
 vAE
 vAE
 vAE
@@ -90436,11 +87566,11 @@ niY
 flQ
 rMN
 qgX
-kTi
-jBi
-jBi
+rMN
+rMN
+rMN
 tQJ
-ciG
+lWv
 cjt
 ftb
 vLy
@@ -90615,12 +87745,12 @@ aAH
 aGt
 aAN
 giZ
-xmC
+xPQ
 fei
 aKZ
 aLS
 daO
-dHa
+eZE
 aPJ
 aRa
 aRX
@@ -90630,11 +87760,11 @@ cpb
 wzu
 beB
 pVr
-qmm
+aZd
 liQ
 lTf
 bbr
-mVV
+wpn
 liQ
 bfs
 bgt
@@ -90644,8 +87774,8 @@ cpQ
 jcT
 aKa
 blu
-vIH
-jcT
+aDm
+rLQ
 eeF
 bBX
 bBX
@@ -90671,7 +87801,7 @@ cCU
 bmD
 bmD
 bmD
-vvn
+dpA
 tgb
 bTC
 bUk
@@ -90681,8 +87811,8 @@ bWC
 mCe
 bYl
 bYK
-diu
-cci
+pyA
+eSW
 xpw
 cci
 vAE
@@ -90691,8 +87821,8 @@ cbj
 igu
 wza
 jBn
+rMN
 wza
-xjl
 chA
 iLF
 uTI
@@ -90823,7 +87953,7 @@ acD
 acL
 sYY
 adb
-adG
+ieU
 ieU
 adM
 kUt
@@ -90872,26 +88002,26 @@ aAH
 aGu
 aHh
 aHV
-jNv
-urT
+xPQ
+tMU
 aLb
-tGm
-fcJ
-fKK
+vGC
+eZE
+eZE
 aPK
 aRb
 aKY
-vBL
+wbR
 aPE
 cpc
 beB
 beB
 aYh
-qmm
+aZd
 liQ
 bbs
 bcq
-mVV
+wpn
 beC
 ajX
 ajX
@@ -90921,10 +88051,10 @@ bHp
 bIx
 bJD
 qOx
-qtD
 qXH
-qOx
-qOx
+qXH
+cDw
+cDw
 qOx
 qOx
 qzm
@@ -90938,18 +88068,18 @@ bWD
 bWD
 bTE
 bYY
-pyA
+cbW
 caw
 cbn
 ccj
-ecB
+xXQ
 mBz
 dsM
 aUG
 mUJ
 gsB
+ozZ
 wza
-wkA
 lWQ
 nZX
 evB
@@ -91077,7 +88207,7 @@ abO
 abO
 abO
 ace
-qcH
+abY
 acT
 add
 adn
@@ -91129,7 +88259,7 @@ aFA
 aGw
 awd
 aaf
-xmC
+xPQ
 fei
 aKZ
 aLU
@@ -91138,7 +88268,7 @@ aOD
 aPL
 aRc
 aKY
-vBL
+wbR
 aPE
 aVj
 aWm
@@ -91148,7 +88278,7 @@ cpk
 liQ
 xsr
 bbp
-mVV
+wpn
 beD
 cpC
 bgv
@@ -91158,7 +88288,7 @@ cpS
 cpU
 bKM
 blv
-fQS
+xbB
 rKh
 boP
 bqb
@@ -91166,7 +88296,7 @@ brp
 byF
 tiI
 byF
-wQI
+tiI
 byE
 bBp
 bBp
@@ -91199,14 +88329,14 @@ bZG
 cax
 cbo
 cck
-cbW
+pyA
 cdY
 cbj
 cfg
 qrw
 cfY
 tJX
-kbV
+uTI
 gEI
 evB
 cdm
@@ -91338,7 +88468,7 @@ rlV
 abO
 add
 ado
-kUR
+ieU
 adX
 adZ
 adZ
@@ -91386,7 +88516,7 @@ aAH
 aGw
 awd
 aHV
-xmC
+xPQ
 aJW
 aKY
 aLV
@@ -91395,7 +88525,7 @@ aLV
 aLV
 aKY
 aKY
-vBL
+wbR
 aPE
 aPE
 aPE
@@ -91410,12 +88540,12 @@ beE
 cpC
 bgw
 jcT
-vIH
+xPQ
 jcT
 bjn
 bKM
 blw
-fQS
+xbB
 cqi
 boQ
 cCl
@@ -91442,7 +88572,7 @@ nnl
 bPL
 kJm
 kMX
-nSZ
+sxT
 cdP
 bTF
 bUm
@@ -91453,10 +88583,10 @@ bXp
 bYn
 bZa
 gZx
-dnE
+ioK
 eSW
-ecX
-cbW
+eSW
+pyA
 cdY
 nZX
 lXk
@@ -91589,9 +88719,9 @@ abO
 act
 abO
 abO
-bRt
-biv
-rzz
+ace
+ace
+sWM
 acU
 acU
 acU
@@ -91643,7 +88773,7 @@ aAH
 aGw
 awd
 aHV
-xmC
+xPQ
 aJR
 anX
 aLW
@@ -91652,7 +88782,7 @@ aOE
 aPM
 anX
 aPB
-vBL
+wbR
 aUf
 aVk
 hxB
@@ -91666,13 +88796,13 @@ alp
 wSz
 ajX
 bgx
-jcT
-vIH
-jcT
+oGZ
+xPQ
+piM
 bKM
 bBo
 blx
-fQS
+xbB
 cqi
 boR
 cCl
@@ -91694,7 +88824,7 @@ cqz
 qzm
 bLT
 rnQ
-mYW
+sLg
 mYW
 mYW
 mYW
@@ -91843,16 +88973,16 @@ ace
 ace
 ace
 aFc
-biv
-biv
-biv
-cnX
+ace
+ace
+ace
+ace
 acd
 acw
 acU
 ade
 ael
-pEs
+xEA
 acU
 adZ
 adZ
@@ -91900,7 +89030,7 @@ aFA
 oxC
 awd
 aHV
-xmC
+xPQ
 fei
 aLc
 aNx
@@ -91909,7 +89039,7 @@ aOF
 aPN
 anX
 aRY
-vBL
+wbR
 aUf
 aVl
 aWo
@@ -91924,12 +89054,12 @@ beG
 ajX
 dXU
 jcT
-vIH
+xPQ
 jcT
 bjp
 bkm
 bly
-pQd
+xbB
 hkc
 dEd
 bqb
@@ -91942,7 +89072,7 @@ byH
 bAo
 bBs
 bCG
-lEU
+hRQ
 bET
 bBp
 bHj
@@ -91956,7 +89086,7 @@ bOM
 bPM
 bRq
 pwa
-nLc
+fZv
 bSP
 pps
 bUo
@@ -92157,16 +89287,16 @@ aFB
 aGx
 aHl
 aHV
-jNv
-urT
+xPQ
+tMU
 aLd
-lji
+xKY
 aNw
 aOG
 aPO
 anX
 aRZ
-vBL
+wbR
 aUf
 aVm
 aWp
@@ -92182,10 +89312,10 @@ bdy
 jcT
 jcT
 wVC
-jcT
-blt
-bmD
-bmD
+aDm
+tGj
+xbB
+xbB
 bmH
 cqi
 boS
@@ -92213,7 +89343,7 @@ qOx
 qOx
 qzm
 bRr
-ybZ
+mRO
 qOx
 fBp
 fBp
@@ -92366,15 +89496,15 @@ abO
 acU
 adg
 uyY
-tof
+xEA
 adQ
-xwG
-xwG
-xwG
-xwG
-xwG
+xEA
+xEA
+xEA
+xEA
+xEA
 aeS
-xxc
+xEA
 ezt
 afS
 acU
@@ -92398,7 +89528,7 @@ abI
 apT
 aqN
 arU
-asX
+adj
 sCQ
 auY
 eJq
@@ -92414,7 +89544,7 @@ aAH
 aGy
 aAN
 aHV
-xmC
+xPQ
 eaB
 aLc
 aNx
@@ -92423,7 +89553,7 @@ aOH
 aPP
 anX
 aSa
-vBL
+wbR
 aUf
 aUf
 aWq
@@ -92438,7 +89568,7 @@ aiG
 bdy
 jcT
 jcT
-vIH
+xPQ
 jcT
 bjr
 nUL
@@ -92470,7 +89600,7 @@ bOO
 bPN
 bRs
 mlD
-uIq
+lXV
 bYq
 cqG
 bUp
@@ -92486,7 +89616,7 @@ eTt
 eTt
 eTt
 iBq
-fBJ
+ndP
 ndP
 adR
 aaa
@@ -92671,8 +89801,8 @@ aAH
 aAN
 aAN
 aIc
-xmC
-fei
+xPQ
+uAj
 anX
 aMa
 aNy
@@ -92695,12 +89825,12 @@ beH
 ajX
 bgz
 jcT
-vIH
+xPQ
 bis
 bKM
 bkp
 blA
-byC
+njH
 bnL
 boU
 cCl
@@ -92723,8 +89853,8 @@ bKP
 bLX
 bMZ
 bOh
-vWp
-vWp
+vld
+vld
 vWp
 vWp
 bSc
@@ -92952,7 +90082,7 @@ ajX
 ajX
 jcT
 jcT
-vIH
+xPQ
 biq
 bGa
 bkq
@@ -92974,7 +90104,7 @@ bDG
 bEW
 bAt
 bHp
-nAx
+xbB
 bJF
 lkh
 bPI
@@ -93185,11 +90315,11 @@ jcT
 jcT
 fcQ
 jcT
-voX
+ygW
 aJX
 dNA
 ydu
-ydu
+nLS
 ydu
 ydu
 aRd
@@ -93209,13 +90339,13 @@ diM
 aKa
 bgA
 jcT
-vIH
+xPQ
 bis
 bKM
 bkr
 blC
 cqe
-bnN
+eKI
 jXw
 bqe
 njH
@@ -93230,8 +90360,8 @@ bCL
 bDH
 bEX
 bGb
-ulr
-aTl
+rLF
+xbB
 bJH
 fBp
 fBp
@@ -93429,44 +90559,44 @@ arX
 ata
 auf
 ava
-pJH
+ygW
 ayh
 ayh
 mew
-dEB
-dEB
+ygW
+ygW
 aCY
-sMn
-sMn
-sMn
-sMn
+xHq
+xHq
+xHq
+xHq
 stt
 qQD
 xHq
-sCW
+ugM
 hwx
-sCW
-sCW
-sCW
-sCW
-sCW
-sCW
-jWn
-sCW
-rcS
-sCW
-sCW
-sCW
+ugM
+ugM
+ugM
+ugM
+ugM
+ugM
+ugM
+ugM
+syA
+ugM
+ugM
+ugM
 rTD
-rPK
-rPK
-rPK
-ueC
-rPK
-kdN
-rPK
+xPQ
+xPQ
+xPQ
+ygW
+xPQ
+yiR
+xPQ
 bhh
-fbz
+xPQ
 bir
 bBo
 bks
@@ -93488,7 +90618,7 @@ bDI
 bEY
 bAt
 qQl
-nAx
+xbB
 cqE
 fBp
 bLY
@@ -93694,7 +90824,7 @@ jcT
 eZv
 jcT
 jcT
-jcT
+rLQ
 jcT
 jcT
 aKa
@@ -93703,7 +90833,7 @@ aJd
 jcT
 aNX
 siF
-siF
+fyK
 siF
 siF
 aXr
@@ -93745,7 +90875,7 @@ bAt
 bAu
 bAu
 qQl
-pQd
+xbB
 dQq
 bKR
 bLZ
@@ -93757,7 +90887,7 @@ hXC
 hXC
 hXC
 keN
-lxl
+vap
 eKY
 wUN
 bOk
@@ -93965,7 +91095,7 @@ jcT
 aLe
 aAN
 aAN
-xmC
+xPQ
 jcT
 vif
 pvZ
@@ -94007,14 +91137,14 @@ bJK
 fBp
 bMa
 wSR
-bOk
+ctd
 bWO
 fJw
 eUb
-tZX
-tZX
+bWO
+bWO
 pln
-aJN
+rud
 ksv
 sGc
 bOk
@@ -94222,7 +91352,7 @@ jcT
 aPT
 aRf
 aPT
-xmC
+xPQ
 jcT
 aVq
 aWs
@@ -94244,27 +91374,27 @@ bkv
 blF
 nox
 nox
-eLo
+nox
 bqh
 brx
 bsX
 buv
 bvE
-teH
+vvn
 byM
 bAw
-fHB
-fHB
-tWh
-fHB
-fHB
+tLm
+tLm
+tLm
+tLm
+tLm
 bHr
 bID
 bJL
-bKR
+waK
 bMb
 wSR
-bOk
+ctd
 bOV
 bPQ
 bQJ
@@ -94470,7 +91600,7 @@ aaa
 aaa
 awd
 xvO
-ffx
+ame
 jcT
 aLe
 aMe
@@ -94478,9 +91608,9 @@ jcT
 eZv
 jcT
 jcT
-jcT
-xmC
-jcT
+oGZ
+xPQ
+piM
 aVq
 aWt
 aXs
@@ -94727,7 +91857,7 @@ aaa
 aaa
 awd
 xvO
-ffx
+ame
 jcT
 aLe
 aMf
@@ -94736,7 +91866,7 @@ aOQ
 aPV
 jcT
 jcT
-xmC
+xPQ
 jcT
 aVq
 aWu
@@ -94778,7 +91908,7 @@ fBp
 fBp
 bMd
 wSR
-bOk
+ctd
 bOX
 bPQ
 bQK
@@ -94984,7 +92114,7 @@ rYC
 aET
 aET
 xvO
-ffx
+ame
 jhl
 lAs
 dMB
@@ -94998,12 +92128,12 @@ aOT
 uZJ
 php
 vZP
-cyi
+dsm
 aZn
 bav
 cuL
 pvZ
-fvN
+oZN
 beI
 bfv
 bgE
@@ -95036,10 +92166,10 @@ bKS
 uvr
 feN
 bOo
-aOr
+fIA
 bPT
 fIA
-bRA
+wCz
 bSf
 bSR
 hfi
@@ -95212,18 +92342,18 @@ aju
 ajt
 alQ
 mnG
-alb
+biy
 otM
 aJc
 anY
 apt
 sbk
 aiS
-alP
+jVK
 cBB
-mtT
-mtT
-mtT
+sFK
+sFK
+sFK
 jVK
 coe
 apX
@@ -95241,7 +92371,7 @@ jOB
 qbZ
 aET
 xvO
-ffx
+ame
 jcT
 lAs
 aMg
@@ -95260,12 +92390,12 @@ aZn
 baw
 bbA
 pvZ
-fvN
+oZN
 beI
 bfw
 bgF
 bhl
-bhS
+ovT
 ovT
 oUl
 bkw
@@ -95278,7 +92408,7 @@ brA
 btb
 bkt
 bvI
-bxz
+sTi
 byQ
 bBo
 aaa
@@ -95292,12 +92422,12 @@ fBp
 bKT
 bWO
 wYi
-jap
-bOZ
-tZX
-tZX
+ctd
+wCz
+bWO
+bWO
 bRz
-tZX
+bWO
 bSS
 bTR
 gbu
@@ -95469,13 +92599,13 @@ akh
 alc
 alR
 amF
-qDi
+hCS
 stG
 anm
-mtT
-gxV
+sFK
+sFK
 uGx
-mtT
+sFK
 cBA
 ajv
 ajv
@@ -95498,7 +92628,7 @@ cor
 aET
 aET
 hFy
-ife
+ame
 piM
 dMB
 aMh
@@ -95517,7 +92647,7 @@ aZn
 bat
 syO
 pvZ
-fvN
+oZN
 beI
 bfx
 bgG
@@ -95535,7 +92665,7 @@ brB
 btc
 bkt
 bvJ
-ptI
+sTi
 byR
 bAA
 bAA
@@ -95550,11 +92680,11 @@ vMt
 bWO
 pEh
 bOk
-bPa
+fIA
 bPU
-aOr
+fIA
 wCz
-aOr
+fIA
 bST
 bTS
 nEp
@@ -95730,7 +92860,7 @@ fui
 cPO
 aJc
 uEr
-eaw
+ajv
 ajv
 ajv
 ajv
@@ -95745,7 +92875,7 @@ avg
 awp
 apX
 ayl
-hIF
+spP
 apX
 aBO
 aDd
@@ -95755,7 +92885,7 @@ fFL
 jOB
 lKL
 xvO
-ffx
+ame
 eZv
 dMB
 aMi
@@ -95763,8 +92893,8 @@ aNK
 mlV
 dMB
 aRj
-wPr
-hDu
+dTT
+hFV
 dTT
 nDP
 pvZ
@@ -95774,7 +92904,7 @@ hNd
 tYn
 nBt
 pvZ
-fvN
+oZN
 beI
 bfy
 bgI
@@ -95987,7 +93117,7 @@ aJc
 aJc
 aJc
 aob
-eaw
+ajv
 ajv
 auq
 ajv
@@ -96012,7 +93142,7 @@ gAV
 aGB
 aET
 tOt
-ffx
+ame
 jcT
 dMB
 aMj
@@ -96021,17 +93151,17 @@ aTB
 lAs
 bdS
 edZ
-fct
-caj
-tUw
+hFV
+tkl
+cay
 pvZ
 abc
 seX
 rJT
-igC
+rJT
 sLD
 vQo
-hdh
+uyp
 beI
 bfz
 bgI
@@ -96049,7 +93179,7 @@ bkt
 bkt
 bkt
 bvQ
-nXu
+sTi
 aba
 bAA
 bBC
@@ -96069,8 +93199,8 @@ vsJ
 vsJ
 vsJ
 bSg
-vsJ
-vsJ
+bMe
+bMe
 bUx
 qQx
 bWO
@@ -96243,7 +93373,7 @@ fNg
 iEU
 aJc
 akj
-mtT
+sFK
 afQ
 raI
 oei
@@ -96259,17 +93389,17 @@ avh
 pec
 axo
 aym
-pec
+xGL
 aav
 aQC
-uUG
+mfZ
 apX
 aET
 bPd
 aET
 aET
 xvO
-ffx
+ame
 aNE
 lAs
 aMk
@@ -96278,7 +93408,7 @@ aOU
 aQa
 wTG
 wTG
-lhy
+xIM
 xIM
 aVu
 pvZ
@@ -96306,7 +93436,7 @@ fwe
 lcA
 buw
 bvM
-nXu
+sTi
 byU
 bAA
 bBE
@@ -96514,19 +93644,19 @@ atj
 apX
 avi
 aws
-con
-pUY
-lAq
 qXD
-eMg
+qXD
+qXD
+qXD
+gLn
 gLn
 cop
-sMn
-lIG
+qxa
+qxa
 aGC
-sMn
+qxa
 dPO
-ioG
+ame
 jcT
 lAs
 lAs
@@ -96537,7 +93667,7 @@ aRl
 blN
 cay
 dTT
-oJw
+xIM
 aWw
 bat
 oxM
@@ -96562,14 +93692,14 @@ bpb
 pdv
 btf
 uVN
-nhr
+uVN
 sTi
 byV
 bAA
 bBG
 bCR
-dyt
-orW
+ocg
+ocg
 rPu
 bCR
 bII
@@ -96771,17 +93901,17 @@ apX
 apX
 avj
 awv
-ayr
+uMh
 azv
 azv
-ivi
+ten
 com
 aXV
 apX
 jcT
 jcT
-jcT
-jcT
+rLQ
+uYW
 jcT
 aJk
 jhl
@@ -96802,12 +93932,12 @@ aZn
 baz
 uwF
 oYq
-iUg
-ngn
-ngn
-ngn
-aRe
-nUW
+set
+uOR
+uOR
+uOR
+fGd
+aFi
 bix
 aFi
 pKd
@@ -96820,12 +93950,12 @@ brF
 bkx
 buy
 bvO
-nXu
+sTi
 byW
 bAA
 bBG
 bCR
-rRI
+hxp
 tct
 bGi
 bHv
@@ -97040,10 +94170,10 @@ cot
 eZv
 jcT
 jcT
-xBX
-dEB
+ame
+pIu
 pez
-qyG
+oZN
 wDZ
 wDZ
 wDZ
@@ -97063,9 +94193,9 @@ bbI
 bbI
 bbI
 bbI
-aEj
-aEj
-biy
+esM
+aFi
+aFi
 bjw
 bjw
 bjw
@@ -97077,7 +94207,7 @@ bjw
 bjw
 bod
 bvP
-nXu
+sTi
 byX
 bAA
 bAA
@@ -97270,7 +94400,7 @@ aaa
 aaa
 aaa
 ajy
-kFP
+sFK
 alg
 aaa
 aaa
@@ -97300,7 +94430,7 @@ aIj
 aJm
 aKg
 aEj
-fvN
+oZN
 wDZ
 aUm
 bcN
@@ -97321,8 +94451,8 @@ amb
 bfB
 bbI
 jaJ
-xba
-hdh
+hxx
+uyp
 bjw
 bky
 blP
@@ -97334,7 +94464,7 @@ brG
 btg
 fjs
 bvQ
-nXu
+sTi
 byY
 bCT
 bCT
@@ -97541,12 +94671,12 @@ asi
 atk
 izB
 com
-awv
-ayr
+nzR
+uMh
 cok
 cok
 ibD
-com
+bdJ
 aDi
 aEd
 aEZ
@@ -97557,7 +94687,7 @@ aEd
 nSz
 aEd
 aEd
-fvN
+oZN
 wDZ
 abh
 mse
@@ -97575,11 +94705,11 @@ bbG
 bcB
 hgV
 hgV
-ame
+hgV
 bbI
 nts
 bbI
-bcM
+lru
 bjw
 bkz
 bky
@@ -97588,7 +94718,7 @@ bnW
 bpe
 bqp
 bqs
-qxO
+vfp
 dGN
 dha
 bxA
@@ -97784,7 +94914,7 @@ aaa
 aaa
 aaa
 ajy
-kFP
+sFK
 alg
 aaa
 aaa
@@ -97799,30 +94929,30 @@ atl
 aum
 uFi
 awv
-lWd
 com
 com
-pEG
+com
+com
 com
 aDj
 aJn
 aGF
-bIy
+aGF
 tfc
-wgQ
-wgQ
+aGF
+aGF
 rtC
 aKh
 aEd
-nCm
+oZN
 aNO
-jBI
-jBI
+ofj
+ofj
 aSj
 ofj
 vgR
-twM
-lAD
+wkM
+myc
 xNS
 cCB
 cCB
@@ -97833,10 +94963,10 @@ bcC
 qfZ
 xPf
 hgV
-peq
-fQD
 bbI
-bcM
+fQD
+aNT
+lru
 bjw
 bkA
 blR
@@ -97845,7 +94975,7 @@ bnX
 eSL
 bqq
 bqs
-gDZ
+vfp
 wlK
 bvQ
 bwa
@@ -98056,22 +95186,22 @@ atn
 atn
 jNg
 awv
-lWd
 com
 com
-pEG
+com
+com
 com
 aDk
 aEd
 aFb
-txz
-aGF
+bnp
+bnp
 aFe
 beh
 sPU
 aGF
 aEd
-fvN
+oZN
 wDZ
 aPa
 aRp
@@ -98088,12 +95218,12 @@ tCS
 qXb
 udR
 dma
-mcf
+pdI
 eUa
-jom
+bbI
 bhr
 bbI
-bcM
+lru
 bjw
 bky
 bky
@@ -98313,10 +95443,10 @@ tYF
 vDh
 atn
 aww
-tXl
+axv
 nvX
 nvX
-giF
+axv
 axv
 atn
 aEd
@@ -98328,7 +95458,7 @@ aEd
 aEd
 aKi
 aEd
-fvN
+oZN
 wDZ
 aPb
 bcS
@@ -98345,12 +95475,12 @@ baD
 jbo
 xkk
 xkk
-xkk
-xkk
+cqI
+cqI
 cqI
 bhs
 bbI
-bcM
+lru
 bjw
 aaj
 aaj
@@ -98570,15 +95700,15 @@ fCX
 ayu
 emV
 awy
-wOl
 ayu
 ayu
-qHl
+ayu
+ayu
 aBT
 atn
 aEf
 aGF
-txz
+bnp
 aGF
 aHp
 aIl
@@ -98608,7 +95738,7 @@ pXH
 bht
 bbI
 biC
-ipI
+uyp
 aaj
 aak
 aam
@@ -98813,36 +95943,36 @@ aaa
 aaa
 aiT
 akq
-mtT
-mtT
-mtT
+sFK
+sFK
+sFK
 anp
-mtT
-mtT
-mtT
-atm
+sFK
+sFK
+sFK
+sFK
 atn
 enI
 ayu
 ayu
 emV
 awy
-fSz
+ayu
 pcg
 ayu
-qHl
+ayu
 aBU
 atn
 aEg
 aFd
-viH
+bnp
 qLU
 aEd
 aEd
 aEd
 aEd
 aEd
-fvN
+oZN
 aQk
 bbG
 bgy
@@ -98865,7 +95995,7 @@ pXH
 bhu
 bbI
 aFi
-bcM
+lru
 aaj
 aau
 aan
@@ -99077,7 +96207,7 @@ aiT
 aiT
 aiT
 aiS
-aun
+sFK
 atn
 low
 ayu
@@ -99087,19 +96217,19 @@ awz
 ayu
 ayv
 azD
-qHl
+ayu
 aBV
 atn
 aEg
 ycl
-txz
+bnp
 aGF
 aHq
 aIl
 aEd
 aKk
-eBO
-iwn
+oZN
+oZN
 aNQ
 bbG
 aQg
@@ -99107,7 +96237,7 @@ cCB
 cCB
 cCB
 bUh
-kAF
+wkM
 sAD
 aXy
 aYB
@@ -99122,23 +96252,23 @@ pXH
 bhv
 bbI
 aEj
-bcM
+lru
 aaj
 aaw
 pJU
-kaV
+ofG
 aas
 jWq
 cpf
-aNZ
+vfp
 bvV
 bts
 bts
 bts
 vTN
-mjG
-mjG
-dXR
+kmn
+kmn
+hNB
 bFj
 bGp
 bHy
@@ -99334,7 +96464,7 @@ aaa
 aaa
 aaa
 aiS
-aun
+sFK
 atn
 atn
 atn
@@ -99344,7 +96474,7 @@ awA
 fCX
 ayu
 wzh
-kTk
+ayu
 aBW
 atn
 aEd
@@ -99354,7 +96484,7 @@ aEd
 aEd
 aEd
 aEd
-fvN
+oZN
 cDa
 aPg
 cDa
@@ -99379,7 +96509,7 @@ bdI
 bbI
 bbI
 aGP
-bcM
+lru
 aat
 aay
 hTq
@@ -99387,7 +96517,7 @@ aax
 aap
 bqt
 bqs
-gDZ
+vfp
 cKA
 bwa
 bwa
@@ -99591,9 +96721,9 @@ aaa
 aaa
 aaa
 aiS
-rvL
 sFK
-atm
+sFK
+sFK
 aiS
 cbw
 atn
@@ -99610,8 +96740,8 @@ aFL
 aGI
 aHr
 aEd
-mmI
-iwn
+oZN
+oZN
 cDa
 aMw
 aQo
@@ -99636,7 +96766,7 @@ bdI
 aaa
 aEj
 pKd
-bcM
+lru
 aaj
 aaA
 aao
@@ -99644,7 +96774,7 @@ aar
 aap
 nBL
 bqs
-ehe
+vfp
 kVP
 bwa
 bwa
@@ -99850,7 +96980,7 @@ aaa
 aiS
 aiS
 aiS
-kFP
+sFK
 atn
 atn
 atn
@@ -99863,11 +96993,11 @@ avm
 atn
 atn
 atn
-aGJ
+lgR
 xqh
 lgR
 aDl
-pGK
+oZN
 cDa
 cDa
 hhJ
@@ -99893,7 +97023,7 @@ bdI
 aht
 aEj
 aEj
-bcM
+lru
 bjw
 bjw
 aap
@@ -99901,7 +97031,7 @@ aap
 aap
 bqv
 bqs
-qLa
+vfp
 djD
 bwa
 bwa
@@ -99909,7 +97039,7 @@ tAK
 bAF
 bBQ
 bDa
-bEa
+stL
 stL
 bGs
 nsD
@@ -100107,7 +97237,7 @@ aaa
 aaa
 aaa
 aiT
-kFP
+sFK
 atn
 aur
 aur
@@ -100151,14 +97281,14 @@ aaa
 aaa
 aEj
 obj
-aLi
+xba
 tim
 eXo
 bof
 eXo
 bqw
-ybo
-hAL
+bqs
+vfp
 wlK
 bwa
 efu
@@ -100166,7 +97296,7 @@ bzh
 bAF
 aah
 bDb
-bEb
+dfU
 dfU
 bGt
 bHz
@@ -100364,7 +97494,7 @@ aaa
 aaa
 aaa
 aiT
-kFP
+sFK
 atn
 aur
 aur
@@ -100381,7 +97511,7 @@ aFN
 aGK
 aHs
 aEj
-fvN
+oZN
 cDa
 aOP
 aMy
@@ -100407,7 +97537,7 @@ aaa
 aaa
 aaa
 aEj
-bcM
+lru
 aFi
 bjw
 nJI
@@ -100415,7 +97545,7 @@ bpo
 bpo
 lAR
 bqs
-gDZ
+vfp
 wlK
 bwa
 bxK
@@ -100642,7 +97772,7 @@ tfz
 aNU
 aLk
 aPi
-aTa
+vBZ
 vBZ
 vBZ
 aPi
@@ -100664,7 +97794,7 @@ aaa
 aaa
 aaa
 aEj
-bcM
+lru
 aEj
 bjw
 bky
@@ -100672,7 +97802,7 @@ boh
 oPr
 bqx
 bqs
-gDZ
+vfp
 gRU
 bwc
 bxL
@@ -100878,7 +98008,7 @@ aaa
 aaa
 aaa
 aiT
-kFP
+sFK
 atn
 aur
 aur
@@ -100921,7 +98051,7 @@ aaa
 aaa
 aaa
 aEj
-bcM
+lru
 aFi
 bkD
 vxp
@@ -100937,11 +98067,11 @@ bjw
 bHy
 bHy
 bHy
-rKI
+rLn
 rLn
 bGw
 rLn
-gfB
+iww
 tLN
 iUX
 iUX
@@ -101135,7 +98265,7 @@ aaa
 aaa
 aaa
 aiT
-kFP
+sFK
 atn
 uSL
 aur
@@ -101178,7 +98308,7 @@ aaa
 aaa
 aaa
 aEj
-bcM
+lru
 aEj
 bjw
 bjw
@@ -101195,14 +98325,14 @@ mSc
 sci
 jiD
 glf
-bFr
+mrA
 qtA
 khk
 bIN
 dAF
 bCV
 bCV
-nJf
+wAr
 bOu
 aht
 aaa
@@ -101392,7 +98522,7 @@ aaa
 aaa
 aaa
 aiS
-kFP
+sFK
 atn
 aur
 aur
@@ -101436,9 +98566,9 @@ aEj
 aEj
 aEj
 oTl
-xba
-lCw
-ecs
+rpa
+rpa
+ipI
 rmP
 bpq
 bnj
@@ -101453,7 +98583,7 @@ gXg
 jiD
 pNy
 bFr
-dwj
+qtA
 bHC
 quF
 bJT
@@ -101681,31 +98811,31 @@ myc
 uzX
 bbG
 nTv
-iUV
+kSG
 kXZ
-eBO
-eBO
-rVm
-ngn
+oZN
+oZN
+tfz
+uOR
 kjA
-ngn
-ecs
-rVm
-ngn
+uOR
+uyp
+tfz
+uOR
 fGd
 aKq
-eaM
+aFi
 wAI
-oFK
-xba
+rpa
+rpa
 bqA
 brU
 roa
 buK
 dqw
 kmq
-uuN
-kBt
+wYb
+uMU
 wFT
 lRW
 veM
@@ -101906,7 +99036,7 @@ aaa
 aaa
 aaa
 aiT
-kFP
+sFK
 atn
 aur
 aur
@@ -101921,26 +99051,26 @@ aur
 atn
 odG
 aFi
-mmI
-eBO
+soL
+soL
 set
 aRs
-ngn
-ngn
-ngn
-ngn
+uOR
+uOR
+uOR
+uOR
 dWw
 mXc
 saR
-ksq
-bdO
+saR
+eCB
 eCB
 ahW
 vHj
-rpa
+uOR
 ajS
-dTR
-dTR
+uOR
+uOR
 vaa
 mri
 aEj
@@ -101961,10 +99091,10 @@ ume
 bkF
 bkF
 lUC
-byg
-lXe
+wYb
+hgf
 nev
-pcM
+uca
 bEf
 bFu
 noM
@@ -102163,7 +99293,7 @@ aaa
 aaa
 aaa
 aiS
-kFP
+sFK
 atn
 aur
 aur
@@ -102218,8 +99348,8 @@ vMx
 xzp
 bkF
 iLl
-isE
-aGT
+ikY
+uuN
 xlA
 jiD
 bAF
@@ -102420,7 +99550,7 @@ aaa
 aaa
 aaa
 aiT
-kFP
+sFK
 atn
 atn
 atn
@@ -102433,9 +99563,9 @@ atn
 atn
 atn
 atn
-mmI
-eBO
-iwn
+soL
+soL
+soL
 aFi
 aMH
 aNV
@@ -102468,15 +99598,15 @@ bkH
 mql
 hEX
 nNW
-hsw
+bCJ
 bzg
 jwD
 csu
 ofN
 bkF
 gdJ
-mLs
-fMR
+uAx
+hgf
 xgt
 oKI
 skj
@@ -102677,7 +99807,7 @@ aaa
 aaa
 aaa
 aiT
-kFP
+sFK
 ato
 ajv
 ajv
@@ -102690,7 +99820,7 @@ atn
 aFi
 aFi
 aFi
-fvN
+soL
 aEj
 aFi
 aFi
@@ -102732,11 +99862,11 @@ uel
 xpr
 bkF
 pXg
-uAx
-fEL
-tag
-tag
-iNd
+rYS
+uMU
+uMU
+uMU
+kNK
 mJm
 gOV
 jiD
@@ -102935,19 +100065,19 @@ aaa
 aaa
 aiS
 hfX
-mtT
-mtT
-mtT
+sFK
+sFK
+sFK
 oqY
 hae
 lhO
 cgB
 hju
 oqY
-eBO
-eBO
-eBO
-iwn
+soL
+soL
+soL
+soL
 aEj
 aFi
 aIq
@@ -103202,8 +100332,8 @@ cgF
 hIQ
 atn
 aGP
-ten
 aFi
+bjM
 bdo
 aEj
 aMD
@@ -103213,8 +100343,8 @@ aEj
 tko
 aaM
 wPc
-hnx
-aey
+pos
+jJK
 ktQ
 rWE
 aht
@@ -103459,7 +100589,7 @@ avm
 avm
 atn
 aIp
-xNH
+aIp
 aFh
 aIp
 aIp
@@ -103468,10 +100598,10 @@ aEl
 aht
 cdm
 rlU
-aaP
 wmE
-hnx
-aey
+wmE
+gmE
+roA
 sZh
 sut
 aTx
@@ -103717,7 +100847,7 @@ aaa
 aaa
 aIp
 aJp
-aFj
+qcR
 wvq
 aIp
 aME
@@ -103726,9 +100856,9 @@ aht
 cdm
 rlU
 aaQ
-wmE
+aco
 lao
-aey
+kAv
 sZh
 sut
 aTy
@@ -103756,7 +100886,7 @@ bpr
 oSc
 bsa
 tzm
-bqS
+uel
 xoo
 bxM
 bzk
@@ -103985,7 +101115,7 @@ rlU
 aco
 aco
 adO
-aey
+frb
 sZh
 sut
 bcK
@@ -104239,10 +101369,10 @@ aht
 aht
 cdm
 rlU
-acC
-adr
-adT
-aey
+uOe
+uOe
+uOe
+xjq
 sZh
 sut
 aTz
@@ -104495,9 +101625,9 @@ aaa
 aaa
 aht
 cdm
-rlU
-adr
-adr
+adU
+adU
+adU
 adU
 aeB
 sZh
@@ -104752,11 +101882,11 @@ aaa
 aaa
 aht
 cdm
-rlU
-uOe
-uOe
-uOe
-uOe
+adU
+adU
+adU
+adU
+aeB
 sZh
 sut
 aaa
@@ -105298,7 +102428,7 @@ ucn
 pkU
 bsa
 tzm
-bqS
+uel
 xoo
 bxM
 bzq
@@ -107868,7 +104998,7 @@ bkF
 pIW
 cPy
 eIL
-pfD
+cft
 gyj
 oNE
 sXR
@@ -108124,7 +105254,7 @@ aaa
 bnd
 kRK
 iqW
-iKj
+nqV
 ufa
 ufa
 voR
@@ -108381,7 +105511,7 @@ aaa
 bnd
 qcD
 xxw
-ekM
+nqV
 lFh
 ufa
 taA
@@ -109151,7 +106281,7 @@ bbP
 aaa
 bkF
 dmT
-tqX
+hHw
 nEb
 pWm
 uvo

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -48413,6 +48413,16 @@
 	},
 /turf/open/floor/plating,
 /area/medical/cryo)
+"qwm" = (
+/obj/structure/table/wood,
+/obj/item/inspector{
+	pixel_x = 4
+	},
+/obj/item/inspector{
+	pixel_x = -4
+	},
+/turf/open/floor/iron,
+/area/security)
 "qwJ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -55494,6 +55504,16 @@
 	dir = 4
 	},
 /area/commons/fitness/recreation)
+"wKU" = (
+/obj/structure/table/wood,
+/obj/item/inspector{
+	pixel_x = -4
+	},
+/obj/item/inspector{
+	pixel_x = 4
+	},
+/turf/open/floor/iron,
+/area/security)
 "wLl" = (
 /obj/machinery/door_buttons/airlock_controller{
 	idExterior = "virology_airlock_exterior";
@@ -81561,7 +81581,7 @@ ajY
 idZ
 alC
 amn
-alC
+qwm
 amn
 tLA
 apb
@@ -82330,7 +82350,7 @@ agP
 ajo
 ghx
 lyd
-alC
+wKU
 tLA
 alC
 okX

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -294,30 +294,6 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
-"aaU" = (
-/obj/machinery/door/airlock{
-	name = "Unisex Restroom"
-	},
-/turf/open/floor/iron/freezer,
-/area/security/prison/toilet)
-"aaV" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/iron/freezer,
-/area/security/prison/toilet)
-"aaW" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/effect/landmark/start/prisoner,
-/turf/open/floor/iron/freezer,
-/area/security/prison/toilet)
 "aaX" = (
 /obj/structure/table,
 /obj/machinery/firealarm/directional/east,
@@ -960,8 +936,7 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
 "adE" = (
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
+/turf/closed/wall/mineral/iron,
 /area/security/prison)
 "adF" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -1139,43 +1114,53 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/prison)
-"aeo" = (
-/obj/machinery/hydroponics/constructable,
-/obj/item/seeds/potato,
-/obj/item/seeds/carrot,
-/obj/item/seeds/corn,
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "aep" = (
-/obj/item/cultivator,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/white,
 /area/security/prison)
 "aeq" = (
-/obj/machinery/hydroponics/constructable,
-/obj/item/seeds/glowshroom,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 32
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
-/obj/machinery/camera{
-	c_tag = "Permabrig Central";
-	network = list("ss13","prison")
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock{
+	name = "Dining Room"
 	},
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron,
 /area/security/prison)
 "aer" = (
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron,
 /area/security/prison)
 "aes" = (
-/obj/structure/easel,
-/obj/item/canvas/nineteen_nineteen,
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron,
 /area/security/prison)
 "aet" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -1191,17 +1176,17 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse/upper)
 "aeu" = (
-/obj/machinery/biogenerator,
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron,
 /area/security/prison)
 "aev" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -1238,41 +1223,58 @@
 /turf/open/space/basic,
 /area/cargo/warehouse/upper)
 "aeC" = (
-/obj/machinery/hydroponics/constructable,
-/obj/item/seeds/grass,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/vending/sustenance,
+/turf/open/floor/iron/white,
 /area/security/prison)
 "aeD" = (
-/obj/item/plant_analyzer,
-/obj/item/shovel/spade,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/vending/cola/red,
+/turf/open/floor/iron/white,
 /area/security/prison)
 "aeE" = (
-/obj/machinery/hydroponics/constructable,
-/obj/item/seeds/sunflower,
-/obj/item/seeds/poppy,
+/obj/structure/sign/painting/library_private{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-08"
+	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "aeF" = (
-/obj/machinery/holopad,
-/turf/open/floor/iron/dark,
-/area/security/prison)
-"aeG" = (
-/obj/item/storage/crayons,
-/turf/open/floor/iron/dark,
-/area/security/prison)
-"aeI" = (
-/obj/machinery/seed_extractor,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/prison)
+"aeG" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/security/prison)
+"aeI" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
 /area/security/prison)
 "aeO" = (
 /obj/machinery/door/airlock/hatch{
@@ -1314,34 +1316,43 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
 "aeT" = (
-/obj/structure/bookcase,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/structure/table/wood/fancy,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "aeV" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron,
 /area/security/prison)
 "aeW" = (
-/obj/structure/sink{
-	pixel_y = 30
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/iron/cafeteria,
+/obj/structure/table/wood,
+/obj/machinery/computer/bookmanagement,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "aeX" = (
-/obj/machinery/washing_machine,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/machinery/light/directional/north,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/trophy{
+	pixel_y = 8
 	},
-/turf/open/floor/iron/cafeteria,
+/obj/item/storage/book/bible,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "aeY" = (
 /obj/machinery/power/apc/auto_name/west,
@@ -1513,8 +1524,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 1
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse/upper)
@@ -1525,40 +1536,41 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
 "afn" = (
-/obj/machinery/computer/bookmanagement,
-/obj/structure/table,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
+/obj/structure/weightmachine/weightlifter,
+/turf/open/floor/iron,
 /area/security/prison)
 "afp" = (
-/obj/item/storage/pill_bottle/dice,
-/obj/structure/table,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
 /area/security/prison)
 "afq" = (
-/obj/structure/table,
-/obj/item/instrument/harmonica,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron,
 /area/security/prison)
 "afr" = (
-/obj/machinery/light/small,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/iron,
 /area/security/prison)
 "afs" = (
-/obj/structure/table,
-/obj/structure/bedsheetbin,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/iron/cafeteria,
+/obj/machinery/light/no_nightlight/directional/north,
+/turf/open/floor/iron,
 /area/security/prison)
 "aft" = (
 /obj/machinery/light/small{
@@ -1629,41 +1641,42 @@
 /obj/item/stack/cable_coil,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
-"afC" = (
-/obj/machinery/light{
+"afE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/dark,
-/area/security/prison)
-"afD" = (
-/obj/structure/chair/stool,
-/turf/open/floor/iron/dark,
-/area/security/prison)
-"afE" = (
-/obj/item/toy/cards/deck,
+/obj/structure/cable,
 /obj/structure/table,
-/obj/item/toy/figure/prisoner,
-/turf/open/floor/iron/dark,
+/obj/item/storage/pill_bottle/dice,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron,
 /area/security/prison)
 "afF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/structure/table,
 /obj/item/paper_bin{
 	pixel_x = -3;
 	pixel_y = 7
 	},
-/obj/item/pen,
-/obj/structure/table,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron,
 /area/security/prison)
 "afH" = (
 /obj/machinery/flasher/portable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "afI" = (
-/obj/effect/spawner/randomarcade{
+/obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron,
 /area/security/prison)
 "afJ" = (
 /obj/effect/landmark/carpspawn,
@@ -1707,6 +1720,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/cargo/warehouse/upper)
 "afP" = (
@@ -1748,32 +1764,50 @@
 /turf/closed/wall,
 /area/security/execution/transfer)
 "afX" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/item/kirbyplants{
+	icon_state = "plant-08"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/dark,
-/area/security/execution/transfer)
+/area/security/prison)
 "afZ" = (
-/obj/machinery/vending/sustenance,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron,
 /area/security/prison)
 "aga" = (
-/turf/open/floor/iron/dark,
-/area/security/prison)
-"agc" = (
-/obj/machinery/light/small{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/grunge{
+	name = "Prison Workshop"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/item/storage/bag/trash,
-/turf/open/floor/iron/freezer,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/prison)
+"agc" = (
+/obj/effect/turf_decal/stripes/white/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron,
 /area/security/prison)
 "agd" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/item/bikehorn/rubberducky,
-/turf/open/floor/iron/freezer,
+/obj/effect/turf_decal/stripes/white/line,
+/turf/open/floor/iron,
 /area/security/prison)
 "age" = (
 /obj/machinery/teleport/station,
@@ -1830,20 +1864,34 @@
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "agn" = (
-/obj/machinery/vending/cola,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron,
 /area/security/prison)
 "ago" = (
-/obj/machinery/door/window/westleft{
-	base_state = "right";
-	icon_state = "right";
-	name = "Unisex Showers"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/turf/open/floor/iron/freezer,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/security/prison)
 "agp" = (
-/obj/item/soap/nanotrasen,
-/turf/open/floor/iron/freezer,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/security/prison)
 "agq" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -1884,43 +1932,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "agy" = (
 /turf/closed/wall,
-/area/security/prison)
-"agz" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "permacell2";
-	name = "cell blast door"
-	},
-/obj/machinery/door/airlock/public/glass{
-	id_tag = "permabolt2";
-	name = "Cell 2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
-"agB" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "permacell1";
-	name = "cell blast door"
-	},
-/obj/machinery/door/airlock/public/glass{
-	id_tag = "permabolt1";
-	name = "Cell 1"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
 /area/security/prison)
 "agD" = (
 /obj/machinery/light/small{
@@ -1951,77 +1967,21 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"agI" = (
-/obj/structure/bed,
-/obj/machinery/camera{
-	c_tag = "Permabrig Cell 2";
-	network = list("ss13","prison")
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/toy/plush/slimeplushie,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/security/prison)
-"agK" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/button/door{
-	id = "permabolt2";
-	name = "Cell Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_y = 25;
-	specialfunctions = 4
-	},
-/obj/structure/chair,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "agL" = (
-/obj/structure/bed,
-/obj/machinery/camera{
-	c_tag = "Permabrig Cell 1";
-	network = list("ss13","prison")
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/flasher/directional/south{
+	id = "Cell 1";
+	pixel_y = 26
 	},
-/obj/item/toy/plush/lizard_plushie,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/safe)
 "agM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/prisoner,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/structure/table,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
-/area/security/prison)
-"agN" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/button/door{
-	id = "permabolt1";
-	name = "Cell Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_y = 25;
-	specialfunctions = 4
-	},
-/obj/structure/chair,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/safe)
 "agP" = (
 /turf/closed/wall,
 /area/security)
@@ -2044,47 +2004,24 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"agW" = (
-/obj/machinery/flasher{
-	id = "PCell 2";
-	pixel_x = -28
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "agX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/structure/bed,
+/obj/item/bedsheet,
+/turf/open/floor/iron,
+/area/security/prison/safe)
+"agZ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/security/prison)
-"agY" = (
-/obj/structure/table,
-/obj/item/paper,
-/obj/item/pen,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/security/prison)
-"agZ" = (
-/obj/machinery/flasher{
-	id = "PCell 1";
-	pixel_x = -28
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/safe)
 "aha" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
 /obj/structure/tank_holder/extinguisher,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/cargo/warehouse/upper)
 "ahd" = (
@@ -2154,41 +2091,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
-"ahm" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Long-Term Cell 2";
-	req_access_txt = "2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "ahp" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Long-Term Cell 1";
-	req_access_txt = "2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
+/turf/closed/wall,
+/area/security/prison/safe)
 "ahr" = (
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
@@ -2256,7 +2164,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "ahB" = (
@@ -2269,47 +2177,21 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "ahC" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/button/flasher{
-	id = "PCell 2";
-	pixel_x = 5;
-	pixel_y = 24
-	},
-/obj/machinery/button/door{
-	id = "permacell2";
-	name = "Cell 2 Lockdown";
-	pixel_x = 4;
-	pixel_y = 34;
-	req_access_txt = "2"
-	},
-/turf/open/floor/iron,
-/area/security/prison)
+/turf/closed/wall/r_wall,
+/area/security/prison/safe)
 "ahF" = (
-/obj/machinery/camera{
-	c_tag = "Brig Prison Hallway";
-	network = list("ss13","prison")
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/computer/security/telescreen/prison{
-	pixel_y = 30
-	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
 "ahG" = (
-/obj/machinery/button/flasher{
-	id = "PCell 1";
-	pixel_x = 5;
-	pixel_y = 24
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
-/obj/machinery/button/door{
-	id = "permacell1";
-	name = "Cell 1 Lockdown";
-	pixel_x = 4;
-	pixel_y = 34;
-	req_access_txt = "2"
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "ahI" = (
 /obj/machinery/light{
@@ -2333,6 +2215,19 @@
 /obj/structure/table,
 /obj/item/melee/chainofcommand,
 /obj/item/melee/baton,
+/obj/machinery/button/flasher{
+	id = "Cell 3";
+	name = "Prisoner Flash";
+	pixel_x = -7;
+	pixel_y = 26
+	},
+/obj/machinery/button/door/directional/west{
+	id = "permashut3";
+	name = "Cell Lockdown Button";
+	pixel_x = 6;
+	pixel_y = 26;
+	req_access_txt = "2"
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "ahL" = (
@@ -2428,7 +2323,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -2472,70 +2367,39 @@
 /area/security/prison)
 "aii" = (
 /obj/structure/table,
-/obj/item/storage/box/chemimp{
-	pixel_x = 6
+/obj/item/storage/box/flashbangs{
+	pixel_x = 6;
+	pixel_y = 3
 	},
-/obj/item/storage/box/trackimp{
-	pixel_x = -3
+/obj/item/storage/box/flashbangs{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/storage/lockbox/loyalty{
+	layer = 4
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "aij" = (
-/obj/structure/closet/secure_closet/contraband/armory,
-/obj/item/poster/random_contraband,
-/obj/item/clothing/suit/security/officer/russian,
-/obj/item/grenade/c4,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/security/armory)
+/turf/open/floor/iron/chapel{
+	dir = 1
+	},
+/area/security/prison)
 "aik" = (
-/obj/machinery/camera/motion{
-	c_tag = "Armory Motion Sensor"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/chapel{
+	dir = 4
 	},
-/obj/vehicle/ridden/secway,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/security/armory)
+/area/security/prison)
 "ail" = (
-/obj/structure/closet/crate/secure/weapon{
-	desc = "A secure clothing crate.";
-	name = "formal uniform crate";
-	req_access_txt = "3"
-	},
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/suit/security/officer,
-/obj/item/clothing/suit/security/officer,
-/obj/item/clothing/suit/security/officer,
-/obj/item/clothing/suit/security/officer,
-/obj/item/clothing/suit/security/officer,
-/obj/item/clothing/suit/security/officer,
-/obj/item/clothing/under/rank/security/warden/formal,
-/obj/item/clothing/suit/security/warden,
-/obj/item/clothing/under/rank/security/head_of_security/formal,
-/obj/item/clothing/suit/security/hos,
-/obj/item/clothing/head/beret/sec/navyofficer,
-/obj/item/clothing/head/beret/sec/navyofficer,
-/obj/item/clothing/head/beret/sec/navyofficer,
-/obj/item/clothing/head/beret/sec/navyofficer,
-/obj/item/clothing/head/beret/sec/navyofficer,
-/obj/item/clothing/head/beret/sec/navyofficer,
-/obj/item/clothing/head/beret/sec/navywarden,
-/obj/item/clothing/head/beret/sec/navyhos,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "aim" = (
-/obj/item/grenade/barrier{
-	pixel_x = 4
-	},
-/obj/item/grenade/barrier,
-/obj/item/grenade/barrier{
-	pixel_x = -4
-	},
 /obj/structure/table,
+/obj/item/storage/box/firingpins,
+/obj/item/storage/box/firingpins,
+/obj/item/key/security,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "ain" = (
@@ -2659,6 +2523,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/machinery/camera{
+	c_tag = "Brig Prison Hallway";
+	dir = 1;
+	network = list("ss13","prison")
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "aiF" = (
@@ -2695,28 +2564,47 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/security/prison)
 "aiL" = (
-/obj/structure/table,
-/obj/item/storage/box/flashbangs{
-	pixel_x = 6;
-	pixel_y = 3
-	},
-/obj/item/storage/box/flashbangs{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/lockbox/loyalty{
-	layer = 4
+/obj/structure/rack,
+/obj/item/gun/energy/ionrifle,
+/obj/item/gun/energy/temperature/security,
+/obj/item/clothing/suit/hooded/ablative,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "aiO" = (
-/obj/structure/table,
-/obj/item/storage/box/firingpins,
-/obj/item/storage/box/firingpins,
-/obj/item/key/security,
+/obj/structure/rack,
+/obj/item/storage/box/rubbershot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/rubbershot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/rubbershot,
+/obj/item/storage/box/rubbershot,
+/obj/item/storage/box/rubbershot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/storage/box/rubbershot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#e8eaff"
+	},
+/obj/structure/sign/warning/nosmoking{
+	pixel_x = 32
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "aiR" = (
@@ -2776,7 +2664,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "ajb" = (
@@ -2810,41 +2698,38 @@
 /area/security/prison)
 "ajg" = (
 /obj/structure/rack,
-/obj/item/gun/energy/ionrifle,
-/obj/item/gun/energy/temperature/security,
-/obj/item/clothing/suit/hooded/ablative,
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
+/obj/item/gun/energy/e_gun{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/energy/e_gun,
+/obj/item/gun/energy/e_gun{
+	pixel_x = 3;
+	pixel_y = -3
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "ajh" = (
 /obj/structure/rack,
-/obj/item/clothing/suit/armor/riot{
+/obj/item/clothing/suit/armor/bulletproof{
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/suit/armor/riot{
+/obj/item/clothing/suit/armor/bulletproof,
+/obj/item/clothing/suit/armor/bulletproof{
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/item/clothing/head/helmet/riot{
+/obj/item/clothing/head/helmet/alt{
+	layer = 3.00001;
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = 3;
-	pixel_y = -3
+/obj/item/clothing/head/helmet/alt{
+	layer = 3.00001
 	},
-/obj/item/shield/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/shield/riot,
-/obj/item/shield/riot{
+/obj/item/clothing/head/helmet/alt{
+	layer = 3.00001;
 	pixel_x = 3;
 	pixel_y = -3
 	},
@@ -2852,30 +2737,14 @@
 /area/ai_monitored/security/armory)
 "ajj" = (
 /obj/structure/rack,
-/obj/item/storage/box/rubbershot{
+/obj/item/gun/energy/laser{
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/storage/box/rubbershot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot{
+/obj/item/gun/energy/laser,
+/obj/item/gun/energy/laser{
 	pixel_x = 3;
 	pixel_y = -3
-	},
-/obj/item/storage/box/rubbershot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
-/obj/structure/sign/warning/nosmoking{
-	pixel_x = 32
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
@@ -2981,7 +2850,7 @@
 	dir = 8
 	},
 /obj/structure/reagent_dispensers/peppertank/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security)
 "ajr" = (
@@ -3080,7 +2949,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/processing/cremation)
 "ajL" = (
@@ -3129,15 +2998,16 @@
 /area/security/brig)
 "ajP" = (
 /obj/structure/rack,
-/obj/item/gun/energy/e_gun{
+/obj/item/gun/energy/disabler{
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/gun/energy/e_gun,
-/obj/item/gun/energy/e_gun{
+/obj/item/gun/energy/disabler,
+/obj/item/gun/energy/disabler{
 	pixel_x = 3;
 	pixel_y = -3
 	},
+/obj/machinery/newscaster/security_unit/directional/west,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "ajQ" = (
@@ -3149,28 +3019,8 @@
 /area/cargo/sorting)
 "ajR" = (
 /obj/structure/rack,
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/suit/armor/bulletproof,
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
-	pixel_x = 3;
-	pixel_y = -3
-	},
+/obj/item/gun/energy/e_gun/dragnet,
+/obj/item/gun/energy/e_gun/dragnet,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "ajS" = (
@@ -3189,15 +3039,16 @@
 /area/maintenance/department/cargo)
 "ajT" = (
 /obj/structure/rack,
-/obj/item/gun/energy/laser{
+/obj/item/gun/ballistic/shotgun/riot{
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/gun/energy/laser,
-/obj/item/gun/energy/laser{
+/obj/item/gun/ballistic/shotgun/riot,
+/obj/item/gun/ballistic/shotgun/riot{
 	pixel_x = 3;
 	pixel_y = -3
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "ajW" = (
@@ -3221,7 +3072,7 @@
 	dir = 4
 	},
 /obj/item/radio/intercom/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security)
 "aka" = (
@@ -3542,34 +3393,20 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "akL" = (
-/obj/structure/rack,
-/obj/item/gun/energy/disabler{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/disabler,
-/obj/item/gun/energy/disabler{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/machinery/newscaster/security_unit/directional/west,
+/obj/machinery/flasher/portable,
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "akM" = (
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "akN" = (
-/obj/effect/landmark/event_spawn,
-/mob/living/simple_animal/bot/secbot{
-	arrest_type = 1;
-	health = 45;
-	icon_state = "secbot1";
-	idcheck = 1;
-	name = "Sergeant-at-Armsky";
-	weaponscheck = 1
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/chapel{
+	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/security/armory)
+/area/security/prison)
 "akO" = (
 /obj/structure/table/reinforced,
 /obj/item/hand_labeler{
@@ -3592,19 +3429,10 @@
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "akP" = (
-/obj/structure/rack,
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_x = -3;
-	pixel_y = 3
+/turf/open/floor/iron/chapel{
+	dir = 4
 	},
-/obj/item/gun/ballistic/shotgun/riot,
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/security/armory)
+/area/security/prison)
 "akQ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -3628,7 +3456,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security)
 "akT" = (
@@ -3747,18 +3575,6 @@
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"all" = (
-/obj/item/radio/intercom/directional/south{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "prison intercom";
-	prison_radio = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "alo" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -3845,11 +3661,11 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "alA" = (
-/obj/machinery/flasher/portable,
-/obj/machinery/power/apc/auto_name/west,
-/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
-/area/ai_monitored/security/armory)
+/area/security/prison)
 "alB" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -3936,7 +3752,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/processing/cremation)
 "alZ" = (
@@ -4051,7 +3867,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security)
 "amq" = (
@@ -4065,7 +3881,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security)
 "amr" = (
@@ -4080,7 +3896,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security)
 "ams" = (
@@ -4091,7 +3907,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security)
 "amt" = (
@@ -4107,7 +3923,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "amu" = (
@@ -4118,7 +3934,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "amv" = (
@@ -4130,7 +3946,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
 "amw" = (
@@ -4144,7 +3960,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
 "amx" = (
@@ -4219,7 +4035,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "amK" = (
@@ -4255,7 +4071,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/security/brig)
 "amN" = (
@@ -4266,7 +4082,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/security/brig)
 "amO" = (
@@ -4287,7 +4103,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/security/brig)
 "amS" = (
@@ -4427,7 +4243,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "anw" = (
@@ -4443,7 +4259,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "any" = (
@@ -4733,7 +4549,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "aot" = (
@@ -4746,7 +4562,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security)
 "aov" = (
@@ -4756,7 +4572,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security)
 "aow" = (
@@ -4829,7 +4645,7 @@
 	},
 /area/maintenance/department/security/brig)
 "aoN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -4880,6 +4696,10 @@
 	pixel_y = 8;
 	req_access_txt = "2"
 	},
+/obj/machinery/computer/security/telescreen/prison{
+	dir = 4;
+	pixel_x = -7
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "aoT" = (
@@ -4908,7 +4728,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "aoX" = (
@@ -4962,7 +4782,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security)
 "apd" = (
@@ -5207,7 +5027,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "apP" = (
@@ -5222,7 +5042,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security)
 "apQ" = (
@@ -5387,7 +5207,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/brig)
 "aqz" = (
@@ -5423,7 +5243,7 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "aqD" = (
@@ -5601,7 +5421,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/brig)
 "arq" = (
@@ -5612,7 +5432,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/brig)
 "arr" = (
@@ -5623,7 +5443,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/brig)
 "aru" = (
@@ -5636,7 +5456,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "arv" = (
@@ -6203,7 +6023,7 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible,
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "asZ" = (
@@ -6342,7 +6162,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -6357,7 +6177,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -6372,7 +6192,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -6723,7 +6543,7 @@
 "auA" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -7052,7 +6872,7 @@
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "avm" = (
@@ -8363,6 +8183,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/item/storage/secure/safe/caps_spare{
+	pixel_x = 6;
+	pixel_y = -28
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
@@ -11262,6 +11086,21 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
+"aJx" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/grunge{
+	name = "Prison Forestry"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/prison)
 "aJD" = (
 /obj/structure/chair{
 	dir = 8
@@ -12375,6 +12214,9 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"aOn" = (
+/turf/closed/wall/r_wall,
+/area/security/prison/toilet)
 "aOs" = (
 /obj/structure/sign/departments/evac,
 /turf/closed/wall,
@@ -20702,6 +20544,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
+"btA" = (
+/obj/structure/closet/crate,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "btB" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -21206,12 +21058,16 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "bvC" = (
-/obj/machinery/newscaster/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron,
 /area/security/prison)
 "bvD" = (
 /obj/structure/sign/poster/random{
@@ -23321,10 +23177,10 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "bCr" = (
-/obj/machinery/chem_heater,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/machinery/chem_heater/withbuffer,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "bCt" = (
@@ -23339,7 +23195,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/chem_heater,
+/obj/machinery/chem_heater/withbuffer,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "bCx" = (
@@ -25406,6 +25262,8 @@
 	req_access_txt = "39"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/medical/virology)
 "bKp" = (
@@ -27417,6 +27275,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "bRI" = (
@@ -27454,6 +27313,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
 "bRL" = (
@@ -27556,6 +27416,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "bRV" = (
@@ -27633,10 +27494,6 @@
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "bSk" = (
-/turf/open/floor/engine/plasma,
-/area/engineering/atmos)
-"bSl" = (
-/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "bSm" = (
@@ -28240,6 +28097,7 @@
 /area/maintenance/department/engine)
 "bUa" = (
 /obj/item/wrench,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bUb" = (
@@ -28276,6 +28134,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "bUh" = (
@@ -28370,7 +28229,9 @@
 /area/engineering/break_room)
 "bUp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bUq" = (
@@ -28690,7 +28551,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Waste to Space"
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bVf" = (
@@ -28950,10 +28813,8 @@
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "bVV" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Waste to Space"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bVY" = (
@@ -29332,6 +29193,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "bXi" = (
@@ -29344,6 +29208,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "bXj" = (
@@ -29551,6 +29418,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -29563,6 +29431,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bXY" = (
@@ -29582,6 +29451,9 @@
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "bYb" = (
@@ -29876,6 +29748,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/iron,
 /area/engineering/main)
 "bYZ" = (
@@ -29961,6 +29834,7 @@
 	req_access_txt = "12"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bZt" = (
@@ -30093,6 +29967,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "cae" = (
@@ -32123,6 +31998,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
+"clE" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/structure/weightmachine/stacklifter,
+/turf/open/floor/iron,
+/area/security/prison)
 "clF" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/closed/mineral/random/low_chance,
@@ -32150,8 +32032,15 @@
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "clK" = (
-/mob/living/simple_animal/mouse/brown/tom,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/structure/table,
+/obj/item/pen,
+/obj/item/instrument/harmonica,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron,
 /area/security/prison)
 "clL" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -34334,7 +34223,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
 "cxq" = (
@@ -34565,7 +34454,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/brig)
 "czB" = (
@@ -34604,6 +34493,15 @@
 	},
 /turf/open/floor/carpet,
 /area/service/library)
+"czK" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison)
 "czN" = (
 /obj/structure/table/wood,
 /obj/item/storage/bag/books,
@@ -35115,6 +35013,22 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"cMa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "permashut2";
+	name = "Permabrig Cell 2";
+	req_access_txt = "2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "cMl" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -35160,6 +35074,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "cPL" = (
@@ -35277,6 +35192,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/lab)
+"cTq" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/seed_extractor,
+/turf/open/floor/iron,
+/area/security/prison)
 "cTr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -35289,7 +35209,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security)
 "cUb" = (
@@ -35363,6 +35283,24 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"dfu" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/microwave,
+/obj/machinery/light/no_nightlight/directional/north,
+/turf/open/floor/iron/white,
+/area/security/prison)
+"dfw" = (
+/obj/machinery/camera/motion{
+	c_tag = "Armory Motion Sensor"
+	},
+/obj/vehicle/ridden/secway,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/security/armory)
 "dfU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -35389,7 +35327,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "dha" = (
@@ -35618,6 +35556,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
+"dsP" = (
+/obj/machinery/computer/security/telescreen/prison{
+	pixel_y = 28
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "dsR" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -35628,6 +35572,10 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"dtj" = (
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/turf/open/floor/iron,
+/area/security/prison)
 "dtK" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -35638,7 +35586,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/brig)
 "duu" = (
@@ -35676,6 +35624,16 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark,
 /area/science/lab)
+"duH" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/grunge{
+	name = "Prison Monastery"
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "duQ" = (
 /obj/machinery/camera{
 	c_tag = "Departure Lounge Aft";
@@ -35694,6 +35652,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating/asteroid,
 /area/service/chapel/asteroid/monastery)
+"dvY" = (
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "dxo" = (
 /obj/machinery/igniter/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
@@ -35763,6 +35726,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
+"dCu" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/toy/cards/deck,
+/turf/open/floor/iron,
+/area/security/prison)
 "dDZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -35843,14 +35814,29 @@
 /turf/open/floor/wood,
 /area/service/bar)
 "dGY" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/dark,
-/area/security/prison)
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
+/obj/structure/sink{
+	pixel_y = 29
+	},
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "dHc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /turf/open/floor/plating,
 /area/engineering/atmos)
+"dIy" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/machinery/light/no_nightlight/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "dJm" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Research Pit";
@@ -35858,6 +35844,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"dJp" = (
+/obj/structure/chair/stool/bar/directional/south,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "dJP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -35918,6 +35912,7 @@
 	pixel_y = -32
 	},
 /obj/machinery/power/shieldwallgen/xenobiologyaccess,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "dNA" = (
@@ -36124,6 +36119,14 @@
 /obj/machinery/atmospherics/components/binary/pump,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"eaA" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "eaB" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -36173,6 +36176,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse/upper)
@@ -36283,6 +36289,20 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse/upper)
+"ekm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/poddoor/preopen{
+	id = "permashut3"
+	},
+/obj/machinery/door/airlock/glass{
+	name = "Cell 3"
+	},
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "ekU" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/loot_site_spawner,
@@ -36487,6 +36507,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"evP" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "ewb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -36529,6 +36562,18 @@
 /obj/item/pen/red,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"eAF" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/prison)
 "eAP" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
@@ -36626,6 +36671,21 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
+"eGF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "permashut1";
+	name = "Permabrig Cell 1";
+	req_access_txt = "2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "eGT" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 9
@@ -36653,6 +36713,21 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"eIJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/poddoor/preopen{
+	id = "permashut2"
+	},
+/obj/machinery/door/airlock/glass{
+	name = "cell 2"
+	},
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "eIL" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -36783,6 +36858,13 @@
 /obj/item/gavelhammer,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"ePM" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/obj/machinery/biogenerator,
+/turf/open/floor/iron,
+/area/security/prison)
 "eQN" = (
 /obj/structure/chair/stool,
 /turf/open/floor/iron,
@@ -36813,6 +36895,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
+"eTi" = (
+/obj/structure/table,
+/obj/item/storage/fancy/egg_box,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/item/book/manual/chef_recipes,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "eTt" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
@@ -36841,13 +36934,25 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/disposal)
-"eTW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+"eTI" = (
+/obj/structure/chair{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron/white,
 /area/security/prison)
+"eTW" = (
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bottle/ammonia,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "eTZ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -36915,6 +37020,11 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/storage_shared)
+"eWl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/department/engine)
 "eXa" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
@@ -37135,6 +37245,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "feh" = (
@@ -37327,9 +37438,25 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"flR" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "fmh" = (
 /turf/open/floor/wood,
 /area/maintenance/department/engine)
+"fmp" = (
+/obj/structure/table,
+/obj/structure/reagent_dispensers/servingdish,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "fmD" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -37507,15 +37634,10 @@
 /turf/open/floor/iron/dark,
 /area/science/server)
 "fwg" = (
-/obj/item/stack/sheet/cardboard{
-	amount = 14
-	},
-/obj/item/vending_refill/cola,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -37576,6 +37698,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/department/engine)
+"fzz" = (
+/obj/machinery/shower{
+	pixel_y = 8
+	},
+/turf/open/floor/iron/freezer,
+/area/security/prison/toilet)
 "fAe" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -37761,9 +37889,15 @@
 /turf/open/floor/plating,
 /area/service/chapel/main/monastery)
 "fJd" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark,
-/area/security/prison)
+/obj/structure/rack,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/clothing/mask/breath,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "fJw" = (
 /obj/machinery/shower{
 	dir = 8
@@ -37775,6 +37909,14 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"fKa" = (
+/obj/item/radio/intercom/directional/north{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	prison_radio = 1
+	},
+/turf/open/floor/iron/freezer,
+/area/security/prison/toilet)
 "fKj" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Mineral Room"
@@ -37815,6 +37957,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"fNb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/freezer,
+/area/security/prison/toilet)
 "fNg" = (
 /turf/open/floor/plating,
 /area/service/abandoned_gambling_den)
@@ -37901,6 +38051,11 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/security)
+"fRl" = (
+/obj/item/bedsheet,
+/obj/structure/bed,
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "fRs" = (
 /turf/closed/wall,
 /area/command/heads_quarters/rd)
@@ -38048,10 +38203,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
-"gcf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "gcn" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/closet,
@@ -38098,8 +38249,8 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "geP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "gfi" = (
@@ -38142,6 +38293,7 @@
 "ggW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/effect/spawner/structure/window,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/medical/virology)
 "ghx" = (
@@ -38300,6 +38452,12 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
+"gnM" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "gnQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38331,6 +38489,13 @@
 	heat_capacity = 1e+006
 	},
 /area/hallway/secondary/exit/departure_lounge)
+"gqx" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/table,
+/obj/item/shovel/spade,
+/obj/item/shovel/spade,
+/turf/open/floor/iron,
+/area/security/prison)
 "gsB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38345,7 +38510,7 @@
 /area/medical/psychology)
 "gta" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -38424,6 +38589,14 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
+"guO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison)
 "guS" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/blue,
@@ -38903,7 +39076,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "gRJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "gRU" = (
@@ -39056,7 +39230,7 @@
 /turf/open/floor/grass,
 /area/medical/psychology)
 "hdB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -39464,6 +39638,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
+"hDg" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/security/prison)
 "hDG" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Auxiliary Base Construction";
@@ -39564,8 +39745,9 @@
 /area/command/heads_quarters/cmo)
 "hID" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/open/floor/iron/freezer,
 /area/medical/virology)
 "hIQ" = (
@@ -39835,12 +40017,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/captain)
-"hVW" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "hWo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -39860,9 +40036,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/brig)
+"hWS" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/security/prison)
 "hXt" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
@@ -40044,7 +40226,6 @@
 /obj/structure/chair/office{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/medical/abandoned)
 "ihM" = (
@@ -40211,9 +40392,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "isF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/hidden/layer2{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
@@ -40231,6 +40409,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
+"ivp" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "ivy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -40247,7 +40433,9 @@
 "ixd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/turf/closed/wall,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/maintenance/department/engine)
 "ixN" = (
 /obj/structure/disposalpipe/junction{
@@ -40265,6 +40453,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
+"iyC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "iyJ" = (
@@ -40328,6 +40524,12 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/space/basic,
 /area/space)
+"iBw" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "iBJ" = (
 /obj/machinery/camera{
 	c_tag = "Telecomms External Fore";
@@ -40399,6 +40601,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"iFG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "iFI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -40435,6 +40643,12 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"iIY" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "iJb" = (
 /obj/structure/chair,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -40511,7 +40725,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/warden)
 "iNg" = (
@@ -40611,6 +40825,14 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
+"iVP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "iWV" = (
 /obj/machinery/light{
 	dir = 4
@@ -40830,7 +41052,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
 "jnp" = (
@@ -41229,6 +41451,18 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/closed/wall,
 /area/commons/fitness/recreation)
+"jNt" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/hydroponics/soil,
+/obj/item/radio/intercom/directional/north{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	prison_radio = 1
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "jOe" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -41315,6 +41549,36 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"jTV" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	layer = 3.1;
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
+	pixel_x = -8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/condiment/enzyme{
+	pixel_x = 9;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron/white,
+/area/security/prison)
+"jUF" = (
+/obj/structure/grille/broken,
+/obj/structure/cable,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/department/engine)
 "jVo" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -41408,12 +41672,32 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/engine)
+"jYn" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 6
+	},
+/obj/item/radio/intercom/directional/north{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	prison_radio = 1
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "jYA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/closed/wall,
 /area/maintenance/department/cargo)
+"kaA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "kbi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
@@ -41495,6 +41779,17 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
+"kiw" = (
+/obj/machinery/door/airlock{
+	name = "Prison Restrooms"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/freezer,
+/area/security/prison/toilet)
 "kjA" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 2;
@@ -41692,14 +41987,24 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "kso" = (
-/obj/machinery/power/apc/auto_name/east,
-/turf/open/floor/iron,
-/area/engineering/main)
+/obj/structure/sign/painting/library_private{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "ksv" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"ksP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "ktv" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -41838,6 +42143,22 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"kBu" = (
+/obj/machinery/airalarm/directional/south,
+/obj/structure/toilet{
+	dir = 1
+	},
+/turf/open/floor/iron/freezer,
+/area/security/prison/toilet)
+"kBD" = (
+/obj/effect/spawner/lootdrop/prison_contraband,
+/obj/structure/closet/crate,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron,
+/area/security/prison)
 "kCc" = (
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/conveyor{
@@ -41994,6 +42315,12 @@
 	},
 /turf/open/space/basic,
 /area/cargo/storage)
+"kLJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "kMt" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -42041,6 +42368,14 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/chapel,
 /area/service/chapel/main/monastery)
+"kPM" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "kPP" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -42183,6 +42518,16 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"kVf" = (
+/obj/structure/table,
+/obj/item/storage/box/chemimp{
+	pixel_x = 6
+	},
+/obj/item/storage/box/trackimp{
+	pixel_x = -3
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/security/armory)
 "kVt" = (
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
@@ -42433,6 +42778,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "ljT" = (
@@ -42465,10 +42811,9 @@
 "lkK" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/medical/virology)
 "llS" = (
@@ -42501,6 +42846,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"lny" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "loc" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Recreation Room"
@@ -42618,7 +42970,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "ltk" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "misclab";
 	name = "test chamber blast door"
@@ -42656,6 +43007,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"lvq" = (
+/turf/closed/wall,
+/area/security/prison/toilet)
 "lwT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -42677,7 +43031,7 @@
 /area/medical/paramedic)
 "lyd" = (
 /obj/effect/landmark/start/security_officer,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security)
 "lyB" = (
@@ -42730,6 +43084,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "lCb" = (
@@ -42784,8 +43139,12 @@
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "lGp" = (
-/obj/structure/weightmachine/weightlifter,
-/turf/open/floor/iron/dark,
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/iron/chapel{
+	dir = 8
+	},
 /area/security/prison)
 "lGq" = (
 /obj/structure/chair/wood{
@@ -42837,6 +43196,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
+"lKk" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "lKL" = (
 /obj/machinery/door/airlock{
 	name = "Starboard Emergency Storage"
@@ -42896,6 +43261,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"lPO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/chapel{
+	dir = 1
+	},
+/area/security/prison)
 "lQn" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -43354,6 +43725,12 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/plating/airless,
 /area/engineering/atmos)
+"mrR" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "mse" = (
 /turf/open/floor/wood,
 /area/cargo/qm)
@@ -43473,6 +43850,12 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/crew_quarters/bar)
+"myn" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "myu" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
@@ -43641,6 +44024,7 @@
 /area/service/library/artgallery)
 "mHy" = (
 /obj/item/storage/fancy/cigarettes/cigpack_shadyjims,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/maintenance/department/engine)
 "mIa" = (
@@ -43650,6 +44034,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "mJe" = (
@@ -43681,6 +44066,12 @@
 "mKE" = (
 /turf/closed/wall,
 /area/medical/medbay/lobby)
+"mLY" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "mMc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -43708,6 +44099,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"mOg" = (
+/obj/machinery/power/apc/auto_name/south,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "mOt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -44042,6 +44442,39 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
+"nfc" = (
+/obj/structure/closet/crate,
+/obj/item/reagent_containers/glass/bowl,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/kitchen/fork/plastic,
+/obj/item/kitchen/fork/plastic,
+/obj/item/kitchen/fork/plastic,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/kitchen/spoon/plastic,
+/obj/item/kitchen/spoon/plastic,
+/obj/item/kitchen/spoon/plastic,
+/obj/item/kitchen/knife/plastic,
+/obj/item/kitchen/knife/plastic,
+/obj/item/kitchen/knife/plastic,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/box/drinkingglasses,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "nfj" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -44308,6 +44741,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"nud" = (
+/obj/item/toy/beach_ball/holoball,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "nvG" = (
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/iron/dark,
@@ -44333,6 +44773,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/chapel/monastery)
+"nwJ" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/obj/machinery/plate_press,
+/turf/open/floor/iron,
+/area/security/prison)
 "nwK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -44474,9 +44921,6 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "misclab";
 	name = "test chamber blast door"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /obj/effect/spawner/structure/window/reinforced,
@@ -44806,6 +45250,13 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"nVs" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/table,
+/obj/item/plant_analyzer,
+/obj/item/plant_analyzer,
+/turf/open/floor/iron,
+/area/security/prison)
 "nVz" = (
 /obj/structure/sign/directions/evac{
 	dir = 8;
@@ -45230,6 +45681,22 @@
 	luminosity = 2
 	},
 /area/maintenance/department/science)
+"orp" = (
+/obj/machinery/button/flasher{
+	id = "Cell 2";
+	name = "Prisoner Flash";
+	pixel_x = -7;
+	pixel_y = 26
+	},
+/obj/machinery/button/door/directional/west{
+	id = "permashut2";
+	name = "Cell Lockdown Button";
+	pixel_x = 6;
+	pixel_y = 26;
+	req_access_txt = "2"
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "ory" = (
 /obj/machinery/light{
 	dir = 4
@@ -45592,7 +46059,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security)
 "oGm" = (
@@ -45608,7 +46075,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
@@ -45621,6 +46088,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -45748,6 +46216,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"oQr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "permashut3";
+	name = "Permabrig Cell 3";
+	req_access_txt = "2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "oRl" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/extinguisher_cabinet/directional/south,
@@ -45794,6 +46277,18 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"oSI" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/door/airlock{
+	name = "Cleaning Closet"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "oTl" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8;
@@ -45886,6 +46381,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "oWL" = (
@@ -46072,8 +46568,23 @@
 "phx" = (
 /obj/effect/landmark/blobstart,
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plating,
 /area/medical/abandoned)
+"pif" = (
+/obj/structure/holohoop{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Prison Yard";
+	dir = 8;
+	network = list("ss13","prison")
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "piI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -46190,8 +46701,6 @@
 	dir = 4;
 	light_color = "#e8eaff"
 	},
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/medical/abandoned)
 "ppQ" = (
@@ -46203,6 +46712,16 @@
 	},
 /turf/open/floor/iron/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
+"pqq" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/rice,
+/obj/item/reagent_containers/food/condiment/flour,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "pqw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -46244,7 +46763,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "pth" = (
@@ -46322,6 +46841,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
+"pxU" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/security/armory)
 "pyA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -46392,12 +46915,26 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/psychology)
+"pEg" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "pEh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"pEp" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "pEv" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1
@@ -46427,6 +46964,16 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"pFE" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/kitchen/fork/plastic,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "pFG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
@@ -46557,6 +47104,11 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
+"pMG" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space)
 "pMM" = (
 /obj/machinery/airalarm/kitchen_cold_room{
 	pixel_y = 22
@@ -46598,10 +47150,17 @@
 /area/science/mixing)
 "pOc" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/freezer,
 /area/medical/virology)
+"pOs" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "pOt" = (
 /obj/structure/flora/junglebush/large,
 /obj/structure/window/reinforced/spawner/north,
@@ -46701,6 +47260,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/wood{
 	icon_state = "wood-broken5"
 	},
@@ -46726,6 +47286,38 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"pWo" = (
+/obj/structure/closet/crate/secure/weapon{
+	desc = "A secure clothing crate.";
+	name = "formal uniform crate";
+	req_access_txt = "3"
+	},
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/suit/security/officer,
+/obj/item/clothing/suit/security/officer,
+/obj/item/clothing/suit/security/officer,
+/obj/item/clothing/suit/security/officer,
+/obj/item/clothing/suit/security/officer,
+/obj/item/clothing/suit/security/officer,
+/obj/item/clothing/under/rank/security/warden/formal,
+/obj/item/clothing/suit/security/warden,
+/obj/item/clothing/under/rank/security/head_of_security/formal,
+/obj/item/clothing/suit/security/hos,
+/obj/item/clothing/head/beret/sec/navyofficer,
+/obj/item/clothing/head/beret/sec/navyofficer,
+/obj/item/clothing/head/beret/sec/navyofficer,
+/obj/item/clothing/head/beret/sec/navyofficer,
+/obj/item/clothing/head/beret/sec/navyofficer,
+/obj/item/clothing/head/beret/sec/navyofficer,
+/obj/item/clothing/head/beret/sec/navywarden,
+/obj/item/clothing/head/beret/sec/navyhos,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/security/armory)
 "pWT" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/botanist,
@@ -46876,6 +47468,7 @@
 "qdj" = (
 /obj/structure/disposalpipe/segment,
 /obj/item/stack/sheet/mineral/wood,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "qdO" = (
@@ -46914,7 +47507,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "qfV" = (
@@ -47277,9 +47870,14 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "quw" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/security/armory)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/iron/chapel,
+/area/security/prison)
 "qux" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -47312,9 +47910,6 @@
 /area/maintenance/department/engine)
 "qvM" = (
 /obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/hidden/layer2{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -47405,6 +48000,13 @@
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/grass,
 /area/medical/medbay/lobby)
+"qEk" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
+/obj/machinery/plate_press,
+/turf/open/floor/iron,
+/area/security/prison)
 "qEm" = (
 /obj/machinery/light{
 	dir = 4;
@@ -47554,6 +48156,14 @@
 	name = "Holodeck Projector Floor"
 	},
 /area/holodeck/rec_center)
+"qLo" = (
+/obj/structure/lattice,
+/obj/machinery/camera/motion{
+	c_tag = "Armory External";
+	dir = 1
+	},
+/turf/open/space,
+/area/space/nearstation)
 "qLU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -47561,8 +48171,10 @@
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
 "qMX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron/freezer,
 /area/medical/virology)
 "qNB" = (
@@ -47816,11 +48428,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/open/floor/plating/airless,
 /area/tcommsat/computer)
+"rcR" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "reH" = (
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/maintenance/department/engine)
 "reR" = (
@@ -47879,6 +48501,29 @@
 /obj/effect/spawner/randomarcade,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
+"rka" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
+"rkv" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/grunge{
+	name = "Prison Monastery"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/security/prison)
+"rle" = (
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/maintenance/department/engine)
 "rli" = (
 /obj/structure/sink{
 	dir = 8;
@@ -47932,6 +48577,10 @@
 	},
 /turf/open/space/basic,
 /area/cargo/storage)
+"rnm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/prison)
 "rnE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48037,6 +48686,23 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"rqQ" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/item/paper/guides/jobs/hydroponics,
+/obj/item/seeds/onion,
+/obj/item/seeds/garlic,
+/obj/item/seeds/potato,
+/obj/item/seeds/tomato,
+/obj/item/seeds/carrot,
+/obj/item/seeds/grass,
+/obj/item/seeds/ambrosia,
+/obj/item/seeds/wheat,
+/obj/item/seeds/pumpkin,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/light/no_nightlight/directional/south,
+/turf/open/floor/iron,
+/area/security/prison)
 "rrt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/circuit/green{
@@ -48073,6 +48739,7 @@
 /area/medical/virology)
 "rse" = (
 /obj/machinery/power/smes/engineering,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "rsy" = (
@@ -48362,6 +49029,18 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"rBL" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/camera{
+	c_tag = "Prison Cafeteria";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/iron/white,
+/area/security/prison)
 "rCe" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -48465,7 +49144,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "rHG" = (
@@ -48512,6 +49191,14 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/engine)
+"rJS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/chapel{
+	dir = 4
+	},
+/area/security/prison)
 "rJT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48641,7 +49328,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "rNB" = (
@@ -48775,7 +49462,6 @@
 /area/medical/surgery)
 "rXJ" = (
 /obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/plating{
@@ -48823,6 +49509,20 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
+"rYZ" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/cargo/warehouse/upper)
 "sah" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -48840,12 +49540,22 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/cargo/warehouse/upper)
 "sbk" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
+"sbt" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/iron,
+/area/security/prison)
 "sbI" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -48862,6 +49572,18 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/service/kitchen)
+"sbU" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/obj/structure/sign/warning/electricshock{
+	pixel_x = 32
+	},
+/obj/structure/table,
+/obj/item/cultivator,
+/obj/item/cultivator,
+/turf/open/floor/iron,
+/area/security/prison)
 "sbY" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/wood,
@@ -48902,16 +49624,17 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "sdk" = (
-/obj/structure/lattice,
-/obj/machinery/camera/motion{
-	c_tag = "Armory External";
+/obj/structure/chair/wood{
 	dir = 1
 	},
-/turf/open/space,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/chapel{
+	dir = 8
+	},
+/area/security/prison)
 "sdE" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -48972,6 +49695,11 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
 /area/medical/storage)
+"shU" = (
+/obj/structure/barricade/wooden,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "sij" = (
 /obj/structure/closet,
 /obj/item/food/meat/slab/monkey,
@@ -49171,6 +49899,7 @@
 /obj/machinery/power/terminal{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "sut" = (
@@ -49344,6 +50073,11 @@
 /obj/item/clothing/mask/gas/plaguedoctor,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"sAN" = (
+/obj/structure/urinal/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/freezer,
+/area/security/prison/toilet)
 "sBf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -49520,6 +50254,16 @@
 /obj/machinery/light/small,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"sKL" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/flasher/directional/south{
+	id = "Cell 3";
+	pixel_y = 26
+	},
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "sLv" = (
 /obj/item/stack/medical/mesh,
 /obj/item/stack/medical/suture,
@@ -49670,6 +50414,13 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/engine)
+"sVF" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/iron,
+/area/security/prison)
 "sWj" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
@@ -50062,7 +50813,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "tlc" = (
@@ -50121,6 +50872,23 @@
 	},
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
+"tot" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/iron,
+/area/security/prison)
+"toR" = (
+/obj/item/stack/sheet/cardboard{
+	amount = 14
+	},
+/obj/item/stack/package_wrap,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "tpb" = (
 /obj/item/food/donut,
 /turf/open/floor/plating{
@@ -50145,11 +50913,11 @@
 /turf/closed/wall,
 /area/medical/storage)
 "tqM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/medical/virology)
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/iron/chapel,
+/area/security/prison)
 "tqO" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
@@ -50246,6 +51014,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "twv" = (
@@ -50423,6 +51192,13 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
+"tCJ" = (
+/obj/structure/closet/secure_closet/contraband/armory,
+/obj/item/poster/random_contraband,
+/obj/item/clothing/suit/security/officer/russian,
+/obj/item/grenade/c4,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/security/armory)
 "tCP" = (
 /obj/docking_port/stationary/public_mining_dock,
 /turf/open/floor/plating,
@@ -50494,12 +51270,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"tGQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "tHk" = (
 /obj/structure/sign/directions/security{
 	dir = 1;
@@ -50531,7 +51301,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security)
 "tLN" = (
@@ -50558,7 +51328,8 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "tNx" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/medical/virology)
 "tOf" = (
@@ -50661,6 +51432,27 @@
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"tTq" = (
+/obj/structure/closet/crate,
+/obj/item/food/breadslice/plain,
+/obj/item/food/breadslice/plain,
+/obj/item/food/breadslice/plain,
+/obj/item/food/grown/potato,
+/obj/item/food/grown/potato,
+/obj/item/food/grown/onion,
+/obj/item/food/grown/onion,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/item/radio/intercom/directional/north{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	prison_radio = 1
+	},
+/turf/open/floor/iron/white,
+/area/security/prison)
 "tUr" = (
 /obj/structure/table/optable,
 /obj/machinery/computer/operating,
@@ -50799,6 +51591,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"ubq" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/item/food/energybar,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "ucd" = (
 /obj/machinery/light/dim{
 	dir = 8
@@ -50901,9 +51702,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"ueX" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/prison)
 "ufa" = (
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
@@ -50975,6 +51787,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/maintenance/department/engine)
 "ujf" = (
@@ -51072,9 +51885,15 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "ulV" = (
-/obj/structure/rack,
-/obj/item/gun/energy/e_gun/dragnet,
-/obj/item/gun/energy/e_gun/dragnet,
+/obj/effect/landmark/event_spawn,
+/mob/living/simple_animal/bot/secbot{
+	arrest_type = 1;
+	health = 45;
+	icon_state = "secbot1";
+	idcheck = 1;
+	name = "Sergeant-at-Armsky";
+	weaponscheck = 1
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "umd" = (
@@ -51309,6 +52128,30 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"uxk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/poddoor/preopen{
+	id = "permashut1"
+	},
+/obj/machinery/door/airlock/glass{
+	name = "Cell 1"
+	},
+/turf/open/floor/iron,
+/area/security/prison/safe)
+"uxx" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/security/prison)
 "uxF" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -51522,6 +52365,17 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/crew_quarters/dorms)
+"uGE" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/light/no_nightlight/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/security/prison)
 "uHJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51535,6 +52389,7 @@
 /area/medical/morgue)
 "uIn" = (
 /obj/machinery/nuclearbomb/beer,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "uIo" = (
@@ -51604,6 +52459,7 @@
 /area/engineering/supermatter)
 "uMt" = (
 /obj/effect/turf_decal/plaque,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "uMY" = (
@@ -51642,6 +52498,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/psychology)
+"uPl" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "uPz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51734,6 +52596,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter/room)
+"uUE" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/turf/open/floor/iron/freezer,
+/area/security/prison/toilet)
 "uUQ" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Engineering Maintenance";
@@ -51943,7 +52811,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/brig)
 "vap" = (
@@ -51951,6 +52819,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"vaF" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/flasher/directional/south{
+	id = "Cell 2";
+	pixel_y = 26
+	},
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "vaR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -52240,7 +53118,7 @@
 /area/maintenance/department/science)
 "vrx" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "vrV" = (
@@ -52469,6 +53347,10 @@
 /obj/structure/training_machine,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
+"vDq" = (
+/obj/structure/curtain,
+/turf/open/floor/iron/freezer,
+/area/security/prison/toilet)
 "vDX" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -52476,6 +53358,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
+"vEU" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/iron,
+/area/security/prison)
 "vFs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -52649,6 +53538,7 @@
 "vNu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "vNA" = (
@@ -52816,6 +53706,14 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/disposal)
+"vTg" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/hydroponics/soil,
+/obj/machinery/light/no_nightlight/directional/north,
+/turf/open/floor/iron,
+/area/security/prison)
 "vTL" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/iron,
@@ -52828,6 +53726,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/mixing)
+"vUQ" = (
+/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/freezer,
+/area/security/prison/toilet)
 "vVk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -52862,6 +53768,20 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
+"vYM" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
 "vYN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -52918,7 +53838,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/brig)
 "wbx" = (
@@ -52931,11 +53851,8 @@
 /turf/open/floor/iron/dark,
 /area/science/explab)
 "wbB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron,
 /area/security/prison)
 "wbR" = (
 /obj/structure/disposalpipe/segment{
@@ -52968,6 +53885,16 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter/room)
+"wcP" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "wdp" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -53140,11 +54067,12 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "wkA" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/obj/structure/punching_bag,
+/obj/machinery/light/no_nightlight/directional/north,
+/turf/open/floor/iron,
 /area/security/prison)
 "wkM" = (
 /obj/structure/disposalpipe/segment{
@@ -53235,6 +54163,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"woO" = (
+/obj/structure/urinal/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/freezer,
+/area/security/prison/toilet)
 "woX" = (
 /obj/structure/sign/painting/library_secure{
 	pixel_y = -32
@@ -53308,7 +54242,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/processing/cremation)
 "wun" = (
@@ -53371,6 +54305,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"wxa" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "wxn" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -53442,6 +54383,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/bar)
+"wzP" = (
+/obj/item/grenade/barrier{
+	pixel_x = 4
+	},
+/obj/item/grenade/barrier,
+/obj/item/grenade/barrier{
+	pixel_x = -4
+	},
+/obj/structure/table,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/security/armory)
 "wAr" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
@@ -53531,6 +54483,37 @@
 "wDZ" = (
 /turf/closed/wall,
 /area/cargo/qm)
+"wEc" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/shield/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/shield/riot,
+/obj/item/shield/riot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/security/armory)
 "wEl" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -53582,6 +54565,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"wFM" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "wFT" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -53606,7 +54595,10 @@
 /turf/open/floor/iron/white,
 /area/medical/psychology)
 "wHD" = (
-/obj/item/radio/intercom/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
 "wHP" = (
@@ -53726,6 +54718,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"wNI" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/iron,
+/area/security/prison)
 "wOf" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -53741,6 +54740,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"wOG" = (
+/obj/item/soap/homemade,
+/turf/open/floor/iron/freezer,
+/area/security/prison/toilet)
 "wOS" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -53763,10 +54766,12 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
 "wPr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
 	},
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/security/prison)
 "wPw" = (
 /obj/structure/disposalpipe/segment{
@@ -53947,6 +54952,12 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"wVS" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "wVV" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/structure/window/reinforced,
@@ -54061,7 +55072,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "xba" = (
@@ -54205,6 +55216,17 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"xga" = (
+/obj/structure/sign/warning/electricshock{
+	pixel_x = -31
+	},
+/obj/structure/chair/stool/bar/directional/south,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "xgt" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -54287,7 +55309,7 @@
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "xjU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/security)
 "xjZ" = (
@@ -54437,7 +55459,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/security)
 "xoD" = (
@@ -54554,8 +55576,10 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
 "xuy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
-/turf/open/floor/iron/dark,
+/obj/effect/spawner/randomarcade,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
 /area/security/prison)
 "xvx" = (
 /obj/structure/disposalpipe/segment{
@@ -54879,6 +55903,16 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/engine)
+"xKM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/vending_refill/cola,
+/obj/item/stack/sheet/cardboard{
+	amount = 14
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "xLi" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -54991,6 +56025,11 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"xPV" = (
+/obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "xQr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -55022,13 +56061,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "xTb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "xTe" = (
@@ -55088,7 +56125,7 @@
 /area/science/xenobiology)
 "xWN" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -55238,6 +56275,9 @@
 	},
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
+"ygc" = (
+/turf/open/floor/iron/freezer,
+/area/security/prison/toilet)
 "ygx" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -55316,6 +56356,22 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"yjF" = (
+/obj/machinery/button/flasher{
+	id = "Cell 1";
+	name = "Prisoner Flash";
+	pixel_x = -7;
+	pixel_y = 26
+	},
+/obj/machinery/button/door/directional/west{
+	id = "permashut1";
+	name = "Cell Lockdown Button";
+	pixel_x = 6;
+	pixel_y = 26;
+	req_access_txt = "2"
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "ykY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -72882,12 +73938,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aOn
+aOn
+aOn
+aOn
+pMG
+pMG
 aaa
 aaa
 aaa
@@ -73139,11 +74195,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-adR
+aOn
+fzz
+wOG
+aOn
+aht
 aht
 afU
 agi
@@ -73396,12 +74452,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-adR
-aht
+aOn
+fzz
+ygc
+lvq
+aOn
+aOn
 afU
 szG
 sOC
@@ -73653,12 +74709,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-adR
-aht
+aOn
+fzz
+ygc
+vDq
+ygc
+uUE
 afU
 lem
 mzl
@@ -73899,23 +74955,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-adR
-aht
+adE
+adE
+adE
+adE
+adE
+adE
+adE
+adE
+aem
+aen
+aen
+aOn
+lvq
+lvq
+lvq
+fKa
+kBu
 afU
 agj
 agv
@@ -74156,23 +75212,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-adR
-aht
+adE
+aeE
+ahG
+kso
+ahG
+kso
+lKk
+adE
+pqq
+wxa
+evP
+xga
+rBL
+wcP
+lvq
+sAN
+vUQ
 afU
 afU
 xaW
@@ -74413,24 +75469,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aed
-adR
-abI
-abI
-abI
-abI
-abI
-afX
+adE
+aeT
+aij
+lGp
+aij
+lGp
+pEp
+agy
+eTi
+wxa
+fmp
+dJp
+wxa
+pFE
+lvq
+woO
+fNb
+aiA
 agl
 xSH
 xSH
@@ -74670,23 +75726,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-adR
-aaa
-abI
-aaa
-aem
-aem
-aem
-aem
+adE
+aeW
+aik
+quw
+rJS
+quw
+rka
+agy
+jTV
+wxa
+fmp
+dJp
+uxx
+eTI
+lvq
+lvq
+kiw
 aiA
 aiA
 aiA
@@ -74927,30 +75983,30 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-adR
-aaa
-aem
-aem
-aem
-aeT
-afn
+adE
+aeX
+akN
+sdk
+lPO
+sdk
+rcR
 agy
+dfu
+wxa
+ubq
+dJp
+aep
+uGE
+agy
+afn
+guO
 afZ
 agn
-agy
-agy
-agy
-agy
-aiF
+uxk
+lny
+lny
+eGF
+wHD
 sdE
 aiC
 ajc
@@ -75184,30 +76240,30 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-adR
-abI
-aem
-aeo
+adE
+aeT
+akP
+tqM
+akP
+tqM
+kPM
+agy
+tTq
+wxa
+eaA
+dJp
+aep
 aeC
-aga
-aga
-afC
-aga
-aga
 agy
-agI
-agW
-agy
-ahC
+clE
+ahF
+aiF
+wbB
+ahp
+agL
+agZ
+ahp
+yjF
 sdE
 aiC
 ajc
@@ -75441,30 +76497,30 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-adR
-aaa
-aen
+adE
+afX
+alA
+alA
+alA
+mrR
+kPM
+agy
+nfc
+wxa
+wxa
+wxa
 aep
 aeD
-fJd
+agy
 wkA
-wkA
-wPr
+ahF
+aiF
 wbB
-agz
+ahp
 agM
 agX
-ahm
-eTW
+ahp
+dsP
 sdE
 aiC
 ajc
@@ -75698,30 +76754,30 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-adR
-abI
-aem
+adE
+adE
+adE
+aen
+aen
+duH
+rkv
+agy
+agy
+aen
+aen
+aen
 aeq
-aeE
-aga
+aen
+agy
 afp
 afE
-aga
+dCu
 wbB
-agy
-agK
-agY
-agy
-adE
+ahp
+ahp
+ahp
+ahp
+aiF
 sdE
 aiE
 agy
@@ -75957,16 +77013,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-adR
-aaa
-aen
+aem
+wPr
+aeF
+afq
+ueX
+aeF
+eAF
+aeF
+aeF
+aeF
 aer
 aeF
 aeV
@@ -75974,10 +77030,10 @@ afq
 afF
 clK
 bvC
-agy
-agy
-agy
-agy
+eIJ
+iVP
+iVP
+cMa
 ahF
 sdE
 aiF
@@ -76214,30 +77270,30 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-adR
-abI
 aem
+czK
+pEg
+aeG
+aeG
 aes
 aeG
-aga
-afD
-afD
-aga
-all
-agy
-agL
-agZ
-agy
-ahG
-sdE
+aeG
+aeG
+aeG
+aes
+aeG
+hDg
 aiF
+wHD
+kLJ
+wbB
+ahp
+vaF
+agZ
+ahp
+orp
+sdE
+wFM
 aen
 ajL
 ark
@@ -76470,29 +77526,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-adR
-aaa
+ahC
+ahC
+oSI
+ahp
+aen
+aen
+aJx
+aen
+aen
+agy
 aen
 aga
-aga
-dGY
+aen
+agy
 xuy
-xuy
-xuy
-wbB
-agB
-agM
-agX
+kaA
+dvY
+hWS
 ahp
-eTW
+agM
+fRl
+ahp
+dsP
 jng
 jng
 cxn
@@ -76727,30 +77783,30 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-adR
-abI
-aem
+ahC
+dGY
+mOg
+ahp
+wNI
+wVS
+afZ
+wVS
+ePM
+agy
+qEk
 aeu
 aeI
-lGp
-aga
+agy
+jYn
 afI
-aga
-aga
-agy
-agN
-agY
-agy
+iBw
+agp
+ahp
+ahp
+ahp
+ahp
 ahI
-hVW
+wHD
 adI
 agy
 ajM
@@ -76984,30 +78040,30 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-adR
-aaa
-aem
-aem
-aem
-aeW
-afr
-agy
-agc
-ago
-agy
-agy
-agy
-agy
+ahC
+eTW
+xPV
+ahp
+vEU
+aiF
 wHD
 aiF
+cTq
+agy
+toR
+rnm
+kBD
+agy
+afr
+wHD
+agc
+ago
+ekm
+lny
+lny
+oQr
+wHD
+wHD
 iTa
 agy
 ajN
@@ -77241,28 +78297,28 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-adR
-aaa
-abI
-aaa
-aem
-aeX
-afs
+ahC
+fJd
+flR
+ahp
+vTg
+rnm
+wHD
+iFG
+rqQ
 agy
+nwJ
+dIy
+btA
+agy
+afs
+aiF
 agd
 agp
-aaU
-aaV
-aaW
-agy
+ahp
+sKL
+agZ
+ahp
 ahK
 aih
 aiK
@@ -77346,7 +78402,7 @@ erQ
 oat
 sEN
 sEN
-sEN
+ksP
 bKo
 tNx
 qMX
@@ -77498,28 +78554,28 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aed
-adR
-abI
+ahC
+ahC
+ahC
+ahC
+jNt
+myn
+aiF
+gnM
+gqx
 aem
 aem
 aem
 aem
 aem
-aem
-aem
-aem
-aem
-aem
+nud
+aiF
+agd
+agp
+ahC
+agM
+fRl
+ahC
 ahL
 ahL
 ahL
@@ -77603,10 +78659,10 @@ qIl
 sEN
 jJN
 iaj
-sEN
+ksP
 bKn
 bKn
-tqM
+bKn
 bKn
 bEr
 aht
@@ -77758,32 +78814,32 @@ aaa
 aaa
 aaa
 aaa
+aem
+vEU
+aiF
+aiF
+aiF
+nVs
+aem
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aby
-abI
-abI
-ahL
+aem
+mLY
+pif
+pOs
+aem
+ahC
+ahC
+ahC
+ahC
+kVf
 aii
 aiL
 ajg
 ajP
 akL
-alA
+afH
 amh
 amV
 usu
@@ -77860,7 +78916,7 @@ kTU
 wMn
 rsd
 rsd
-rsd
+iIY
 aSr
 pOc
 hID
@@ -77872,7 +78928,7 @@ pEv
 bRD
 qpT
 bSo
-bSq
+xKM
 wlc
 bUF
 bNK
@@ -78015,30 +79071,30 @@ aaa
 aaa
 aaa
 aaa
+aem
+tot
+uPl
+aiF
+dtj
+sbU
+aem
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sQP
+sQP
+sQP
+sQP
+sQP
 aaa
 aby
 abI
-abI
-ahL
-aij
+lTW
+tCJ
 akM
 akM
 akM
+pxU
 gRJ
 geP
 iMH
@@ -78117,7 +79173,7 @@ wLl
 stc
 cis
 hdK
-hdK
+ksP
 ggW
 lkK
 bQS
@@ -78272,13 +79328,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aem
+aem
+tot
+sbt
+sVF
+aem
+aem
 aaa
 aaa
 aaa
@@ -78289,15 +79345,15 @@ aaa
 aaa
 aaa
 aby
-abI
-sdk
-ahL
-aik
+qLo
+lTW
+dfw
 akM
+wEc
 ajh
 ajR
 ulV
-akN
+akM
 amh
 anI
 usu
@@ -78530,11 +79586,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aem
+aen
+aen
+aen
+aem
 aaa
 aaa
 aaa
@@ -78547,10 +79603,10 @@ aaa
 aaa
 aby
 abI
-abI
-ahL
+lTW
+pWo
 ail
-quw
+rEZ
 rEZ
 rEZ
 rEZ
@@ -78804,13 +79860,13 @@ aaa
 aaa
 aby
 abI
-abI
-ahL
+lTW
+wzP
 aim
 aiO
 ajj
 ajT
-akP
+afH
 afH
 amh
 amZ
@@ -78917,7 +79973,7 @@ bva
 stQ
 bDi
 bDi
-bDi
+fSx
 bUa
 dNr
 bBX
@@ -79175,7 +80231,7 @@ pVD
 kDY
 fmh
 rSH
-bSo
+ivp
 bIZ
 bBX
 wfO
@@ -79678,18 +80734,18 @@ bVy
 ohR
 hVx
 bXU
-bDi
-bZt
+fSx
+jUF
 bZs
-kRq
+eWl
 uMt
-bME
+shU
 fef
-fmh
+rle
 bNU
 nYb
 dSr
-fmh
+rle
 dJm
 bDi
 wfO
@@ -80460,7 +81516,7 @@ dye
 nVU
 bDi
 qBv
-bDi
+fSx
 dNr
 bBX
 bDi
@@ -80705,7 +81761,7 @@ bva
 bDi
 bDi
 bDi
-iFA
+iyC
 bDi
 nWP
 bva
@@ -81217,8 +82273,8 @@ bDi
 bDi
 bOB
 ygZ
-iFA
-iFA
+iyC
+iyC
 cad
 eYM
 bQl
@@ -89440,7 +90496,7 @@ qoK
 aoq
 bZc
 bZJ
-kso
+cbW
 cbW
 cbW
 jPo
@@ -92763,7 +93819,7 @@ aht
 aaa
 fBp
 bKT
-bWO
+sGc
 wYi
 lyB
 wCz
@@ -95597,7 +96653,7 @@ bPh
 bQb
 bPh
 bJP
-bSl
+bSk
 bSY
 bSk
 bJP
@@ -96127,7 +97183,7 @@ caP
 foz
 bYw
 auX
-tGQ
+xTb
 bYw
 aht
 fon
@@ -96382,7 +97438,7 @@ rLJ
 aqB
 caQ
 asY
-gcf
+xTb
 avl
 xTb
 azC
@@ -99405,8 +100461,8 @@ mdx
 dWw
 mXc
 saR
-saR
-eCB
+rYZ
+vYM
 eCB
 ahW
 vHj

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -1975,6 +1975,10 @@
 	id = "Cell 1";
 	pixel_y = 26
 	},
+/obj/machinery/camera{
+	c_tag = "Permabrig - Cell 1";
+	network = list("ss13","prison")
+	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "agM" = (
@@ -36276,20 +36280,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"eiu" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/cargo/storage)
 "ejn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -36956,6 +36946,11 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/camera{
+	c_tag = "Permabrig - Kitchen";
+	dir = 1;
+	network = list("ss13","prison")
+	},
 /turf/open/floor/iron/white,
 /area/security/prison)
 "eTW" = (
@@ -38175,20 +38170,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"fZK" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/cargo/warehouse/upper)
 "fZV" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/blue,
@@ -43228,6 +43209,11 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
+/obj/machinery/camera{
+	c_tag = "Permabrig - Monastery";
+	dir = 4;
+	network = list("ss13","prison")
+	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "lKL" = (
@@ -43442,6 +43428,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
+"lYA" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/camera{
+	c_tag = "Permabrig - Hall";
+	dir = 1;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "lYE" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -46111,6 +46106,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"oJp" = (
+/obj/machinery/light/no_nightlight/directional/north,
+/turf/open/floor/iron,
+/area/security/prison)
 "oKD" = (
 /obj/structure/disposalpipe/junction,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -46604,7 +46603,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Prison Yard";
+	c_tag = "Permabrig - Yard";
 	dir = 8;
 	network = list("ss13","prison")
 	},
@@ -49058,16 +49057,16 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "rBL" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/red,
+/obj/machinery/hydroponics/soil,
 /obj/machinery/camera{
-	c_tag = "Prison Cafeteria";
-	dir = 4;
+	c_tag = "Permabrig - Garden";
+	dir = 8;
 	network = list("ss13","prison")
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron,
 /area/security/prison)
 "rCe" = (
 /obj/structure/table,
@@ -50276,6 +50275,10 @@
 	id = "Cell 3";
 	pixel_y = 26
 	},
+/obj/machinery/camera{
+	c_tag = "Permabrig - Cell 3";
+	network = list("ss13","prison")
+	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "sLv" = (
@@ -50901,6 +50904,10 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
+/obj/machinery/camera{
+	c_tag = "Permabrig - Workroom";
+	network = list("ss13","prison")
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "tpb" = (
@@ -51022,6 +51029,20 @@
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
+"tvy" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
 "tvP" = (
 /obj/item/storage/toolbox/mechanical,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -51146,6 +51167,20 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/engine)
+"tAm" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/cargo/warehouse/upper)
 "tAK" = (
 /obj/structure/rack,
 /obj/item/integrated_circuit/loaded/speech_relay,
@@ -52840,6 +52875,10 @@
 /obj/machinery/flasher/directional/south{
 	id = "Cell 2";
 	pixel_y = 26
+	},
+/obj/machinery/camera{
+	c_tag = "Permabrig - Cell 2";
+	network = list("ss13","prison")
 	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
@@ -54765,6 +54804,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
+"wPo" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Permabrig - Upper Hall";
+	dir = 8;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "wPr" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
@@ -75224,7 +75274,7 @@ pqq
 wxa
 evP
 xga
-rBL
+wxa
 wcP
 lvq
 sAN
@@ -76515,7 +76565,7 @@ agy
 wkA
 ahF
 aiF
-wbB
+lYA
 ahp
 agM
 agX
@@ -76777,7 +76827,7 @@ ahp
 ahp
 ahp
 ahp
-aiF
+oJp
 sdE
 aiE
 agy
@@ -77278,7 +77328,7 @@ aeG
 aes
 aeG
 aeG
-aeG
+wPo
 aeG
 aes
 aeG
@@ -79072,7 +79122,7 @@ aaa
 aaa
 aaa
 aem
-tot
+rBL
 uPl
 aiF
 dtj
@@ -100461,8 +100511,8 @@ mdx
 dWw
 mXc
 saR
-fZK
-eiu
+tAm
+tvy
 eCB
 ahW
 vHj

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -48413,16 +48413,6 @@
 	},
 /turf/open/floor/plating,
 /area/medical/cryo)
-"qwm" = (
-/obj/structure/table/wood,
-/obj/item/inspector{
-	pixel_x = 4
-	},
-/obj/item/inspector{
-	pixel_x = -4
-	},
-/turf/open/floor/iron,
-/area/security)
 "qwJ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -48468,6 +48458,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/lobby)
+"qzW" = (
+/obj/structure/table/wood,
+/obj/item/inspector{
+	pixel_x = 4
+	},
+/obj/item/inspector{
+	pixel_x = -4
+	},
+/turf/open/floor/iron,
+/area/security)
 "qAF" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -48847,6 +48847,7 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/east,
+/obj/structure/rack,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "qXb" = (
@@ -53358,6 +53359,16 @@
 "uRk" = (
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
+"uSv" = (
+/obj/structure/table/wood,
+/obj/item/inspector{
+	pixel_x = -4
+	},
+/obj/item/inspector{
+	pixel_x = 4
+	},
+/turf/open/floor/iron,
+/area/security)
 "uSL" = (
 /obj/machinery/camera{
 	c_tag = "Holodeck - Fore";
@@ -55504,16 +55515,6 @@
 	dir = 4
 	},
 /area/commons/fitness/recreation)
-"wKU" = (
-/obj/structure/table/wood,
-/obj/item/inspector{
-	pixel_x = -4
-	},
-/obj/item/inspector{
-	pixel_x = 4
-	},
-/turf/open/floor/iron,
-/area/security)
 "wLl" = (
 /obj/machinery/door_buttons/airlock_controller{
 	idExterior = "virology_airlock_exterior";
@@ -74883,8 +74884,8 @@ aOn
 aOn
 aOn
 aOn
-fon
-fon
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -75140,8 +75141,8 @@ aOn
 fzz
 wOG
 aOn
-aht
-aht
+aaa
+aaa
 afU
 agi
 agi
@@ -81581,7 +81582,7 @@ ajY
 idZ
 alC
 amn
-qwm
+qzW
 amn
 tLA
 apb
@@ -82350,7 +82351,7 @@ agP
 ajo
 ghx
 lyd
-wKU
+uSv
 tLA
 alC
 okX

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -5089,7 +5089,6 @@
 	dir = 4
 	},
 /obj/structure/table,
-/obj/item/stack/sheet/plasteel/fifty,
 /obj/item/stack/sheet/iron/fifty{
 	pixel_x = 2;
 	pixel_y = 2
@@ -52362,14 +52361,9 @@
 /area/service/chapel/main/monastery)
 "udE" = (
 /obj/structure/table,
-/obj/item/circuitboard/machine/HFR_core,
-/obj/item/circuitboard/machine/HFR_fuel_input,
-/obj/item/circuitboard/machine/HFR_interface,
-/obj/item/circuitboard/machine/HFR_moderator_input,
-/obj/item/circuitboard/machine/HFR_waste_output,
 /obj/item/stack/cable_coil{
-	pixel_x = -3;
-	pixel_y = 3
+	pixel_x = 3;
+	pixel_y = -7
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
@@ -57068,16 +57062,12 @@
 /area/medical/virology)
 "yby" = (
 /obj/structure/table,
-/obj/item/circuitboard/machine/HFR_corner,
-/obj/item/circuitboard/machine/HFR_corner,
-/obj/item/circuitboard/machine/HFR_corner,
-/obj/item/circuitboard/machine/HFR_corner,
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 10
+	},
 /obj/item/stack/cable_coil{
 	pixel_x = 3;
 	pixel_y = -7
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 10
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -1251,9 +1251,6 @@
 /turf/open/floor/iron/white,
 /area/security/prison)
 "aeE" = (
-/obj/structure/sign/painting/library_private{
-	pixel_x = -32
-	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
@@ -1598,10 +1595,10 @@
 /turf/closed/wall,
 /area/service/kitchen/coldroom)
 "afv" = (
-/obj/structure/chair/stool,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
 "afw" = (
@@ -2207,6 +2204,9 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
+/obj/structure/sign/painting/library{
+	pixel_x = -32
+	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "ahI" = (
@@ -2563,13 +2563,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/door/window/westright{
+	base_state = "left";
+	dir = 4;
+	icon_state = "left";
+	name = "Cargo Desk";
+	req_access_txt = "50"
+	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "aiK" = (
@@ -2933,7 +2936,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "ajC" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "ajD" = (
@@ -2958,7 +2961,7 @@
 /obj/machinery/door/airlock/security{
 	aiControlDisabled = 1;
 	name = "Crematorium";
-	req_access_txt = "3;27"
+	req_access_txt = "3"
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -3068,8 +3071,8 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "ajW" = (
-/obj/structure/chair/stool,
 /obj/effect/landmark/start/security_officer,
+/obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/iron,
 /area/security)
 "ajX" = (
@@ -3752,18 +3755,18 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "alQ" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/wood{
 	icon_state = "wood-broken7"
 	},
 /area/service/abandoned_gambling_den)
 "alR" = (
 /obj/effect/landmark/blobstart,
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "alS" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "alT" = (
@@ -4458,12 +4461,12 @@
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "anV" = (
-/obj/structure/chair/stool,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/west,
 /obj/structure/cable,
+/obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "anX" = (
@@ -4760,9 +4763,8 @@
 /area/security/warden)
 "aoX" = (
 /obj/structure/rack,
-/obj/item/crowbar,
-/obj/item/wrench,
 /obj/item/laser_pointer/red,
+/obj/item/storage/toolbox/drone,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "aoY" = (
@@ -5041,6 +5043,11 @@
 	input_dir = 4;
 	output_dir = 8
 	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/eastleft{
+	dir = 8;
+	name = "Ore Redemtion Window"
+	},
 /turf/open/floor/iron,
 /area/cargo/office)
 "apM" = (
@@ -5270,7 +5277,7 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/hidden,
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "aqD" = (
@@ -5867,9 +5874,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "asm" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/item/cigbutt,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -6050,7 +6054,7 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/hidden,
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "asZ" = (
@@ -8737,11 +8741,11 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
 "aAX" = (
-/obj/structure/chair/stool,
 /obj/machinery/power/terminal{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
 "aAY" = (
@@ -9502,10 +9506,10 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "aDz" = (
-/obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "aDA" = (
@@ -10673,8 +10677,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aGL" = (
-/obj/structure/chair/stool,
 /obj/item/clothing/suit/apron/chef,
+/obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aGM" = (
@@ -11830,8 +11834,8 @@
 /turf/open/floor/iron/solarpanel/airless,
 /area/solars/starboard)
 "aMr" = (
-/obj/structure/chair/stool,
 /obj/item/cigbutt/cigarbutt,
+/obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
 "aMs" = (
@@ -12360,15 +12364,15 @@
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
 "aOF" = (
-/obj/structure/chair/stool,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/iron,
 /area/command/teleporter)
 "aOG" = (
-/obj/structure/chair/stool,
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/iron,
 /area/command/teleporter)
 "aOH" = (
@@ -14345,10 +14349,6 @@
 /area/service/theater)
 "aWs" = (
 /obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
 /obj/item/pen/red{
 	pixel_y = 7
 	},
@@ -14365,15 +14365,19 @@
 	pixel_y = -2
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/cargo/sorting)
-"aWt" = (
-/obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1;
 	pixel_y = 1
 	},
+/turf/open/floor/iron,
+/area/cargo/sorting)
+"aWt" = (
+/obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "aWu" = (
@@ -15690,11 +15694,11 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "bbe" = (
-/obj/structure/chair/stool,
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "bbg" = (
@@ -15765,17 +15769,17 @@
 /turf/open/floor/plating,
 /area/service/bar/atrium)
 "bbv" = (
-/obj/structure/chair/stool,
 /obj/item/trash/can,
+/obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/carpet/lone,
 /area/service/bar/atrium)
 "bbw" = (
 /obj/effect/landmark/start/assistant,
-/obj/structure/chair/stool,
+/obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/carpet/lone,
 /area/service/bar/atrium)
 "bbx" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/carpet/lone,
 /area/service/bar/atrium)
 "bbA" = (
@@ -18359,17 +18363,16 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "blC" = (
-/obj/structure/chair/stool,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "blD" = (
-/obj/structure/chair/stool,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
@@ -18377,6 +18380,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "blE" = (
@@ -19162,9 +19166,7 @@
 	dir = 1
 	},
 /obj/machinery/light,
-/obj/item/kirbyplants{
-	icon_state = "plant-10"
-	},
+/obj/machinery/destructive_scanner,
 /turf/open/floor/iron/dark,
 /area/hallway/primary/aft)
 "boX" = (
@@ -19573,7 +19575,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/structure/chair/stool,
+/obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/iron/white,
 /area/science/explab)
 "bqq" = (
@@ -19767,6 +19769,7 @@
 	req_one_access_txt = "12; 55"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "bqV" = (
@@ -20631,6 +20634,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "btF" = (
@@ -20645,6 +20649,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "btK" = (
@@ -21340,6 +21345,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "bwq" = (
@@ -21778,7 +21784,7 @@
 	},
 /area/hallway/secondary/entry)
 "bxK" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/iron/dark,
 /area/science/explab)
 "bxL" = (
@@ -22467,7 +22473,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bzD" = (
-/obj/structure/chair/stool,
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -22476,6 +22481,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -22655,10 +22661,6 @@
 /area/command/heads_quarters/rd)
 "bAp" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/research{
-	name = "Research Director's Office";
-	req_access_txt = "30"
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -22671,6 +22673,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/door/airlock/command{
+	name = "Research Director's Office";
+	req_access_txt = "30"
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/rd)
@@ -22871,8 +22877,7 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "bBi" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
+/obj/machinery/chem_mass_spec,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "bBk" = (
@@ -23291,7 +23296,6 @@
 	pixel_y = 11
 	},
 /obj/structure/table/glass,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "bCv" = (
@@ -23527,9 +23531,6 @@
 /area/medical/chemistry)
 "bDv" = (
 /obj/machinery/holopad,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/effect/turf_decal/trimline/yellow/line,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
@@ -23704,6 +23705,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/science/explab)
 "bDU" = (
@@ -23722,6 +23726,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "bDV" = (
@@ -23731,6 +23738,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
@@ -24099,11 +24109,11 @@
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "bFj" = (
-/obj/structure/chair/stool,
 /obj/effect/landmark/start/scientist,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "bFk" = (
@@ -25242,7 +25252,7 @@
 	pixel_x = -24
 	},
 /obj/machinery/atmospherics/components/binary/pump/on,
-/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible{
+/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -25260,8 +25270,8 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/supply/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/bridge_pipe/supply/hidden{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
@@ -25324,7 +25334,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/chair/stool,
+/obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/engine,
 /area/maintenance/department/engine)
 "bKi" = (
@@ -26231,7 +26241,7 @@
 	name = "Arena"
 	},
 /obj/structure/window/reinforced,
-/obj/structure/chair/stool,
+/obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/engine,
 /area/maintenance/department/engine)
 "bNK" = (
@@ -26332,10 +26342,10 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/structure/chair/stool,
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "bOe" = (
@@ -26468,7 +26478,7 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/department/engine)
 "bOA" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/iron/dark,
 /area/maintenance/department/engine)
 "bOB" = (
@@ -26708,7 +26718,7 @@
 /turf/closed/wall/r_wall,
 /area/engineering/gravity_generator)
 "bPC" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bPD" = (
@@ -26758,7 +26768,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bPK" = (
-/obj/structure/chair/stool,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -26768,6 +26777,7 @@
 	name = "Engineering Foyer Requests Console"
 	},
 /obj/structure/cable,
+/obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "bPL" = (
@@ -27779,8 +27789,8 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bST" = (
-/obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
+/obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bSU" = (
@@ -30563,7 +30573,7 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "cci" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/iron,
 /area/engineering/main)
 "ccj" = (
@@ -32689,18 +32699,17 @@
 "cnJ" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/machinery/camera{
+	c_tag = "Brig Equipment Room"
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/security)
 "cnN" = (
 /obj/structure/closet/secure_closet/security/sec,
-/obj/machinery/camera{
-	c_tag = "Brig Equipment Room"
-	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/newscaster/security_unit/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/security)
 "cnP" = (
@@ -34627,14 +34636,16 @@
 /turf/open/floor/iron/dark,
 /area/service/library)
 "czO" = (
-/obj/structure/table/wood,
-/obj/item/instrument/saxophone,
+/obj/machinery/modular_computer/console/preset/curator{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/service/library)
 "czP" = (
 /obj/structure/table/wood,
 /obj/item/stack/package_wrap,
 /obj/item/coin/gold,
+/obj/item/instrument/saxophone,
 /turf/open/floor/iron/dark,
 /area/service/library)
 "czQ" = (
@@ -34840,7 +34851,7 @@
 /turf/open/floor/carpet,
 /area/service/abandoned_gambling_den)
 "cBs" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/carpet,
 /area/service/abandoned_gambling_den)
 "cBv" = (
@@ -35011,12 +35022,12 @@
 /turf/open/floor/iron/cafeteria,
 /area/hallway/primary/aft)
 "cCV" = (
-/obj/structure/chair/stool,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/west,
 /obj/structure/cable,
+/obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "cCW" = (
@@ -35517,6 +35528,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/explab)
+"dkU" = (
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron,
+/area/security/prison)
 "dlS" = (
 /obj/machinery/status_display/evac{
 	pixel_x = -32
@@ -35593,6 +35609,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"doP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair/stool/bar/directional/east,
+/turf/open/floor/iron,
+/area/engineering/main)
 "dpa" = (
 /obj/machinery/light{
 	dir = 1
@@ -35736,18 +35757,14 @@
 	pixel_y = 2
 	},
 /obj/structure/table/glass,
-/obj/item/reagent_containers/glass/beaker/large{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = -2
-	},
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 2;
-	pixel_y = -6
-	},
 /obj/machinery/newscaster/directional/west,
+/obj/item/experi_scanner{
+	pixel_x = 6
+	},
+/obj/item/experi_scanner,
+/obj/item/experi_scanner{
+	pixel_x = -6
+	},
 /turf/open/floor/iron/dark,
 /area/science/lab)
 "duH" = (
@@ -36010,7 +36027,6 @@
 /area/security/checkpoint/supply)
 "dMI" = (
 /obj/item/clothing/suit/apron/surgical,
-/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -36450,15 +36466,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "elc" = (
-/obj/machinery/door/window/westleft{
-	dir = 4;
-	name = "Cargo Desk";
-	req_access_txt = "50"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/computer/piratepad_control/civilian{
 	dir = 8;
 	pixel_y = -2
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
@@ -36515,6 +36530,10 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
+"epk" = (
+/obj/machinery/light/no_nightlight/directional/west,
+/turf/open/floor/iron/freezer,
+/area/security/prison/toilet)
 "epJ" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
@@ -37015,7 +37034,7 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "eQN" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "eQR" = (
@@ -37040,8 +37059,8 @@
 /turf/open/floor/iron/dark,
 /area/science/explab)
 "eSW" = (
-/obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/iron,
 /area/engineering/main)
 "eTi" = (
@@ -37068,7 +37087,6 @@
 	pixel_y = 6;
 	req_access_txt = "12"
 	},
-/obj/structure/chair/stool,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -37081,6 +37099,7 @@
 	pixel_x = -24;
 	pixel_y = -5
 	},
+/obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/iron,
 /area/maintenance/disposal)
 "eTI" = (
@@ -38268,8 +38287,8 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "fUc" = (
-/obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "fUA" = (
@@ -38281,6 +38300,10 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
+"fUJ" = (
+/obj/machinery/light/no_nightlight/directional/south,
+/turf/open/floor/iron/freezer,
+/area/security/prison/toilet)
 "fVi" = (
 /obj/machinery/space_heater,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39103,6 +39126,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "gIG" = (
@@ -40037,6 +40061,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "hOz" = (
@@ -40379,6 +40406,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/teleporter)
+"igs" = (
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron,
+/area/security/prison)
 "igu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -41054,6 +41085,15 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"iXt" = (
+/obj/structure/chair/stool/bar/directional/south,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "iYH" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay";
@@ -42202,9 +42242,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "kso" = (
-/obj/structure/sign/painting/library_private{
-	pixel_x = -32
-	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
@@ -42479,10 +42516,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "kGl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/yellow/line,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "kGE" = (
@@ -43461,6 +43499,9 @@
 	dir = 4;
 	network = list("ss13","prison")
 	},
+/obj/structure/sign/painting/library{
+	pixel_x = -32
+	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "lKL" = (
@@ -43524,6 +43565,7 @@
 /area/maintenance/department/engine)
 "lPO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron/chapel{
 	dir = 1
 	},
@@ -43785,6 +43827,17 @@
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
+	},
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = -2
+	},
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 2;
+	pixel_y = -6
 	},
 /turf/open/floor/iron/white,
 /area/science/lab)
@@ -44325,6 +44378,11 @@
 	},
 /turf/open/floor/grass,
 /area/science/genetics)
+"mKa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron,
+/area/security/prison)
 "mKc" = (
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/iron/dark,
@@ -44557,7 +44615,7 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "mYW" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "mZi" = (
@@ -44689,12 +44747,12 @@
 /turf/open/space/basic,
 /area/space)
 "ndU" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/piratepad/civilian,
 /obj/structure/window/reinforced{
 	dir = 4;
 	layer = 2.9
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/piratepad/civilian,
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "nev" = (
@@ -45939,6 +45997,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "ops" = (
@@ -46248,9 +46308,9 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "oCi" = (
-/obj/structure/chair/stool,
 /obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/iron,
 /area/security)
 "oCn" = (
@@ -47475,6 +47535,14 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/medical/virology)
+"pOd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron,
+/area/security/prison)
 "pOs" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 9
@@ -47639,12 +47707,12 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "pWT" = (
-/obj/structure/chair/stool,
 /obj/effect/landmark/start/botanist,
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "pXg" = (
@@ -48242,7 +48310,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "qvM" = (
-/obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -48561,10 +48628,10 @@
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "qPB" = (
-/obj/structure/chair/stool,
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/abandoned_gambling_den)
 "qQl" = (
@@ -50586,6 +50653,7 @@
 	c_tag = "Permabrig - Cell 3";
 	network = list("ss13","prison")
 	},
+/obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "sLv" = (
@@ -53565,6 +53633,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/psychology)
+"vso" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "vsq" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Chapel"
@@ -54028,6 +54103,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -54637,6 +54713,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/processing/cremation)
+"wtp" = (
+/obj/machinery/suit_storage_unit/security,
+/obj/effect/turf_decal/bot,
+/obj/machinery/newscaster/security_unit/directional/north,
+/turf/open/floor/iron/showroomfloor,
+/area/security)
 "wun" = (
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 8
@@ -55196,6 +55278,7 @@
 /area/medical/psychology)
 "wQU" = (
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/cable,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -55313,7 +55396,7 @@
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "wUz" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -55998,10 +56081,10 @@
 	},
 /area/security/prison)
 "xvx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/structure/cable,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
 	},
-/turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "xvO" = (
 /obj/structure/disposalpipe/segment{
@@ -56023,6 +56106,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"xwC" = (
+/obj/structure/chair/stool/bar/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "xwX" = (
 /obj/machinery/door/airlock/security{
 	name = "Equipment Room";
@@ -74883,7 +74970,7 @@ aaa
 aaa
 aOn
 fzz
-ygc
+fUJ
 lvq
 aOn
 aOn
@@ -75142,7 +75229,7 @@ aOn
 fzz
 ygc
 vDq
-ygc
+epk
 uUE
 afU
 lem
@@ -76423,7 +76510,7 @@ adE
 dfu
 wxa
 ubq
-dJp
+iXt
 aep
 uGE
 agy
@@ -76690,7 +76777,7 @@ aiF
 wbB
 ahp
 agL
-agZ
+vso
 ahp
 yjF
 sdE
@@ -76943,7 +77030,7 @@ aeD
 agy
 wkA
 ahF
-aiF
+igs
 lYA
 ahp
 agM
@@ -77440,8 +77527,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+pDW
+aht
 aem
 wPr
 aeF
@@ -77697,8 +77784,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+pDW
+aht
 aem
 czK
 pEg
@@ -77718,7 +77805,7 @@ kLJ
 wbB
 ahp
 vaF
-agZ
+vso
 ahp
 orp
 sdE
@@ -77953,8 +78040,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+pDW
+aht
 ahC
 ahC
 oSI
@@ -78210,8 +78297,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+pDW
+aht
 ahC
 dGY
 mOg
@@ -78467,8 +78554,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+pDW
+aht
 ahC
 eTW
 xPV
@@ -78480,7 +78567,7 @@ aiF
 cTq
 agy
 toR
-rnm
+mKa
 kBD
 agy
 afr
@@ -78724,15 +78811,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+pDW
+aht
 ahC
 fJd
 flR
 ahp
 vTg
 rnm
-wHD
+pOd
 iFG
 rqQ
 agy
@@ -78742,7 +78829,7 @@ btA
 agy
 afs
 aiF
-agd
+dkU
 agp
 ahp
 sKL
@@ -78981,8 +79068,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+pDW
+aht
 ahC
 ahC
 ahC
@@ -79238,11 +79325,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+pDW
+aht
+aht
+aht
+aht
 aem
 vEU
 aiF
@@ -79250,9 +79337,9 @@ aiF
 aiF
 nVs
 aem
-aaa
-aaa
-aaa
+aht
+aht
+aht
 aem
 mLY
 pif
@@ -79496,10 +79583,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+pDW
+pDW
+pDW
+aht
 aem
 rBL
 uPl
@@ -79507,9 +79594,9 @@ aiF
 dtj
 sbU
 aem
-aaa
-aaa
-aaa
+aht
+pDW
+aht
 aem
 aem
 aem
@@ -79755,8 +79842,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+pDW
+aht
 aem
 aem
 tot
@@ -79764,8 +79851,8 @@ sbt
 sVF
 aem
 aem
-aaa
-aaa
+aht
+pDW
 aaa
 aaa
 aaa
@@ -80012,17 +80099,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+pDW
+aht
+aht
 aem
 aen
 aen
 aen
 aem
-aaa
-aaa
-aaa
+aht
+aht
+pDW
 aaa
 aaa
 aaa
@@ -80269,15 +80356,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+pDW
+pDW
+aht
+aht
+aht
+aht
+aht
+aht
+aht
 aaa
 aaa
 aaa
@@ -80527,14 +80614,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+pDW
+pDW
+pDW
+pDW
+pDW
+pDW
+pDW
+pDW
 aaa
 aaa
 aaa
@@ -81927,7 +82014,7 @@ xbD
 bDi
 bva
 nGx
-bPC
+xwC
 bUc
 bva
 bva
@@ -82857,7 +82944,7 @@ aaa
 aby
 aaa
 agP
-cnQ
+wtp
 aiq
 aiq
 ahQ
@@ -86017,7 +86104,7 @@ bpV
 bzZ
 bBg
 bCr
-kGl
+iTx
 tta
 uXp
 xqq
@@ -86274,7 +86361,7 @@ bpW
 brk
 bsK
 bsK
-kGl
+iTx
 tta
 mXI
 xqq
@@ -90412,8 +90499,8 @@ bYn
 bZa
 gZx
 iok
-eSW
-eSW
+doP
+doP
 pyA
 cdY
 nZX
@@ -106047,12 +106134,12 @@ aEl
 wOf
 aFi
 uSW
-wAI
-xvx
+qHf
+pvc
 wQU
-qJB
-aFi
-aFi
+xvx
+bjM
+bjM
 bqO
 btB
 btF

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -24477,6 +24477,7 @@
 	dir = 8;
 	layer = 2.9
 	},
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2,
 /turf/open/floor/plating/airless,
 /area/service/chapel/dock)
 "bGH" = (
@@ -24965,6 +24966,9 @@
 /area/service/chapel/dock)
 "bIW" = (
 /obj/machinery/computer/shuttle/monastery_shuttle,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/dock)
 "bIX" = (
@@ -35763,6 +35767,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"dPk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/service/chapel/dock)
 "dPO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -35871,12 +35881,6 @@
 "dUh" = (
 /obj/effect/turf_decal/sand,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/service/chapel/asteroid/monastery)
 "dUZ" = (
@@ -41387,6 +41391,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
+"jAx" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/door/airlock/grunge{
+	name = "Chapel"
+	},
+/turf/open/floor/iron/dark,
+/area/service/chapel/main/monastery)
 "jAy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -41744,12 +41756,6 @@
 "jXz" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/dock)
 "jXA" = (
@@ -45768,15 +45774,9 @@
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "odF" = (
+/obj/structure/cable,
 /obj/machinery/door/airlock/grunge{
 	name = "Chapel"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/dock)
@@ -48136,6 +48136,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/rd)
+"qny" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/service/chapel/dock)
 "qnJ" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Medbay Security Post";
@@ -56442,6 +56449,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"xrO" = (
+/obj/structure/cable,
+/turf/open/floor/carpet,
+/area/service/chapel/main/monastery)
 "xsr" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -72185,9 +72196,9 @@ aaa
 aaa
 aaa
 bGG
-bHL
+qny
 bIW
-bMu
+tCV
 xlh
 eAP
 hCj
@@ -72202,12 +72213,12 @@ dUh
 dUh
 dUh
 dUh
-vsq
-yiF
-wEz
-wEz
-wEz
-wEz
+jAx
+qFp
+xrO
+xrO
+xrO
+xrO
 wEz
 wEz
 cbO
@@ -72444,7 +72455,7 @@ aaa
 bGH
 bHL
 bIX
-bMu
+dPk
 xlh
 dQg
 bNv

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -35404,6 +35404,12 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
+"cYn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "daO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -101057,7 +101063,7 @@ tfz
 mdx
 fGd
 aKq
-aFi
+cYn
 wAI
 rpa
 rpa

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -189,7 +189,6 @@
 /turf/open/floor/engine,
 /area/science/nanite)
 "aaB" = (
-/obj/machinery/light,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -263,6 +262,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "aaQ" = (
@@ -492,9 +492,13 @@
 /turf/open/floor/iron/white,
 /area/ai_monitored/turret_protected/ai)
 "acl" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /obj/structure/cable,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/iron,
+/area/security/brig)
 "acm" = (
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat External Port";
@@ -564,14 +568,12 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "act" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/command/glass{
-	name = "AI Core";
-	req_access_txt = "65"
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
-/area/ai_monitored/turret_protected/ai)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison)
 "acu" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -616,6 +618,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "acC" = (
@@ -645,6 +648,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "acF" = (
@@ -688,18 +692,18 @@
 /obj/machinery/ai_slipper{
 	uses = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/ai_monitored/turret_protected/ai)
-"acM" = (
-/obj/machinery/door/firedoor/heavy,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/ai_monitored/turret_protected/ai)
+"acM" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "acN" = (
 /turf/closed/wall/r_wall,
 /area/engineering/storage_shared)
@@ -837,6 +841,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "adq" = (
@@ -865,7 +871,6 @@
 	dir = 1;
 	network = list("minisat")
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
@@ -876,17 +881,16 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "adv" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "MiniSat Maintenance";
-	req_access_txt = "65"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "MiniSat Maintenance";
+	req_access_txt = "65"
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
@@ -895,8 +899,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "adz" = (
@@ -972,12 +974,11 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "adH" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "MiniSat Maintenance";
 	req_access_txt = "65"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
 "adI" = (
@@ -1003,16 +1004,15 @@
 /turf/open/floor/iron,
 /area/security)
 "adM" = (
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Chamber Observation";
-	req_one_access_txt = "65"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Chamber Observation";
+	req_one_access_txt = "65"
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -1040,6 +1040,7 @@
 /area/space/nearstation)
 "adT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "adU" = (
@@ -1147,6 +1148,7 @@
 	name = "Dining Room"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
 "aer" = (
@@ -1159,7 +1161,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
@@ -1286,18 +1287,17 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "aeO" = (
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Chamber Hallway";
-	req_one_access_txt = "65"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Chamber Hallway";
+	req_one_access_txt = "65"
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -1364,8 +1364,6 @@
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "aeY" = (
-/obj/machinery/power/apc/auto_name/west,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
@@ -1373,7 +1371,6 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/visible{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
 "afa" = (
@@ -1381,7 +1378,6 @@
 	c_tag = "MiniSat Maintenance Port Aft";
 	network = list("minisat")
 	},
-/obj/structure/cable,
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -1425,7 +1421,7 @@
 	},
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /turf/open/floor/iron,
-/area/cargo/warehouse/upper)
+/area/cargo/storage)
 "afe" = (
 /obj/item/kirbyplants/photosynthetic{
 	pixel_y = 10
@@ -1534,6 +1530,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Drone Bay";
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -2832,15 +2832,13 @@
 /area/security)
 "ajo" = (
 /obj/machinery/vending/coffee,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/security)
 "ajp" = (
@@ -3117,13 +3115,11 @@
 "akc" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
 /obj/machinery/light{
 	dir = 1;
 	light_color = "#706891"
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "akd" = (
@@ -3646,6 +3642,7 @@
 /turf/open/floor/iron/white,
 /area/security/brig)
 "als" = (
+/obj/machinery/holopad,
 /turf/open/floor/iron/white,
 /area/security/brig)
 "alt" = (
@@ -5456,6 +5453,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/security/brig)
 "arq" = (
@@ -6078,6 +6076,7 @@
 /area/command/gateway)
 "atc" = (
 /obj/effect/landmark/event_spawn,
+/obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/command/gateway)
 "atd" = (
@@ -6243,6 +6242,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "atF" = (
@@ -6594,6 +6594,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "auC" = (
@@ -7418,9 +7419,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -7455,6 +7454,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "awN" = (
@@ -8978,11 +8978,9 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "aBF" = (
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
 /obj/structure/bed/dogbed/ian,
 /mob/living/simple_animal/pet/dog/corgi/ian,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "aBG" = (
@@ -9047,6 +9045,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/machinery/camera{
+	c_tag = "HFR Room";
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "aBS" = (
@@ -9123,6 +9125,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/holopad,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "aCl" = (
@@ -9449,6 +9452,9 @@
 /obj/machinery/camera{
 	c_tag = "Dormitories Aft";
 	dir = 1
+	},
+/obj/machinery/status_display/ai{
+	pixel_y = -32
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
@@ -10905,10 +10911,8 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aHL" = (
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
 /obj/structure/cable,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aHO" = (
@@ -11050,6 +11054,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aJa" = (
@@ -11758,6 +11763,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aMe" = (
@@ -12135,10 +12141,15 @@
 /turf/open/floor/iron,
 /area/command/teleporter)
 "aND" = (
-/obj/machinery/light,
-/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/security/brig)
 "aNE" = (
 /obj/machinery/camera{
 	c_tag = "Dormitories Hallway";
@@ -12236,6 +12247,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/assistant,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron{
 	heat_capacity = 1e+006
 	},
@@ -12791,9 +12803,18 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "aQt" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
-/area/hallway/secondary/exit/departure_lounge)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "aQu" = (
 /obj/structure/flora/ausbushes/leafybush,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -14456,6 +14477,9 @@
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 8
+	},
+/obj/machinery/status_display/ai{
+	pixel_y = 32
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
@@ -16726,9 +16750,7 @@
 /area/science/robotics/mechbay)
 "bfy" = (
 /obj/machinery/mech_bay_recharge_port,
-/obj/machinery/status_display/evac{
-	pixel_y = 30
-	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/plating,
 /area/science/robotics/mechbay)
 "bfz" = (
@@ -16922,6 +16944,9 @@
 /obj/structure/table,
 /obj/item/trash/waffles,
 /obj/item/storage/fancy/rollingpapers,
+/obj/machinery/status_display/ai{
+	pixel_y = 32
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bgp" = (
@@ -17551,6 +17576,7 @@
 "biy" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "biC" = (
@@ -17636,10 +17662,12 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "biS" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/tile/blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/holopad,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/commons/storage/primary)
 "biT" = (
 /obj/structure/closet/firecloset,
 /obj/structure/sign/poster/official/random{
@@ -18476,6 +18504,9 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/obj/machinery/status_display/ai{
+	pixel_y = 32
+	},
 /turf/open/floor/iron,
 /area/science/robotics)
 "blL" = (
@@ -18497,17 +18528,14 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "blP" = (
-/obj/effect/landmark/event_spawn,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/rnd/experimentor,
 /turf/open/floor/engine,
 /area/science/explab)
 "blR" = (
 /obj/item/beacon,
 /obj/effect/landmark/blobstart,
-/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/engine,
 /area/science/explab)
 "blS" = (
@@ -19108,6 +19136,7 @@
 	dir = 1;
 	network = list("ss13","medbay")
 	},
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "boN" = (
@@ -19357,6 +19386,18 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/white,
 /area/medical/paramedic)
+"bpT" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/status_display/ai{
+	pixel_y = 32
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "bpU" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -19723,6 +19764,7 @@
 	id = "xenobio5";
 	name = "containment blast door"
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bqI" = (
@@ -19731,6 +19773,7 @@
 	name = "containment blast door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bqJ" = (
@@ -19740,6 +19783,7 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bqK" = (
@@ -19753,6 +19797,7 @@
 	id = "xenobio6";
 	name = "containment blast door"
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bqL" = (
@@ -19761,6 +19806,7 @@
 	name = "containment blast door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bqO" = (
@@ -20649,6 +20695,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "btK" = (
@@ -20913,6 +20960,9 @@
 	},
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/science/explab)
 "buy" = (
@@ -22362,6 +22412,7 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bzl" = (
@@ -22376,6 +22427,7 @@
 	name = "Containment Pen #1";
 	req_access_txt = "55"
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bzm" = (
@@ -22384,6 +22436,7 @@
 	name = "containment blast door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bzn" = (
@@ -22393,6 +22446,7 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bzp" = (
@@ -22401,6 +22455,7 @@
 	name = "containment blast door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bzq" = (
@@ -22410,6 +22465,7 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bzr" = (
@@ -22424,6 +22480,7 @@
 	name = "Containment Pen #3";
 	req_access_txt = "55"
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bzs" = (
@@ -22432,6 +22489,7 @@
 	name = "containment blast door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bzy" = (
@@ -23588,6 +23646,7 @@
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/rd)
 "bDD" = (
+/obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/rd)
 "bDE" = (
@@ -23943,9 +24002,6 @@
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/rd)
 "bET" = (
-/obj/machinery/status_display/evac{
-	pixel_y = -30
-	},
 /obj/machinery/camera{
 	c_tag = "Research Director's Office";
 	dir = 1;
@@ -23957,6 +24013,7 @@
 	},
 /obj/machinery/suit_storage_unit/rd,
 /obj/machinery/airalarm/directional/south,
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/rd)
 "bEU" = (
@@ -25153,6 +25210,9 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/machinery/status_display/ai{
+	pixel_y = -32
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "bJF" = (
@@ -25395,6 +25455,9 @@
 "bKp" = (
 /obj/structure/chair/sofa/right,
 /obj/item/toy/plush/moth,
+/obj/machinery/status_display/ai{
+	pixel_y = 32
+	},
 /turf/open/floor/carpet,
 /area/medical/psychology)
 "bKq" = (
@@ -26112,8 +26175,8 @@
 	dir = 1;
 	name = "Air to Distro"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -26827,11 +26890,9 @@
 /turf/closed/wall,
 /area/engineering/atmos)
 "bPR" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Waste In"
-	},
 /obj/machinery/firealarm/directional/west,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bPT" = (
@@ -28531,10 +28592,10 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/suit_storage_unit/engine,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
 "bUR" = (
-/obj/structure/tank_dispenser,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -28545,7 +28606,7 @@
 	c_tag = "Engineering Power Storage"
 	},
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/suit_storage_unit/engine,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
 "bUT" = (
@@ -29024,6 +29085,7 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "bWp" = (
+/obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "bWr" = (
@@ -29091,24 +29153,6 @@
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "bWv" = (
-/obj/structure/table,
-/obj/item/stack/sheet/plasteel/twenty{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/stack/sheet/glass/fifty{
-	layer = 4
-	},
-/obj/item/stack/sheet/glass/fifty{
-	layer = 4
-	},
-/obj/item/stack/sheet/glass/fifty{
-	layer = 4
-	},
-/obj/item/storage/box/lights/mixed{
-	pixel_x = 6;
-	pixel_y = 8
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -29119,6 +29163,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/structure/tank_dispenser,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
 "bWw" = (
@@ -32387,9 +32432,6 @@
 /turf/open/space,
 /area/space/nearstation)
 "cmu" = (
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
 /obj/structure/table,
 /obj/item/book/manual/wiki/tcomms,
 /obj/item/paper_bin{
@@ -32404,6 +32446,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "cmv" = (
@@ -33298,6 +33341,9 @@
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
+	},
+/obj/machinery/status_display/ai{
+	pixel_y = -32
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
@@ -34988,14 +35034,12 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "cCO" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/white{
-	heat_capacity = 1e+006
-	},
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/iron/grimy,
+/area/ai_monitored/turret_protected/aisat_interior)
 "cCP" = (
 /obj/effect/turf_decal/bot/right,
 /turf/open/floor/iron/white,
@@ -35131,6 +35175,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron/white,
 /area/science/explab)
 "cKF" = (
@@ -35455,6 +35500,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "dgI" = (
@@ -35534,9 +35580,6 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "dlS" = (
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -35545,6 +35588,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
 "dma" = (
@@ -35574,6 +35618,7 @@
 /obj/structure/sign/warning/electricshock{
 	pixel_x = 32
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "doe" = (
@@ -35721,6 +35766,7 @@
 /area/engineering/atmos)
 "dtj" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
 "dtK" = (
@@ -36222,20 +36268,12 @@
 /turf/open/floor/iron/dark,
 /area/engineering/transit_tube)
 "dWw" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	name = "Docking Arm Maintenance";
-	req_access_txt = "12"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/cargo/warehouse/upper)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison)
 "dWO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -36315,6 +36353,7 @@
 	name = "containment blast door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "ecR" = (
@@ -36509,6 +36548,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "enI" = (
@@ -36526,6 +36566,20 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"eoP" = (
+/obj/machinery/disposal/bin,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/science/xenobiology)
 "eoS" = (
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark/telecomms,
@@ -36798,9 +36852,31 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/suit_storage_unit/engine,
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty{
+	layer = 4
+	},
+/obj/item/storage/box/lights/mixed{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/stack/sheet/plasteel/twenty{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/stack/sheet/glass/fifty{
+	layer = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
+"eDR" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "eER" = (
 /obj/machinery/light{
 	dir = 8
@@ -37308,6 +37384,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "faT" = (
@@ -37454,7 +37531,7 @@
 /area/maintenance/department/cargo)
 "feN" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers{
+/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -38044,6 +38121,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
+"fGH" = (
+/obj/effect/landmark/event_spawn,
+/obj/machinery/rnd/experimentor,
+/turf/open/floor/engine,
+/area/science/explab)
 "fIc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -38264,8 +38346,8 @@
 /area/maintenance/department/engine)
 "fTp" = (
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/iron,
+/area/security/prison)
 "fTY" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -38649,6 +38731,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
 "gnQ" = (
@@ -38685,6 +38768,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron{
 	heat_capacity = 1e+006
 	},
@@ -38862,6 +38946,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
+"gxO" = (
+/obj/machinery/disposal/bin,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/science/xenobiology)
 "gyj" = (
 /obj/structure/sink{
 	dir = 4;
@@ -39506,6 +39602,7 @@
 	name = "Containment Pen #4";
 	req_access_txt = "55"
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "hiU" = (
@@ -39719,6 +39816,7 @@
 	name = "containment blast door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "hwd" = (
@@ -39854,7 +39952,6 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "hCS" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
@@ -40123,6 +40220,13 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
+"hQd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "hQh" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -40417,6 +40521,7 @@
 /area/command/teleporter)
 "igs" = (
 /obj/effect/landmark/start/prisoner,
+/obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/security/prison)
 "igu" = (
@@ -40541,11 +40646,13 @@
 /turf/closed/wall,
 /area/maintenance/department/engine)
 "inG" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engineering/atmos)
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "ioj" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -40855,6 +40962,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
 "iFI" = (
@@ -40909,6 +41017,12 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
+"iJc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "iJI" = (
 /obj/structure/sink{
 	dir = 8;
@@ -41962,7 +42076,6 @@
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "kbV" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -42071,14 +42184,13 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/department/engine)
 "kjK" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "MiniSat Maintenance";
 	req_access_txt = "65"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
 "kkk" = (
@@ -42452,7 +42564,6 @@
 	id = "EngLoad"
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "kDS" = (
@@ -42620,6 +42731,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "kNb" = (
@@ -42771,7 +42883,6 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "kUt" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
@@ -43272,6 +43383,7 @@
 	name = "test chamber blast door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "ltl" = (
@@ -43427,6 +43539,7 @@
 /area/medical/chemistry)
 "lFh" = (
 /obj/machinery/holopad,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "lFx" = (
@@ -43934,6 +44047,12 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
+"mjO" = (
+/obj/machinery/status_display/ai{
+	pixel_y = -32
+	},
+/turf/open/floor/iron,
+/area/cargo/miningdock)
 "mkf" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
@@ -44074,6 +44193,7 @@
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "mse" = (
+/obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/cargo/qm)
 "msw" = (
@@ -44083,6 +44203,7 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "msX" = (
@@ -44260,6 +44381,10 @@
 /obj/item/blood_filter,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
+"mAo" = (
+/obj/machinery/holopad,
+/turf/open/floor/iron/white,
+/area/science/explab)
 "mAu" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -44610,7 +44735,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/cargo/warehouse/upper)
+/area/cargo/storage)
 "mXq" = (
 /obj/item/taperecorder,
 /obj/item/cartridge/lawyer,
@@ -44983,6 +45108,12 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
+"nmF" = (
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron,
+/area/medical/cryo)
 "nnf" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -45295,6 +45426,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "nEp" = (
@@ -45351,6 +45483,9 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/status_display/ai{
+	pixel_y = 32
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "nIU" = (
@@ -45940,7 +46075,6 @@
 /turf/open/space,
 /area/space/nearstation)
 "olO" = (
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
 "olV" = (
@@ -45988,6 +46122,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"onJ" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "onX" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Primary Tool Storage"
@@ -46612,8 +46756,10 @@
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "oRl" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/structure/extinguisher_cabinet/directional/south,
+/obj/structure/cable,
+/obj/machinery/status_display/ai{
+	pixel_y = 32
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "oRF" = (
@@ -46645,6 +46791,7 @@
 	id = "xenobio5";
 	name = "containment blast door"
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "oSC" = (
@@ -46803,7 +46950,6 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "oYq" = (
@@ -47033,6 +47179,7 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "pln" = (
@@ -47068,6 +47215,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"pmB" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/science/xenobiology)
 "pnF" = (
 /obj/structure/flora/junglebush,
 /obj/structure/flora/grass/jungle/b,
@@ -47319,9 +47477,7 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "pEh" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
+/obj/machinery/atmospherics/components/binary/thermomachine/heater,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "pEp" = (
@@ -47691,6 +47847,7 @@
 	id = "misclab";
 	name = "test chamber blast door"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "pWo" = (
@@ -47952,6 +48109,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "qgX" = (
@@ -47987,6 +48145,10 @@
 /obj/item/stack/medical/gauze,
 /turf/open/floor/iron,
 /area/medical/medbay/central)
+"qih" = (
+/obj/machinery/holopad,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "qit" = (
 /obj/structure/table/wood,
 /obj/item/kirbyplants{
@@ -48287,6 +48449,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "quw" = (
@@ -48411,6 +48574,10 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/primary)
+"qDU" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/science/xenobiology)
 "qEf" = (
 /obj/structure/flora/junglebush/b,
 /obj/structure/window/reinforced/spawner/north,
@@ -48841,8 +49008,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/camera{
+	c_tag = "Drone Bay Ext.";
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/cargo/warehouse/upper)
+/area/cargo/storage)
 "rcF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/open/floor/plating/airless,
@@ -49397,7 +49568,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/suit_storage_unit/engine,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
 "rAe" = (
@@ -49460,6 +49630,17 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"rBP" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/science/xenobiology)
 "rCe" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -49949,7 +50130,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron,
-/area/cargo/warehouse/upper)
+/area/cargo/storage)
 "sbk" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
@@ -50506,6 +50687,11 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/security/brig)
+"sBV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "sBW" = (
 /obj/structure/closet/crate/bin,
 /obj/item/reagent_containers/glass/rag,
@@ -50580,8 +50766,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "sFL" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "sGc" = (
@@ -50740,6 +50926,10 @@
 "sSj" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/item/radio/intercom/directional/south,
+/obj/machinery/camera{
+	c_tag = "Central Primary Hallway Custodial";
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "sSl" = (
@@ -50836,6 +51026,7 @@
 	dir = 6
 	},
 /obj/machinery/hydroponics/soil,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
 "sWj" = (
@@ -50883,6 +51074,7 @@
 "sYE" = (
 /obj/structure/chair,
 /obj/effect/landmark/start/hangover,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron{
 	heat_capacity = 1e+006
 	},
@@ -51110,7 +51302,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/cargo/warehouse/upper)
+/area/cargo/storage)
 "tfc" = (
 /obj/effect/landmark/start/assistant,
 /obj/effect/landmark/start/hangover,
@@ -51373,6 +51565,7 @@
 	id = "misclab";
 	name = "test chamber blast door"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "trt" = (
@@ -51481,6 +51674,7 @@
 	name = "containment blast door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "twS" = (
@@ -51594,8 +51788,11 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
+/obj/machinery/status_display/ai{
+	pixel_x = 32
+	},
 /turf/open/floor/iron,
-/area/cargo/warehouse/upper)
+/area/cargo/storage)
 "tAK" = (
 /obj/structure/rack,
 /obj/item/integrated_circuit/loaded/speech_relay,
@@ -51713,6 +51910,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/holopad,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
 "tFt" = (
@@ -51885,6 +52083,13 @@
 /mob/living/simple_animal/hostile/retaliate/goose/vomit,
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
+"tSR" = (
+/obj/structure/chair,
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/hallway/secondary/exit/departure_lounge)
 "tSU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -52148,6 +52353,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "ueu" = (
@@ -52561,6 +52767,7 @@
 	id = "misclab";
 	name = "test chamber blast door"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "uvq" = (
@@ -52613,6 +52820,10 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"uxj" = (
+/obj/machinery/holopad,
+/turf/open/floor/iron,
+/area/engineering/main)
 "uxk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -52710,6 +52921,16 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"uAg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/holopad,
+/turf/open/floor/iron,
+/area/security/checkpoint/customs)
 "uAh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -52724,6 +52945,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/machinery/light,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "uAq" = (
@@ -52936,8 +53158,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/south,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "uMr" = (
@@ -53069,6 +53289,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"uTt" = (
+/obj/effect/landmark/xeno_spawn,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "uTI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -53241,6 +53468,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "uXX" = (
@@ -53273,6 +53501,9 @@
 	dir = 1
 	},
 /obj/machinery/light/small,
+/obj/machinery/status_display/ai{
+	pixel_x = -32
+	},
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "uYW" = (
@@ -53441,6 +53672,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "vgR" = (
@@ -53853,6 +54085,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "vDh" = (
@@ -53908,6 +54141,15 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/storage)
+"vHR" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/north,
+/turf/open/floor/plating,
+/area/ai_monitored/turret_protected/ai_sat_ext_ap)
 "vIa" = (
 /obj/machinery/smartfridge/organ,
 /turf/closed/wall,
@@ -53944,6 +54186,7 @@
 /area/medical/medbay/lobby)
 "vIM" = (
 /obj/effect/turf_decal/delivery,
+/obj/machinery/holopad,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "vJD" = (
@@ -54430,6 +54673,13 @@
 /obj/structure/ore_box,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"wfp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "wfr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -54751,6 +55001,13 @@
 /obj/machinery/newscaster/security_unit/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/security)
+"wtZ" = (
+/obj/structure/cable,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "wun" = (
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 8
@@ -55080,6 +55337,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"wFO" = (
+/obj/machinery/status_display/evac/directional/east,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "wFT" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -55094,6 +55355,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "wGM" = (
@@ -55247,6 +55509,7 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "wOG" = (
@@ -55362,8 +55625,11 @@
 /turf/open/floor/iron/dark,
 /area/service/bar/atrium)
 "wSR" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -55463,12 +55729,12 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "wVQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -55534,9 +55800,8 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "wYi" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 9
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -55997,6 +56262,7 @@
 	id = "xenobio7";
 	name = "containment blast door"
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "xpr" = (
@@ -56100,6 +56366,7 @@
 	id = "xenobio8";
 	name = "containment blast door"
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "xuv" = (
@@ -56206,6 +56473,7 @@
 	name = "Containment Pen #2";
 	req_access_txt = "55"
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "xxS" = (
@@ -75512,8 +75780,8 @@ adE
 adE
 adE
 aem
-aen
-aen
+acM
+acM
 aOn
 lvq
 lvq
@@ -75769,7 +76037,7 @@ kso
 lKk
 adE
 pqq
-wxa
+inG
 evP
 xga
 wxa
@@ -75818,15 +76086,15 @@ aiu
 rgs
 jeq
 pGe
-aQt
-aOf
+aHz
+tSR
 xLi
 aQr
 aQr
 aQr
 oLR
 pGe
-aQt
+aHz
 sYE
 aie
 aYG
@@ -76026,7 +76294,7 @@ lGp
 pEp
 adE
 eTi
-wxa
+inG
 fmp
 dJp
 wxa
@@ -76283,7 +76551,7 @@ quw
 rka
 adE
 jTV
-wxa
+inG
 fmp
 dJp
 uxx
@@ -76332,7 +76600,7 @@ irF
 pvK
 aKD
 gmO
-aQt
+aHz
 aOh
 pgv
 aRE
@@ -76340,7 +76608,7 @@ aSw
 aTL
 neB
 gmO
-aQt
+aHz
 gpC
 ppQ
 aYG
@@ -76540,7 +76808,7 @@ sdk
 rcR
 adE
 dfu
-wxa
+inG
 ubq
 iXt
 aep
@@ -76797,7 +77065,7 @@ tqM
 kPM
 adE
 tTq
-wxa
+inG
 eaA
 dJp
 aep
@@ -76846,16 +77114,16 @@ aiu
 niy
 jat
 pGe
-aQt
-aOf
+aHz
+tSR
 aPo
 nGi
 nGi
 nGi
 aPn
 pGe
-aQt
-aOf
+aHz
+tSR
 bxH
 aYG
 nJB
@@ -77054,7 +77322,7 @@ mrR
 kPM
 adE
 nfc
-wxa
+inG
 wxa
 wxa
 aep
@@ -77311,11 +77579,11 @@ duH
 rkv
 adE
 agy
-aen
-aen
-aen
+acM
+acM
+acM
 aeq
-aen
+acM
 agy
 afp
 afE
@@ -77569,8 +77837,8 @@ ueX
 aeF
 eAF
 aeF
-aeF
-aeF
+afZ
+afZ
 aer
 aeF
 aeV
@@ -77821,11 +78089,11 @@ aht
 aem
 czK
 pEg
-aeG
+act
 aeG
 aes
 aeG
-aeG
+act
 wPo
 aeG
 aes
@@ -78078,11 +78346,11 @@ ahC
 ahC
 oSI
 ahp
-aen
-aen
+acM
+acM
 aJx
-aen
-aen
+acM
+acM
 agy
 aen
 aga
@@ -78338,7 +78606,7 @@ ahp
 wNI
 wVS
 afZ
-wVS
+dWw
 ePM
 agy
 qEk
@@ -78595,7 +78863,7 @@ ahp
 vEU
 aiF
 wHD
-aiF
+fTp
 cTq
 agy
 toR
@@ -79366,7 +79634,7 @@ aem
 vEU
 aiF
 aiF
-aiF
+fTp
 nVs
 aem
 aht
@@ -79637,7 +79905,7 @@ aem
 aaa
 aby
 abI
-lTW
+ahL
 tCJ
 akM
 akM
@@ -79685,7 +79953,7 @@ ihM
 bcl
 aXJ
 fow
-tdj
+uAg
 baS
 bbV
 bop
@@ -79894,7 +80162,7 @@ aaa
 aaa
 aby
 qLo
-lTW
+ahL
 dfw
 akM
 wEc
@@ -80135,9 +80403,9 @@ pDW
 aht
 aht
 aem
-aen
-aen
-aen
+acM
+acM
+acM
 aem
 aht
 aht
@@ -80151,7 +80419,7 @@ aaa
 aaa
 aby
 abI
-lTW
+ahL
 pWo
 ail
 rEZ
@@ -80408,7 +80676,7 @@ aaa
 aaa
 aby
 abI
-lTW
+ahL
 wzP
 aim
 aiO
@@ -80681,13 +80949,13 @@ amh
 amg
 aqv
 vao
-mJe
+acl
 atE
 auB
-avB
+aND
 awL
-aAm
-qNG
+ioZ
+aQt
 ioZ
 aBg
 aEs
@@ -80697,7 +80965,7 @@ aFr
 oOy
 rvS
 ptL
-ptL
+wtZ
 ptL
 rvS
 ptL
@@ -81227,7 +81495,7 @@ aVR
 gpu
 aXL
 aYL
-jcT
+wFO
 baW
 rLQ
 jcT
@@ -81469,7 +81737,7 @@ aBi
 aBi
 hqo
 yiR
-aND
+aKa
 aKJ
 aKK
 aKJ
@@ -81751,7 +82019,7 @@ bgg
 coy
 xPQ
 jcT
-biS
+bik
 bjL
 bla
 bmi
@@ -82264,8 +82532,8 @@ aVS
 bgi
 jcT
 xPQ
-oRl
-bjL
+bik
+nmF
 bjL
 blb
 bml
@@ -82495,9 +82763,9 @@ mxg
 aDA
 aGg
 aBi
-ptL
+oRl
 xPQ
-jcT
+jhl
 aKJ
 aKJ
 aKJ
@@ -82748,7 +83016,7 @@ awR
 aBj
 aCv
 aDz
-mxg
+biS
 qDb
 aGh
 aBi
@@ -86160,7 +86428,7 @@ bWr
 bXj
 bXY
 bYK
-cbW
+uxj
 cai
 cbf
 ccb
@@ -87409,7 +87677,7 @@ bjg
 fmD
 cpZ
 cqc
-ufo
+qih
 boL
 bja
 yat
@@ -88663,7 +88931,7 @@ aAB
 aAB
 arA
 arA
-aHY
+bpT
 xPQ
 aJR
 kVO
@@ -88881,7 +89149,7 @@ cnD
 adV
 adV
 acP
-kbV
+vHR
 acP
 acP
 acP
@@ -89126,7 +89394,7 @@ abO
 abO
 acC
 acC
-cCO
+aci
 acP
 acP
 acP
@@ -89383,11 +89651,11 @@ abO
 abO
 abO
 acB
-acM
+rlV
 abO
 add
 adk
-ieU
+cCO
 adX
 adV
 adV
@@ -89634,13 +89902,13 @@ ace
 abO
 abO
 acF
-acl
+ace
 acq
 abO
 abO
 abO
 aaN
-fTp
+abY
 acT
 add
 adl
@@ -89904,10 +90172,10 @@ ieU
 sFL
 adM
 kUt
-gAY
-gAY
-gAY
-gAY
+hQd
+hQd
+hQd
+hQd
 aeO
 aff
 afy
@@ -90406,7 +90674,7 @@ abO
 abO
 abO
 abO
-act
+bhU
 abO
 abO
 abO
@@ -90663,7 +90931,7 @@ ace
 abO
 abO
 abO
-act
+bhU
 abO
 abO
 adT
@@ -92812,7 +93080,7 @@ bkt
 bku
 bkt
 bkt
-cqp
+onJ
 vvn
 cqt
 bAu
@@ -92828,7 +93096,7 @@ bKR
 bLZ
 vap
 wVQ
-hXC
+sBV
 bPR
 hXC
 hXC
@@ -93340,7 +93608,7 @@ bID
 bJL
 iJN
 bMb
-wSR
+rud
 lyB
 bOV
 bPQ
@@ -93854,7 +94122,7 @@ bIE
 fBp
 fBp
 bMd
-wSR
+rud
 lyB
 bOX
 bPQ
@@ -94367,7 +94635,7 @@ aht
 aaa
 fBp
 bKT
-sGc
+uTt
 wYi
 lyB
 wCz
@@ -94624,9 +94892,9 @@ bCP
 bAA
 bHw
 vMt
-bWO
+iJc
 pEh
-bOk
+wfp
 fIA
 bPU
 fIA
@@ -94881,9 +95149,9 @@ bCR
 bIG
 bHw
 bKV
-bWO
-bWO
-bOk
+eDR
+eUb
+lyB
 bPb
 bWO
 bQM
@@ -95921,7 +96189,7 @@ pFG
 fEj
 bUz
 wWR
-inG
+pFG
 fEj
 eGT
 fBp
@@ -96652,14 +96920,14 @@ bbG
 bcB
 hgV
 hgV
-hgV
+mjO
 bbI
 nts
 bbI
 lru
 bjw
 bkz
-bky
+fGH
 bky
 bnW
 bpe
@@ -97949,7 +98217,7 @@ aan
 jnp
 aap
 bqt
-bqs
+mAo
 vfp
 bqs
 bqs
@@ -100749,7 +101017,7 @@ aFi
 aQj
 aTw
 aGP
-tko
+bbG
 afd
 teN
 rbx
@@ -101006,7 +101274,7 @@ mdx
 mdx
 mdx
 mdx
-dWw
+vHj
 mXc
 saR
 tAm
@@ -102831,11 +103099,11 @@ blX
 blX
 bpr
 oSc
-bsa
-tzm
+eoP
+pmB
 uel
-xoo
-bxM
+rBP
+gxO
 bzk
 bAH
 blX
@@ -107202,7 +107470,7 @@ bnd
 kRK
 iqW
 nqV
-ufa
+qDU
 ufa
 voR
 bkF
@@ -107716,7 +107984,7 @@ bnd
 uPA
 ufa
 nqV
-ufa
+qDU
 ufa
 ufa
 jtf

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -6816,15 +6816,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/sign/map{
-	icon_state = "map-pubby";
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
+	},
+/obj/structure/sign/map{
+	icon_state = "map-pubby";
+	pixel_y = 32
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
@@ -9318,6 +9318,7 @@
 /area/commons/dorms)
 "aDk" = (
 /obj/machinery/requests_console/directional/south{
+	department = "Dormitories";
 	name = "Dorms Requests Console"
 	},
 /turf/open/floor/iron/white/corner{
@@ -13567,6 +13568,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aUi" = (
@@ -14112,6 +14116,9 @@
 /obj/machinery/airalarm/directional/north,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/service)
 "aWh" = (
@@ -14122,6 +14129,9 @@
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "aWm" = (
@@ -15917,7 +15927,7 @@
 	},
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
-/area/maintenance/department/cargo)
+/area/cargo/miningdock)
 "bcC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20826,6 +20836,9 @@
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/service)
 "buH" = (
@@ -28429,14 +28442,19 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 6
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bVf" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bVk" = (
@@ -28686,9 +28704,6 @@
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "bVV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Waste to Space"
@@ -33741,6 +33756,12 @@
 /obj/machinery/door/airlock/external{
 	name = "Dock Access"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
 "cvB" = (
@@ -36257,13 +36278,6 @@
 	icon_state = "wood-broken"
 	},
 /area/service/abandoned_gambling_den)
-"eru" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
-	dir = 1
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engineering/atmos)
 "ery" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -40473,6 +40487,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "ivp" = (
@@ -42991,7 +43006,6 @@
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/medical/virology)
@@ -43500,7 +43514,6 @@
 /turf/closed/wall,
 /area/cargo/sorting)
 "lQv" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/supply/visible,
 /obj/machinery/atmospherics/pipe/layer_manifold/supply,
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
@@ -43866,6 +43879,16 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"mlS" = (
+/obj/structure/chair/wood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/service/chapel/main/monastery)
 "mlV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -44654,6 +44677,9 @@
 /area/science/xenobiology)
 "naX" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "nbw" = (
@@ -48775,6 +48801,12 @@
 	},
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
+"qUv" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/service/chapel/main/monastery)
 "qVd" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general{
 	dir = 6
@@ -50538,10 +50570,11 @@
 	},
 /area/maintenance/department/security/brig)
 "syt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/effect/turf_decal/box/white,
+/obj/effect/turf_decal/arrows/white{
+	color = "#0000FF";
+	pixel_y = 15
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "syA" = (
@@ -51102,7 +51135,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "tal" = (
@@ -51463,14 +51496,6 @@
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
 "tlU" = (
-/obj/effect/turf_decal/box/white,
-/obj/effect/turf_decal/arrows/white{
-	color = "#0000FF";
-	pixel_y = 15
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"tna" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
 /obj/structure/table/reinforced,
 /obj/item/stack/cable_coil{
@@ -51488,6 +51513,11 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"tna" = (
+/obj/structure/lattice,
+/obj/structure/grille/broken,
+/turf/open/space/basic,
+/area/space/nearstation)
 "tnY" = (
 /obj/machinery/button/door{
 	id = "aux_base_shutters";
@@ -51925,11 +51955,17 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "tEB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "tEE" = (
@@ -52136,10 +52172,15 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "tSV" = (
-/obj/structure/lattice,
-/obj/structure/grille/broken,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "tTq" = (
 /obj/structure/closet/crate,
 /obj/item/food/breadslice/plain,
@@ -54750,9 +54791,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "wfr" = (
@@ -55500,6 +55539,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/service/chapel/main/monastery)
 "wKa" = (
@@ -55557,7 +55599,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "wMn" = (
@@ -55668,14 +55712,9 @@
 /turf/open/floor/carpet,
 /area/medical/psychology)
 "wQE" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
+/turf/open/floor/plating,
 /area/engineering/atmos)
 "wQU" = (
 /obj/effect/spawner/lootdrop/maintenance,
@@ -56057,9 +56096,11 @@
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "xdQ" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
+	dir = 1
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
 /area/engineering/atmos)
 "xdY" = (
 /obj/machinery/door/window/eastright{
@@ -67062,7 +67103,7 @@ cfN
 bWV
 ciJ
 pmv
-csS
+qUv
 cjZ
 bWV
 cfN
@@ -67318,8 +67359,8 @@ bWV
 bWV
 bWV
 ciK
-csS
-csS
+hAF
+ykY
 cka
 bWV
 cfN
@@ -67576,7 +67617,7 @@ chV
 bWV
 bWV
 cvq
-csS
+ykY
 bWV
 bWV
 bWV
@@ -68090,7 +68131,7 @@ chX
 bWV
 ciz
 cvr
-csS
+ykY
 cvR
 csS
 csS
@@ -68347,7 +68388,7 @@ chY
 bWV
 ciz
 cvs
-rut
+mlS
 rut
 gEh
 csS
@@ -92216,7 +92257,7 @@ bSQ
 bTI
 bUq
 bVf
-syt
+bWJ
 bWJ
 bXs
 pln
@@ -93495,7 +93536,7 @@ lyB
 bOV
 bWO
 bNk
-bIG
+bWO
 bWO
 bWO
 bTQ
@@ -94545,7 +94586,7 @@ kJU
 xJb
 xJb
 xJb
-wfp
+tSV
 auI
 aaa
 aaa
@@ -95058,7 +95099,7 @@ auI
 bUp
 rsy
 rjl
-tlU
+syt
 uWA
 auI
 aaa
@@ -95830,9 +95871,9 @@ mrH
 pGV
 bWO
 bWO
-wMm
+wfp
+wQE
 xdQ
-eru
 aaa
 aaa
 aaa
@@ -96343,8 +96384,8 @@ mkf
 mNv
 rfm
 sxs
-tna
-wQE
+tlU
+wMm
 auI
 aaa
 aaa
@@ -96799,7 +96840,7 @@ aWw
 aWw
 rMn
 pvZ
-jYA
+nts
 lcH
 amb
 bfB
@@ -97055,7 +97096,7 @@ aXx
 aYx
 aZq
 baA
-bbG
+bbI
 bcB
 hgV
 hgV
@@ -98656,7 +98697,7 @@ tlJ
 azC
 rLJ
 aaa
-tSV
+tna
 aaa
 aaa
 aaa

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -4554,17 +4554,8 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "aor" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/computer/atmos_control/incinerator,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
+/turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "aos" = (
 /obj/machinery/door/airlock/security{
@@ -4823,20 +4814,13 @@
 /turf/open/floor/iron,
 /area/security)
 "ape" = (
-/obj/structure/table,
-/obj/item/circuitboard/machine/HFR_corner,
-/obj/item/circuitboard/machine/HFR_corner,
-/obj/item/circuitboard/machine/HFR_corner,
-/obj/item/circuitboard/machine/HFR_corner,
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = -7
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 10
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/disposal/incinerator)
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "apf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -4962,18 +4946,19 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "apv" = (
-/obj/structure/table,
-/obj/item/circuitboard/machine/HFR_core,
-/obj/item/circuitboard/machine/HFR_fuel_input,
-/obj/item/circuitboard/machine/HFR_interface,
-/obj/item/circuitboard/machine/HFR_moderator_input,
-/obj/item/circuitboard/machine/HFR_waste_output,
-/obj/item/stack/cable_coil{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/maintenance/disposal/incinerator)
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "apw" = (
 /obj/item/camera_film,
 /obj/structure/table,
@@ -5100,10 +5085,19 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/command/nuke_storage)
 "apV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 4
 	},
-/obj/structure/cable,
+/obj/structure/table,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = -4
+	},
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "apX" = (
@@ -5144,17 +5138,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "aqm" = (
-/obj/machinery/power/smes,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/maintenance/disposal/incinerator)
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/science/storage)
 "aqn" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -5172,22 +5158,12 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "aqp" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Incinerator";
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/structure/table/glass,
-/obj/item/paper_bin,
-/obj/item/pen,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
@@ -5226,8 +5202,7 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "aqx" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
@@ -5265,17 +5240,10 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "aqB" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 10
 	},
-/obj/machinery/airlock_sensor/incinerator_atmos{
-	pixel_y = 22
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/hidden,
-/turf/open/floor/engine,
+/turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "aqD" = (
 /obj/machinery/status_display/ai{
@@ -5327,11 +5295,11 @@
 	},
 /area/ai_monitored/command/nuke_storage)
 "aqO" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/incinerator_input{
-	dir = 8
-	},
-/turf/open/floor/engine/vacuum,
-/area/maintenance/disposal/incinerator)
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/science/storage)
 "aqP" = (
 /obj/structure/filingcabinet,
 /obj/item/folder/documents,
@@ -5426,20 +5394,28 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "arl" = (
-/obj/structure/sign/warning/fire,
-/turf/closed/wall/r_wall,
+/obj/structure/lattice,
+/turf/open/space,
 /area/maintenance/disposal/incinerator)
 "arm" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Incinerator";
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/tank/toxins{
-	dir = 4;
-	initialize_directions = 4
+/obj/structure/table/glass,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -5492,12 +5468,9 @@
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "arv" = (
-/obj/machinery/igniter/incinerator_atmos,
-/obj/machinery/air_sensor/atmos/incinerator_tank{
-	pixel_x = 32;
-	pixel_y = -32
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/incinerator_input{
+	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "arx" = (
@@ -5788,18 +5761,15 @@
 /turf/open/floor/iron,
 /area/command/gateway)
 "asb" = (
-/obj/machinery/power/compressor{
-	comp_id = "incineratorturbine";
-	dir = 8;
-	luminosity = 2
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "Turbine Chamber";
-	network = list("turbine")
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = -32
 	},
 /obj/structure/cable,
-/turf/open/floor/engine/vacuum,
-/area/maintenance/disposal/incinerator)
+/turf/open/floor/engine,
+/area/science/storage)
 "asc" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -5881,13 +5851,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "aso" = (
-/obj/machinery/power/turbine{
-	dir = 4;
-	luminosity = 2
-	},
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
-/turf/open/floor/engine/vacuum,
-/area/maintenance/disposal/incinerator)
+/turf/open/floor/engine,
+/area/science/storage)
 "asu" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -5924,8 +5892,8 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "asA" = (
-/obj/machinery/door/poddoor/incinerator_atmos_main,
-/turf/open/floor/engine/vacuum,
+/obj/structure/sign/warning/fire,
+/turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "asB" = (
 /obj/machinery/light,
@@ -6048,11 +6016,8 @@
 	},
 /area/ai_monitored/command/nuke_storage)
 "asY" = (
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/hidden,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "asZ" = (
@@ -6088,9 +6053,12 @@
 /turf/open/floor/iron/dark,
 /area/command/gateway)
 "atf" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/igniter/incinerator_atmos,
+/obj/machinery/air_sensor/atmos/incinerator_tank{
+	pixel_x = 32;
+	pixel_y = -32
 	},
+/obj/structure/cable,
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "atg" = (
@@ -6246,7 +6214,10 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "atF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 6
+	},
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "atG" = (
@@ -6274,7 +6245,9 @@
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "atJ" = (
-/obj/machinery/door/poddoor/incinerator_atmos_aux,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "atK" = (
@@ -6681,12 +6654,10 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "auL" = (
-/obj/machinery/door/airlock/atmos{
-	name = "HFR";
-	req_access_txt = "24"
+/obj/structure/sign/poster/random{
+	pixel_x = 32
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
+/turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "auO" = (
 /obj/effect/turf_decal/tile/purple{
@@ -6738,29 +6709,33 @@
 /area/command/bridge)
 "auW" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
-/obj/effect/turf_decal/bot,
-/obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching the turbine vent.";
+	dir = 4;
+	name = "turbine vent monitor";
+	network = list("turbine");
+	pixel_x = -29
+	},
+/obj/structure/closet/radiation,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "auX" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/door/airlock/external{
-	name = "Atmospherics External Access";
-	req_access_txt = "24"
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/disposal/incinerator)
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "auY" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/vault{
@@ -6897,16 +6872,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
-"avl" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/turf/open/floor/plating,
-/area/maintenance/disposal/incinerator)
 "avm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -7056,15 +7021,12 @@
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "avD" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
 	},
-/obj/machinery/door/airlock/external{
-	name = "Atmospherics External Access";
-	req_access_txt = "24"
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal/incinerator)
+/turf/open/space,
+/area/space/nearstation)
 "avE" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -7330,16 +7292,11 @@
 /turf/open/floor/iron/dark,
 /area/commons/dorms)
 "awr" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/machinery/camera{
+	c_tag = "Atmospherics Waste Tank";
+	network = list("ss13","engine")
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/engine/vacuum,
 /area/engineering/atmos)
 "aws" = (
 /obj/structure/disposalpipe/junction/flip,
@@ -7664,13 +7621,12 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "axl" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Air to Distro"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -7695,18 +7651,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/commons/dorms)
-"axu" = (
-/obj/structure/closet/radiation,
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "axv" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -7718,8 +7662,12 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/structure/closet/secure_closet/atmospherics,
+/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "axy" = (
@@ -7786,16 +7734,10 @@
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/captain)
 "axO" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "axP" = (
@@ -7874,10 +7816,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"ayc" = (
-/obj/effect/turf_decal/bot/right,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "aye" = (
 /obj/machinery/door/airlock/command{
 	name = "External Access";
@@ -7960,12 +7898,6 @@
 /obj/structure/weightmachine/stacklifter,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
-"ayy" = (
-/obj/effect/turf_decal/box/white{
-	color = "#9FED58"
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "ayz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external{
@@ -7988,10 +7920,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
-"ayC" = (
-/obj/effect/turf_decal/bot/left,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "ayD" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -8024,9 +7952,13 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "ayG" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ayI" = (
@@ -8046,18 +7978,12 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "ayJ" = (
-/obj/structure/rack,
-/obj/item/hfr_box/body/fuel_input,
-/obj/item/hfr_box/body/interface,
-/obj/item/hfr_box/body/moderator_input,
-/obj/item/hfr_box/body/waste_output,
-/obj/item/hfr_box/core,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/machinery/firealarm/directional/east,
+/obj/structure/closet/radiation,
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -8093,9 +8019,12 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "ayP" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
+/turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "ayQ" = (
 /obj/item/beacon,
@@ -8225,9 +8154,7 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "azi" = (
-/obj/effect/turf_decal/box/white{
-	color = "#52B4E9"
-	},
+/obj/effect/turf_decal/bot/right,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "azj" = (
@@ -8270,12 +8197,8 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "azm" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"azn" = (
 /obj/effect/turf_decal/box/white{
-	color = "#EFB341"
+	color = "#9FED58"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -8319,16 +8242,19 @@
 /area/commons/dorms)
 "azt" = (
 /obj/structure/rack,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/glass/fifty,
+/obj/item/hfr_box/body/fuel_input,
+/obj/item/hfr_box/body/interface,
+/obj/item/hfr_box/body/moderator_input,
+/obj/item/hfr_box/body/waste_output,
+/obj/item/hfr_box/core,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
-	},
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/camera{
-	c_tag = "HFR Room";
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -8363,12 +8289,8 @@
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "azC" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 1;
-	frequency = 1441;
-	id = "inc_in"
-	},
-/turf/open/floor/plating/airless,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "azD" = (
 /obj/structure/weightmachine/weightlifter,
@@ -8389,11 +8311,7 @@
 /turf/open/space,
 /area/solars/port)
 "azN" = (
-/obj/effect/turf_decal/box/white,
-/obj/effect/turf_decal/arrows/white{
-	color = "#0000FF";
-	pixel_y = 15
-	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "azR" = (
@@ -8548,20 +8466,17 @@
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
 "aAu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
-/obj/structure/table/reinforced,
-/obj/item/stack/cable_coil{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/stack/sheet/plasteel/fifty,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
+/obj/structure/rack,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/glass/fifty,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/camera{
+	c_tag = "HFR Room";
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -8698,10 +8613,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aAK" = (
-/obj/structure/lattice,
-/obj/structure/grille/broken,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "aAM" = (
 /obj/structure/chair,
 /turf/open/floor/iron,
@@ -9045,10 +8959,18 @@
 /turf/open/floor/iron/grimy,
 /area/commons/dorms)
 "aBR" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
+/obj/structure/table/reinforced,
+/obj/item/stack/cable_coil{
+	pixel_x = -3;
+	pixel_y = 3
 	},
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -11446,16 +11368,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/auxiliary)
-"aKS" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "aKT" = (
 /turf/closed/wall,
 /area/maintenance/department/crew_quarters/bar)
@@ -13097,6 +13009,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"aRu" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/atmos/air_output{
+	dir = 1
+	},
+/turf/open/floor/engine/air,
+/area/engineering/atmos)
 "aRB" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron/dark,
@@ -22501,9 +22419,11 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bzy" = (
-/obj/structure/grille,
-/turf/open/space,
-/area/space/nearstation)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/engine/vacuum,
+/area/engineering/atmos)
 "bzz" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/chair{
@@ -25057,25 +24977,23 @@
 /turf/open/floor/iron/dark,
 /area/hallway/primary/aft)
 "bIG" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/science/storage)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "bIH" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/science/storage)
-"bII" = (
-/obj/structure/sign/warning/nosmoking{
-	pixel_y = -32
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/structure/grille,
+/turf/closed/wall/r_wall,
+/area/engineering/atmos)
+"bII" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/mix_input{
 	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/science/storage)
+/turf/open/floor/engine/vacuum,
+/area/engineering/atmos)
 "bIL" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_interior,
@@ -25213,7 +25131,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "bJE" = (
-/obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -25221,14 +25138,15 @@
 /obj/machinery/status_display/ai{
 	pixel_y = -32
 	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "bJF" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "bJG" = (
@@ -25241,53 +25159,56 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "bJH" = (
+/obj/effect/turf_decal/tile/green,
 /obj/machinery/camera{
 	c_tag = "Research Division Entrance";
 	dir = 1
 	},
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "bJK" = (
-/obj/machinery/space_heater,
 /obj/structure/sign/poster/random{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-18";
+	layer = 3
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "bJL" = (
-/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/space_heater,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "bJM" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/structure/sign/poster/random{
-	pixel_x = 32
-	},
 /obj/structure/sign/poster/random{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
 	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
@@ -25304,13 +25225,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bJO" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/atmos{
-	name = "Toxins Storage";
-	req_access_txt = "24"
-	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
 /area/science/storage)
 "bJP" = (
 /obj/structure/grille,
@@ -25546,7 +25463,7 @@
 	},
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron/dark,
-/area/engineering/atmos)
+/area/hallway/primary/aft)
 "bKP" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/preopen{
@@ -25556,88 +25473,107 @@
 /obj/machinery/door/firedoor/heavy,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
-/area/engineering/atmos)
+/area/hallway/primary/aft)
 "bKR" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "bKS" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 6
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bKT" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Atmospherics Monitoring";
+	req_access_txt = "24"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/north,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bKV" = (
-/obj/machinery/light{
+/obj/machinery/camera{
+	c_tag = "Atmospherics Monitoring";
 	dir = 1
 	},
+/obj/machinery/space_heater,
+/obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bKY" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/structure/table,
+/obj/item/book/manual/wiki/atmospherics,
+/obj/item/clothing/head/welding{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/welding{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/multitool{
+	layer = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Mix Outlet Pump"
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bLb" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
-"bLc" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/mix_output{
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/storage/belt/utility,
+/obj/item/t_scanner,
+/obj/item/t_scanner,
+/obj/item/t_scanner,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/engine/vacuum,
+/obj/item/grenade/chem_grenade/smart_metal_foam,
+/obj/item/grenade/chem_grenade/smart_metal_foam,
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron,
+/area/engineering/atmos)
+"bLc" = (
+/obj/structure/table,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/stack/sheet/glass,
+/obj/item/stack/rods/fifty,
+/obj/item/pipe_dispenser,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "bLd" = (
-/obj/machinery/camera{
-	c_tag = "Atmospherics Waste Tank";
-	network = list("ss13","engine")
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Pure to Port"
 	},
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "bLe" = (
 /turf/open/floor/engine/vacuum,
@@ -25663,6 +25599,14 @@
 	},
 /turf/open/floor/plating,
 /area/science/mixing)
+"bLp" = (
+/obj/machinery/power/turbine{
+	dir = 4;
+	luminosity = 2
+	},
+/obj/structure/cable,
+/turf/open/floor/engine/vacuum,
+/area/maintenance/disposal/incinerator)
 "bLq" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Monastery Transit"
@@ -25844,19 +25788,6 @@
 /obj/item/clothing/suit/hazardvest{
 	pixel_x = 3
 	},
-/obj/item/clothing/mask/gas{
-	layer = 4;
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/clothing/mask/gas{
-	layer = 4
-	},
-/obj/item/clothing/mask/gas{
-	layer = 4;
-	pixel_x = -3;
-	pixel_y = -3
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -25869,6 +25800,9 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bLZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 8
+	},
 /obj/machinery/meter/atmos/atmos_waste_loop,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -25876,13 +25810,13 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 8
-	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bMa" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Distro to Waste"
+	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -25892,23 +25826,20 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Distro to Waste"
-	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bMb" = (
-/obj/machinery/meter/atmos/distro_loop,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/visible,
-/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
+/obj/machinery/meter/atmos/distro_loop,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bMd" = (
@@ -25922,7 +25853,6 @@
 	dir = 8;
 	name = "Mix to Distro"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bMe" = (
@@ -25932,28 +25862,36 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bMh" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/computer/atmos_control/tank/mix_tank{
-	dir = 8
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Mix Outlet Pump"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bMi" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating/airless,
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/obj/structure/grille,
+/turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "bMj" = (
-/obj/machinery/air_sensor/atmos/mix_tank,
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/mix_output{
+	dir = 8
+	},
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos)
 "bMk" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/engine/vacuum,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "bMl" = (
 /obj/structure/sign/warning/vacuum/external{
@@ -26126,25 +26064,10 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/structure/chair/office{
-	dir = 1
-	},
-/obj/effect/landmark/start/atmospheric_technician,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "External to Filter"
-	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bMZ" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/chair/office{
-	dir = 1
-	},
-/obj/effect/landmark/start/atmospheric_technician,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bNa" = (
@@ -26152,52 +26075,45 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
-	freq = 1400;
-	location = "Atmospherics"
-	},
 /obj/machinery/door/window/westleft{
 	dir = 1;
 	name = "Atmospherics Delivery";
 	req_access_txt = "24"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bNb" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Atmospherics Monitoring";
-	req_access_txt = "24"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
+/obj/machinery/firealarm/directional/west,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bNg" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Air to Distro"
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible{
-	dir = 4
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bNj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 6
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/machinery/requests_console/directional/east{
+	department = "Atmospherics";
+	departmentType = 2;
+	name = "Atmos RC"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bNk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
-	dir = 1
+/obj/machinery/light{
+	dir = 8
 	},
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Air to Port"
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bNl" = (
@@ -26205,15 +26121,13 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
+/obj/machinery/computer/atmos_control/tank/mix_tank{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bNo" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/mix_input{
-	dir = 8
-	},
+/obj/machinery/air_sensor/atmos/mix_tank,
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos)
 "bNp" = (
@@ -26441,19 +26355,23 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/effect/landmark/start/atmospheric_technician,
 /obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8;
-	name = "Air to External"
+	dir = 4;
+	name = "External to Filter"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bOh" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
+/obj/structure/chair/office{
+	dir = 1
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/effect/landmark/start/atmospheric_technician,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -26464,57 +26382,42 @@
 	name = "Atmospherics Monitoring";
 	req_access_txt = "24"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bOk" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bOn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Mix to Port"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bOo" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Mix to Port"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/computer/atmos_control/tank/nitrous_tank{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bOp" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Pure to Mix"
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 6
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bOq" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Unfiltered to Mix"
+/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -26623,16 +26526,16 @@
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "bOO" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Air to External"
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bOQ" = (
@@ -26640,89 +26543,58 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/conveyor_switch{
-	id = "atmosdeliver"
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
 	},
-/obj/machinery/requests_console/directional/east{
-	department = "Atmospherics";
-	departmentType = 2;
-	name = "Atmospherics Requests Console"
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bOS" = (
-/obj/machinery/camera{
-	c_tag = "Atmospherics Monitoring";
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
 	},
-/obj/machinery/space_heater,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bOV" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/atmospherics,
-/obj/item/clothing/head/welding{
-	pixel_x = -5;
-	pixel_y = 3
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/item/clothing/head/welding{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/multitool{
-	layer = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bOW" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/storage/belt/utility,
-/obj/item/t_scanner,
-/obj/item/t_scanner,
-/obj/item/t_scanner,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/item/grenade/chem_grenade/smart_metal_foam,
-/obj/item/grenade/chem_grenade/smart_metal_foam,
-/obj/machinery/newscaster/directional/south,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bOX" = (
-/obj/structure/table,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty{
-	pixel_x = 2;
-	pixel_y = 2
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
 	},
-/obj/item/stack/sheet/glass,
-/obj/item/stack/rods/fifty,
-/obj/item/pipe_dispenser,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"bPb" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Pure to Port"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bPc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Pure to Mix"
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bPd" = (
@@ -26743,19 +26615,19 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "N2O Outlet Pump"
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bPg" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrous_output{
-	dir = 8
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
 "bPh" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
 "bPo" = (
@@ -26874,23 +26746,30 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "bPN" = (
+/obj/machinery/light{
+	dir = 8
+	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bPP" = (
-/obj/structure/tank_dispenser,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
+	},
+/obj/machinery/conveyor_switch{
+	id = "atmosdeliver"
+	},
+/obj/machinery/requests_console/directional/east{
+	department = "Atmospherics";
+	departmentType = 2;
+	name = "Atmospherics Requests Console"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -26898,25 +26777,8 @@
 /turf/closed/wall,
 /area/engineering/atmos)
 "bPR" = (
-/obj/machinery/firealarm/directional/west,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"bPT" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Air to Port"
-	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"bPU" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Mix to Port"
-	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bPX" = (
@@ -26924,23 +26786,19 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/computer/atmos_control/tank/nitrous_tank{
-	dir = 8
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "N2O Outlet Pump"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bPZ" = (
-/obj/machinery/air_sensor/atmos/nitrous_tank,
-/turf/open/floor/engine/n2o,
-/area/engineering/atmos)
-"bQa" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrous_output{
+	dir = 8
+	},
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
 "bQb" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
 "bQc" = (
@@ -27183,9 +27041,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "bQG" = (
-/obj/machinery/computer/atmos_control{
-	dir = 8
-	},
+/obj/structure/tank_dispenser,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -27193,11 +27049,13 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bQH" = (
-/obj/machinery/pipedispenser,
+/obj/machinery/atmospherics/components/trinary/filter/atmos/n2o{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bQJ" = (
-/obj/structure/closet/secure_closet/atmospherics,
+/obj/machinery/suit_storage_unit/atmos,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -27218,16 +27076,8 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"bQN" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/n2o{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "bQP" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrous_input{
-	dir = 8
-	},
+/obj/machinery/air_sensor/atmos/nitrous_tank,
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
 "bQQ" = (
@@ -27376,7 +27226,10 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -27393,10 +27246,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "bRu" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/computer/atmos_alert{
+/obj/machinery/computer/atmos_control{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
@@ -27406,36 +27256,21 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bRv" = (
-/obj/machinery/pipedispenser/disposal,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics Central";
-	dir = 4
-	},
+/obj/machinery/pipedispenser,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bRx" = (
-/obj/machinery/suit_storage_unit/atmos,
+/obj/structure/closet/secure_closet/atmospherics,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bRz" = (
-/obj/machinery/holopad,
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"bRB" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrous_input{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/engine/n2o,
 /area/engineering/atmos)
 "bRC" = (
 /obj/structure/window/reinforced{
@@ -27630,68 +27465,65 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "bSc" = (
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 2;
-	sortType = 6
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/obj/structure/grille,
+/turf/open/space,
+/area/space/nearstation)
 "bSd" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"bSe" = (
-/obj/machinery/pipedispenser/disposal/transit_tube,
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"bSf" = (
-/obj/item/wrench,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"bSg" = (
-/obj/machinery/atmospherics/components/trinary/mixer{
-	dir = 1;
-	name = "plasma mixer"
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"bSh" = (
-/obj/machinery/camera{
-	c_tag = "Atmospherics Starboard";
+/obj/machinery/computer/atmos_alert{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Plasma Outlet Pump"
+/turf/open/floor/iron,
+/area/engineering/atmos)
+"bSe" = (
+/obj/machinery/pipedispenser/disposal,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics Central";
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
+"bSf" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
+"bSg" = (
+/obj/machinery/holopad,
+/turf/open/floor/iron,
+/area/engineering/atmos)
+"bSh" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bSj" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/toxin_output{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/engine/plasma,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "bSk" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "bSm" = (
@@ -27838,62 +27670,60 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "bSQ" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Atmospherics Monitoring";
-	req_access_txt = "24"
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 2;
+	sortType = 6
 	},
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bSR" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Port to Filter"
-	},
-/obj/structure/extinguisher_cabinet/directional/west,
+/obj/item/wrench,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bSS" = (
-/obj/item/beacon,
+/obj/machinery/pipedispenser/disposal/transit_tube,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bST" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
-/obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bSU" = (
-/obj/machinery/atmospherics/components/binary/thermomachine/heater{
-	dir = 8
+/obj/machinery/atmospherics/components/trinary/mixer{
+	dir = 1;
+	name = "plasma mixer"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bSV" = (
+/obj/machinery/camera{
+	c_tag = "Atmospherics Starboard";
+	dir = 8
+	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/computer/atmos_control/tank/toxin_tank{
-	dir = 8
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Plasma Outlet Pump"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bSW" = (
-/obj/machinery/air_sensor/atmos/toxin_tank,
-/turf/open/floor/engine/plasma,
-/area/engineering/atmos)
-"bSX" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/toxin_output{
+	dir = 8
+	},
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "bSY" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "bSZ" = (
@@ -28173,114 +28003,62 @@
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "bTI" = (
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Atmospherics Monitoring";
+	req_access_txt = "24"
+	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 6
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bTK" = (
-/obj/structure/plaque/static_plaque/atmos{
-	pixel_y = 32
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics Entrance"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bTO" = (
-/obj/machinery/vending/wardrobe/atmos_wardrobe,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bTP" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/structure/fireaxecabinet{
-	pixel_y = 32
+/obj/machinery/shower{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bTQ" = (
-/obj/machinery/camera{
-	c_tag = "Atmospherics Mixing"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/structure/reagent_dispensers/fueltank/large,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
+/obj/machinery/computer/atmos_control/tank/toxin_tank{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bTR" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Port to Filter"
-	},
+/obj/item/beacon,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bTS" = (
-/obj/item/cigbutt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
+/obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bTT" = (
-/obj/machinery/atmospherics/components/binary/thermomachine/freezer{
+/obj/machinery/atmospherics/components/binary/thermomachine/heater{
 	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"bTU" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
-	dir = 1
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bTV" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxin_input{
-	dir = 8
-	},
+/obj/machinery/air_sensor/atmos/toxin_tank,
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "bTW" = (
@@ -28426,53 +28204,39 @@
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "bUp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 6
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bUq" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"bUv" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "incinerator mix pump"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"bUx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"bUy" = (
-/obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/atmos)
+"bUv" = (
+/obj/machinery/atmospherics/components/binary/thermomachine/freezer{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"bUz" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+"bUx" = (
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/open/floor/plating,
+/turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "bUC" = (
 /obj/structure/flora/ausbushes/fernybush,
@@ -28751,26 +28515,18 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bVe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Waste to Space"
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 6
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bVf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"bVh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bVk" = (
@@ -28778,19 +28534,35 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "CO2 Outlet Pump"
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bVn" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/carbon_output{
-	dir = 8
+/obj/structure/plaque/static_plaque/atmos{
+	pixel_y = 32
 	},
-/turf/open/floor/engine/co2,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics Entrance"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "bVo" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
 "bVp" = (
@@ -29019,49 +28791,39 @@
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "bVV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Waste to Space"
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bVY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "O2 to Pure"
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"bWa" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "N2 to Pure"
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 6
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bWb" = (
-/obj/machinery/computer/atmos_control/tank/carbon_tank{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "CO2 Outlet Pump"
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bWe" = (
-/obj/machinery/air_sensor/atmos/carbon_tank,
-/turf/open/floor/engine/co2,
-/area/engineering/atmos)
-"bWf" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/carbon_output{
+	dir = 8
+	},
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
 "bWg" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
 "bWi" = (
@@ -29287,45 +29049,37 @@
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "bWI" = (
-/obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bWJ" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"bWK" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/o2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bWO" = (
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bWP" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Air to Pure"
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"bWQ" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"bWQ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "bWT" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/carbon_input{
-	dir = 8
-	},
+/obj/machinery/air_sensor/atmos/carbon_tank,
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
 "bWV" = (
@@ -29463,47 +29217,20 @@
 /area/engineering/break_room)
 "bXr" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bXs" = (
 /obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"bXu" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/computer/atmos_control/tank/nitrogen_tank{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"bXw" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 5
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bXx" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/computer/atmos_control/tank/oxygen_tank{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -29515,44 +29242,42 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bXz" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
+	dir = 1
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bXA" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/trinary/mixer/airmix,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bXB" = (
-/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/vending/wardrobe/atmos_wardrobe,
 /obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/computer/atmos_control/tank/air_tank{
 	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bXC" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/structure/fireaxecabinet{
+	pixel_y = 32
 	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "Air Outlet Pump"
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -29561,10 +29286,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -29703,33 +29425,44 @@
 /area/engineering/main)
 "bYq" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "bYs" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/turf/closed/wall/r_wall,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Air Outlet Pump"
+	},
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "bYt" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/turf/closed/wall,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 1
+	},
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "bYu" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Incinerator";
-	req_access_txt = "24"
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/obj/machinery/navbeacon/wayfinding/incinerator,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
+	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "bYw" = (
 /turf/closed/wall/r_wall,
@@ -29966,11 +29699,11 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "bZf" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/turf/closed/wall,
 /area/engineering/atmos)
 "bZh" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -29979,10 +29712,10 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
+/obj/machinery/computer/atmos_control/incinerator,
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 5
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "bZl" = (
@@ -30064,58 +29797,39 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "bZK" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 1
-	},
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
-/turf/open/floor/plating/airless,
-/area/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
+/turf/open/space,
+/area/space/nearstation)
 "bZL" = (
-/obj/machinery/meter,
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
-"bZM" = (
-/obj/machinery/meter{
-	name = "Mixed Air Tank In"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
-"bZN" = (
-/obj/machinery/meter{
-	name = "Mixed Air Tank Out"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
+/turf/open/space,
+/area/space/nearstation)
 "bZT" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 6
+/obj/machinery/camera{
+	c_tag = "Atmospherics Mixing"
 	},
-/turf/open/floor/iron/dark,
-/area/maintenance/disposal/incinerator)
-"bZU" = (
-/obj/machinery/button/door/incinerator_vent_atmos_main{
-	pixel_x = 24;
-	pixel_y = 6
-	},
-/obj/machinery/button/door/incinerator_vent_atmos_aux{
-	pixel_x = 24;
-	pixel_y = -6
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/power/terminal{
-	dir = 1
+/obj/structure/reagent_dispensers/fueltank/large,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+/turf/open/floor/iron,
+/area/engineering/atmos)
+"bZU" = (
+/obj/machinery/power/smes,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
 /obj/structure/cable,
@@ -30247,67 +29961,58 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/cargo/office)
-"caz" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrogen_input{
-	dir = 1
-	},
-/turf/open/floor/engine/n2,
-/area/engineering/atmos)
-"caA" = (
-/obj/machinery/air_sensor/atmos/nitrogen_tank,
-/turf/open/floor/engine/n2,
-/area/engineering/atmos)
 "caB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrogen_output{
-	dir = 1
-	},
-/turf/open/floor/engine/n2,
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/structure/grille,
+/turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "caC" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/oxygen_input{
-	dir = 1
-	},
-/turf/open/floor/engine/o2,
-/area/engineering/atmos)
-"caD" = (
-/obj/machinery/air_sensor/atmos/oxygen_tank,
-/turf/open/floor/engine/o2,
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/structure/grille,
+/turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "caE" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/oxygen_output{
-	dir = 1
-	},
-/turf/open/floor/engine/o2,
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/obj/structure/grille,
+/turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "caF" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/air_input{
-	dir = 1
+/obj/machinery/meter{
+	name = "Mixed Air Tank In"
 	},
-/turf/open/floor/engine/air,
-/area/engineering/atmos)
-"caG" = (
-/obj/machinery/air_sensor/atmos/air_tank,
-/turf/open/floor/engine/air,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/structure/grille,
+/turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "caH" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/atmos/air_output{
-	dir = 1
+/obj/machinery/meter{
+	name = "Mixed Air Tank Out"
 	},
-/turf/open/floor/engine/air,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/structure/grille,
+/turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "caP" = (
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/public/glass/incinerator/atmos_interior,
-/obj/machinery/embedded_controller/radio/airlock_controller/incinerator_atmos{
-	pixel_x = -6;
-	pixel_y = -26
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/engine,
+/turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "caQ" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos,
-/obj/structure/cable,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/airlock_sensor/incinerator_atmos{
+	pixel_y = 22
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/hidden,
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "caS" = (
@@ -30435,14 +30140,14 @@
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
 "cbt" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/air_sensor/atmos/nitrogen_tank,
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
 "cbu" = (
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
 "cbv" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/air_sensor/atmos/oxygen_tank,
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
 "cbw" = (
@@ -30450,8 +30155,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "cbx" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/landmark/event_spawn,
+/obj/machinery/air_sensor/atmos/air_tank,
 /turf/open/floor/engine/air,
 /area/engineering/atmos)
 "cby" = (
@@ -30464,23 +30168,20 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/structure/closet/radiation,
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/tank/toxins{
+	dir = 4;
+	initialize_directions = 4
+	},
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "cbF" = (
-/obj/machinery/button/ignition/incinerator/atmos{
-	pixel_x = 26;
-	pixel_y = -6
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "cbK" = (
@@ -30652,15 +30353,16 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "ccm" = (
-/obj/machinery/light/small,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
 "ccn" = (
-/obj/machinery/light/small,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
 "cco" = (
-/obj/machinery/light/small,
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/engine/air,
 /area/engineering/atmos)
 "ccs" = (
@@ -30668,6 +30370,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "ccu" = (
@@ -33367,26 +33070,13 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "cqE" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-18";
-	layer = 3
-	},
+/obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"cqG" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "cqH" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -34818,9 +34508,6 @@
 /area/service/library)
 "cAO" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /turf/open/space,
 /area/space/nearstation)
@@ -35105,11 +34792,17 @@
 	},
 /area/maintenance/department/science)
 "cEJ" = (
+/obj/machinery/button/ignition/incinerator/atmos{
+	pixel_x = 26;
+	pixel_y = -6
+	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/airalarm/directional/east,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "cFB" = (
@@ -35172,6 +34865,14 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"cIR" = (
+/obj/machinery/requests_console/directional/east{
+	department = "Atmospherics";
+	departmentType = 2;
+	name = "Atmos RC"
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "cJo" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating{
@@ -35460,9 +35161,6 @@
 /turf/open/floor/iron,
 /area/command/gateway)
 "dej" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
@@ -35747,6 +35445,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
+"drU" = (
+/obj/machinery/computer/turbine_computer{
+	id = "incineratorturbine"
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "dsv" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -35769,14 +35473,10 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "dsR" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxin_input{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "dtj" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
@@ -36029,9 +35729,14 @@
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "dHc" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/dark/visible{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "dIy" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -36154,11 +35859,11 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/dock)
 "dQq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "dQr" = (
@@ -36700,12 +36405,9 @@
 /turf/open/floor/iron/white,
 /area/medical/paramedic)
 "euv" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/dark/visible{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -36886,9 +36588,19 @@
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
 "eDR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/light{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "eER" = (
@@ -36947,10 +36659,12 @@
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "eGT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
 	},
-/turf/closed/wall/r_wall,
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/engineering/atmos)
 "eHb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -37032,15 +36746,20 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "eKY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "eLt" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
+"eMs" = (
+/obj/effect/turf_decal/box/white{
+	color = "#52B4E9"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "eNo" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 9
@@ -37071,10 +36790,7 @@
 	},
 /area/maintenance/department/engine)
 "eNC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "eNF" = (
@@ -37112,6 +36828,11 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/department/engine)
+"eOS" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/maintenance/disposal/incinerator)
 "eOZ" = (
 /obj/structure/closet,
 /obj/item/clothing/suit/judgerobe,
@@ -37238,7 +36959,7 @@
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "eUb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "eUe" = (
@@ -37274,10 +36995,9 @@
 /turf/open/floor/iron/dark,
 /area/engineering/transit_tube)
 "eVD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "eVW" = (
@@ -37317,11 +37037,10 @@
 /turf/open/floor/carpet,
 /area/service/library/lounge)
 "eYd" = (
-/obj/machinery/meter,
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
+/turf/open/space,
+/area/space/nearstation)
 "eYr" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -37412,7 +37131,7 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "faU" = (
-/obj/machinery/atmospherics/components/trinary/filter,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "faY" = (
@@ -37439,19 +37158,14 @@
 /area/medical/abandoned)
 "fbC" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the turbine vent.";
-	dir = 4;
-	name = "turbine vent monitor";
-	network = list("turbine");
-	pixel_x = -29
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
 /obj/structure/closet/radiation,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "fcK" = (
@@ -37466,11 +37180,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "fda" = (
-/obj/machinery/meter,
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
+/turf/open/space,
+/area/space/nearstation)
 "fdl" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -37516,16 +37229,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "feh" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "fei" = (
@@ -37544,10 +37248,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "feN" = (
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "feU" = (
@@ -37784,10 +37486,14 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
 "foz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/public/glass/incinerator/atmos_interior,
+/obj/machinery/embedded_controller/radio/airlock_controller/incinerator_atmos{
+	pixel_x = -6;
+	pixel_y = -26
 	},
-/turf/closed/wall/r_wall,
+/obj/structure/cable,
+/turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "fqJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -37811,12 +37517,12 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "frC" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/trinary/mixer/airmix,
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "frX" = (
 /obj/structure/chair{
@@ -37834,11 +37540,7 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "fsO" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/machinery/atmospherics/components/trinary/filter,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "ftb" = (
@@ -37893,9 +37595,10 @@
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "fuR" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/n2{
+/obj/machinery/atmospherics/pipe/layer_manifold/visible{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "fvq" = (
@@ -38036,16 +37739,12 @@
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "fDm" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/dark,
-/area/maintenance/disposal/incinerator)
-"fEj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Supermatter Mix Pump"
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "fEo" = (
 /obj/structure/disposalpipe/segment{
@@ -38147,7 +37846,12 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "fIA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Mix to Port"
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "fIH" = (
@@ -38180,14 +37884,11 @@
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "fJw" = (
-/obj/machinery/shower{
-	dir = 8
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "incinerator mix pump"
 	},
-/obj/machinery/requests_console/directional/east{
-	department = "Atmospherics";
-	departmentType = 2;
-	name = "Atmos RC"
-	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "fJU" = (
@@ -38344,16 +38045,6 @@
 "fRs" = (
 /turf/closed/wall,
 /area/command/heads_quarters/rd)
-"fSq" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "fSx" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -38483,9 +38174,8 @@
 "gbu" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
-	name = "Supermatter Mix Pump"
+	name = "Port to Filter"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "gbK" = (
@@ -38787,6 +38477,10 @@
 	heat_capacity = 1e+006
 	},
 /area/hallway/secondary/exit/departure_lounge)
+"gqp" = (
+/obj/machinery/door/poddoor/incinerator_atmos_main,
+/turf/open/floor/engine/vacuum,
+/area/maintenance/disposal/incinerator)
 "gqx" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/table,
@@ -38872,10 +38566,10 @@
 /turf/open/floor/iron/white,
 /area/medical/psychology)
 "gur" = (
-/obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
-	dir = 8
+	dir = 1
 	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -38942,6 +38636,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"gwQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "gxe" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -32
@@ -39122,9 +38822,16 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
 "gEv" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
-/turf/open/floor/plating,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "gEI" = (
 /obj/effect/turf_decal/stripes/line{
@@ -39305,10 +39012,12 @@
 /obj/effect/spawner/randomsnackvend,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"gMk" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+"gMt" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/light,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "gMA" = (
@@ -39372,12 +39081,14 @@
 	},
 /area/cargo/warehouse)
 "gQj" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "gQX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -39569,7 +39280,13 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "hfi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Port to Filter"
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "hfC" = (
@@ -39654,12 +39371,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
-"hjJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "hjO" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -39784,9 +39495,20 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "hqI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
 /obj/structure/cable,
 /turf/open/floor/iron,
+/area/engineering/atmos)
+"hrR" = (
+/obj/machinery/door/airlock/atmos{
+	name = "HFR";
+	req_access_txt = "24"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "htK" = (
 /obj/structure/disposalpipe/segment,
@@ -39943,9 +39665,12 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/department/engine)
 "hCg" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "hCj" = (
 /obj/structure/cable,
@@ -40139,8 +39864,15 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "hMa" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/closet/secure_closet/atmospherics,
+/turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "hMc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -40617,10 +40349,24 @@
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
 "iiP" = (
+/obj/machinery/button/door/incinerator_vent_atmos_main{
+	pixel_x = 24;
+	pixel_y = 6
+	},
+/obj/machinery/button/door/incinerator_vent_atmos_aux{
+	pixel_x = 24;
+	pixel_y = -6
+	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 4
+	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
@@ -40887,10 +40633,13 @@
 /turf/open/floor/iron/dark,
 /area/service/library)
 "iBq" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/space/basic,
-/area/space)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/turf/open/floor/plating,
+/area/engineering/atmos)
 "iBw" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 5
@@ -41030,9 +40779,16 @@
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "iJc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "iJI" = (
@@ -41104,6 +40860,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/warden)
+"iMK" = (
+/obj/machinery/door/poddoor/incinerator_atmos_aux,
+/turf/open/floor/engine/vacuum,
+/area/space/nearstation)
 "iNg" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/green{
@@ -41154,16 +40914,10 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "iQR" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Incinerator";
-	req_access_txt = "24"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
 	dir = 1
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "iRs" = (
 /obj/effect/turf_decal/tile/blue{
@@ -41230,6 +40984,12 @@
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron/white,
 /area/security/prison)
+"iXz" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "iYH" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay";
@@ -41280,11 +41040,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "jaS" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/purple/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "jbo" = (
@@ -41571,12 +41329,8 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "jty" = (
-/obj/machinery/requests_console/directional/east{
-	department = "Atmospherics";
-	departmentType = 2;
-	name = "Atmos RC"
-	},
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "jtJ" = (
 /obj/structure/cable,
@@ -41802,8 +41556,9 @@
 /turf/open/floor/iron/white,
 /area/medical/psychology)
 "jMl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 6
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "N2 to Pure"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -41860,9 +41615,10 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "jOl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+/obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "jOw" = (
@@ -41876,6 +41632,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
+"jOx" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/maintenance/disposal/incinerator)
 "jOB" = (
 /turf/open/floor/plating,
 /area/commons/storage/emergency/starboard)
@@ -41896,6 +41656,10 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/science)
+"jRv" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
 "jRG" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
@@ -42106,9 +41870,13 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "keN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/computer/atmos_control/tank/carbon_tank{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "kfl" = (
@@ -42288,6 +42056,19 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/cryo)
+"koA" = (
+/obj/machinery/power/compressor{
+	comp_id = "incineratorturbine";
+	dir = 8;
+	luminosity = 2
+	},
+/obj/machinery/camera{
+	c_tag = "Turbine Chamber";
+	network = list("turbine")
+	},
+/obj/structure/cable,
+/turf/open/floor/engine/vacuum,
+/area/maintenance/disposal/incinerator)
 "koW" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -42382,8 +42163,9 @@
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "ksv" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ksP" = (
@@ -42658,6 +42440,12 @@
 /obj/machinery/newscaster/security_unit/directional/south,
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
+"kGY" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/air_input{
+	dir = 1
+	},
+/turf/open/floor/engine/air,
+/area/engineering/atmos)
 "kHO" = (
 /obj/structure/bed/dogbed/renault,
 /mob/living/simple_animal/pet/fox/renault,
@@ -42715,6 +42503,18 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"kMq" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "kMt" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -42784,17 +42584,9 @@
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "kPP" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/turf/open/floor/plating,
 /area/engineering/atmos)
 "kQy" = (
 /obj/machinery/computer/med_data,
@@ -42866,6 +42658,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"kTL" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "kTU" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/effect/turf_decal/tile/green{
@@ -42968,6 +42770,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/explab)
+"kWy" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 5
+	},
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating/airless,
+/area/engineering/atmos)
 "kXe" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -42987,6 +42796,16 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/grass,
 /area/medical/psychology)
+"kZM" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "kZU" = (
 /obj/structure/table/wood/fancy,
 /obj/structure/sign/painting/library_secure{
@@ -43102,6 +42921,11 @@
 /obj/item/pen,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
+"ldG" = (
+/obj/structure/lattice,
+/obj/structure/grille/broken,
+/turf/open/space/basic,
+/area/space/nearstation)
 "lem" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -43203,7 +43027,7 @@
 /obj/machinery/door/firedoor/heavy,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
-/area/engineering/atmos)
+/area/hallway/primary/aft)
 "lku" = (
 /obj/structure/table/glass,
 /obj/machinery/microwave{
@@ -43405,9 +43229,7 @@
 /turf/open/space,
 /area/space/nearstation)
 "ltu" = (
-/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
-/obj/machinery/airalarm/directional/south,
 /turf/open/floor/engine,
 /area/science/storage)
 "ltE" = (
@@ -43458,12 +43280,7 @@
 /turf/open/floor/iron,
 /area/security)
 "lyB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/binary/thermomachine/heater,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "lzJ" = (
@@ -43517,11 +43334,28 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/gateway)
+"lDk" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "lDw" = (
 /obj/structure/flora/grass/jungle,
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/science/genetics)
+"lDS" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "lEn" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -43671,6 +43505,16 @@
 /obj/structure/plasticflaps/opaque,
 /turf/open/floor/plating,
 /area/cargo/storage)
+"lMl" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "Atmospherics External Access";
+	req_access_txt = "24"
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal/incinerator)
 "lMQ" = (
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
@@ -43734,19 +43578,15 @@
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
 "lQQ" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/engine/co2,
 /area/engineering/atmos)
 "lRh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "lRC" = (
@@ -43941,6 +43781,13 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet,
 /area/service/library)
+"mcS" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
+	dir = 1
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/engineering/atmos)
 "mcV" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -44067,24 +43914,22 @@
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "mkf" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating/airless,
 /area/engineering/atmos)
 "mkS" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "mlD" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -44195,9 +44040,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "mrv" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/open/floor/plating/airless,
+/obj/machinery/atmospherics/components/trinary/filter/atmos/o2{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "mrR" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -44257,12 +44103,13 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "mvA" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
+/turf/open/space,
+/area/space/nearstation)
 "mvJ" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -44285,6 +44132,10 @@
 /obj/item/gun/ballistic/shotgun/toy,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"mwG" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "mxg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -44455,8 +44306,8 @@
 /area/security/checkpoint/engineering)
 "mDo" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -44635,12 +44486,11 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "mOH" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/carbon_input{
+	dir = 8
 	},
-/turf/open/space,
-/area/space/nearstation)
+/turf/open/floor/engine/co2,
+/area/engineering/atmos)
 "mQc" = (
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	id = "Supermatter";
@@ -44812,15 +44662,9 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "mZO" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/obj/structure/grille,
+/turf/open/space,
+/area/space)
 "mZR" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
@@ -44856,9 +44700,12 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "nbE" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Unfiltered to Mix"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -44914,9 +44761,10 @@
 	},
 /area/maintenance/department/science)
 "ndP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "ndU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/piratepad/civilian,
@@ -45217,14 +45065,23 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"nqQ" = (
+/obj/machinery/light/small,
+/turf/open/floor/engine/o2,
+/area/engineering/atmos)
 "nqV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "nrD" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
-/turf/closed/wall/r_wall,
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "nsy" = (
 /obj/structure/table,
@@ -45456,7 +45313,7 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "nEp" = (
-/obj/structure/cable,
+/obj/item/cigbutt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -45595,6 +45452,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
+"nNe" = (
+/obj/effect/turf_decal/box/white{
+	color = "#EFB341"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "nNk" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
@@ -45669,10 +45532,13 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "nSc" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/science/storage)
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "nSe" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -45689,6 +45555,19 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
+"nTh" = (
+/obj/structure/table,
+/obj/item/circuitboard/machine/HFR_core,
+/obj/item/circuitboard/machine/HFR_fuel_input,
+/obj/item/circuitboard/machine/HFR_interface,
+/obj/item/circuitboard/machine/HFR_moderator_input,
+/obj/item/circuitboard/machine/HFR_waste_output,
+/obj/item/stack/cable_coil{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "nTt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -45768,10 +45647,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "nUq" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/visible{
-	dir = 4
-	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "nUL" = (
@@ -45813,6 +45689,16 @@
 /obj/item/spear,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"nWv" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/plating,
+/area/maintenance/disposal/incinerator)
 "nWw" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -45958,12 +45844,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
-"oeQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "ofj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -46052,11 +45932,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "oib" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
 	},
-/obj/machinery/light,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "ojJ" = (
@@ -46098,6 +45976,9 @@
 "oln" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
 /turf/open/space,
 /area/space/nearstation)
 "olO" = (
@@ -46127,6 +46008,12 @@
 	},
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
+"omN" = (
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/public/glass/incinerator/atmos_exterior,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/maintenance/disposal/incinerator)
 "omS" = (
 /obj/effect/decal/cleanable/ash{
 	pixel_x = 4
@@ -46959,6 +46846,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/execution/transfer)
+"oXr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/turf/open/space/basic,
+/area/space/nearstation)
 "oXU" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -47046,6 +46937,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/server)
+"pdS" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "pec" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -47209,10 +47106,13 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "pln" = (
-/obj/machinery/shower{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/east,
+/obj/machinery/computer/atmos_control/tank/nitrogen_tank{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "plA" = (
@@ -47410,9 +47310,10 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "pxE" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "pxU" = (
@@ -47424,14 +47325,9 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "pyH" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "pzm" = (
@@ -47474,6 +47370,12 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
+"pCJ" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/oxygen_input{
+	dir = 1
+	},
+/turf/open/floor/engine/o2,
+/area/engineering/atmos)
 "pDf" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -47503,7 +47405,11 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "pEh" = (
-/obj/machinery/atmospherics/components/binary/thermomachine/heater,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "pEp" = (
@@ -47550,8 +47456,11 @@
 /turf/open/floor/iron/white,
 /area/security/prison)
 "pFG" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "pGe" = (
@@ -47590,15 +47499,18 @@
 /turf/open/floor/iron/dark,
 /area/service/library)
 "pHb" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 8
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Air to Pure"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"pHj" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "pHo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -47690,6 +47602,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"pMJ" = (
+/obj/machinery/light/small,
+/turf/open/floor/engine/air,
+/area/engineering/atmos)
 "pMM" = (
 /obj/machinery/airalarm/kitchen_cold_room{
 	pixel_y = 22
@@ -48002,11 +47918,9 @@
 /turf/closed/wall,
 /area/hallway/secondary/service)
 "qbv" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/machinery/atmospherics/components/trinary/filter/atmos/n2{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "qbP" = (
@@ -48212,11 +48126,15 @@
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "qkk" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 5
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "qkS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -48450,9 +48368,8 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "qsH" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron,
@@ -48494,10 +48411,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/visible{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
+	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "quF" = (
@@ -48563,6 +48479,12 @@
 	},
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
+"qyg" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrogen_input{
+	dir = 1
+	},
+/turf/open/floor/engine/n2,
+/area/engineering/atmos)
 "qyR" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -48647,11 +48569,13 @@
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
 "qFJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "qGk" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
@@ -48698,11 +48622,15 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "qIz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
+/obj/machinery/computer/atmos_control/tank/oxygen_tank{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "qIC" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -48826,6 +48754,19 @@
 "qOE" = (
 /turf/open/floor/iron/dark,
 /area/service/library/lounge)
+"qPa" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "qPu" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -48857,7 +48798,11 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "qQx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "qQD" = (
@@ -49074,11 +49019,16 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "rfm" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 5
+/obj/machinery/door/airlock/atmos{
+	name = "Incinerator";
+	req_access_txt = "24"
 	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating/airless,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "rgs" = (
 /obj/structure/table,
@@ -49136,6 +49086,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/prison)
+"rlb" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "Atmospherics External Access";
+	req_access_txt = "24"
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal/incinerator)
 "rle" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -49359,10 +49319,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "rsy" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/bot/left,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "rsK" = (
@@ -49438,8 +49395,19 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal)
 "rud" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
+/obj/structure/rack,
+/obj/item/clothing/mask/gas{
+	layer = 4;
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/gas{
+	layer = 4
+	},
+/obj/item/clothing/mask/gas{
+	layer = 4;
+	pixel_x = 3;
+	pixel_y = 3
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -49664,6 +49632,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
+"rBT" = (
+/obj/effect/turf_decal/box/white,
+/obj/effect/turf_decal/arrows/white{
+	color = "#0000FF";
+	pixel_y = 15
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "rCe" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -49720,11 +49696,12 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=4";
+	freq = 1400;
+	location = "Atmospherics"
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -49748,14 +49725,16 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "rGo" = (
-/obj/structure/lattice,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/open/space,
-/area/space/nearstation)
+/turf/open/floor/plating,
+/area/engineering/atmos)
 "rGD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "rHh" = (
@@ -49893,10 +49872,8 @@
 /turf/closed/wall/r_wall,
 /area/science/mixing)
 "rLJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
+/obj/structure/lattice,
+/turf/open/space/basic,
 /area/maintenance/disposal/incinerator)
 "rLQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -50290,9 +50267,12 @@
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "shs" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "O2 to Pure"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -50578,12 +50558,18 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "sxs" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
-	dir = 1
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
+/turf/open/floor/plating,
 /area/engineering/atmos)
+"sxH" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1;
+	frequency = 1441;
+	id = "inc_in"
+	},
+/turf/open/floor/plating/airless,
+/area/maintenance/disposal/incinerator)
 "sxT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -50602,6 +50588,9 @@
 	},
 /area/maintenance/department/security/brig)
 "syt" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -50713,8 +50702,14 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "sBV" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "sBW" = (
@@ -50756,11 +50751,15 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "sEx" = (
-/obj/machinery/atmospherics/components/binary/pump{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/maintenance/disposal/incinerator)
+/obj/machinery/computer/atmos_control/tank/air_tank{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "sEz" = (
 /obj/machinery/pinpointer_dispenser,
 /turf/closed/wall/r_wall,
@@ -50796,7 +50795,8 @@
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "sGc" = (
-/obj/effect/landmark/xeno_spawn,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "sGr" = (
@@ -51182,9 +51182,12 @@
 "taw" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -51429,6 +51432,15 @@
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
 "tiG" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Incinerator";
+	req_access_txt = "24"
+	},
+/obj/machinery/navbeacon/wayfinding/incinerator,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 9
+	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
@@ -51494,14 +51506,9 @@
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
 "tlU" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/open/floor/iron,
+/turf/open/floor/plating/airless,
 /area/engineering/atmos)
 "tnY" = (
 /obj/machinery/button/door{
@@ -51620,6 +51627,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"tuu" = (
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "tuy" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Test Chamber";
@@ -51651,16 +51664,16 @@
 /turf/open/floor/iron/dark,
 /area/service/abandoned_gambling_den)
 "tvq" = (
-/obj/structure/lattice,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/turf/open/space,
-/area/space/nearstation)
+/turf/open/floor/plating,
+/area/engineering/atmos)
 "tvr" = (
-/obj/machinery/computer/turbine_computer{
-	id = "incineratorturbine"
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 9
 	},
-/turf/open/floor/iron/dark,
-/area/maintenance/disposal/incinerator)
+/turf/closed/wall/r_wall,
+/area/engineering/atmos)
 "tvy" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -52022,6 +52035,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/medical/virology)
+"tNz" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/oxygen_output{
+	dir = 1
+	},
+/turf/open/floor/engine/o2,
+/area/engineering/atmos)
 "tOf" = (
 /obj/structure/sign/poster/random{
 	pixel_y = 32
@@ -52059,8 +52078,7 @@
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "tQj" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -52126,8 +52144,9 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "tSV" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
-/turf/closed/wall/r_wall,
+/turf/open/space,
 /area/maintenance/disposal/incinerator)
 "tTq" = (
 /obj/structure/closet/crate,
@@ -52705,7 +52724,16 @@
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "urG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
+	dir = 8
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "urO" = (
@@ -52805,10 +52833,16 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "uvr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "uwb" = (
@@ -52832,11 +52866,10 @@
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "uwI" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
-/turf/open/space,
-/area/space/nearstation)
+/turf/closed/wall/r_wall,
+/area/engineering/atmos)
 "uwX" = (
 /obj/machinery/field/generator,
 /turf/open/floor/plating,
@@ -53316,10 +53349,17 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "uTt" = (
-/obj/effect/landmark/xeno_spawn,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 6
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "uTI" = (
@@ -53574,7 +53614,9 @@
 /area/security/brig)
 "vap" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "vaF" = (
@@ -53765,12 +53807,6 @@
 /obj/structure/lattice,
 /turf/closed/wall,
 /area/maintenance/department/science)
-"vlv" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "vlF" = (
 /obj/item/coin/silver,
 /obj/effect/decal/cleanable/oil{
@@ -53880,6 +53916,12 @@
 	luminosity = 2
 	},
 /area/maintenance/department/science)
+"vqY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrogen_output{
+	dir = 1
+	},
+/turf/open/floor/engine/n2,
+/area/engineering/atmos)
 "vrx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
@@ -53958,8 +54000,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "vtD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -54060,9 +54102,6 @@
 /area/medical/medbay/central)
 "vzg" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "vzi" = (
@@ -54114,6 +54153,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
+"vDa" = (
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "vDh" = (
 /obj/item/target,
 /obj/structure/training_machine,
@@ -54137,6 +54182,9 @@
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/iron,
 /area/security/prison)
+"vFe" = (
+/turf/open/space/basic,
+/area/maintenance/disposal/incinerator)
 "vFs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -54216,10 +54264,10 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "vJD" = (
-/obj/structure/lattice,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
-/turf/open/space,
-/area/space/nearstation)
+/turf/open/floor/plating,
+/area/engineering/atmos)
 "vJH" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -54257,20 +54305,8 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "vLx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/stack/sheet/plasteel/fifty,
-/obj/item/stack/sheet/iron/fifty{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/stack/sheet/glass/fifty{
-	pixel_x = 3;
-	pixel_y = -4
-	},
-/turf/open/floor/iron/dark,
+/obj/structure/grille,
+/turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "vLy" = (
 /obj/effect/turf_decal/stripes/line{
@@ -54287,17 +54323,13 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "vMt" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/airlock/atmos{
+	name = "Toxins Storage";
+	req_access_txt = "24"
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "vMx" = (
 /obj/structure/disposalpipe/segment{
@@ -54471,6 +54503,13 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"vRY" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
+/turf/open/floor/plating/airless,
+/area/engineering/atmos)
 "vSB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -54497,6 +54536,18 @@
 /obj/machinery/light/no_nightlight/directional/north,
 /turf/open/floor/iron,
 /area/security/prison)
+"vTl" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "vTL" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/iron,
@@ -54700,12 +54751,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "wfp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space,
+/area/space)
 "wfr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -54792,10 +54841,10 @@
 	},
 /area/maintenance/department/security/brig)
 "wit" = (
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/public/glass/incinerator/atmos_exterior,
-/obj/structure/cable,
-/turf/open/floor/engine,
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "wiy" = (
 /obj/structure/table,
@@ -54837,11 +54886,12 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "wjT" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
+	dir = 5
 	},
-/turf/open/floor/iron/dark,
-/area/maintenance/disposal/incinerator)
+/turf/open/floor/plating,
+/area/engineering/atmos)
 "wkA" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -55082,12 +55132,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "wwr" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
 	},
-/turf/open/space,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engineering/atmos)
 "wwG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -55227,8 +55278,9 @@
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
 "wCz" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "wDb" = (
@@ -55384,6 +55436,13 @@
 /obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/service/lawoffice)
+"wGa" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "wGM" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -55480,9 +55539,8 @@
 /area/commons/dorms)
 "wLU" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 10
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -55556,6 +55614,10 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse/upper)
+"wPf" = (
+/obj/machinery/light/small,
+/turf/open/floor/engine/n2,
+/area/engineering/atmos)
 "wPl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -55589,6 +55651,10 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"wQc" = (
+/obj/structure/sign/warning/fire,
+/turf/closed/wall/r_wall,
+/area/space)
 "wQy" = (
 /obj/machinery/light_switch{
 	dir = 8;
@@ -55651,11 +55717,9 @@
 /turf/open/floor/iron/dark,
 /area/service/bar/atrium)
 "wSR" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -55726,9 +55790,9 @@
 	},
 /area/maintenance/department/security/brig)
 "wUN" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "wVC" = (
@@ -55755,12 +55819,8 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "wVQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -55784,11 +55844,10 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "wWR" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 10
+	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "wXk" = (
@@ -55826,10 +55885,12 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "wYi" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 9
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/turf/open/floor/plating,
 /area/engineering/atmos)
 "wYr" = (
 /obj/structure/cable,
@@ -55843,7 +55904,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "wYC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "wYH" = (
@@ -55942,7 +56006,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "xbZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+/obj/machinery/atmospherics/pipe/bridge_pipe/purple/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
@@ -55950,12 +56014,10 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "xca" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/turf/open/floor/iron,
+/turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "xdc" = (
 /obj/structure/table/reinforced,
@@ -56051,8 +56113,8 @@
 /area/science/genetics)
 "xgG" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
@@ -56415,6 +56477,13 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"xvT" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "xvV" = (
 /obj/effect/turf_decal/caution{
 	dir = 8
@@ -56892,8 +56961,12 @@
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "xTb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/turf/closed/wall/r_wall,
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/hidden,
+/turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "xTe" = (
 /obj/structure/cable,
@@ -56978,9 +57051,8 @@
 /turf/open/floor/iron/dark,
 /area/service/bar/atrium)
 "xXv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 1
-	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "xXQ" = (
@@ -56999,11 +57071,18 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "yby" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
+/obj/structure/table,
+/obj/item/circuitboard/machine/HFR_corner,
+/obj/item/circuitboard/machine/HFR_corner,
+/obj/item/circuitboard/machine/HFR_corner,
+/obj/item/circuitboard/machine/HFR_corner,
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -7
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 10
+	},
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "ybX" = (
@@ -91591,7 +91670,7 @@ fBp
 fBp
 fBp
 fBp
-bXk
+fBp
 bXk
 bXk
 bXk
@@ -91840,8 +91919,8 @@ bPN
 bRs
 mlD
 gur
-bYq
-cqG
+bSj
+vzg
 bUp
 bVe
 bVV
@@ -91850,13 +91929,13 @@ bXr
 nrD
 uwI
 bZK
+vRY
 eTt
 eTt
 eTt
 eTt
-iBq
 ndP
-ndP
+oXr
 adR
 aaa
 gBb
@@ -92092,11 +92171,11 @@ bKP
 bLX
 bMZ
 bOh
+bKS
 faY
 faY
 vWp
 vWp
-bSc
 bSQ
 bTI
 bUq
@@ -92104,6 +92183,7 @@ bVf
 syt
 bWJ
 bXs
+nSc
 fBp
 abI
 bJP
@@ -92111,7 +92191,6 @@ bJP
 bJP
 bJP
 bJP
-abI
 abI
 abI
 adR
@@ -92357,18 +92436,18 @@ bSd
 gEv
 kPP
 urG
+feh
 bWO
 bWO
-fuR
 qbv
 mkS
 tvq
 bZL
-caz
+caC
+qyg
 cbs
 cbs
 bJP
-aaa
 aaa
 aaa
 adR
@@ -92604,28 +92683,28 @@ xbB
 bJH
 fBp
 fBp
-bNb
+fBp
 bOj
+bKT
 fBp
 fBp
 fBp
 fBp
 fBp
 fBp
-bTK
-urG
+bVn
+feh
 bWO
 bWO
-oeQ
-bXu
-bYq
+bXx
+pln
+vzg
 abI
-bMi
-caA
+mkf
 cbt
 ccm
+wPf
 bJP
-aaa
 aaa
 aaa
 aaa
@@ -92862,27 +92941,27 @@ cqE
 fBp
 bLY
 rud
-fSq
+ksv
 bOS
+bKV
 bPQ
-bQH
 bRv
 bSe
+bSS
 bPQ
+bWP
 feh
-urG
 bWO
-jMl
 eVD
 qsH
-pFG
+pEh
 rGo
 fda
 caB
+vqY
 cbs
 cbs
 bJP
-aaa
 aaa
 aaa
 aaa
@@ -93114,7 +93193,7 @@ bAt
 bAu
 bAu
 qQl
-xbB
+ape
 dQq
 bKR
 bLZ
@@ -93122,26 +93201,26 @@ vap
 wVQ
 sBV
 bPR
+bNb
 hXC
 hXC
 hXC
-keN
-vap
+bTO
 eKY
 wUN
 bOk
-oeQ
-bXw
-bYq
+wCz
+bXx
+qFJ
+vzg
 abI
 bJP
 bJP
 bJP
 bJP
 bJP
-aaa
-aby
-aaa
+mZE
+bBW
 aaa
 aaa
 aht
@@ -93377,28 +93456,28 @@ fBp
 bMa
 wSR
 lyB
+bOV
 bWO
-fJw
-eUb
+bNj
+bIG
 bWO
 bWO
-pln
-rud
+bTP
 ksv
 sGc
-bOk
-bWK
-qbv
+eUb
+wCz
+mrv
 mkS
 tvq
 bZL
 caC
+pCJ
 cbu
 cbu
 bJP
 abI
-aby
-aaa
+jRv
 fon
 fon
 fon
@@ -93632,30 +93711,30 @@ bID
 bJL
 iJN
 bMb
-rud
-lyB
+axl
+bXA
 bOV
+bKY
 bPQ
-bQJ
 bRx
 bQJ
+bRx
 bPQ
-bTO
-ksv
+bXB
+sGc
 bWO
-bOk
-oeQ
+wCz
 bXx
-bYq
+qIz
+vzg
 abI
-bMi
-caD
+mkf
 cbv
 ccn
+nqQ
 bJP
-aaa
-aby
-aht
+mZE
+abI
 fon
 aaa
 aht
@@ -93887,19 +93966,19 @@ rMY
 bHs
 nUL
 bJM
-fBp
+auL
 qux
 bNg
-bOn
+bWO
 bOW
+bLb
 bPQ
 bPQ
 bPQ
 bPQ
 bPQ
-bTP
-ksv
-bVh
+bXC
+sGc
 bVY
 shs
 euv
@@ -93907,6 +93986,7 @@ dHc
 vJD
 eYd
 caE
+tNz
 cbu
 cbu
 bJP
@@ -93917,7 +93997,6 @@ auI
 auI
 auI
 fBp
-aaa
 aaa
 aaa
 pDW
@@ -94143,24 +94222,25 @@ bEZ
 bGe
 bHt
 bIE
-fBp
+apv
 fBp
 bMd
-rud
-lyB
+aAK
+bIG
 bOX
+bLc
 bPQ
 bQK
 bQK
 bQK
 bPQ
-bTQ
-ksv
-hjJ
-bOk
-vlv
+bZT
+sGc
+vtD
+wCz
 pyH
 qkk
+wjT
 abI
 bJP
 bJP
@@ -94168,13 +94248,12 @@ bJP
 bJP
 bJP
 auI
-awr
+vTl
 ayY
 ayY
 ayY
-mZO
+kZM
 auI
-aaa
 aaa
 aaa
 aaa
@@ -94400,38 +94479,38 @@ bCO
 bBo
 bCO
 bBo
+bCO
 fBp
-bKS
 uvr
 feN
-bOo
+vsJ
 fIA
-bPT
-fIA
-wCz
+bST
+bNk
+bST
 bSf
 bSR
 hfi
 nUq
-hjJ
+fuR
 vtD
 lRh
 bXA
 frC
-rGo
-bZM
+wwr
+fda
 caF
+kGY
 cby
 cby
 bJP
 auI
-cqG
-ayc
+bUp
 azi
-ayC
+eMs
 rsy
+wGa
 auI
-aaa
 aaa
 aaa
 aaa
@@ -94657,38 +94736,38 @@ aaa
 aht
 aht
 aaa
+aht
 fBp
-bKT
 uTt
-wYi
-lyB
+bWO
+bWO
 wCz
+bSf
 bWO
 bWO
-bRz
+bSg
 bWO
-bSS
 bTR
 gbu
-hjJ
-bWa
+fDm
+vtD
+jMl
 bWO
-bXB
-vzg
+sEx
+xgG
 abI
-bMi
-caG
+mkf
 cbx
 cco
+pMJ
 bJP
 auI
-cqG
-ayy
+bUp
 azm
 azN
-rsy
+rBT
+wGa
 auI
-aaa
 aaa
 aaa
 aaa
@@ -94914,38 +94993,38 @@ bCP
 bAA
 bCP
 bAA
-bHw
-vMt
+bCP
+fBp
 iJc
-pEh
-wfp
-fIA
-bPU
-fIA
+bWO
+bWO
 wCz
-fIA
+bST
+bOn
+bST
+bSf
 bST
 bTS
 nEp
 xXv
+iQR
 bMe
-bWP
 pHb
 gQj
-rGo
-bZN
+wYi
+fda
 caH
+aRu
 cby
 cby
 bJP
 auI
-cqG
-ayC
-azn
-ayc
+bUp
 rsy
+nNe
+azi
+wGa
 auI
-aaa
 aaa
 aaa
 aaa
@@ -95170,25 +95249,26 @@ bDL
 bFa
 bGf
 bCR
-bIG
-bHw
-bKV
+bCR
+aqm
+fBp
 eDR
 eUb
-lyB
-bPb
+bWO
+wCz
+bLd
 bWO
 bQM
 bQM
 bQM
-bSU
 bTT
 bUv
-hjJ
+fJw
+vtD
 bWO
 bWO
-bXC
 bYs
+xca
 fBp
 bJP
 bJP
@@ -95196,13 +95276,12 @@ bJP
 bJP
 bJP
 fBp
-axl
+kMq
 bWO
 bWO
 bWO
-taw
+kTL
 auI
-aaa
 aaa
 aaa
 aaa
@@ -95427,40 +95506,40 @@ bDL
 bFb
 bGg
 bCR
-nSc
+bCR
 bJO
 vMt
+iJc
 bWO
-bNj
 bOp
 bPc
+bMk
 vsJ
 vsJ
 vsJ
-bSg
+bSU
 bMe
 bMe
-bUx
 qQx
+jty
 bWO
 bWO
-dsR
 bYt
 bZf
 jOl
+gwQ
 wMm
 wMm
 wMm
 wMm
-mrv
 tlU
 ayG
+pdS
 bWO
 bWO
-xca
 hCg
 sxs
-aaa
+mcS
 aaa
 aaa
 aaa
@@ -95684,19 +95763,19 @@ bDN
 bFc
 bGh
 bCR
-bIH
-bHw
-lQQ
+bCR
+aqO
+fBp
+auX
 bWO
-bNk
 bOq
 nbE
 wYC
-bQN
-wYC
 eNC
-wYC
-bTU
+bQH
+eNC
+bTK
+eNC
 jaS
 xbZ
 hqI
@@ -95705,18 +95784,18 @@ bXz
 bYu
 tiG
 dej
+lDk
 yeD
 yeD
 yeD
 yeD
-auL
-cqG
+hrR
+bUp
 bWO
 bWO
 bWO
-rsy
+wGa
 auI
-aaa
 aaa
 aaa
 aaa
@@ -95941,39 +96020,39 @@ qnQ
 qnQ
 rPu
 bCR
-bII
-bHw
-bKY
+bCR
+asb
+fBp
 bMh
 bNl
-aKS
+bXF
 bPe
 bPX
-bNl
-bRB
+bOo
+bXF
 bSh
 bSV
-bNl
-bUy
+bTQ
+bXF
 bVk
 bWb
-bNl
+keN
 bXF
+taw
 fBp
-jty
-dej
+cIR
+lDk
 yeD
 yeD
 yeD
 yeD
-bMi
-axu
+mkf
 ayJ
 azt
 aAu
 aBR
+lDS
 auI
-aaa
 aaa
 aaa
 aaa
@@ -96199,28 +96278,29 @@ tct
 bGi
 bHv
 ltu
-bHw
-mvA
+aso
+fBp
 bYq
 vzg
 xgG
 wWR
 pFG
-fEj
-pFG
-wWR
-pFG
-fEj
-bUz
-wWR
-pFG
-fEj
+rGo
 eGT
+rGo
+pFG
+rGo
+eGT
+iBq
+pFG
+rGo
+eGT
+tvr
 fBp
 fBp
-iQR
 rfm
-bMi
+kWy
+mkf
 fBp
 fBp
 fBp
@@ -96230,7 +96310,6 @@ fBp
 fBp
 fBp
 fBp
-aaa
 aaa
 aaa
 aaa
@@ -96457,22 +96536,22 @@ bAA
 bHw
 bHw
 bHw
-mOH
+fBp
+avD
 abI
-wwr
+mDo
 abI
-mOH
+avD
 abI
-wwr
+mDo
 abI
-mOH
+avD
 abI
-wwr
 mDo
 wLU
 oln
 cAO
-oln
+mvA
 tSV
 aor
 bZh
@@ -96483,7 +96562,7 @@ fbC
 auW
 axx
 hMa
-aaa
+jOx
 aaa
 aaa
 aaa
@@ -96713,34 +96792,34 @@ bCT
 bGj
 buz
 abI
+aht
 bJP
-bLb
 bMi
 mkf
+bIH
 bJP
-bLb
 bMi
 mkf
+bIH
 bJP
-bLb
 bMi
 mkf
+bIH
 bJP
-bLb
 bMi
 mkf
-bJP
-bYw
+bIH
 vLx
-apV
-gMk
-usl
-usl
-usl
-sEx
-tQj
 bYw
-aaa
+apV
+pxE
+iXz
+usl
+usl
+usl
+tQj
+xvT
+bYw
 aaa
 aaa
 aaa
@@ -96970,34 +97049,34 @@ wbx
 bGk
 buz
 abI
+aht
 bJP
-bLc
 bMj
 bNo
+bII
 bJP
-bPg
 bPZ
 bQP
+bRz
 bJP
-bSj
 bSW
 bTV
+dsR
 bJP
-bVn
 bWe
 bWT
-bJP
+mOH
+vLx
 bYw
-ape
 yby
 rGD
+vDa
 usl
 usl
 usl
-wjT
 oib
+gMt
 bYw
-aaa
 aaa
 aaa
 aaa
@@ -97227,34 +97306,34 @@ ovv
 bGl
 buz
 abI
+aht
 bJP
-bLd
+awr
 bLe
 bLe
 bJP
+bQb
 bPh
-bQa
-bPh
+bQb
 bJP
+bSY
 bSk
-bSX
-bSk
+bSY
 bJP
+bWg
 bVo
-bWf
-bVo
-bJP
+bWg
+vLx
 bYw
-apv
-apV
+nTh
 pxE
+tuu
 usl
-fDm
+mwG
 usl
-wjT
-tQj
+oib
+xvT
 bYw
-aaa
 aaa
 aaa
 aaa
@@ -97484,35 +97563,35 @@ bCV
 bAF
 bHy
 aaa
+aaa
 bJP
 bLe
-bMk
+bzy
 bLe
 bJP
-bPh
 bQb
-bPh
+bPg
+bQb
 bJP
-bSk
 bSY
-bSk
+bUx
+bSY
 bJP
-bVo
 bWg
-bVo
-bJP
+lQQ
+bWg
+vLx
 bYw
-tvr
-apV
+drU
 pxE
+tuu
 usl
-bZT
 atF
 faU
 fsO
 ayP
-azC
-aaa
+eOS
+sxH
 aaa
 aaa
 aaa
@@ -97741,6 +97820,7 @@ bFh
 bGm
 bHy
 aaa
+aaa
 bJP
 bJP
 bJP
@@ -97757,20 +97837,19 @@ bJP
 bJP
 bJP
 bJP
-bJP
+vLx
 bYw
 bYw
-aqm
 bZU
 iiP
 cbF
 cEJ
 ccs
 axO
+qPa
 bYw
 aaa
 gYo
-aaa
 aaa
 aaa
 aaa
@@ -97997,7 +98076,8 @@ hNB
 kmn
 bGn
 bHy
-aaa
+aht
+aht
 aht
 aaa
 aht
@@ -98015,19 +98095,18 @@ aaa
 aaa
 aaa
 abI
-aht
+rLJ
 bYw
-qIz
 aqx
 caP
 foz
+pHj
 bYw
-auX
-xTb
+lMl
+azC
 bYw
 aht
 fon
-aaa
 aaa
 aaa
 aaa
@@ -98255,36 +98334,36 @@ bFi
 bGo
 bHy
 aaa
-aby
-aaa
-aby
-aaa
-aby
-aaa
-aaa
-bzy
-aby
-aby
-aby
-aby
-aby
-aby
-aby
-aby
-aby
-aaa
 aht
+aby
+aaa
+aby
+aaa
+aby
+aaa
+aaa
+bSc
+aby
+aby
+aby
+aby
+aby
+aby
+aby
+aby
+wfp
+aaa
 rLJ
 aqB
 caQ
 asY
 xTb
-avl
-xTb
 azC
+nWv
+azC
+sxH
 aaa
-aAK
-aaa
+ldG
 aaa
 aaa
 aaa
@@ -98512,6 +98591,7 @@ bFj
 bGp
 bHy
 abI
+aht
 aby
 aht
 aby
@@ -98530,18 +98610,17 @@ abI
 aaa
 aht
 aht
-aht
+rLJ
 bYw
-qFJ
 wit
-foz
+omN
+pHj
 bYw
-avD
-bYw
+rlb
+lTW
 abI
 aht
 fon
-aaa
 aaa
 aaa
 aaa
@@ -98769,35 +98848,35 @@ bFk
 bGq
 bHy
 aaa
-aby
-aaa
-aby
-aaa
-aby
-aaa
-aaa
-aaa
-acO
-aby
-aby
-aby
-aaa
-acO
-aby
-bzy
-aaa
-aaa
 aht
+aby
+aaa
+aby
+aaa
+aby
+aaa
+aaa
+aaa
+acO
+aby
+aby
+aby
+aaa
+acO
+aby
+mZO
+aaa
+aaa
+rLJ
 bYw
-aqO
 arv
 atf
 atJ
+iMK
 cdm
 cdm
 aaa
 aht
-aaa
 aaa
 aaa
 aaa
@@ -99044,17 +99123,17 @@ aaa
 aaa
 aaa
 aaa
-aht
+aaa
+rLJ
 bYw
 bYw
-asb
+koA
 bYw
-bYw
+lTW
 aaa
 aaa
 aaa
 fon
-aaa
 aaa
 aaa
 aaa
@@ -99303,15 +99382,15 @@ aaa
 aaa
 aaa
 aaa
+vFe
 bYw
-aso
-bYw
+bLp
+lTW
 aht
 fon
 fon
 fon
 fon
-aaa
 aaa
 aaa
 aaa
@@ -99558,12 +99637,12 @@ aaa
 aaa
 aaa
 aaa
-abI
+aaa
 abI
 arl
 asA
-arl
-aaa
+gqp
+wQc
 aaa
 aaa
 aaa

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -7744,6 +7744,8 @@
 /obj/machinery/recharger,
 /obj/machinery/requests_console/directional/north{
 	announcementConsole = 1;
+	department = "Captain's Desk";
+	departmentType = 5;
 	name = "Captain's Requests Console"
 	},
 /turf/open/floor/carpet,
@@ -15996,12 +15998,11 @@
 /obj/item/cartridge/quartermaster,
 /obj/item/coin/silver,
 /obj/item/stamp/qm,
-/obj/machinery/requests_console/directional/east{
+/obj/machinery/requests_console/directional/west{
 	announcementConsole = 1;
 	department = "Quartermaster's Desk";
 	departmentType = 5;
-	name = "Quartermaster's Requests Console";
-	pixel_x = -30
+	name = "Quartermaster's Requests Console"
 	},
 /turf/open/floor/wood,
 /area/cargo/qm)

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -2014,6 +2014,7 @@
 "agX" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
+/obj/effect/spawner/lootdrop/prison_contraband,
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "agZ" = (
@@ -35724,6 +35725,8 @@
 /obj/structure/sink{
 	pixel_y = 29
 	},
+/obj/structure/closet/crate/trashcart/laundry,
+/obj/effect/spawner/lootdrop/prison_contraband,
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "dHc" = (
@@ -36947,6 +36950,8 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
+/obj/structure/closet/crate/trashcart,
+/obj/effect/spawner/lootdrop/prison_contraband,
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "eTZ" = (
@@ -39811,6 +39816,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"hHu" = (
+/obj/item/bedsheet,
+/obj/structure/bed,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "hHG" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
@@ -40976,6 +40987,14 @@
 /obj/effect/turf_decal/trimline/yellow/line,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"iTR" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/structure/table/wood/fancy,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "iUX" = (
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
@@ -41756,6 +41775,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/effect/spawner/lootdrop/prison_contraband,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "jUF" = (
@@ -53418,6 +53438,7 @@
 /obj/structure/toilet{
 	dir = 1
 	},
+/obj/effect/spawner/lootdrop/prison_contraband,
 /turf/open/floor/iron/freezer,
 /area/security/prison/toilet)
 "uUQ" = (
@@ -75397,7 +75418,7 @@ aaa
 aOn
 fzz
 fUJ
-lvq
+aOn
 aOn
 aOn
 afU
@@ -76412,7 +76433,7 @@ aaa
 aaa
 aaa
 adE
-aeT
+iTR
 aij
 lGp
 aij
@@ -79514,9 +79535,9 @@ nud
 aiF
 agd
 agp
-ahC
+ahp
 agM
-fRl
+hHu
 ahC
 ahL
 ahL

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -393,6 +393,18 @@
 /obj/structure/grille,
 /turf/open/space,
 /area/space/nearstation)
+"abz" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/chemistry)
 "abI" = (
 /obj/structure/lattice,
 /turf/open/space,
@@ -3273,7 +3285,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "akx" = (
-/obj/structure/bodycontainer/crematorium,
+/obj/structure/bodycontainer/crematorium{
+	id = "seccrematorium";
+	id_tag = null
+	},
 /turf/open/floor/iron/dark,
 /area/security/processing/cremation)
 "akz" = (
@@ -3360,6 +3375,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -3757,6 +3776,10 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/button/crematorium{
+	id = "seccrematorium";
+	pixel_x = -25
+	},
 /turf/open/floor/iron/dark,
 /area/security/processing/cremation)
 "alZ" = (
@@ -7541,6 +7564,9 @@
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/paramedic)
 "awX" = (
@@ -10054,7 +10080,7 @@
 /area/command/heads_quarters/hop)
 "aEP" = (
 /obj/machinery/modular_computer/console/preset/id{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
@@ -10931,10 +10957,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aHY" = (
-/obj/machinery/light{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -11458,6 +11484,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "aLc" = (
@@ -11475,6 +11502,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/teleporter)
 "aLe" = (
@@ -11714,6 +11742,7 @@
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/teleporter)
 "aMd" = (
@@ -12590,6 +12619,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "aPK" = (
@@ -16573,6 +16603,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/white/corner,
 /area/hallway/secondary/entry)
 "bfb" = (
@@ -18197,6 +18228,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "bli" = (
@@ -18205,6 +18239,9 @@
 	dir = 1
 	},
 /obj/machinery/newscaster/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/paramedic)
 "bll" = (
@@ -18793,6 +18830,9 @@
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/paramedic)
 "bnC" = (
@@ -19016,6 +19056,9 @@
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/paramedic)
 "boH" = (
@@ -19046,6 +19089,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "boL" = (
@@ -19326,6 +19372,9 @@
 /obj/machinery/door/airlock/medical/glass,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "bpV" = (
@@ -20268,6 +20317,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bsB" = (
@@ -20280,6 +20332,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bsD" = (
@@ -20295,6 +20350,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bsG" = (
@@ -20341,6 +20399,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "bsJ" = (
@@ -20352,6 +20413,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "bsK" = (
@@ -20651,6 +20715,9 @@
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "bua" = (
@@ -20737,6 +20804,9 @@
 /area/security/checkpoint/medical)
 "bum" = (
 /obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -20918,6 +20988,10 @@
 	req_access_txt = "5"
 	},
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bvi" = (
@@ -20957,6 +21031,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "bvm" = (
@@ -20965,6 +21042,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bvn" = (
@@ -20977,6 +21057,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bvo" = (
@@ -21003,6 +21086,9 @@
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "bvp" = (
@@ -21031,6 +21117,9 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "bvw" = (
@@ -21872,6 +21961,9 @@
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
 "byp" = (
@@ -22455,6 +22547,7 @@
 	dir = 4;
 	light_color = "#e8eaff"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bzX" = (
@@ -22754,6 +22847,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bBg" = (
@@ -23171,6 +23267,9 @@
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "bCp" = (
@@ -23421,6 +23520,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "bDv" = (
@@ -23678,7 +23780,7 @@
 	req_access_txt = "12;24"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/atmospherics/pipe/layer_manifold{
+/obj/machinery/atmospherics/pipe/layer_manifold/supply{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -24146,6 +24248,9 @@
 /obj/structure/cable,
 /obj/machinery/newscaster/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "bFU" = (
@@ -24837,6 +24942,9 @@
 "bIy" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bIC" = (
@@ -25867,6 +25975,9 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "bMM" = (
@@ -33141,13 +33252,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"cql" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/turf/open/floor/engine,
-/area/engineering/supermatter/room)
 "cqp" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -33283,6 +33387,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "cre" = (
@@ -34811,6 +34918,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "cBM" = (
@@ -34830,6 +34940,7 @@
 /area/maintenance/department/cargo)
 "cBT" = (
 /obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "cBU" = (
@@ -35039,7 +35150,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/security/prison/safe)
 "cMl" = (
 /obj/machinery/conveyor{
@@ -35391,6 +35502,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "djD" = (
@@ -35718,10 +35832,13 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal)
 "dBC" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/light,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "dBQ" = (
 /obj/structure/chair{
 	dir = 4
@@ -36125,6 +36242,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
 "dZj" = (
@@ -36253,6 +36373,15 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/security/brig)
+"egX" = (
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/chemistry)
 "ehr" = (
 /obj/structure/table/glass,
 /obj/item/clothing/gloves/color/latex,
@@ -36551,6 +36680,11 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"ezm" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "ezn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -36667,6 +36801,9 @@
 	pixel_x = -25
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
 "eFj" = (
@@ -36696,7 +36833,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/security/prison/safe)
 "eGT" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
@@ -37375,6 +37512,9 @@
 /obj/structure/cable,
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "fhE" = (
@@ -37403,6 +37543,9 @@
 /obj/structure/cable,
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "fhM" = (
@@ -37449,6 +37592,14 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark,
 /area/science/explab)
+"flq" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "flQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37926,6 +38077,10 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"fJU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/engineering/supermatter/room)
 "fKa" = (
 /obj/item/radio/intercom/directional/north{
 	desc = "A station intercom. It looks like it has been modified to not broadcast.";
@@ -38483,6 +38638,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"gnS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "gpu" = (
 /obj/structure/sign/directions/medical{
 	pixel_x = 32;
@@ -38718,6 +38880,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "gAG" = (
@@ -38929,11 +39094,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
-"gHX" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/turf/open/floor/engine,
-/area/engineering/supermatter/room)
 "gIC" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -38977,6 +39137,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
+"gKB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "gLd" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/green{
@@ -39211,6 +39380,10 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/sorting)
+"gZl" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "gZx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39484,6 +39657,9 @@
 /area/engineering/atmos)
 "htK" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "hua" = (
@@ -39763,6 +39939,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
 "hID" = (
@@ -39842,6 +40021,9 @@
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "hNd" = (
@@ -39918,6 +40100,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "hQz" = (
@@ -40191,17 +40376,9 @@
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "igj" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/engineering/main)
+/area/command/teleporter)
 "igu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -40451,6 +40628,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "ivQ" = (
@@ -41931,6 +42109,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "koW" = (
@@ -41984,6 +42165,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
 "krC" = (
@@ -42056,6 +42240,13 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/warehouse/upper)
+"ktU" = (
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "kvj" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
@@ -42172,6 +42363,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "kBu" = (
@@ -42399,6 +42593,18 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/chapel,
 /area/service/chapel/main/monastery)
+"kPA" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/main)
 "kPM" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -42575,6 +42781,9 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "kVO" = (
@@ -42856,9 +43065,15 @@
 /turf/open/floor/grass,
 /area/science/genetics)
 "lmU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall,
-/area/engineering/supermatter/room)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "lmV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -42875,6 +43090,9 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "lny" = (
@@ -42917,6 +43135,9 @@
 "lpW" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "lpX" = (
@@ -43027,6 +43248,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "ltJ" = (
@@ -43153,6 +43375,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "lFh" = (
@@ -44175,6 +44400,9 @@
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "mOH" = (
@@ -44312,6 +44540,22 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/wood,
 /area/service/lawoffice)
+"mXI" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/chemistry)
 "mYW" = (
 /obj/structure/chair/stool,
 /turf/open/floor/iron,
@@ -44330,6 +44574,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "mZE" = (
@@ -45624,6 +45871,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/teleporter)
 "olY" = (
@@ -45994,6 +46242,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "oCi" = (
@@ -46279,7 +46530,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/security/prison/safe)
 "oRl" = (
 /obj/effect/turf_decal/tile/blue,
@@ -46303,6 +46554,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "oSc" = (
@@ -46453,6 +46707,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/execution/transfer)
+"oXU" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "oYc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -46927,6 +47188,9 @@
 "pAo" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "pBm" = (
@@ -46996,9 +47260,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "pEK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/turf/closed/wall/r_wall,
-/area/engineering/supermatter/room)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "pFy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -47152,10 +47419,16 @@
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "pMG" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/space)
+/obj/machinery/firealarm/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "pMM" = (
 /obj/machinery/airalarm/kitchen_cold_room{
 	pixel_y = 22
@@ -47519,16 +47792,18 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "qdO" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "qfa" = (
 /obj/structure/window/reinforced,
 /obj/structure/table,
@@ -47737,6 +48012,9 @@
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "qnQ" = (
@@ -47812,6 +48090,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
+"qqr" = (
+/obj/effect/turf_decal/trimline/blue/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "qqz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -50420,6 +50706,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/explab)
+"sTF" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "sTY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50614,6 +50907,16 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/supermatter)
+"tbQ" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/chemistry)
 "tbS" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Morgue";
@@ -50766,6 +51069,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "tgb" = (
@@ -50774,8 +51078,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "tgd" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "tgT" = (
@@ -51119,6 +51424,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "txZ" = (
@@ -51260,6 +51568,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "tCJ" = (
@@ -51638,6 +51947,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
+"tZX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "uaC" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -51851,6 +52167,9 @@
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "uiP" = (
@@ -51992,6 +52311,9 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "umh" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "umO" = (
@@ -52416,6 +52738,9 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "uFi" = (
@@ -52721,6 +53046,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "uVN" = (
@@ -52771,6 +53099,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "uXv" = (
@@ -52904,10 +53235,11 @@
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "vaR" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
-/area/medical/cryo)
+/area/medical/paramedic)
 "vbv" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -54589,6 +54921,9 @@
 /obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "wEn" = (
@@ -55160,6 +55495,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/newscaster/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
 "xbB" = (
@@ -55599,6 +55937,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/service/bar/atrium)
+"xst" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/closed/wall/r_wall,
+/area/engineering/supermatter/room)
 "xsO" = (
 /obj/item/ectoplasm,
 /turf/open/floor/plating{
@@ -55610,6 +55952,9 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "xtI" = (
@@ -56194,6 +56539,13 @@
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"xWB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "xWN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
@@ -56356,6 +56708,9 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "ygW" = (
@@ -56397,6 +56752,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "yiF" = (
@@ -74013,8 +74371,8 @@ aOn
 aOn
 aOn
 aOn
-pMG
-pMG
+fon
+fon
 aaa
 aaa
 aaa
@@ -78138,7 +78496,7 @@ wHD
 iTa
 agy
 ajN
-ark
+aoN
 aly
 amg
 amS
@@ -78185,12 +78543,12 @@ iWV
 jsa
 jsa
 jsa
-jsa
-jsa
-hGq
-iWV
+lmU
+lmU
+pMG
+qdO
 tfS
-jsa
+lmU
 uxF
 bkT
 jsa
@@ -78699,7 +79057,7 @@ baQ
 aXH
 bdd
 jsa
-ejn
+pEK
 bfb
 bgU
 bhF
@@ -79152,11 +79510,11 @@ aem
 aaa
 aaa
 aaa
-sQP
-sQP
-sQP
-sQP
-sQP
+aem
+aem
+aem
+aem
+aem
 aaa
 aby
 abI
@@ -81548,7 +81906,7 @@ pPN
 cKQ
 cKQ
 suU
-cKQ
+gZl
 uyg
 cKQ
 aFa
@@ -81796,7 +82154,7 @@ vtX
 bjL
 ryC
 bqX
-vaR
+mEo
 umh
 dGH
 qma
@@ -81805,7 +82163,7 @@ qma
 duu
 qma
 lOK
-qma
+flq
 esz
 qma
 bHY
@@ -82567,13 +82925,13 @@ bny
 boB
 bpF
 xUU
-tgd
-peY
+uWC
+qqr
 bvh
-cKQ
+xWB
 ivy
 bzO
-cKQ
+eyL
 bCh
 bjc
 bEu
@@ -83075,7 +83433,7 @@ xPQ
 bik
 bjc
 bjS
-cKQ
+tgd
 eyL
 cKQ
 suU
@@ -83332,8 +83690,8 @@ xPQ
 bik
 bjc
 bjT
-cKQ
-eyL
+tgd
+gnS
 pAo
 lpW
 yhR
@@ -83589,7 +83947,7 @@ xPQ
 bik
 bjc
 bjU
-cKQ
+tgd
 eyL
 cKQ
 uQu
@@ -83851,7 +84209,7 @@ idj
 tCi
 xQO
 bpG
-ixN
+ktU
 uFc
 buc
 kQy
@@ -84108,7 +84466,7 @@ cRi
 bny
 boB
 bpF
-xUU
+tZX
 uFc
 buc
 tix
@@ -84625,9 +84983,9 @@ ftW
 qpu
 bsF
 fhc
-qdO
-qdO
-qdO
+koW
+koW
+koW
 hQh
 bBe
 bCn
@@ -84884,16 +85242,16 @@ bIy
 tWt
 bvm
 tWt
-tWt
-pPN
+oXU
+gKB
 peY
 bCp
 rlT
 tcX
-tSm
+egX
 tSm
 tcX
-tSm
+egX
 rFq
 bsK
 ygx
@@ -85131,7 +85489,7 @@ xPQ
 bik
 jze
 bjZ
-eus
+vaR
 eus
 bnC
 jze
@@ -85147,7 +85505,7 @@ bIi
 bCp
 tal
 hvS
-qwJ
+tbQ
 qwJ
 cbQ
 bum
@@ -85388,7 +85746,7 @@ xPQ
 bik
 jze
 bka
-eus
+vaR
 bmv
 bnD
 jze
@@ -85404,10 +85762,10 @@ bpY
 bpY
 kGl
 tta
-xqq
+mXI
 xqq
 dMR
-gFf
+abz
 bKA
 prD
 dVv
@@ -85431,11 +85789,11 @@ cai
 cbe
 cca
 pyA
-igj
-lmU
+kPA
+fJU
 iEJ
-pEK
-pEK
+xst
+xst
 nZX
 nZX
 nZX
@@ -85664,7 +86022,7 @@ tta
 uXp
 xqq
 dMR
-gFf
+abz
 bKA
 vcC
 dVv
@@ -85693,7 +86051,7 @@ cbj
 ceX
 wdp
 cfS
-cql
+sTF
 eoo
 bCk
 xqI
@@ -85918,10 +86276,10 @@ bsK
 bsK
 kGl
 tta
-xqq
+mXI
 xqq
 dMR
-gFf
+abz
 bKA
 bLL
 dVv
@@ -85952,7 +86310,7 @@ mUJ
 uBs
 uBs
 wza
-gHX
+ezm
 nZX
 nZX
 nZX
@@ -86130,9 +86488,9 @@ aAB
 aAB
 arA
 arA
-aHV
+aHY
 xPQ
-fei
+dBC
 kVO
 kVO
 kVO
@@ -86175,7 +86533,7 @@ bBi
 bCt
 bDv
 pKf
-xqq
+mXI
 xqq
 dMR
 rLd
@@ -86432,7 +86790,7 @@ bsK
 bsK
 iTx
 prD
-xqq
+mXI
 xqq
 dMR
 gFf
@@ -86675,7 +87033,7 @@ cQN
 bkf
 bys
 gnQ
-dBC
+gnQ
 boK
 bpU
 bsI
@@ -86689,7 +87047,7 @@ bsN
 bCv
 iTx
 prD
-xqq
+mXI
 xqq
 dMR
 gFf
@@ -87158,7 +87516,7 @@ aEG
 aAB
 aGq
 awd
-aHY
+aHV
 aIX
 coB
 aBv
@@ -88186,7 +88544,7 @@ aAB
 aAB
 arA
 arA
-aHV
+aHY
 xPQ
 aJR
 kVO
@@ -91017,7 +91375,7 @@ aHV
 xPQ
 eaB
 aLc
-aNx
+igj
 nzP
 aOH
 aPP

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -9140,7 +9140,8 @@
 	id = "datboidetective";
 	name = "Privacy Shutters";
 	pixel_x = 2;
-	pixel_y = 26
+	pixel_y = 26;
+	req_access_txt = "4"
 	},
 /obj/machinery/light_switch{
 	pixel_x = -8;
@@ -13184,10 +13185,6 @@
 /turf/closed/wall,
 /area/service/kitchen)
 "aRO" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
 	name = "Kitchen Maintenance";
@@ -14381,7 +14378,6 @@
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "aWu" = (
-/obj/structure/table/reinforced,
 /obj/machinery/computer/cargo,
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -16239,6 +16235,9 @@
 "bdn" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -24531,6 +24530,10 @@
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/machinery/door/airlock/research{
+	name = "Toxins Launch Room";
+	req_access_txt = "8"
+	},
 /turf/open/floor/iron,
 /area/science/mixing)
 "bGB" = (
@@ -28566,8 +28569,14 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/west,
 /obj/structure/cable,
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching the engine containment area.";
+	dir = 4;
+	name = "Engine Monitor";
+	network = list("engine");
+	pixel_x = -32
+	},
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "bUW" = (
@@ -28935,7 +28944,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "bVV" = (
@@ -29139,13 +29150,6 @@
 /area/engineering/engine_smes)
 "bWz" = (
 /obj/structure/table,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the engine containment area.";
-	dir = 8;
-	name = "Engine Monitor";
-	network = list("engine");
-	pixel_x = 32
-	},
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/iron/fifty,
@@ -29172,13 +29176,6 @@
 /area/engineering/engine_smes)
 "bWA" = (
 /obj/structure/filingcabinet,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the engine containment area.";
-	dir = 4;
-	name = "Engine Monitor";
-	network = list("engine");
-	pixel_x = -32
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -29186,6 +29183,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "bWB" = (
@@ -29985,6 +29983,7 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/north,
+/obj/item/pipe_dispenser,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "bZE" = (
@@ -36594,6 +36593,8 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/hud/health,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "esz" = (
@@ -36868,10 +36869,11 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/department/engine)
 "eHq" = (
-/obj/effect/landmark/start/hangover,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/commons/fitness/recreation)
 "eHY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -37718,10 +37720,10 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "frC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/atmos)
@@ -37947,18 +37949,13 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "fEj" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
 	},
-/obj/machinery/door/airlock/research{
-	name = "Toxins Launch Room";
-	req_access_txt = "8"
-	},
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engineering/atmos)
 "fEo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -39871,7 +39868,7 @@
 "hDG" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Auxiliary Base Construction";
-	req_one_access_txt = "32;47;48"
+	req_access_txt = "72"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -39938,6 +39935,17 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"hGN" = (
+/obj/structure/window/plasma/reinforced/spawner/east,
+/obj/machinery/power/rad_collector/anchored,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/camera{
+	c_tag = "Engineering Supermatter Chamber";
+	network = list("ss13","engine")
+	},
+/turf/open/floor/engine,
+/area/engineering/supermatter)
 "hGQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
@@ -40533,10 +40541,11 @@
 /turf/closed/wall,
 /area/maintenance/department/engine)
 "inG" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engineering/atmos)
 "ioj" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -42390,9 +42399,6 @@
 	},
 /obj/machinery/door/firedoor/heavy,
 /obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/engineering/break_room)
@@ -43519,6 +43525,18 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"lLL" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/displaycase/forsale/kitchen,
+/turf/open/floor/iron/dark,
+/area/service/bar)
 "lLS" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -44152,6 +44170,7 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/structure/closet/secure_closet/medical1,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "myc" = (
@@ -45486,7 +45505,6 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "nSc" = (
@@ -47634,17 +47652,17 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "pVr" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/displaycase/forsale/kitchen,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
-/area/service/bar)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/bar)
 "pVD" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -49982,8 +50000,7 @@
 "scp" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Auxiliary Base Maintenance";
-	req_access_txt = "12";
-	req_one_access_txt = "32;47;48"
+	req_access_txt = "72"
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -52076,6 +52093,13 @@
 "uco" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching the engine containment area.";
+	dir = 1;
+	name = "Engine Monitor";
+	network = list("engine");
+	pixel_y = -32
+	},
 /turf/open/floor/iron,
 /area/engineering/main)
 "ucA" = (
@@ -53098,6 +53122,13 @@
 /obj/item/pen/fountain,
 /obj/item/stamp/law,
 /obj/machinery/newscaster/directional/east,
+/obj/machinery/button/door{
+	id = "lawyer_shutters";
+	name = "Privacy Shutters";
+	pixel_x = 2;
+	pixel_y = -26;
+	req_access_txt = "38"
+	},
 /turf/open/floor/carpet,
 /area/service/lawoffice)
 "uVB" = (
@@ -84797,7 +84828,7 @@ aZW
 wxO
 pWT
 bcc
-inG
+eZv
 bem
 aDm
 aJN
@@ -85056,7 +85087,7 @@ bbe
 bcd
 jcT
 ttN
-jcT
+uYW
 aKa
 tWc
 xPQ
@@ -85299,7 +85330,7 @@ aLI
 aNg
 aKT
 aPB
-wbR
+pVr
 afu
 pMM
 aTZ
@@ -87684,7 +87715,7 @@ tlN
 fsA
 sWj
 tZU
-wXy
+hGN
 wXy
 wXy
 uRk
@@ -87885,9 +87916,9 @@ liQ
 bex
 bfr
 awg
-eHq
+eZv
 xPQ
-piM
+jcT
 bjg
 bki
 ufo
@@ -88142,9 +88173,9 @@ liQ
 bnb
 ajX
 aPT
-jcT
+oGZ
 xPQ
-jcT
+piM
 cQN
 mKE
 uKD
@@ -88647,7 +88678,7 @@ aUg
 tEB
 tEB
 beB
-aYg
+lLL
 qmm
 liQ
 lGq
@@ -89675,7 +89706,7 @@ aPE
 cpb
 wzu
 beB
-pVr
+aYg
 aZd
 liQ
 lTf
@@ -95883,15 +95914,15 @@ vzg
 xgG
 wWR
 pFG
-gQj
+fEj
 pFG
 wWR
 pFG
-gQj
+fEj
 bUz
 wWR
-pFG
-gQj
+inG
+fEj
 eGT
 fBp
 fBp
@@ -96407,7 +96438,7 @@ bLb
 bMi
 mkf
 bJP
-sQP
+bYw
 vLx
 apV
 gMk
@@ -96664,7 +96695,7 @@ bVn
 bWe
 bWT
 bJP
-sQP
+bYw
 ape
 yby
 rGD
@@ -96921,7 +96952,7 @@ bVo
 bWf
 bVo
 bJP
-sQP
+bYw
 apv
 apV
 pxE
@@ -97178,7 +97209,7 @@ bVo
 bWg
 bVo
 bJP
-sQP
+bYw
 tvr
 apV
 pxE
@@ -97435,7 +97466,7 @@ bJP
 bJP
 bJP
 bJP
-sQP
+bYw
 bYw
 aqm
 bZU
@@ -98126,7 +98157,7 @@ aiS
 sFK
 atn
 low
-ayu
+eHq
 wKP
 wRG
 awz
@@ -100241,7 +100272,7 @@ mSc
 sci
 jiD
 glf
-fEj
+bFr
 qtA
 khk
 bIN

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -872,6 +872,7 @@
 	network = list("minisat")
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
 "adu" = (
@@ -892,6 +893,7 @@
 	name = "MiniSat Maintenance";
 	req_access_txt = "65"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
 "adx" = (
@@ -899,6 +901,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "adz" = (
@@ -1021,15 +1024,14 @@
 /turf/open/floor/plating,
 /area/cargo/warehouse/upper)
 "adQ" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "MiniSat Maintenance";
-	req_access_txt = "65"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "MiniSat Maintenance";
+	req_access_txt = "65"
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
@@ -1310,17 +1312,16 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "aeS" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "MiniSat Maintenance";
-	req_access_txt = "65"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "MiniSat Maintenance";
+	req_access_txt = "65"
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
@@ -1398,15 +1399,14 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/eva)
 "afc" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "MiniSat Maintenance";
-	req_access_txt = "65"
-	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "MiniSat Maintenance";
+	req_access_txt = "65"
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
@@ -1432,7 +1432,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -1446,7 +1445,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -1465,7 +1463,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -1485,15 +1482,14 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse/upper)
 "afi" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "MiniSat Maintenance";
-	req_access_txt = "65"
-	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "MiniSat Maintenance";
+	req_access_txt = "65"
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
@@ -1517,7 +1513,6 @@
 	c_tag = "MiniSat Maintenance Starboard Aft";
 	network = list("minisat")
 	},
-/obj/structure/cable,
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -1540,8 +1535,6 @@
 /area/cargo/warehouse/upper)
 "afm" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
 "afn" = (
@@ -1599,6 +1592,7 @@
 	dir = 1
 	},
 /obj/structure/chair/stool/bar/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
 "afw" = (
@@ -9699,7 +9693,6 @@
 /area/command/heads_quarters/hop)
 "aEb" = (
 /obj/machinery/newscaster/directional/north,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -34719,6 +34712,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cCP" = (
@@ -38759,8 +38753,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/machinery/power/apc/auto_name/east,
+/turf/open/floor/plating,
+/area/ai_monitored/turret_protected/ai_sat_ext_as)
 "gBb" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -39714,6 +39709,8 @@
 /area/engineering/supermatter/room)
 "hCS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
 "hDg" = (
@@ -41896,6 +41893,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
 "kdb" = (
@@ -46374,6 +46372,10 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/lawyer,
+/obj/machinery/computer/security/telescreen/prison{
+	dir = 1;
+	pixel_y = -28
+	},
 /turf/open/floor/carpet,
 /area/service/lawoffice)
 "oCX" = (
@@ -50614,6 +50616,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/library)
+"szb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ai_monitored/turret_protected/ai_sat_ext_as)
 "szG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -54215,12 +54224,10 @@
 /turf/open/floor/plating,
 /area/cargo/storage)
 "vHR" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
 "vIa" = (
@@ -89761,7 +89768,7 @@ cnD
 adV
 adV
 adX
-gAY
+hQd
 afw
 kfl
 agf
@@ -91303,7 +91310,7 @@ cnG
 adZ
 adZ
 acU
-xEA
+szb
 acU
 acU
 acU
@@ -91809,15 +91816,15 @@ abO
 acU
 adg
 uyY
-xEA
+gAY
 adQ
-xEA
-xEA
-xEA
-xEA
-xEA
+szb
+szb
+szb
+szb
+szb
 aeS
-xEA
+szb
 ezt
 afS
 acU

--- a/Station Maps/PubbyStation/information.txt
+++ b/Station Maps/PubbyStation/information.txt
@@ -17,5 +17,4 @@
 }
 
 
-// Latest commit since update: https://github.com/tgstation/tgstation/commit/e7a98f2808c82b29c569e9a07dc5dd2fa3570eb2
-
+// Latest commit since update: https://github.com/tgstation/tgstation/commit/3d15be634c5a69b6fe1a5de5868024764aa9d3c9

--- a/Station Maps/PubbyStation/information.txt
+++ b/Station Maps/PubbyStation/information.txt
@@ -17,4 +17,5 @@
 }
 
 
-// Latest commit since update: https://github.com/tgstation/tgstation/commit/fbfefee3cde4d1f5bf3e4cc56f589b86e465ad3a
+// Latest commit since update: https://github.com/tgstation/tgstation/commit/e7a98f2808c82b29c569e9a07dc5dd2fa3570eb2
+


### PR DESCRIPTION
You can consider this an 'Update' PR for Pubby, but my old PR was also an 'update' one since it re-did cables and atmos piping entirely, and the commit message on the old one is incorrect as there were some things missing.

Pubby was out of rotation for a while and I wasn't able to see everything that the map needed to be updated to latest TG.


(Not full) List of things my PR does:

- Makes drone bay smaller
- Adds smart pipes everywhere except Atmos (like on other maps) - I was told I should do this instead of keep the old pipes because it'll have to be changed anyways if TG plans on re-adding Pubby
- Adds a heater to supply pipes leading to distro
- Replaces more varedits with new directionals
- Adds safe of captain's spare at the Bridge
- Fixes minor fuck up I did at the SM due to smart pipes
- Replaces chem heaters with the full buffer versions
- Makes Perma large to be consistent with all other maps
- Makes solar SMES cables not clip into the wall, same for (some of) viro's atmos pipes
- Makes turbine compatible with smart pipes
- Makes aux base use aux base access instead of construction
- Makes aux base use the aux base console rather than the 'general' one that allows you to access the entire station.
- Adds the Curator's civilian console to the Library
- Adds n-spect scanners to Security office
- Adds extinguisher tank holders around the station
- Removes nanite chamber, to compensate moves experimentor where nanite chamber used to be, and adds a break room
- Removes some places where there were 4 walls connecting to eachother like a big wall box
A bunch of other stuff I forgot to write down.

Also updates latest commit this PR works on, as I've tested it on TG this time.
![Pubbystation](https://user-images.githubusercontent.com/53777086/127409309-cc3ecc17-6051-4597-9777-b550c4d13d30.png)
