### PR TITLE
Updates Pubby to latest TG

### DIFF
--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -23660,11 +23660,8 @@
 /area/science/storage)
 "bDQ" = (
 /obj/machinery/door/firedoor/heavy,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
 /obj/machinery/door/airlock/research{
-	name = "Toxins Storage";
+	name = "Ordnance Storage";
 	req_access_txt = "71"
 	},
 /obj/machinery/door/firedoor,
@@ -23674,6 +23671,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci-ordnance-storage-passthrough"
 	},
 /turf/open/floor/iron/dark,
 /area/science/storage)
@@ -23713,9 +23713,6 @@
 	name = "Ordnance Lab";
 	req_access_txt = "8"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -23725,6 +23722,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci-ordnance-storage-passthrough"
 	},
 /turf/open/floor/iron/dark,
 /area/science/mixing)
@@ -25000,7 +25000,9 @@
 "bIL" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/research/glass/incinerator/ordmix_interior,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci-ordnance-passthrough"
+	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "bIN" = (
@@ -25573,8 +25575,8 @@
 "bLf" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/research/glass/incinerator/ordmix_exterior,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci-ordnance-passthrough"
 	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -1136,29 +1136,30 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/prison)
-"aep" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/machinery/skill_station,
-/turf/open/floor/iron,
-/area/security/prison)
 "aeq" = (
-/obj/structure/punching_bag,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock{
+	name = "Dining Room"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
 "aer" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
 "aet" = (
@@ -1175,10 +1176,16 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse/upper)
 "aeu" = (
-/obj/effect/turf_decal/stripes/white/line{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
-/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
 "aev" = (
@@ -1220,17 +1227,6 @@
 /turf/open/floor/iron/showroomfloor,
 /area/security)
 "aeC" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
-	},
-/obj/structure/sink{
-	pixel_y = 29
-	},
-/obj/structure/closet/crate/trashcart/laundry,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/turf/open/floor/iron,
-/area/security/prison)
-"aeD" = (
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/mop,
 /obj/item/reagent_containers/glass/bottle/ammonia,
@@ -1239,41 +1235,38 @@
 	},
 /obj/structure/closet/crate/trashcart,
 /obj/effect/spawner/lootdrop/prison_contraband,
-/obj/machinery/light/no_nightlight/directional/north,
 /turf/open/floor/iron,
+/area/security/prison/safe)
+"aeD" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/chapel{
+	dir = 8
+	},
 /area/security/prison)
 "aeE" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
+	dir = 9
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-08"
 	},
 /turf/open/floor/iron/dark,
-/area/security/prison)
-"aeF" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/iron,
 /area/security/prison)
 "aeG" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Permabrig - Upper Hall";
-	dir = 8;
-	network = list("ss13","prison")
-	},
 /turf/open/floor/iron,
 /area/security/prison)
 "aeI" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 5
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/security/prison)
@@ -1315,37 +1308,43 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
 "aeT" = (
-/obj/structure/chair{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron/chapel,
+/obj/structure/table/wood/fancy,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "aeV" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/structure/chair/stool/directional/north,
 /turf/open/floor/iron,
 /area/security/prison)
 "aeW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/chair{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron/chapel,
+/obj/structure/table/wood,
+/obj/machinery/computer/bookmanagement,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "aeX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/structure/chair{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron/chapel{
-	dir = 8
+/obj/machinery/light/directional/north,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/trophy{
+	pixel_y = 8
 	},
+/obj/item/storage/book/bible,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "aeY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
@@ -1522,44 +1521,32 @@
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
 "afn" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/structure/weightmachine/weightlifter,
 /turf/open/floor/iron,
 /area/security/prison)
 "afp" = (
-/obj/structure/table,
-/obj/item/toy/cards/deck/cas/black{
-	pixel_x = -7
-	},
-/obj/item/toy/cards/deck/cas{
-	pixel_x = 5;
-	pixel_y = 10
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/security/prison)
 "afr" = (
-/obj/structure/rack,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/clothing/mask/breath,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
+/obj/structure/chair/wood{
+	dir = 1
 	},
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/chapel,
 /area/security/prison)
 "afs" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
+/obj/machinery/power/apc/auto_name/south,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
 	},
-/obj/item/kirbyplants{
-	icon_state = "plant-08"
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "aft" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1635,8 +1622,9 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/structure/table,
+/obj/item/storage/pill_bottle/dice,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
 "afF" = (
@@ -1644,9 +1632,12 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/structure/table,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
 "afH" = (
@@ -1739,8 +1730,11 @@
 /turf/closed/wall,
 /area/security/execution/transfer)
 "afX" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
+/obj/item/kirbyplants{
+	icon_state = "plant-08"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
@@ -1755,21 +1749,32 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "aga" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark/side{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
-/area/security/prison)
-"agc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/grunge{
+	name = "Prison Workshop"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/prison)
+"agc" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
 "agd" = (
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/structure/chair/stool/directional/west,
+/obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/iron,
 /area/security/prison)
 "age" = (
@@ -1846,12 +1851,9 @@
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/iron,
-/area/security/prison)
-"agp" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/light/no_nightlight/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/security/prison)
 "agq" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -2153,20 +2155,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
-"ahG" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 10
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig - Monastery";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/obj/structure/sign/painting/library{
-	pixel_x = -32
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "ahI" = (
 /obj/machinery/light{
 	dir = 1
@@ -2252,22 +2240,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/security/execution/transfer)
 "ahT" = (
-/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/security/execution/transfer)
-"ahU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
 /area/security/execution/transfer)
 "ahW" = (
 /obj/structure/disposalpipe/segment,
@@ -2360,16 +2336,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"aij" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "aik" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/chapel{
+	dir = 4
 	},
-/turf/open/floor/iron/dark,
 /area/security/prison)
 "ail" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -3390,13 +3361,10 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "akN" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/chapel{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/iron/dark,
 /area/security/prison)
 "akO" = (
 /obj/structure/table/reinforced,
@@ -3651,14 +3619,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
-"alA" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "alB" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -5382,12 +5342,12 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "arl" = (
-/obj/structure/chair{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron/chapel{
-	dir = 8
-	},
+/obj/structure/table/wood/fancy,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "arm" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
@@ -10732,8 +10692,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "aHz" = (
@@ -10997,9 +10955,19 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
 "aJx" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/grunge{
+	name = "Prison Forestry"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron,
 /area/security/prison)
 "aJD" = (
 /obj/structure/chair{
@@ -12041,13 +12009,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aNT" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/structure/table/wood/fancy,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/turf/open/floor/iron/dark,
-/area/security/prison)
+/obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "aNU" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Cargo Bay Warehouse Maintenance";
@@ -12318,13 +12283,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"aOX" = (
-/obj/structure/weightmachine/stacklifter,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "aPa" = (
 /obj/structure/sign/poster/random{
 	pixel_y = 32
@@ -15911,12 +15869,11 @@
 /turf/open/floor/iron/dark,
 /area/service/bar/atrium)
 "bcn" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison/safe)
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "bco" = (
 /obj/structure/table/wood/fancy,
 /obj/item/gun/ballistic/revolver/russian{
@@ -16155,12 +16112,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "bdp" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/beaker/large,
+/obj/machinery/oven,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "bdq" = (
-/obj/machinery/oven,
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker/large,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "bdr" = (
@@ -16654,11 +16611,6 @@
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
-	},
-/obj/machinery/requests_console/directional/south{
-	department = "Mining";
-	departmentType = 2;
-	name = "Mining Bay Requests Console"
 	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
@@ -17182,7 +17134,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/closet/secure_closet/miner,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "bhs" = (
@@ -17190,7 +17141,6 @@
 	dir = 9
 	},
 /obj/structure/cable,
-/obj/structure/closet/secure_closet/miner,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "bht" = (
@@ -18977,15 +18927,11 @@
 /turf/open/floor/engine,
 /area/science/explab)
 "bol" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "bon" = (
 /obj/effect/turf_decal/tile/blue{
@@ -20639,8 +20585,13 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "btA" = (
-/obj/effect/turf_decal/stripes/white/line,
-/obj/effect/landmark/start/prisoner,
+/obj/structure/closet/crate,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "btB" = (
@@ -23759,7 +23710,7 @@
 "bDU" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/research/glass{
-	name = "Toxins Lab";
+	name = "Ordnance Lab";
 	req_access_txt = "8"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -24195,10 +24146,9 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/computer/pod/old/mass_driver_controller/ordnancedriver/longrange,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/plasteel/fifty,
-/obj/structure/table,
+/obj/machinery/computer/pod/old/mass_driver_controller/ordnancedriver/longrange{
+	pixel_x = 24
+	},
 /turf/open/floor/iron,
 /area/science/mixing)
 "bFx" = (
@@ -24568,7 +24518,7 @@
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/machinery/door/airlock/research{
-	name = "Toxins Launch Room";
+	name = "Ordnance Launch Room";
 	req_access_txt = "8"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -24774,7 +24724,7 @@
 /area/science/mixing)
 "bHz" = (
 /obj/machinery/button/door/incinerator_vent_ordmix{
-	pixel_y = -25
+	pixel_y = -24
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -24784,15 +24734,15 @@
 /area/science/mixing)
 "bHA" = (
 /obj/machinery/embedded_controller/radio/airlock_controller/incinerator_ordmix{
-	pixel_x = 4;
-	pixel_y = -28
+	pixel_x = 6;
+	pixel_y = -26
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/machinery/button/ignition/incinerator/ordmix{
-	pixel_x = -7;
-	pixel_y = -25
+	pixel_x = -6;
+	pixel_y = -24
 	},
 /obj/machinery/atmospherics/components/binary/valve,
 /turf/open/floor/iron/dark,
@@ -24817,9 +24767,6 @@
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
-	},
-/obj/machinery/computer/pod/old/mass_driver_controller/ordnancedriver{
-	pixel_x = 25
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
@@ -25297,7 +25244,7 @@
 	dir = 8
 	},
 /obj/machinery/airlock_sensor/incinerator_ordmix{
-	pixel_x = -25
+	pixel_x = -24
 	},
 /obj/machinery/atmospherics/components/binary/pump/on,
 /obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/hidden{
@@ -25306,7 +25253,9 @@
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "bJR" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_ordmix,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_ordmix{
+	dir = 8
+	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "bJS" = (
@@ -29292,17 +29241,14 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bXu" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_x = -31
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/rack,
-/obj/item/card/id/advanced/prisoner/chef,
-/turf/open/floor/iron/white,
-/area/security/prison/upper)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "bXx" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
@@ -31570,8 +31516,17 @@
 /turf/open/floor/iron/showroomfloor,
 /area/service/chapel/monastery)
 "cja" = (
-/turf/closed/wall,
-/area/security/prison/upper)
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/grunge{
+	name = "Prison Monastery"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "cjl" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Monastery Cemetary"
@@ -31932,12 +31887,15 @@
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "clE" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
 	},
-/obj/structure/table/wood,
-/obj/machinery/computer/bookmanagement,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron,
 /area/security/prison)
 "clF" = (
 /obj/effect/spawner/lootdrop/maintenance,
@@ -31967,15 +31925,9 @@
 /area/tcommsat/computer)
 "clK" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
+	dir = 8
 	},
-/obj/machinery/light/directional/north,
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/trophy{
-	pixel_y = 8
-	},
-/obj/item/storage/book/bible,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/security/prison)
 "clL" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -32787,12 +32739,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "cpv" = (
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	dir = 4;
-	name = "security red"
-	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
 "cpw" = (
@@ -33139,11 +33086,10 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/dock)
 "cqI" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/obj/structure/table/wood/fancy,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/security/prison)
 "cqS" = (
 /obj/structure/lattice,
@@ -34101,8 +34047,8 @@
 /turf/open/floor/iron/dark,
 /area/service/library/lounge)
 "cxa" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 9
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/security/prison)
@@ -34425,14 +34371,12 @@
 /turf/open/floor/carpet,
 /area/service/library)
 "czK" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
 "czN" = (
@@ -34777,9 +34721,10 @@
 /turf/closed/wall/r_wall,
 /area/command/gateway)
 "cCc" = (
-/obj/structure/chair/office{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
 	},
+/obj/machinery/hydroponics/soil,
 /turf/open/floor/iron,
 /area/security/prison)
 "cCl" = (
@@ -34792,9 +34737,12 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "cCs" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall,
-/area/maintenance/department/cargo)
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/iron,
+/area/security/prison)
 "cCt" = (
 /turf/open/floor/iron/white,
 /area/science/lab)
@@ -35170,12 +35118,8 @@
 /turf/open/floor/iron/dark,
 /area/science/lab)
 "cTq" = (
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/structure/closet/crate,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
 /obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/seed_extractor,
 /turf/open/floor/iron,
 /area/security/prison)
 "cTr" = (
@@ -35206,13 +35150,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "cZu" = (
-/obj/effect/turf_decal/tile/red{
+/obj/structure/chair/wood{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/landmark/start/prisoner,
-/turf/open/floor/iron/white,
-/area/security/prison/upper)
+/turf/open/floor/iron/chapel{
+	dir = 8
+	},
+/area/security/prison)
 "daO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -35382,13 +35326,14 @@
 /turf/open/floor/iron/white,
 /area/science/explab)
 "dkU" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-08"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/red,
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/rice,
+/obj/item/reagent_containers/food/condiment/flour,
+/turf/open/floor/iron/white,
 /area/security/prison)
 "dlS" = (
 /obj/structure/reagent_dispensers/water_cooler,
@@ -35440,9 +35385,15 @@
 /turf/open/floor/iron/white,
 /area/engineering/gravity_generator)
 "dof" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/structure/table,
+/obj/item/storage/fancy/egg_box,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/item/book/manual/chef_recipes,
+/turf/open/floor/iron/white,
 /area/security/prison)
 "dok" = (
 /obj/effect/turf_decal/trimline/green/line{
@@ -35587,11 +35538,25 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "dtj" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
+/obj/structure/closet/crate,
+/obj/item/food/breadslice/plain,
+/obj/item/food/breadslice/plain,
+/obj/item/food/breadslice/plain,
+/obj/item/food/grown/potato,
+/obj/item/food/grown/potato,
+/obj/item/food/grown/onion,
+/obj/item/food/grown/onion,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red,
+/obj/item/radio/intercom/directional/north{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	prison_radio = 1
+	},
+/turf/open/floor/iron/white,
 /area/security/prison)
 "dtK" = (
 /obj/effect/turf_decal/tile/red{
@@ -35648,13 +35613,37 @@
 /turf/open/floor/iron/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
 "dvY" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
+/obj/structure/closet/crate,
+/obj/item/reagent_containers/glass/bowl,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/kitchen/fork/plastic,
+/obj/item/kitchen/fork/plastic,
+/obj/item/kitchen/fork/plastic,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/kitchen/spoon/plastic,
+/obj/item/kitchen/spoon/plastic,
+/obj/item/kitchen/spoon/plastic,
+/obj/item/kitchen/knife/plastic,
+/obj/item/kitchen/knife/plastic,
+/obj/item/kitchen/knife/plastic,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/box/drinkingglasses,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/structure/sign/painting/library{
-	pixel_x = -32
-	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron/white,
 /area/security/prison)
 "dxo" = (
 /obj/machinery/igniter/incinerator_ordmix,
@@ -35729,9 +35718,11 @@
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
 "dCu" = (
-/turf/open/floor/iron/chapel{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/security/prison)
 "dDZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35822,19 +35813,21 @@
 /turf/open/floor/wood,
 /area/service/bar)
 "dGV" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/machinery/light/no_nightlight/directional/north,
-/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
 "dGY" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
+	dir = 9
 	},
+/obj/structure/sink{
+	pixel_y = 29
+	},
+/obj/structure/closet/crate/trashcart/laundry,
+/obj/effect/spawner/lootdrop/prison_contraband,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/safe)
 "dHc" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -35984,7 +35977,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/cargo/miningdock)
 "dRU" = (
 /obj/structure/window/reinforced/spawner/east,
@@ -36101,16 +36094,10 @@
 /turf/open/floor/iron/dark,
 /area/engineering/transit_tube)
 "dWw" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
 "dWO" = (
@@ -36145,15 +36132,13 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "eaA" = (
+/obj/structure/table,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/machinery/vending/sustenance,
-/obj/machinery/power/apc/auto_name/south,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/security/prison/upper)
+/area/security/prison)
 "eaB" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -36360,7 +36345,10 @@
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "elj" = (
-/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/obj/machinery/hydroponics/soil,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
@@ -36382,11 +36370,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "emp" = (
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	dir = 4;
-	name = "security red"
-	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/table,
+/obj/item/shovel/spade,
+/obj/item/shovel/spade,
 /turf/open/floor/iron,
 /area/security/prison)
 "emB" = (
@@ -36582,10 +36569,13 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/item/kitchen/fork/plastic,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria,
 /turf/open/floor/iron/white,
-/area/security/prison/upper)
+/area/security/prison)
 "evU" = (
 /obj/effect/turf_decal/bot/left,
 /turf/open/floor/iron,
@@ -36638,15 +36628,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "eAF" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
@@ -36945,12 +36934,10 @@
 /turf/closed/wall,
 /area/space/nearstation)
 "eNW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/structure/chair/stool/directional/west,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/table,
+/obj/item/plant_analyzer,
+/obj/item/plant_analyzer,
 /turf/open/floor/iron,
 /area/security/prison)
 "eOe" = (
@@ -36994,9 +36981,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
+/obj/machinery/biogenerator,
 /turf/open/floor/iron,
 /area/security/prison)
 "eQN" = (
@@ -37008,9 +36993,15 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "eQT" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 10
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
 	},
+/obj/structure/sign/warning/electricshock{
+	pixel_x = 32
+	},
+/obj/structure/table,
+/obj/item/cultivator,
+/obj/item/cultivator,
 /turf/open/floor/iron,
 /area/security/prison)
 "eQZ" = (
@@ -37033,7 +37024,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron/white,
-/area/security/prison/upper)
+/area/security/prison)
 "eSL" = (
 /turf/closed/wall/r_wall,
 /area/science/breakroom)
@@ -37071,18 +37062,24 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal)
 "eTI" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/structure/chair{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/camera{
+	c_tag = "Permabrig - Kitchen";
+	dir = 1;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/iron/white,
 /area/security/prison)
 "eTW" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/chapel{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron,
 /area/security/prison)
 "eTZ" = (
 /obj/structure/cable,
@@ -37095,10 +37092,14 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "eUa" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/chapel{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
+/obj/machinery/light/no_nightlight/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/security/prison)
 "eUb" = (
 /obj/effect/landmark/xeno_spawn,
@@ -37143,14 +37144,13 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "eVE" = (
-/obj/structure/chair/stool/bar/directional/south,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/structure/cable,
+/obj/machinery/vending/sustenance,
 /turf/open/floor/iron/white,
-/area/security/prison/upper)
+/area/security/prison)
 "eVW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37448,12 +37448,13 @@
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "ffL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison/safe)
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/vending/cola/red,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "fgs" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -37594,32 +37595,15 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "flR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/effect/landmark/start/prisoner,
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/safe)
 "fmh" = (
 /turf/open/floor/wood,
 /area/maintenance/department/engine)
-"fmp" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/camera{
-	c_tag = "Permabrig - Kitchen";
-	dir = 1;
-	network = list("ss13","prison")
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/security/prison/upper)
 "fmD" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -38082,9 +38066,15 @@
 /turf/open/floor/plating,
 /area/service/chapel/monastery)
 "fJd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/rack,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/clothing/mask/breath,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/safe)
 "fJw" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -38237,7 +38227,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/closet/secure_closet/miner,
+/obj/machinery/door/airlock/maintenance{
+	name = "Mining Maintenance";
+	req_access_txt = "48"
+	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "fQN" = (
@@ -38263,8 +38256,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "fTp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/effect/landmark/start/prisoner,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
 "fTY" = (
@@ -38386,12 +38378,10 @@
 /turf/open/floor/iron,
 /area/service/kitchen)
 "gaW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/structure/table,
-/obj/item/storage/pill_bottle/dice,
+/obj/structure/weightmachine/stacklifter,
 /turf/open/floor/iron,
 /area/security/prison)
 "gbu" = (
@@ -38668,9 +38658,15 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "gnM" = (
-/turf/open/floor/iron/chapel{
-	dir = 4
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 6
 	},
+/obj/item/radio/intercom/directional/north{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	prison_radio = 1
+	},
+/turf/open/floor/iron,
 /area/security/prison)
 "gnQ" = (
 /obj/structure/disposalpipe/segment,
@@ -38712,10 +38708,10 @@
 	},
 /area/hallway/secondary/exit/departure_lounge)
 "gqx" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/security/prison)
 "gsB" = (
 /obj/structure/disposalpipe/segment{
@@ -38817,12 +38813,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/security/prison)
 "guS" = (
@@ -39065,9 +39055,10 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "gEA" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
 	},
+/obj/machinery/light/no_nightlight/directional/north,
 /turf/open/floor/iron,
 /area/security/prison)
 "gEI" = (
@@ -39264,15 +39255,10 @@
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "gMF" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/item/toy/beach_ball/holoball,
+/obj/effect/turf_decal/stripes/white/line{
 	dir = 1
 	},
-/obj/item/radio/intercom/directional/north{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "prison intercom";
-	prison_radio = 1
-	},
-/obj/machinery/hydroponics/constructable,
 /turf/open/floor/iron,
 /area/security/prison)
 "gMG" = (
@@ -39409,15 +39395,11 @@
 	},
 /area/maintenance/department/engine)
 "gVg" = (
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	name = "security red"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/machinery/light/no_nightlight/directional/south,
+/obj/structure/table,
+/obj/item/toy/cards/deck,
 /turf/open/floor/iron,
 /area/security/prison)
 "gVk" = (
@@ -39933,15 +39915,14 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/department/engine)
 "hCd" = (
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	dir = 8;
-	name = "security red"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /obj/structure/cable,
+/obj/structure/table,
+/obj/item/pen,
+/obj/item/instrument/harmonica,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
 "hCg" = (
@@ -39976,11 +39957,10 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
 "hDg" = (
-/obj/structure/chair/stool/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/prison)
 "hDG" = (
@@ -40242,15 +40222,10 @@
 	},
 /area/maintenance/department/science)
 "hQc" = (
-/obj/structure/chair{
+/turf/open/floor/iron/dark/side{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron/white,
-/area/security/prison/upper)
+/area/security/prison)
 "hQd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -40420,8 +40395,8 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "hWS" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 5
 	},
 /turf/open/floor/iron,
 /area/security/prison)
@@ -40443,7 +40418,6 @@
 	id = "executionfireblast"
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "iab" = (
@@ -40559,6 +40533,7 @@
 /turf/open/floor/iron,
 /area/command/teleporter)
 "igs" = (
+/obj/effect/landmark/start/prisoner,
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/security/prison)
@@ -40891,8 +40866,11 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "iAC" = (
-/obj/structure/table,
-/obj/item/toy/cards/deck,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
 "iBk" = (
@@ -40924,9 +40902,8 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "iBw" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
-	},
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron,
 /area/security/prison)
 "iBJ" = (
@@ -41002,13 +40979,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "iFG" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/machinery/light/no_nightlight/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
 "iFI" = (
@@ -41113,10 +41087,10 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "iKi" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron/dark/corner{
+	dir = 4
 	},
-/turf/open/floor/iron,
 /area/security/prison)
 "iLl" = (
 /obj/structure/sink{
@@ -41295,8 +41269,14 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "iXt" = (
-/turf/closed/wall/r_wall,
-/area/security/prison/upper)
+/obj/structure/chair/stool/bar/directional/south,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "iYH" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay";
@@ -41347,10 +41327,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/door/airlock/maintenance{
-	name = "Mining Maintenance";
-	req_access_txt = "48"
-	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "jaS" = (
@@ -41769,10 +41745,9 @@
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "jzI" = (
-/obj/structure/chair/stool/directional/north,
-/obj/effect/landmark/start/prisoner,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security)
 "jAx" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -41948,10 +41923,15 @@
 /turf/closed/wall,
 /area/commons/fitness/recreation)
 "jNt" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/table,
-/obj/item/shovel/spade,
-/obj/item/shovel/spade,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/hydroponics/soil,
+/obj/item/radio/intercom/directional/north{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	prison_radio = 1
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "jOe" = (
@@ -42047,16 +42027,29 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "jTV" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	layer = 3.1;
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
+	pixel_x = -8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/condiment/enzyme{
+	pixel_x = 9;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
+/obj/effect/spawner/lootdrop/prison_contraband,
 /turf/open/floor/iron/white,
-/area/security/prison/upper)
+/area/security/prison)
 "jUF" = (
 /obj/structure/grille/broken,
 /obj/structure/cable,
@@ -42151,13 +42144,13 @@
 	},
 /area/maintenance/department/engine)
 "jYn" = (
-/obj/structure/bedsheetbin,
-/obj/structure/table,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
+/obj/machinery/requests_console/directional/south{
+	department = "Mining";
+	departmentType = 2;
+	name = "Mining Bay Requests Console"
 	},
 /turf/open/floor/iron,
-/area/security/prison)
+/area/cargo/miningdock)
 "jYA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42177,38 +42170,23 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/structure/chair/stool/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
 /area/security/prison)
 "kbi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "kbB" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 6;
-	pixel_y = 10
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
-/obj/item/reagent_containers/syringe{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/structure/sign/painting/library{
+	pixel_x = -32
 	},
-/obj/item/holosign_creator/robot_seat/restaurant/prison{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	dir = 1;
-	name = "Security red corner"
-	},
-/obj/effect/turf_decal/tile{
-	color = "#FF6700";
-	name = "Prison Orange"
-	},
-/turf/open/floor/iron,
-/area/security/prison/upper)
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "kbV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -42229,14 +42207,14 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "kdk" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/structure/table,
-/obj/item/pen,
-/obj/item/instrument/harmonica,
 /turf/open/floor/iron,
 /area/security/prison)
 "keN" = (
@@ -42422,11 +42400,14 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "kmV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
 "knx" = (
@@ -42731,7 +42712,12 @@
 /turf/open/floor/iron/freezer,
 /area/security/prison/toilet)
 "kBD" = (
-/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/obj/structure/closet/crate,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron,
 /area/security/prison)
 "kCc" = (
@@ -42747,16 +42733,11 @@
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "kCY" = (
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	dir = 6;
-	name = "security red"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/machinery/light{
+	light_color = "#cee5d2"
 	},
 /turf/open/floor/iron,
-/area/security/prison)
+/area/cargo/miningdock)
 "kDf" = (
 /obj/machinery/light/small,
 /turf/open/floor/carpet/black,
@@ -43003,26 +42984,13 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "kPM" = (
-/obj/structure/table,
-/obj/item/kitchen/fork/plastic,
-/obj/item/kitchen/fork/plastic,
-/obj/item/kitchen/fork/plastic,
-/obj/item/kitchen/fork/plastic,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/kitchen/knife/plastic,
-/obj/item/kitchen/knife/plastic,
-/obj/item/kitchen/knife/plastic,
-/obj/item/kitchen/knife/plastic,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/item/kitchen/rollingpin,
-/turf/open/floor/iron/white,
-/area/security/prison/upper)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "kPP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
@@ -43599,18 +43567,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"lsj" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig - Garden";
-	dir = 8;
-	network = list("ss13","prison")
-	},
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/iron,
-/area/security/prison)
 "lsq" = (
 /obj/structure/transit_tube/curved{
 	dir = 1
@@ -43691,11 +43647,6 @@
 "lvq" = (
 /turf/closed/wall,
 /area/security/prison/toilet)
-"lwM" = (
-/turf/open/floor/iron/dark/side{
-	dir = 4
-	},
-/area/security/prison)
 "lwT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -43724,11 +43675,6 @@
 /obj/machinery/atmospherics/components/binary/thermomachine/heater,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"lyF" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "lzJ" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/carpet,
@@ -43788,33 +43734,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/gateway)
-"lDj" = (
-/obj/machinery/button/flasher{
-	id = "wardenpermaoffice";
-	name = "Prisoner Flash";
-	pixel_x = 5;
-	pixel_y = 8
-	},
-/obj/machinery/button/door/directional/north{
-	id = "Warden Perma Office";
-	name = "Privacy Shutters";
-	normaldoorcontrol = 1;
-	pixel_x = -6;
-	pixel_y = 8;
-	specialfunctions = 4
-	},
-/obj/machinery/computer/security/telescreen{
-	network = list("ss13");
-	pixel_y = -6
-	},
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	dir = 9;
-	name = "security red"
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "lDw" = (
 /obj/structure/flora/grass/jungle,
 /mob/living/carbon/human/species/monkey,
@@ -43914,20 +43833,19 @@
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "lKk" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable,
-/obj/structure/table,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/turf/open/floor/iron/white,
-/area/security/prison/upper)
+/obj/machinery/camera{
+	c_tag = "Permabrig - Monastery";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/obj/structure/sign/painting/library{
+	pixel_x = -32
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "lKL" = (
 /obj/machinery/door/airlock{
 	name = "Starboard Emergency Storage"
@@ -44000,20 +43918,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "lPO" = (
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron/chapel{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/griddle,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/white,
-/area/security/prison/upper)
-"lQl" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
-	},
-/obj/machinery/plate_press,
-/turf/open/floor/iron,
 /area/security/prison)
 "lQn" = (
 /obj/machinery/light/small{
@@ -44369,14 +44278,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
-"mjO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "mkf" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating/airless,
@@ -44431,14 +44332,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/engineering/storage_shared)
-"mmC" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
-	},
-/obj/structure/cable,
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/iron,
-/area/security/prison)
 "mnw" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -44558,12 +44451,14 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "mrR" = (
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/chair/wood{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron/white,
-/area/security/prison/upper)
+/turf/open/floor/iron/chapel,
+/area/security/prison)
 "mse" = (
 /obj/machinery/holopad,
 /turf/open/floor/wood,
@@ -44583,7 +44478,6 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast"
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "mtu" = (
@@ -44686,15 +44580,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/crew_quarters/bar)
-"myn" = (
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "myu" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
@@ -44920,7 +44805,14 @@
 /turf/open/floor/grass,
 /area/science/genetics)
 "mKa" = (
-/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
 "mKc" = (
@@ -44935,14 +44827,8 @@
 /turf/closed/wall,
 /area/medical/medbay/lobby)
 "mLY" = (
-/obj/effect/spawner/randomarcade{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/machinery/flasher/directional/east{
-	id = "wardenpermaoffice"
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 10
 	},
 /turf/open/floor/iron,
 /area/security/prison)
@@ -44987,18 +44873,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"mOg" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/machinery/door/airlock{
-	name = "Cleaning Closet"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
 "mOt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -45034,16 +44908,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /turf/open/space,
 /area/space/nearstation)
-"mPn" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/computer/chef_order{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/security/prison/upper)
 "mPP" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -45150,7 +45014,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
 	dir = 9
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "mWQ" = (
@@ -45721,11 +45584,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/chapel/monastery)
 "nwJ" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
 	},
-/obj/machinery/light/no_nightlight/directional/north,
-/obj/item/toy/beach_ball/holoball,
+/obj/machinery/plate_press,
 /turf/open/floor/iron,
 /area/security/prison)
 "nwK" = (
@@ -45792,28 +45654,15 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"nAV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/security/prison)
 "nBc" = (
+/obj/structure/table,
+/obj/structure/reagent_dispensers/servingdish,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/item/skillchip/job/chef,
-/obj/structure/closet/crate/secure/gear{
-	desc = "Contains the most important part of any Chef.";
-	name = "chef crate";
-	req_access_txt = "3"
-	},
 /turf/open/floor/iron/white,
-/area/security/prison/upper)
+/area/security/prison)
 "nBt" = (
 /obj/structure/disposaloutlet{
 	dir = 8
@@ -46225,15 +46074,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"nVs" = (
-/obj/machinery/power/apc/auto_name/south,
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
 "nVz" = (
 /obj/structure/sign/directions/evac{
 	dir = 8;
@@ -46399,10 +46239,10 @@
 /turf/open/space/basic,
 /area/space)
 "ofe" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron/dark/side{
+	dir = 1
 	},
-/turf/open/floor/iron,
 /area/security/prison)
 "ofj" = (
 /obj/structure/cable,
@@ -46477,13 +46317,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
-"ohQ" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
-	},
-/obj/machinery/vending/games,
-/turf/open/floor/iron,
-/area/security/prison)
 "ohR" = (
 /obj/item/chair,
 /turf/open/floor/plating,
@@ -46789,13 +46622,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/explab)
-"ovC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison/safe)
 "ovM" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals Port Fore"
@@ -46860,13 +46686,6 @@
 	},
 /turf/open/floor/carpet,
 /area/service/library/artgallery)
-"oyk" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/iron,
-/area/security/prison)
 "oyF" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -47095,14 +46914,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"oId" = (
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	dir = 8;
-	name = "security red"
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "oJp" = (
 /obj/machinery/light/no_nightlight/directional/north,
 /turf/open/floor/iron,
@@ -47117,15 +46928,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/engine)
-"oKE" = (
-/obj/structure/chair/stool/bar/directional/south,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/landmark/start/prisoner,
-/turf/open/floor/iron/white,
-/area/security/prison/upper)
 "oKI" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -47315,20 +47117,17 @@
 /turf/open/floor/iron/dark,
 /area/command/gateway)
 "oSI" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/grunge{
-	name = "Prison Forestry"
+/obj/machinery/door/airlock{
+	name = "Cleaning Closet"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/safe)
 "oTl" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8;
@@ -47618,13 +47417,17 @@
 /turf/open/floor/plating,
 /area/medical/abandoned)
 "pif" = (
-/obj/effect/spawner/randomarcade{
+/obj/structure/holohoop{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/machinery/camera{
+	c_tag = "Permabrig - Yard";
+	dir = 8;
+	network = list("ss13","prison")
+	},
+/obj/effect/turf_decal/stripes/white/line{
 	dir = 4
 	},
-/obj/machinery/light/no_nightlight/directional/east,
 /turf/open/floor/iron,
 /area/security/prison)
 "piI" = (
@@ -47767,14 +47570,6 @@
 	},
 /turf/open/floor/iron/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
-"pqq" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/security/prison/upper)
 "pqw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -47930,27 +47725,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"pAv" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "Warden Perma Office";
-	name = "Warden's Office";
-	req_access_txt = "3"
-	},
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	name = "security red"
-	},
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	dir = 1;
-	name = "security red"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/iron,
-/area/security/prison)
 "pBm" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -47990,6 +47764,10 @@
 "pEg" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/security/prison)
@@ -48033,13 +47811,14 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "pFE" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/machinery/light/no_nightlight/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/kitchen/fork/plastic,
+/turf/open/floor/iron/white,
 /area/security/prison)
 "pFG" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
@@ -48244,18 +48023,16 @@
 /turf/open/floor/iron/freezer,
 /area/medical/virology)
 "pOd" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/plate_press,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron,
 /area/security/prison)
 "pOs" = (
-/obj/effect/spawner/randomarcade{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 9
 	},
 /turf/open/floor/iron,
 /area/security/prison)
@@ -48341,14 +48118,6 @@
 /obj/machinery/newscaster/security_unit/directional/south,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
-"pUx" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/processor,
-/turf/open/floor/iron/white,
-/area/security/prison/upper)
 "pVr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48893,18 +48662,10 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "qpG" = (
-/obj/item/radio/intercom/directional/north{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "prison intercom";
-	prison_radio = 1
+/turf/open/floor/iron/chapel{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/closet/secure_closet/freezer/fridge,
-/turf/open/floor/iron/white,
-/area/security/prison/upper)
+/area/security/prison)
 "qpT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -49169,14 +48930,10 @@
 /turf/open/floor/grass,
 /area/medical/medbay/lobby)
 "qEk" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 6
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
 	},
-/obj/item/radio/intercom/directional/north{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "prison intercom";
-	prison_radio = 1
-	},
+/obj/machinery/plate_press,
 /turf/open/floor/iron,
 /area/security/prison)
 "qEm" = (
@@ -49425,20 +49182,6 @@
 /obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/abandoned_gambling_den)
-"qQe" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box,
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	dir = 5;
-	name = "security red"
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig - Warden Office";
-	network = list("ss13","prison")
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "qQl" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -49735,18 +49478,19 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "rka" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron/dark,
+/area/security/prison)
+"rkv" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron/white,
-/area/security/prison/upper)
-"rkv" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/upper)
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/grunge{
+	name = "Prison Monastery"
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "rle" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -49805,12 +49549,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"rnm" = (
-/obj/machinery/airalarm/directional/south,
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/security/prison)
 "rnE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49916,13 +49654,20 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "rqQ" = (
-/obj/structure/closet/crate,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
-	},
+/obj/structure/closet/crate/hydroponics,
+/obj/item/paper/guides/jobs/hydroponics,
+/obj/item/seeds/onion,
+/obj/item/seeds/garlic,
+/obj/item/seeds/potato,
+/obj/item/seeds/tomato,
+/obj/item/seeds/carrot,
+/obj/item/seeds/grass,
+/obj/item/seeds/ambrosia,
+/obj/item/seeds/wheat,
+/obj/item/seeds/pumpkin,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/light/no_nightlight/directional/south,
 /turf/open/floor/iron,
 /area/security/prison)
 "rrt" = (
@@ -50013,15 +49758,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/psychology)
-"rtm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/iron/dark/corner{
-	dir = 4
-	},
-/area/security/prison)
 "rtC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -50110,18 +49846,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
-"ruW" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable,
-/obj/structure/sink/kitchen{
-	dir = 4;
-	pixel_x = -11
-	},
-/turf/open/floor/iron/white,
-/area/security/prison/upper)
 "rvA" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
@@ -50284,14 +50008,14 @@
 /area/hallway/primary/central)
 "rBL" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
+	dir = 5
 	},
-/obj/structure/sign/warning/electricshock{
-	pixel_x = 32
+/obj/machinery/hydroponics/soil,
+/obj/machinery/camera{
+	c_tag = "Permabrig - Garden";
+	dir = 8;
+	network = list("ss13","prison")
 	},
-/obj/structure/table,
-/obj/item/cultivator,
-/obj/item/cultivator,
 /turf/open/floor/iron,
 /area/security/prison)
 "rBP" = (
@@ -50462,15 +50186,13 @@
 	},
 /area/maintenance/department/engine)
 "rJS" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/microwave,
-/obj/machinery/light/no_nightlight/directional/north,
-/turf/open/floor/iron/white,
-/area/security/prison/upper)
+/turf/open/floor/iron/chapel{
+	dir = 4
+	},
+/area/security/prison)
 "rJT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50798,21 +50520,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/service)
-"saw" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/grunge{
-	name = "Prison Workshop"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/iron,
-/area/security/prison)
 "saR" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -50831,13 +50538,6 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
-"sbt" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
-	},
-/obj/machinery/washing_machine,
-/turf/open/floor/iron,
-/area/security/prison)
 "sbI" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -50854,14 +50554,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/service/kitchen)
-"sbU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/chapel{
-	dir = 4
-	},
-/area/security/prison)
 "sbY" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/wood,
@@ -50945,19 +50637,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
-"sfX" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
-	name = "Dining Room"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison/upper)
 "sgc" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron/dark,
@@ -51763,13 +51442,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/engine)
-"sVF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/effect/landmark/start/prisoner,
-/turf/open/floor/iron/chapel{
-	dir = 1
-	},
-/area/security/prison)
 "sWj" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
@@ -51825,13 +51497,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "sYW" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/closet/secure_closet/freezer/kitchen,
-/turf/open/floor/iron/white,
-/area/security/prison/upper)
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "sYY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -52270,19 +51940,17 @@
 	},
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
-"tot" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/machinery/light/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "toR" = (
-/obj/effect/turf_decal/stripes/white/line{
+/obj/item/stack/sheet/cardboard{
+	amount = 14
+	},
+/obj/item/stack/package_wrap,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Permabrig - Workroom";
+	network = list("ss13","prison")
 	},
 /turf/open/floor/iron,
 /area/security/prison)
@@ -52316,8 +51984,11 @@
 /turf/closed/wall,
 /area/medical/storage)
 "tqM" = (
-/turf/closed/wall/mineral/iron,
-/area/security/prison/upper)
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "tqO" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
@@ -52934,32 +52605,14 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "tTq" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
+/obj/structure/table,
 /obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/structure/cable,
+/obj/machinery/microwave,
+/obj/machinery/light/no_nightlight/directional/north,
 /turf/open/floor/iron/white,
-/area/security/prison/upper)
-"tTG" = (
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	name = "security red"
-	},
-/obj/effect/turf_decal/siding/red/corner{
-	color = "#FF0000";
-	dir = 1;
-	name = "security red"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/iron,
 /area/security/prison)
 "tUr" = (
 /obj/structure/table/optable,
@@ -53107,14 +52760,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "ubq" = (
+/obj/structure/table,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/machinery/light/no_nightlight/directional/south,
-/obj/machinery/restaurant_portal/restaurant/prison,
+/obj/item/food/energybar,
 /turf/open/floor/iron/white,
-/area/security/prison/upper)
+/area/security/prison)
 "ucd" = (
 /obj/machinery/light/dim{
 	dir = 8
@@ -53239,16 +52892,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"ueX" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/grunge{
-	name = "Prison Monastery"
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "ufa" = (
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
@@ -53396,18 +53039,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/breakroom)
-"ukE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "ukM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -53561,7 +53192,6 @@
 /area/medical/psychology)
 "uqJ" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "urG" = (
@@ -53596,10 +53226,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
-"usD" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison/safe)
 "usI" = (
 /obj/structure/chair/wood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -53744,11 +53370,14 @@
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "uxx" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/spawner/randomcolavend,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/security/prison)
 "uxF" = (
 /obj/machinery/door/firedoor,
@@ -53989,14 +53618,15 @@
 	},
 /area/maintenance/department/crew_quarters/dorms)
 "uGE" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/light/no_nightlight/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/security/prison)
 "uHJ" = (
 /obj/structure/disposalpipe/segment{
@@ -54118,17 +53748,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/psychology)
-"uPl" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/iron,
-/area/security/prison)
 "uPz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54169,16 +53788,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"uQv" = (
-/obj/structure/holohoop{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
 "uQB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -54192,17 +53801,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"uQG" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/secure_data/laptop,
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	dir = 1;
-	name = "security red"
-	},
-/obj/machinery/light/no_nightlight/directional/north,
-/turf/open/floor/iron,
-/area/security/prison)
 "uQR" = (
 /obj/item/ammo_casing/shotgun/beanbag,
 /turf/open/floor/plating,
@@ -54707,16 +54305,6 @@
 /obj/structure/reagent_dispensers/fueltank/large,
 /turf/open/floor/iron,
 /area/engineering/main)
-"vjY" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig - Yard";
-	network = list("ss13","prison")
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "vkd" = (
 /obj/structure/lattice,
 /turf/closed/wall,
@@ -55077,11 +54665,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
-"vEU" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/seed_extractor,
-/turf/open/floor/iron,
-/area/security/prison)
 "vFs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -55409,18 +54992,6 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"vSh" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/grunge{
-	name = "Prison Monastery"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "vSB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -55440,11 +55011,11 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal)
 "vTg" = (
-/obj/machinery/light/no_nightlight/directional/south,
-/obj/machinery/vending/hydroseeds{
-	slogan_delay = 700
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/hydroponics/soil,
+/obj/machinery/light/no_nightlight/directional/north,
 /turf/open/floor/iron,
 /area/security/prison)
 "vTL" = (
@@ -55454,7 +55025,7 @@
 "vTN" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/research{
-	name = "Toxins Lab";
+	name = "Ordnance Lab";
 	req_access_txt = "8"
 	},
 /turf/open/floor/iron/dark,
@@ -55521,39 +55092,18 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "vXu" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/security/prison/upper)
+/area/security/prison)
 "vXF" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	layer = 3.1;
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
-	pixel_x = -8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/food/condiment/enzyme{
-	pixel_x = 9;
-	pixel_y = 3
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/iron/chapel{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/turf/open/floor/iron/white,
-/area/security/prison/upper)
+/area/security/prison)
 "vXW" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -55691,13 +55241,14 @@
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter/room)
 "wcP" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 10
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron/white,
 /area/security/prison)
 "wdp" = (
 /obj/structure/disposalpipe/trunk{
@@ -55885,7 +55436,11 @@
 /turf/open/space,
 /area/space)
 "wkA" = (
-/obj/structure/chair/stool/directional/west,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/structure/punching_bag,
+/obj/machinery/light/no_nightlight/directional/north,
 /turf/open/floor/iron,
 /area/security/prison)
 "wkM" = (
@@ -55940,13 +55495,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
-"wlJ" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/machinery/vending/cigarette,
-/turf/open/floor/iron,
-/area/security/prison)
 "wlK" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -56154,9 +55702,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/machinery/vending/cola/red,
 /turf/open/floor/iron/white,
-/area/security/prison/upper)
+/area/security/prison)
 "wxn" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -56424,10 +55971,10 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "wFz" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/table,
-/obj/item/plant_analyzer,
-/obj/item/plant_analyzer,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/hydroponics/soil,
 /turf/open/floor/iron,
 /area/security/prison)
 "wFM" = (
@@ -56598,9 +56145,9 @@
 /area/medical/chemistry)
 "wNI" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 10
+	dir = 9
 	},
-/obj/machinery/biogenerator,
+/obj/machinery/hydroponics/soil,
 /turf/open/floor/iron,
 /area/security/prison)
 "wOf" = (
@@ -56645,21 +56192,22 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "wPo" = (
-/obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Permabrig - Upper Hall";
+	dir = 8;
+	network = list("ss13","prison")
 	},
 /turf/open/floor/iron,
 /area/security/prison)
 "wPr" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
 "wPw" = (
@@ -56844,13 +56392,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"wVS" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
-	},
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/iron,
-/area/security/prison)
 "wVV" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/structure/window/reinforced,
@@ -57084,13 +56625,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/engineering/atmos)
-"xdW" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
-	},
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/iron,
-/area/security/prison)
 "xdY" = (
 /obj/machinery/door/window/eastright{
 	name = "Danger: Conveyor Access";
@@ -57143,10 +56677,16 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "xga" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/prison/upper)
+/obj/structure/sign/warning/electricshock{
+	pixel_x = -31
+	},
+/obj/structure/chair/stool/bar/directional/south,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "xgt" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -57363,12 +56903,15 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "xnW" = (
-/obj/machinery/light/no_nightlight/directional/north,
-/obj/structure/weightmachine/weightlifter,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/white,
 /area/security/prison)
 "xog" = (
 /obj/structure/cable,
@@ -57522,8 +57065,10 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
 "xuy" = (
-/obj/structure/chair/stool/directional/east,
-/turf/open/floor/iron,
+/obj/effect/spawner/randomarcade,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
 /area/security/prison)
 "xvx" = (
 /obj/structure/cable,
@@ -57600,20 +57145,6 @@
 	},
 /turf/open/floor/iron/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
-"xxJ" = (
-/obj/item/stack/sheet/cardboard{
-	amount = 14
-	},
-/obj/item/stack/package_wrap,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig - Workroom";
-	network = list("ss13","prison")
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "xxK" = (
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -57717,17 +57248,6 @@
 	},
 /turf/closed/wall,
 /area/cargo/storage)
-"xAZ" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/iron,
-/area/security/prison)
 "xBB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -58030,13 +57550,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"xPV" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/iron,
-/area/security/prison)
 "xQr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -58184,14 +57697,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
-"xYO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
 "yat" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -71647,7 +71152,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cFB
 aaa
 aaa
 aaa
@@ -71891,7 +71396,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cFB
 aaa
 aaa
 aaa
@@ -73924,7 +73429,7 @@ aaa
 aaa
 aaa
 aaa
-abN
+aaa
 aaa
 aaa
 aaa
@@ -74704,7 +74209,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cFB
 aaa
 aaa
 aaa
@@ -76762,15 +76267,15 @@ aaa
 aaa
 aaa
 aaa
-iXt
-iXt
-rkv
-xga
-iXt
-rkv
-rkv
-iXt
-iXt
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aOn
 fzz
 ygc
 vDq
@@ -76782,7 +76287,7 @@ mzl
 sJp
 hZL
 mWI
-ahU
+aHu
 aHu
 aiw
 afU
@@ -77012,6 +76517,10 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
 adE
 adE
 adE
@@ -77019,15 +76528,11 @@ adE
 adE
 adE
 adE
-tqM
-pUx
-ruW
-mPn
-bXu
-pqq
-mrR
-hQc
-iXt
+adE
+aem
+acM
+acM
+aOn
 lvq
 lvq
 lvq
@@ -77269,23 +76774,23 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
 adE
-afs
-dvY
 aeE
-dvY
-aeE
-ahG
+kbB
 tqM
 kbB
-pqq
+tqM
 lKk
-eVE
-pqq
-mrR
+adE
+dkU
+vXu
 evP
 xga
-ohQ
+wxa
 wcP
 lvq
 sAN
@@ -77526,23 +77031,23 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
 adE
-aNT
-dCu
 arl
-dCu
-arl
-aij
-tqM
+vXF
+cZu
 vXF
 cZu
 rka
+adE
+dof
+vXu
+nBc
 eRV
-pqq
-pqq
-fmp
-xga
-wlJ
+wxa
 pFE
 lvq
 woO
@@ -77783,22 +77288,22 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
 adE
-clE
-eTW
-aeW
-sbU
 aeW
 aik
-tqM
+mrR
 rJS
 mrR
-rka
-eRV
+bol
+adE
 jTV
-mrR
+vXu
 nBc
-xga
+eRV
 uxx
 eTI
 lvq
@@ -78040,25 +77545,25 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
 adE
-clK
-eUa
-aeX
-sVF
 aeX
 akN
-tqM
+aeD
 lPO
-mrR
-rka
-oKE
+aeD
+bXu
+adE
 tTq
 vXu
 ubq
 iXt
-aep
+xnW
 uGE
-afn
+agy
 afn
 guO
 afZ
@@ -78297,26 +77802,26 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
 adE
-cqI
-gnM
 aeT
-gnM
-aeT
-alA
-tqM
 qpG
-mrR
+afr
+qpG
+afr
 kPM
-eRV
-tTq
-pqq
+adE
+dtj
+vXu
 eaA
-iXt
-aOX
-aiF
-aiF
-aiF
+eRV
+xnW
+eVE
+agy
+gaW
 ahF
 aiF
 wbB
@@ -78554,27 +78059,27 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
 adE
-dkU
-gqx
-gqx
-gqx
 afX
-alA
-tqM
 sYW
-mrR
-mrR
-mrR
-tTq
-mrR
+sYW
+sYW
+bcn
+kPM
+adE
+dvY
+vXu
 wxa
-iXt
+wxa
 xnW
-aiF
-aiF
+ffL
+agy
 wkA
-eNW
+ahF
 igs
 lYA
 ahp
@@ -78811,29 +78316,29 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
 adE
 adE
 adE
 aen
 aen
-ueX
-vSh
-tqM
+rkv
 cja
-rkv
-rkv
-rkv
-sfX
-xga
-xga
-iXt
+adE
+agy
+acM
+acM
+acM
 aeq
-aiF
-jzI
+acM
+agy
 afp
 afE
-wFM
-agp
+gVg
+wbB
 ahp
 ahp
 ahp
@@ -79066,30 +78571,30 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 pDW
-fon
 aht
 aem
-hWS
-mjO
 wPr
-uPl
-xAZ
-wPr
-aeF
-wPr
-afZ
-afZ
+kmV
+kdk
+clE
+kmV
 eAF
+kmV
 afZ
-ukE
-bol
+afZ
 aer
 kmV
 aeV
 kdk
 afF
-ahF
+hCd
 bvC
 eIJ
 iVP
@@ -79322,30 +78827,30 @@ aaa
 aaa
 aaa
 aaa
-pDW
-aht
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+fon
 aht
 aht
 aem
-iBw
-myn
-tot
-act
-pEg
 czK
 pEg
 act
 aeG
-pEg
-czK
-pEg
-wPo
-aiF
 mKa
-aiF
+aeG
+act
+wPo
+aeG
+mKa
+aeG
 hDg
-iAC
-gaW
+aiF
+wHD
 kLJ
 wbB
 ahp
@@ -79579,32 +79084,32 @@ aaa
 aaa
 aaa
 aaa
-fon
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+pDW
 aht
-aem
-aem
-aem
-aem
-mOg
-agy
-acM
-acM
+ahC
+ahC
 oSI
-lyF
+ahp
+acM
+acM
+aJx
+acM
 acM
 agy
-aJx
-saw
 aen
-aem
-lwM
 aga
-lwM
-rtm
+aen
+agy
 xuy
 kaA
-aiF
-wbB
+hQc
+iKi
 ahp
 agM
 fRl
@@ -79836,32 +79341,32 @@ aaa
 aaa
 aaa
 aaa
-fon
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+pDW
 aht
-aem
-aeC
-dtj
+ahC
 dGY
-nVs
-agy
-wVS
-dGY
-afZ
-bcn
+afs
+ahp
 wNI
-agy
-lQl
+clK
+afZ
 dWw
 ePM
-aem
+agy
 qEk
 aeu
 aeI
-nAV
-aiF
+agy
+gnM
 agc
-aiF
-agp
+hWS
+ofe
 ahp
 ahp
 ahp
@@ -80093,31 +79598,31 @@ aaa
 aaa
 aaa
 aaa
-fon
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+pDW
 aht
-aem
-aeD
-aiF
-aiF
-rnm
-agy
-xPV
+ahC
+aeC
+aNT
+ahp
+wFz
 aiF
 wHD
-usD
-vEU
-agy
-xxJ
 fTp
 cTq
-aem
+agy
 toR
-mKa
+eTW
 kBD
-nAV
-aiF
-agc
-agc
+agy
+gqx
+wHD
+iAC
 ago
 ekm
 lny
@@ -80350,32 +79855,32 @@ aaa
 aaa
 aaa
 aaa
-fon
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+pDW
 aht
-aem
-afr
-pEg
-jYn
-sbt
-agy
-dGV
+ahC
 fJd
 flR
-ovC
+ahp
 vTg
-agy
+cpv
 pOd
 iFG
 rqQ
-aem
+agy
 nwJ
-mKa
+eUa
 btA
-nAV
+agy
+gEA
 aiF
-aiF
-aiF
-wbB
+iBw
+ofe
 ahp
 sKL
 agZ
@@ -80607,30 +80112,30 @@ aaa
 aaa
 aaa
 aaa
-fon
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+pDW
 aht
-aem
+ahC
+ahC
+ahC
+ahC
+jNt
+cqI
+aiF
+dCu
+emp
 aem
 aem
 aem
 aem
 aem
 gMF
-iKi
 aiF
-ffL
-jNt
-aem
-aem
-aem
-aem
-aem
-vjY
-mKa
-kBD
-nAV
-wkA
-wkA
 agd
 ofe
 ahp
@@ -80864,28 +80369,28 @@ aaa
 aaa
 aaa
 aaa
-fon
-aht
-aht
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+pDW
 aht
 aht
 aht
 aht
 aem
-xPV
-aiF
-aiF
-mKa
 wFz
+aiF
+aiF
+fTp
+eNW
 aem
 aht
 aht
 aht
 aem
-eQT
-uQv
-cxa
-nAV
 mLY
 pif
 pOs
@@ -81121,28 +80626,28 @@ aaa
 aaa
 aaa
 aaa
-fon
-fon
-fon
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 pDW
 pDW
 pDW
 aht
 aem
-lsj
-gEA
-aiF
-elj
 rBL
+cxa
+aiF
+dGV
+eQT
 aem
 aht
 pDW
 aht
 aem
-acM
-dof
-acM
-pAv
 aem
 aem
 aem
@@ -81383,24 +80888,24 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
 pDW
 aht
 aem
 aem
-xdW
-oyk
-mmC
+cCc
+cCs
+elj
 aem
 aem
 aht
 pDW
 aaa
-aem
-lDj
-oId
-hCd
-tTG
-aem
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -81640,6 +81145,10 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
 pDW
 aht
 aht
@@ -81652,12 +81161,8 @@ aht
 aht
 pDW
 aaa
-aem
-uQG
-cCc
-xYO
-gVg
-aem
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -81898,6 +81403,10 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
 pDW
 aht
 aht
@@ -81909,12 +81418,8 @@ aht
 fon
 aaa
 aaa
-aem
-qQe
-emp
-cpv
-kCY
-aem
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -82156,6 +81661,10 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
 pDW
 pDW
 pDW
@@ -82166,18 +81675,14 @@ pDW
 aaa
 aaa
 aaa
-aem
-aem
-acM
-acM
-acM
-aem
+aaa
+aaa
 aaa
 aby
 abI
 agP
-agQ
-agQ
+jzI
+jzI
 agP
 ahL
 ahL
@@ -97911,7 +97416,7 @@ amb
 bfB
 bbI
 jaJ
-cCs
+xba
 dSK
 eSL
 cBN
@@ -98165,10 +97670,10 @@ bbI
 bcB
 hgV
 hgV
-hgV
-hgV
-dRI
+jYn
 bbI
+dRI
+bfJ
 lru
 eSL
 bkz
@@ -98422,8 +97927,8 @@ bbI
 bcC
 qfZ
 xPf
-hgV
-hgV
+kCY
+bbI
 fQD
 bbI
 lru
@@ -100509,7 +100014,7 @@ iUX
 iUX
 iUX
 bOs
-mZE
+aaa
 aaa
 aaa
 aaa
@@ -100766,7 +100271,7 @@ suz
 bMl
 bNp
 bOt
-mZE
+aaa
 aaa
 aaa
 aaa
@@ -101023,7 +100528,7 @@ bLf
 bMm
 dxo
 bOt
-mZE
+aaa
 aaa
 aaa
 aaa
@@ -101280,7 +100785,7 @@ nWX
 bMn
 bNp
 bOt
-mZE
+aaa
 aaa
 aaa
 aaa

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -22275,9 +22275,9 @@
 /turf/open/floor/iron/dark,
 /area/science/explab)
 "bzd" = (
-/obj/structure/table,
-/obj/item/stock_parts/cell/high,
-/obj/machinery/cell_charger,
+/obj/item/integrated_circuit/loaded/hello_world,
+/obj/item/integrated_circuit/loaded/speech_relay,
+/obj/structure/rack,
 /turf/open/floor/iron/dark,
 /area/science/explab)
 "bzg" = (
@@ -22300,6 +22300,7 @@
 	dir = 1;
 	network = list("ss13","rd")
 	},
+/obj/machinery/module_duplicator,
 /turf/open/floor/iron/dark,
 /area/science/explab)
 "bzi" = (
@@ -22308,8 +22309,8 @@
 /area/science/explab)
 "bzj" = (
 /obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/item/stock_parts/cell/high,
+/obj/machinery/cell_charger,
 /turf/open/floor/iron/dark,
 /area/science/explab)
 "bzk" = (
@@ -52020,9 +52021,9 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "tAK" = (
-/obj/structure/rack,
-/obj/item/integrated_circuit/loaded/speech_relay,
-/obj/item/integrated_circuit/loaded/hello_world,
+/obj/machinery/modular_computer/console/preset/civilian{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/science/explab)
 "tBb" = (

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -8911,7 +8911,7 @@
 	},
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "aBT" = (
 /obj/structure/closet/wardrobe/white,
 /obj/effect/turf_decal/tile/blue{
@@ -9501,12 +9501,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"aDL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai_upload)
 "aDM" = (
 /obj/machinery/camera/motion{
 	c_tag = "AI Upload Center";
@@ -9514,12 +9508,6 @@
 	network = list("aiupload")
 	},
 /obj/machinery/holopad/secure,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
 /turf/open/floor/circuit,
@@ -22997,12 +22985,12 @@
 /turf/open/floor/iron/dark,
 /area/hallway/primary/aft)
 "bBC" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/portable_atmospherics/canister/plasma,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/engine,
 /area/science/storage)
 "bBE" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/portable_atmospherics/canister/plasma,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/light{
 	dir = 1
@@ -23377,7 +23365,7 @@
 /turf/open/floor/plating,
 /area/science/storage)
 "bCQ" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/portable_atmospherics/canister/plasma,
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -23957,15 +23945,15 @@
 	pixel_x = -8;
 	pixel_y = 14
 	},
-/obj/item/cartridge/signal/toxins{
+/obj/item/cartridge/signal/ordnance{
 	pixel_x = -9;
 	pixel_y = 4
 	},
-/obj/item/cartridge/signal/toxins{
+/obj/item/cartridge/signal/ordnance{
 	pixel_x = -5;
 	pixel_y = 1
 	},
-/obj/item/cartridge/signal/toxins{
+/obj/item/cartridge/signal/ordnance{
 	pixel_x = -9;
 	pixel_y = -1
 	},
@@ -24102,7 +24090,7 @@
 /area/science/mixing)
 "bFk" = (
 /obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/toxins,
+/obj/item/book/manual/wiki/ordnance,
 /obj/item/analyzer,
 /obj/item/wrench,
 /obj/item/screwdriver{
@@ -24142,7 +24130,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/computer/pod/old/mass_driver_controller/toxinsdriver/longrange{
+/obj/machinery/computer/pod/old/mass_driver_controller/ordnancedriver/longrange{
 	pixel_x = 24
 	},
 /turf/open/floor/iron,
@@ -24487,7 +24475,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/machinery/computer/atmos_control/toxinsmix{
+/obj/machinery/computer/atmos_control/ordnancemix{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -24719,7 +24707,7 @@
 /turf/closed/wall/r_wall,
 /area/science/mixing)
 "bHz" = (
-/obj/machinery/button/door/incinerator_vent_toxmix{
+/obj/machinery/button/door/incinerator_vent_ordmix{
 	pixel_y = -24
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -24729,14 +24717,14 @@
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "bHA" = (
-/obj/machinery/embedded_controller/radio/airlock_controller/incinerator_toxmix{
+/obj/machinery/embedded_controller/radio/airlock_controller/incinerator_ordmix{
 	pixel_x = 6;
 	pixel_y = -26
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/button/ignition/incinerator/toxmix{
+/obj/machinery/button/ignition/incinerator/ordmix{
 	pixel_x = -6;
 	pixel_y = -24
 	},
@@ -24995,7 +24983,7 @@
 /area/engineering/atmos)
 "bIL" = (
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/research/glass/incinerator/toxmix_interior,
+/obj/machinery/door/airlock/research/glass/incinerator/ordmix_interior,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
@@ -25239,7 +25227,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/airlock_sensor/incinerator_toxmix{
+/obj/machinery/airlock_sensor/incinerator_ordmix{
 	pixel_x = -24
 	},
 /obj/machinery/atmospherics/components/binary/pump/on,
@@ -25249,7 +25237,7 @@
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "bJR" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_toxmix{
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_ordmix{
 	dir = 8
 	},
 /turf/open/floor/engine,
@@ -25275,7 +25263,7 @@
 /turf/open/floor/plating,
 /area/science/mixing)
 "bJV" = (
-/obj/machinery/mass_driver/toxins,
+/obj/machinery/mass_driver/ordnance,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -25568,7 +25556,7 @@
 /area/engineering/atmos)
 "bLf" = (
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/research/glass/incinerator/toxmix_exterior,
+/obj/machinery/door/airlock/research/glass/incinerator/ordmix_exterior,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
@@ -25898,7 +25886,7 @@
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
 "bMm" = (
-/obj/machinery/air_sensor/atmos/toxins_mixing_tank,
+/obj/machinery/air_sensor/atmos/ordnance_mixing_tank,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
 "bMn" = (
@@ -25918,7 +25906,7 @@
 /turf/open/floor/plating,
 /area/science/mixing)
 "bMq" = (
-/obj/machinery/door/poddoor/massdriver_toxins,
+/obj/machinery/door/poddoor/massdriver_ordnance,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -26414,7 +26402,7 @@
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
 "bOt" = (
-/obj/machinery/door/poddoor/incinerator_toxmix,
+/obj/machinery/door/poddoor/incinerator_ordmix,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
 "bOu" = (
@@ -27514,7 +27502,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bSk" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/portable_atmospherics/canister/plasma,
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "bSm" = (
@@ -27713,7 +27701,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bSW" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/toxin_output{
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/plasma_output{
 	dir = 8
 	},
 /turf/open/floor/engine/plasma,
@@ -28050,7 +28038,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bTV" = (
-/obj/machinery/air_sensor/atmos/toxin_tank,
+/obj/machinery/air_sensor/atmos/plasma_tank,
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "bTW" = (
@@ -28229,7 +28217,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/computer/atmos_control/tank/toxin_tank{
+/obj/machinery/computer/atmos_control/tank/plasma_tank{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -29078,7 +29066,7 @@
 /area/engineering/atmos)
 "bWV" = (
 /turf/closed/wall,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "bWZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -29466,17 +29454,17 @@
 	name = "Confession Booth"
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "bYA" = (
 /obj/structure/chair/wood,
 /turf/open/floor/iron/chapel{
 	dir = 8
 	},
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "bYB" = (
 /obj/structure/chair/wood,
 /turf/open/floor/iron/chapel,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "bYI" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21";
@@ -29706,13 +29694,13 @@
 /turf/open/floor/iron/chapel{
 	dir = 1
 	},
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "bZm" = (
 /obj/structure/chair/wood,
 /turf/open/floor/iron/chapel{
 	dir = 4
 	},
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "bZr" = (
 /obj/item/trash/tray,
 /obj/structure/disposalpipe/segment{
@@ -30008,7 +29996,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/tinted/fulltile,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "caV" = (
 /obj/machinery/holopad,
 /obj/item/flashlight/lantern,
@@ -30016,7 +30004,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/chapel,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "caW" = (
 /obj/item/flashlight/lantern,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -30025,7 +30013,7 @@
 /turf/open/floor/iron/chapel{
 	dir = 8
 	},
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "caZ" = (
 /obj/structure/table,
 /obj/item/wirecutters,
@@ -30162,17 +30150,17 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cbM" = (
 /turf/open/floor/iron/chapel{
 	dir = 4
 	},
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cbN" = (
 /obj/item/storage/book/bible,
 /obj/structure/altar_of_gods,
 /turf/open/floor/carpet,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cbO" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/trophy{
@@ -30186,12 +30174,12 @@
 	dir = 8
 	},
 /turf/open/floor/carpet,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cbP" = (
 /turf/open/floor/iron/chapel{
 	dir = 1
 	},
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cbQ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -30356,16 +30344,16 @@
 	dir = 8
 	},
 /turf/open/floor/carpet,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "ccH" = (
 /turf/open/floor/iron/chapel,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "ccJ" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "ccL" = (
 /obj/item/flashlight/lantern{
 	icon_state = "lantern-on"
@@ -30455,12 +30443,12 @@
 	network = list("ss13","monastery")
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cdu" = (
 /turf/open/floor/iron/chapel{
 	dir = 8
 	},
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cdD" = (
 /obj/structure/table,
 /obj/item/trash/waffles,
@@ -30679,12 +30667,12 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cen" = (
 /obj/structure/table/wood,
 /obj/item/storage/photo_album,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "ceo" = (
 /obj/structure/chair{
 	dir = 1
@@ -30751,7 +30739,7 @@
 	icon_state = "plant-08"
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "ceL" = (
 /obj/structure/table/wood/fancy,
 /obj/item/storage/box/matches{
@@ -30760,7 +30748,7 @@
 	},
 /obj/machinery/light/small,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "ceT" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/closet/emcloset,
@@ -30837,10 +30825,10 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cfm" = (
 /turf/closed/wall/mineral/iron,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cfr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -30874,24 +30862,24 @@
 "cfC" = (
 /obj/machinery/biogenerator,
 /turf/open/floor/iron,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cfH" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plating,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cfI" = (
 /turf/open/floor/plating,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cfJ" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plating,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cfL" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/machinery/camera{
@@ -30964,7 +30952,7 @@
 "cgb" = (
 /obj/item/storage/firstaid/regular,
 /turf/open/floor/iron,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cgj" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -31045,7 +31033,7 @@
 "cgG" = (
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cgH" = (
 /turf/open/floor/grass,
 /area/service/hydroponics/garden/monastery)
@@ -31075,14 +31063,14 @@
 	specialfunctions = 4
 	},
 /turf/open/floor/iron/grimy,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cgM" = (
 /obj/structure/dresser,
 /obj/structure/sign/plaques/deempisi{
 	pixel_y = 28
 	},
 /turf/open/floor/iron/grimy,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cgN" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -31091,7 +31079,7 @@
 	},
 /obj/item/flashlight/lantern,
 /turf/open/floor/iron/grimy,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cgO" = (
 /obj/structure/toilet{
 	pixel_y = 8
@@ -31101,7 +31089,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cgP" = (
 /obj/structure/transit_tube,
 /turf/open/floor/plating/airless,
@@ -31141,11 +31129,11 @@
 	network = list("ss13","monastery")
 	},
 /turf/open/floor/iron,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "chc" = (
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/iron,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "chd" = (
 /obj/item/clothing/suit/apron/chef,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -31155,7 +31143,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "chi" = (
 /obj/structure/flora/ausbushes/pointybush,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -31183,7 +31171,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/grimy,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "chr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -31192,20 +31180,20 @@
 	dir = 4
 	},
 /turf/open/floor/iron/grimy,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cht" = (
 /obj/machinery/door/airlock{
 	name = "Bathroom"
 	},
 /turf/open/floor/iron/grimy,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "chu" = (
 /obj/structure/sink{
 	dir = 8;
 	pixel_x = 11
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "chv" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -31235,7 +31223,7 @@
 /obj/item/seeds/grass,
 /obj/item/seeds/grape,
 /turf/open/floor/iron,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "chC" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -31244,7 +31232,7 @@
 	},
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/iron,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "chG" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/wheat,
@@ -31257,18 +31245,18 @@
 	},
 /obj/item/instrument/violin,
 /turf/open/floor/iron/grimy,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "chL" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/open/floor/iron/grimy,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "chM" = (
 /obj/structure/bed,
 /obj/item/bedsheet/green,
 /turf/open/floor/iron/grimy,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "chN" = (
 /obj/machinery/shower{
 	dir = 8;
@@ -31276,19 +31264,19 @@
 	},
 /obj/item/soap/homemade,
 /turf/open/floor/iron/showroomfloor,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "chU" = (
 /obj/structure/sink{
 	dir = 8;
 	pixel_x = 11
 	},
 /turf/open/floor/iron,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "chV" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /turf/open/floor/iron,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "chW" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/saltshaker{
@@ -31300,7 +31288,7 @@
 	layer = 3.1
 	},
 /turf/open/floor/iron,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "chX" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/flour,
@@ -31308,15 +31296,15 @@
 /obj/item/kitchen/knife,
 /obj/machinery/light/small,
 /turf/open/floor/iron,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "chY" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/iron,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "chZ" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/iron,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cib" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
@@ -31354,7 +31342,7 @@
 	specialfunctions = 4
 	},
 /turf/open/floor/iron/grimy,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cip" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -31362,13 +31350,13 @@
 /obj/structure/easel,
 /obj/item/canvas/twentythree_nineteen,
 /turf/open/floor/iron/grimy,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "ciq" = (
 /obj/structure/toilet{
 	pixel_y = 8
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cis" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
@@ -31382,11 +31370,11 @@
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/iron,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "ciz" = (
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "ciE" = (
 /obj/structure/flora/ausbushes/genericbush,
 /obj/machinery/light/small{
@@ -31406,7 +31394,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/grimy,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "ciH" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/engineering/glass/critical{
@@ -31421,15 +31409,15 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "ciK" = (
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "ciN" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "ciO" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/condiment/saltshaker{
@@ -31442,7 +31430,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "ciS" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/grass,
@@ -31469,12 +31457,12 @@
 	},
 /obj/item/storage/crayons,
 /turf/open/floor/iron/grimy,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "ciY" = (
 /obj/structure/bed,
 /obj/item/bedsheet/yellow,
 /turf/open/floor/iron/grimy,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "ciZ" = (
 /obj/machinery/shower{
 	dir = 8;
@@ -31486,7 +31474,7 @@
 	},
 /obj/item/bikehorn/rubberducky,
 /turf/open/floor/iron/showroomfloor,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cjl" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Monastery Cemetary"
@@ -31499,7 +31487,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cjm" = (
 /turf/closed/wall,
 /area/maintenance/department/chapel/monastery)
@@ -31567,7 +31555,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cjH" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Chapel Garden"
@@ -31580,7 +31568,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cjO" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/item/stack/sheet/glass/fifty{
@@ -31602,7 +31590,7 @@
 /turf/open/floor/carpet,
 /area/service/library)
 "cjV" = (
-/obj/machinery/camera/preset/toxins,
+/obj/machinery/camera/preset/ordnance,
 /turf/open/floor/plating/asteroid/airless,
 /area/asteroid/nearstation/bomb_site)
 "cjZ" = (
@@ -31610,19 +31598,19 @@
 /obj/item/storage/crayons,
 /obj/item/wrench,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cka" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "ckb" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /turf/open/floor/carpet,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "ckg" = (
 /obj/item/wrench,
 /turf/open/floor/plating,
@@ -31665,7 +31653,7 @@
 	name = "Mass Driver"
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "ckw" = (
 /obj/machinery/mass_driver/chapelgun,
 /obj/structure/window/reinforced{
@@ -31673,7 +31661,7 @@
 	layer = 2.9
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cky" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -31715,14 +31703,14 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "ckN" = (
 /obj/structure/window/reinforced{
 	dir = 4;
 	layer = 2.9
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "ckO" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -31771,7 +31759,7 @@
 "clb" = (
 /obj/machinery/door/poddoor/massdriver_chapel,
 /turf/open/floor/plating,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "clf" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -31919,7 +31907,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/transit_tube/station/dispenser{
+/obj/structure/transit_tube/station/dispenser/flipped{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -31936,7 +31924,7 @@
 "clU" = (
 /obj/item/wrench,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "clV" = (
@@ -31946,8 +31934,8 @@
 /area/tcommsat/computer)
 "clY" = (
 /obj/item/beacon,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "cma" = (
@@ -31955,8 +31943,8 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "cmb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "cmc" = (
@@ -32008,8 +31996,8 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "cmj" = (
@@ -32024,8 +32012,8 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "cml" = (
@@ -32305,7 +32293,7 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "cnp" = (
-/obj/machinery/camera/preset/toxins{
+/obj/machinery/camera/preset/ordnance{
 	c_tag = "Bomb Testing Asteroid Aft";
 	dir = 1
 	},
@@ -33141,7 +33129,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "crl" = (
 /obj/structure/sign/warning/vacuum/external,
 /obj/effect/spawner/structure/window/reinforced,
@@ -33169,7 +33157,7 @@
 /obj/structure/table/wood,
 /obj/item/food/grown/harebell,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cry" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -33228,7 +33216,7 @@
 /obj/structure/table/wood,
 /obj/item/food/grown/poppy,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "crK" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -33239,7 +33227,7 @@
 	network = list("ss13","monastery")
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "crN" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -33251,7 +33239,7 @@
 	},
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "crO" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -33278,7 +33266,7 @@
 	pixel_y = 8
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "csd" = (
 /turf/open/floor/carpet/black,
 /area/service/chapel/office)
@@ -33299,7 +33287,7 @@
 	pixel_y = 8
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "csn" = (
 /obj/structure/closet,
 /obj/item/storage/backpack/cultpack,
@@ -33337,7 +33325,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "csy" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/disposalpipe/segment{
@@ -33391,7 +33379,7 @@
 /area/service/chapel/office)
 "csS" = (
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "csT" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -33402,11 +33390,11 @@
 	},
 /obj/structure/chair/wood,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "csU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "csY" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/iron/dark,
@@ -33416,7 +33404,7 @@
 /obj/item/storage/fancy/candle_box,
 /obj/machinery/light/small,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "ctr" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -33451,7 +33439,7 @@
 	icon_state = "plant-10"
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "ctM" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/airalarm/directional/south,
@@ -33466,20 +33454,20 @@
 	network = list("ss13","monastery")
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "ctP" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "ctQ" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "ctS" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
@@ -33511,18 +33499,18 @@
 /obj/item/melee/flyswatter,
 /obj/item/melee/flyswatter,
 /turf/open/floor/iron,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cul" = (
 /obj/machinery/chem_master/condimaster,
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cum" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/iron,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cun" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -33556,18 +33544,18 @@
 /obj/item/honey_frame,
 /obj/item/honey_frame,
 /turf/open/floor/iron,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cut" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/iron,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cuu" = (
 /obj/item/storage/bag/plants,
 /obj/item/storage/bag/plants/portaseeder,
 /obj/item/storage/bag/plants/portaseeder,
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cuv" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -33579,18 +33567,18 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cuw" = (
 /obj/structure/table/wood,
 /obj/item/trash/waffles,
 /obj/item/kitchen/fork,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cux" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/mug/tea,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cuz" = (
 /obj/machinery/camera{
 	c_tag = "Monastery Cloister Port";
@@ -33598,7 +33586,7 @@
 	network = list("ss13","monastery")
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cuA" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -33619,22 +33607,22 @@
 /obj/structure/closet/secure_closet/freezer/fridge/open,
 /obj/machinery/light/small,
 /turf/open/floor/iron,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cuH" = (
 /obj/item/hatchet,
 /turf/open/floor/iron,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cuI" = (
 /obj/machinery/vending/hydronutrients,
 /turf/open/floor/iron,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cuJ" = (
 /obj/item/shovel/spade,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cuK" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -33645,7 +33633,7 @@
 	network = list("ss13","monastery")
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cuL" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -33678,7 +33666,7 @@
 "cuR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cuS" = (
 /obj/machinery/door/airlock{
 	name = "Kitchen"
@@ -33691,7 +33679,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cuU" = (
 /obj/machinery/door/airlock{
 	name = "Dining Room"
@@ -33704,21 +33692,21 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cuY" = (
 /obj/machinery/door/airlock{
 	name = "Garden"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cuZ" = (
 /obj/item/wrench,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cvb" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/wheat,
@@ -33732,13 +33720,13 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cve" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cvg" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/brflowers,
@@ -33771,7 +33759,7 @@
 	network = list("ss13","monastery")
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cvq" = (
 /obj/machinery/camera{
 	c_tag = "Monastery Secondary Dock";
@@ -33779,7 +33767,7 @@
 	network = list("ss13","monastery")
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cvr" = (
 /obj/machinery/door/window/eastleft{
 	dir = 1;
@@ -33787,13 +33775,13 @@
 	req_one_access_txt = "22"
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cvs" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cvt" = (
 /obj/machinery/door/window/eastleft{
 	base_state = "right";
@@ -33803,7 +33791,7 @@
 	req_one_access_txt = "22"
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cvy" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/highcap/five_k{
@@ -33817,7 +33805,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cvA" = (
 /obj/machinery/door/airlock/external{
 	name = "Dock Access"
@@ -33829,11 +33817,11 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cvB" = (
 /obj/structure/chair/wood,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cvI" = (
 /obj/machinery/light/small,
 /obj/machinery/camera{
@@ -33843,12 +33831,12 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cvJ" = (
 /obj/machinery/light/small,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cvR" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -33862,11 +33850,11 @@
 	network = list("ss13","monastery")
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cvT" = (
 /obj/structure/chair/wood,
 /turf/open/floor/carpet,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cwa" = (
 /turf/closed/wall/mineral/iron,
 /area/maintenance/department/chapel/monastery)
@@ -33904,16 +33892,16 @@
 	},
 /obj/structure/table/wood,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cwk" = (
 /turf/open/floor/carpet,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cwl" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/item/storage/fancy/candle_box,
 /obj/structure/table/wood,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cwm" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/structure/cable,
@@ -33944,12 +33932,12 @@
 /obj/item/food/grown/poppy,
 /obj/item/food/grown/harebell,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cwx" = (
 /obj/structure/table/wood/fancy,
 /obj/item/storage/book/bible,
 /turf/open/floor/carpet,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cwy" = (
 /obj/structure/table/wood/fancy,
 /obj/item/candle,
@@ -33962,7 +33950,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/carpet,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cwz" = (
 /obj/item/clothing/under/misc/burial,
 /obj/item/clothing/under/misc/burial,
@@ -33970,14 +33958,14 @@
 /obj/item/clothing/under/misc/burial,
 /obj/structure/table/wood,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cwA" = (
 /turf/open/floor/plating,
 /area/maintenance/department/chapel/monastery)
 "cwF" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cwG" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -33986,7 +33974,7 @@
 	pixel_x = 24
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cwM" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -33997,7 +33985,7 @@
 "cwO" = (
 /obj/item/flashlight/lantern,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cwR" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -35027,7 +35015,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "cRY" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/oxygen_input{
 	dir = 1
@@ -35389,8 +35377,8 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "dpV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "dqw" = (
@@ -35544,7 +35532,7 @@
 	},
 /area/security/prison)
 "dxo" = (
-/obj/machinery/igniter/incinerator_toxmix,
+/obj/machinery/igniter/incinerator_ordmix,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
 "dxF" = (
@@ -36557,7 +36545,7 @@
 	},
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/grimy,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "eDH" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -37013,9 +37001,9 @@
 /turf/open/floor/iron,
 /area/maintenance/department/engine)
 "eXa" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "eXo" = (
@@ -37151,7 +37139,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/tank/toxins{
+/obj/machinery/atmospherics/components/tank/plasma{
 	dir = 4;
 	initialize_directions = 4
 	},
@@ -37211,7 +37199,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "fdN" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -37245,7 +37233,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "feh" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxin_input{
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/plasma_input{
 	dir = 8
 	},
 /turf/open/floor/engine/plasma,
@@ -37482,7 +37470,7 @@
 "fnN" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "fon" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -37902,7 +37890,7 @@
 "fIT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "fJd" = (
 /obj/structure/rack,
 /obj/item/tank/internals/emergency_oxygen,
@@ -38449,8 +38437,8 @@
 /area/science/mixing)
 "gmH" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "gmO" = (
@@ -38720,7 +38708,6 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/green,
 /obj/structure/sign/warning/vacuum{
 	pixel_x = -32;
 	pixel_y = -32
@@ -38860,7 +38847,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "gEv" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -39008,7 +38995,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "gKn" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -39279,7 +39266,7 @@
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "hae" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/structure/cable,
@@ -39513,7 +39500,7 @@
 /obj/structure/chair/wood,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/chapel,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "hpp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -39611,7 +39598,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "hwj" = (
 /obj/structure/window/reinforced,
-/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/portable_atmospherics/canister/plasma,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
@@ -39683,7 +39670,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "hBn" = (
 /obj/structure/table/glass,
 /obj/item/folder/white,
@@ -39762,7 +39749,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/grimy,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "hEc" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -39833,7 +39820,7 @@
 "hGQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "hHr" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -40110,7 +40097,7 @@
 "hTw" = (
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "hUx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -40554,13 +40541,11 @@
 	name = "Test Chamber";
 	req_access_txt = "55"
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "ivp" = (
@@ -41353,9 +41338,6 @@
 "jtf" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -41477,7 +41459,7 @@
 	name = "Chapel"
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "jAy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -42644,7 +42626,7 @@
 "kOF" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/chapel,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "kPA" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/segment{
@@ -42978,6 +42960,9 @@
 /obj/item/paper_bin,
 /obj/item/folder/blue,
 /obj/item/pen,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "lem" = (
@@ -43017,7 +43002,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "lgR" = (
 /obj/machinery/shower{
 	dir = 8
@@ -43491,8 +43476,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/green{
-	dir = 8
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "lHX" = (
@@ -43659,8 +43645,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "lTW" = (
-/turf/closed/wall/r_wall,
-/area/space/nearstation)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/ai_upload)
 "lUC" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -43989,7 +43978,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "mlV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -44160,9 +44149,11 @@
 /turf/closed/wall,
 /area/maintenance/department/security/brig)
 "mtB" = (
-/obj/structure/sign/warning/biohazard,
-/turf/closed/wall/r_wall,
-/area/space)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/ai_upload)
 "mtC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -45072,7 +45063,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "nkY" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -45310,7 +45301,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "nxT" = (
 /obj/machinery/smartfridge/extract/preloaded,
 /obj/machinery/requests_console/directional/east{
@@ -45486,7 +45477,11 @@
 	pixel_y = 2
 	},
 /obj/structure/table/reinforced,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "nIt" = (
 /obj/structure/disposalpipe/segment{
@@ -45575,8 +45570,8 @@
 	},
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "nNk" = (
@@ -45881,7 +45876,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "obj" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -46412,7 +46407,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "oAk" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/lizard/wags_his_tail,
@@ -46648,7 +46643,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/grimy,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "oMH" = (
 /obj/structure/table,
 /obj/item/airlock_painter/decal,
@@ -47213,7 +47208,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "pmw" = (
 /obj/machinery/mass_driver/trash{
 	dir = 4
@@ -47297,7 +47292,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/grimy,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "prD" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -48033,7 +48028,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "qcD" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -48202,7 +48197,7 @@
 	},
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "qjx" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/yellow,
@@ -48249,7 +48244,11 @@
 /obj/item/clothing/glasses/science,
 /obj/structure/table,
 /obj/item/wrench,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "qlz" = (
 /obj/structure/window/reinforced/spawner/east,
@@ -48668,7 +48667,7 @@
 "qFp" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "qFu" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -48688,7 +48687,7 @@
 "qGk" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "qHa" = (
 /obj/structure/closet/wardrobe/red,
 /obj/effect/turf_decal/tile/red,
@@ -48955,7 +48954,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "qVd" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general{
 	dir = 6
@@ -49045,7 +49044,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "rax" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -49218,7 +49217,7 @@
 	},
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/showroomfloor,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "rlj" = (
 /obj/structure/flora/junglebush/large,
 /turf/open/floor/grass,
@@ -49564,7 +49563,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "rvA" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
@@ -50148,7 +50147,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/chapel,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "rVA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -51089,8 +51088,15 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "sQP" = (
-/turf/closed/wall/r_wall,
-/area/space)
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/science/xenobiology)
 "sSj" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/item/radio/intercom/directional/south,
@@ -51334,6 +51340,9 @@
 /area/engineering/atmos)
 "taA" = (
 /obj/structure/chair/office/light,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "taF" = (
@@ -51720,7 +51729,7 @@
 /obj/item/crowbar,
 /obj/item/clothing/mask/gas,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "tpC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -51818,7 +51827,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/portable_atmospherics/canister/plasma,
 /turf/open/floor/plating,
 /area/engineering/storage_shared)
 "tuM" = (
@@ -51904,7 +51913,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "txB" = (
 /obj/structure/bookcase/random/adult,
 /obj/machinery/light/small,
@@ -52415,7 +52424,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "tWt" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
@@ -52573,7 +52582,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "udE" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
@@ -52991,7 +53000,7 @@
 /turf/open/floor/iron/chapel{
 	dir = 8
 	},
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "ute" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -53176,8 +53185,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "uzr" = (
@@ -53527,7 +53536,6 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
@@ -54167,7 +54175,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "vpz" = (
 /obj/structure/girder,
 /turf/open/floor/plating{
@@ -54237,7 +54245,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "vsJ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /turf/open/floor/iron,
@@ -54420,7 +54428,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "vEU" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -54433,7 +54441,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "vFZ" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -54442,7 +54450,7 @@
 	pixel_x = 29
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "vHj" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance{
@@ -54798,7 +54806,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "vWe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /turf/closed/wall,
@@ -55098,7 +55106,7 @@
 	pixel_x = -27
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "whJ" = (
 /turf/closed/wall/mineral/iron,
 /area/service/library/artgallery)
@@ -55608,7 +55616,7 @@
 "wDx" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "wDA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -55697,11 +55705,8 @@
 	dir = 8
 	},
 /turf/open/floor/carpet,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "wEJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "wFr" = (
@@ -55771,7 +55776,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "wIX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -55791,7 +55796,7 @@
 	dir = 4
 	},
 /turf/open/floor/carpet,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "wKa" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -55924,7 +55929,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "wPo" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -56195,7 +56200,7 @@
 /area/engineering/atmos)
 "wYr" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "wYu" = (
@@ -56545,7 +56550,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "xlh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -56710,7 +56715,7 @@
 "xrO" = (
 /obj/structure/cable,
 /turf/open/floor/carpet,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "xsr" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -57593,7 +57598,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "yiL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -57643,7 +57648,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/main/monastery)
+/area/service/chapel/monastery)
 "ylb" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -88087,8 +88092,8 @@ ayb
 juf
 aAB
 aLv
-aCK
-aDL
+lTW
+wEJ
 aEF
 aAB
 aGp
@@ -88601,7 +88606,7 @@ ayb
 azk
 aAB
 aBu
-aCK
+mtB
 wEJ
 aEH
 aAB
@@ -108691,7 +108696,7 @@ oEW
 iuM
 wXu
 qlk
-lGS
+sQP
 bnd
 aaa
 aaa
@@ -110226,15 +110231,15 @@ aaa
 aaa
 aaa
 aaa
-sQP
-lTW
-sQP
-mtB
-lTW
-mtB
-sQP
-lTW
-sQP
+bkF
+bkF
+bkF
+xKc
+bkF
+xKc
+bkF
+bkF
+bkF
 aaa
 aby
 aaa

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -9478,12 +9478,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"aDL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai_upload)
 "aDM" = (
 /obj/machinery/camera/motion{
 	c_tag = "AI Upload Center";
@@ -9491,12 +9485,6 @@
 	network = list("aiupload")
 	},
 /obj/machinery/holopad/secure,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
 /turf/open/floor/circuit,
@@ -31600,7 +31588,7 @@
 	width = 35
 	},
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "cjC" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
@@ -31977,7 +31965,7 @@
 "clU" = (
 /obj/item/wrench,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "clV" = (
@@ -31987,8 +31975,8 @@
 /area/tcommsat/computer)
 "clY" = (
 /obj/item/beacon,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "cma" = (
@@ -31996,8 +31984,8 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "cmb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "cmc" = (
@@ -32049,8 +32037,8 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "cmj" = (
@@ -32065,8 +32053,8 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "cml" = (
@@ -34937,8 +34925,8 @@
 	name = "Permabrig Cell 2";
 	req_access_txt = "2"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "perma-cell-2-passthrough"
 	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
@@ -35459,8 +35447,8 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "dpV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "dqw" = (
@@ -36320,12 +36308,14 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/poddoor/preopen{
 	id = "permashut3"
 	},
 /obj/machinery/door/airlock/glass{
 	name = "Cell 3"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "perma-cell-3-passthrough"
 	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
@@ -36783,8 +36773,8 @@
 	name = "Permabrig Cell 1";
 	req_access_txt = "2"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "perma-cell-1-passthrough"
 	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
@@ -36837,12 +36827,14 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/poddoor/preopen{
 	id = "permashut2"
 	},
 /obj/machinery/door/airlock/glass{
 	name = "cell 2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "perma-cell-2-passthrough"
 	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
@@ -37165,9 +37157,9 @@
 /turf/open/floor/iron,
 /area/maintenance/department/engine)
 "eXa" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "eXo" = (
@@ -38628,8 +38620,8 @@
 /area/science/mixing)
 "gmH" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "gmO" = (
@@ -43984,8 +43976,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "lTW" = (
-/turf/closed/wall/r_wall,
-/area/space/nearstation)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/ai_upload)
 "lUC" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -44492,9 +44487,11 @@
 /turf/closed/wall,
 /area/maintenance/department/security/brig)
 "mtB" = (
-/obj/structure/sign/warning/biohazard,
-/turf/closed/wall/r_wall,
-/area/space)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/ai_upload)
 "mtC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -45890,8 +45887,8 @@
 	},
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "nNk" = (
@@ -47069,8 +47066,8 @@
 	name = "Permabrig Cell 3";
 	req_access_txt = "2"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "perma-cell-3-passthrough"
 	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
@@ -49352,7 +49349,7 @@
 	dir = 4
 	},
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "raF" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
@@ -51343,9 +51340,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"sQP" = (
-/turf/closed/wall/r_wall,
-/area/space)
 "sSj" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/item/radio/intercom/directional/south,
@@ -53362,12 +53356,14 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/poddoor/preopen{
 	id = "permashut1"
 	},
 /obj/machinery/door/airlock/glass{
 	name = "Cell 1"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "perma-cell-1-passthrough"
 	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
@@ -53421,8 +53417,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "uzr" = (
@@ -55960,9 +55956,6 @@
 /turf/open/floor/carpet,
 /area/service/chapel/monastery)
 "wEJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "wFr" = (
@@ -56457,7 +56450,7 @@
 /area/engineering/atmos)
 "wYr" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "wYu" = (
@@ -85026,7 +85019,7 @@ aaa
 aaa
 aaa
 aaa
-afJ
+cFB
 aaa
 aaa
 abI
@@ -88392,8 +88385,8 @@ ayb
 juf
 aAB
 aLv
-aCK
-aDL
+lTW
+wEJ
 aEF
 aAB
 aGp
@@ -88906,7 +88899,7 @@ ayb
 azk
 aAB
 aBu
-aCK
+mtB
 wEJ
 aEH
 aAB
@@ -110531,15 +110524,15 @@ aaa
 aaa
 aaa
 aaa
-sQP
-lTW
-sQP
-mtB
-lTW
-mtB
-sQP
-lTW
-sQP
+bkF
+bkF
+bkF
+xKc
+bkF
+xKc
+bkF
+bkF
+bkF
 aaa
 aby
 aaa

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -1050,8 +1050,11 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "adU" = (
-/turf/open/space/basic,
-/area/cargo/warehouse/upper)
+/obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/security)
 "adV" = (
 /turf/open/space,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
@@ -1134,51 +1137,28 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "aep" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/security/prison)
-"aeq" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
-	name = "Dining Room"
+/obj/machinery/skill_station,
+/turf/open/floor/iron,
+/area/security/prison)
+"aeq" = (
+/obj/structure/punching_bag,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
 "aer" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/iron,
-/area/security/prison)
-"aes" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
 "aet" = (
@@ -1195,16 +1175,10 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse/upper)
 "aeu" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
 "aev" = (
@@ -1238,31 +1212,39 @@
 /turf/open/space,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
 "aeB" = (
-/obj/structure/window/reinforced,
-/turf/open/space/basic,
-/area/cargo/warehouse/upper)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/security)
 "aeC" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/vending/sustenance,
-/turf/open/floor/iron/white,
-/area/security/prison)
-"aeD" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/vending/cola/red,
-/turf/open/floor/iron/white,
-/area/security/prison)
-"aeE" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
-/obj/item/kirbyplants{
-	icon_state = "plant-08"
+/obj/structure/sink{
+	pixel_y = 29
+	},
+/obj/structure/closet/crate/trashcart/laundry,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/turf/open/floor/iron,
+/area/security/prison)
+"aeD" = (
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bottle/ammonia,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/structure/closet/crate/trashcart,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/obj/machinery/light/no_nightlight/directional/north,
+/turf/open/floor/iron,
+/area/security/prison)
+"aeE" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
@@ -1270,6 +1252,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -1281,14 +1264,16 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
+/obj/machinery/camera{
+	c_tag = "Permabrig - Upper Hall";
+	dir = 8;
+	network = list("ss13","prison")
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "aeI" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 10
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 5
 	},
 /turf/open/floor/iron,
 /area/security/prison)
@@ -1330,43 +1315,37 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
 "aeT" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/structure/chair{
 	dir = 1
 	},
-/obj/structure/table/wood/fancy,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/chapel,
 /area/security/prison)
 "aeV" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/chair/stool/directional/north,
 /turf/open/floor/iron,
 /area/security/prison)
 "aeW" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/chair{
 	dir = 1
 	},
-/obj/structure/table/wood,
-/obj/machinery/computer/bookmanagement,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/chapel,
 /area/security/prison)
 "aeX" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/chair{
 	dir = 1
 	},
-/obj/machinery/light/directional/north,
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/trophy{
-	pixel_y = 8
+/turf/open/floor/iron/chapel{
+	dir = 8
 	},
-/obj/item/storage/book/bible,
-/turf/open/floor/iron/dark,
 /area/security/prison)
 "aeY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
@@ -1543,40 +1522,43 @@
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
 "afn" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
+	dir = 8
 	},
-/obj/structure/weightmachine/weightlifter,
-/turf/open/floor/iron,
-/area/security/prison)
-"afp" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/prison)
-"afq" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/prison)
+"afp" = (
+/obj/structure/table,
+/obj/item/toy/cards/deck/cas/black{
+	pixel_x = -7
+	},
+/obj/item/toy/cards/deck/cas{
+	pixel_x = 5;
+	pixel_y = 10
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "afr" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
+/obj/structure/rack,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/clothing/mask/breath,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
 	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
 /area/security/prison)
 "afs" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
 	},
-/obj/machinery/light/no_nightlight/directional/north,
-/turf/open/floor/iron,
+/obj/item/kirbyplants{
+	icon_state = "plant-08"
+	},
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "aft" = (
 /obj/machinery/light/small{
@@ -1653,9 +1635,8 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/structure/table,
-/obj/item/storage/pill_bottle/dice,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/table,
 /turf/open/floor/iron,
 /area/security/prison)
 "afF" = (
@@ -1663,28 +1644,15 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/table,
+/obj/item/paper_bin,
 /turf/open/floor/iron,
 /area/security/prison)
 "afH" = (
 /obj/machinery/flasher/portable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"afI" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/iron,
-/area/security/prison)
 "afJ" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space/basic,
@@ -1771,11 +1739,8 @@
 /turf/closed/wall,
 /area/security/execution/transfer)
 "afX" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-08"
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
@@ -1790,30 +1755,21 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "aga" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
+/obj/structure/cable,
+/turf/open/floor/iron/dark/side{
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/grunge{
-	name = "Prison Workshop"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/iron,
 /area/security/prison)
 "agc" = (
-/obj/effect/turf_decal/stripes/white/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
 "agd" = (
-/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/structure/chair/stool/directional/west,
 /turf/open/floor/iron,
 /area/security/prison)
 "age" = (
@@ -1890,15 +1846,12 @@
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
+/turf/open/floor/iron,
 /area/security/prison)
 "agp" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
+/obj/machinery/light/no_nightlight/directional/south,
+/turf/open/floor/iron,
 /area/security/prison)
 "agq" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -1998,6 +1951,7 @@
 /area/security)
 "agQ" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security)
 "agR" = (
@@ -2201,7 +2155,12 @@
 /area/security/prison)
 "ahG" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
+	dir = 10
+	},
+/obj/machinery/camera{
+	c_tag = "Permabrig - Monastery";
+	dir = 4;
+	network = list("ss13","prison")
 	},
 /obj/structure/sign/painting/library{
 	pixel_x = -32
@@ -2263,9 +2222,12 @@
 /turf/open/floor/iron/showroomfloor,
 /area/security)
 "ahN" = (
-/obj/structure/window/reinforced,
-/turf/open/space/basic,
-/area/cargo/storage)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/security)
 "ahP" = (
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
@@ -2290,9 +2252,11 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/security/execution/transfer)
 "ahT" = (
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/security/execution/transfer)
 "ahU" = (
@@ -2302,6 +2266,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "ahW" = (
@@ -2396,15 +2361,15 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "aij" = (
-/turf/open/floor/iron/chapel{
-	dir = 1
-	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "aik" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/chapel{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "ail" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -2867,6 +2832,7 @@
 	},
 /obj/structure/reagent_dispensers/peppertank/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security)
 "ajr" = (
@@ -3089,6 +3055,7 @@
 	},
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security)
 "aka" = (
@@ -3423,10 +3390,13 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "akN" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/chapel{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "akO" = (
 /obj/structure/table/reinforced,
@@ -3449,11 +3419,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/sorting)
-"akP" = (
-/turf/open/floor/iron/chapel{
-	dir = 4
-	},
-/area/security/prison)
 "akQ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -3478,14 +3443,17 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security)
 "akT" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/heads_quarters/hos)
 "akU" = (
 /obj/effect/turf_decal/tile/red,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "akV" = (
@@ -3520,6 +3488,7 @@
 	id = "hos_spess_shutters";
 	name = "Space shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/heads_quarters/hos)
 "ala" = (
@@ -3683,9 +3652,11 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "alA" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "alB" = (
@@ -3853,6 +3824,7 @@
 /area/security/warden)
 "amh" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/warden)
 "amk" = (
@@ -3866,6 +3838,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/warden)
 "amm" = (
@@ -3992,18 +3965,21 @@
 "amx" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
 "amy" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
 "amz" = (
 /obj/machinery/computer/security/hos{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
 "amA" = (
@@ -4194,11 +4170,8 @@
 /turf/open/floor/iron,
 /area/security)
 "anf" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
 /area/security)
 "ani" = (
 /obj/structure/chair/office{
@@ -4418,6 +4391,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "anS" = (
@@ -4500,7 +4474,9 @@
 	name = "Engineering";
 	req_one_access_txt = "10;24"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "Engineering-passthrough"
+	},
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "aof" = (
@@ -4515,12 +4491,12 @@
 /area/maintenance/department/security/brig)
 "aoj" = (
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /obj/machinery/door/airlock/engineering{
 	name = "Engine Room";
 	req_one_access_txt = "10;24"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "Engineering-passthrough"
 	},
 /turf/open/floor/iron,
 /area/engineering/break_room)
@@ -4567,6 +4543,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "aot" = (
@@ -4629,6 +4607,7 @@
 /area/maintenance/fore)
 "aoA" = (
 /obj/effect/turf_decal/bot_white/right,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/gateway)
 "aoB" = (
@@ -4636,6 +4615,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/bot_white,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/gateway)
 "aoC" = (
@@ -4696,6 +4676,7 @@
 /obj/item/clothing/ears/earmuffs,
 /obj/item/clothing/glasses/sunglasses,
 /obj/structure/table/reinforced,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "aoS" = (
@@ -4899,12 +4880,14 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "apm" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "apn" = (
@@ -4935,6 +4918,7 @@
 /area/command/gateway)
 "apr" = (
 /obj/machinery/gateway/centerstation,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/gateway)
 "apt" = (
@@ -5073,6 +5057,7 @@
 /area/maintenance/fore)
 "apR" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "apS" = (
@@ -5175,6 +5160,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "aqv" = (
@@ -5269,6 +5255,7 @@
 	id = "bridgespace";
 	name = "bridge external shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/bridge)
 "aqL" = (
@@ -5395,12 +5382,12 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "arl" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/structure/chair{
 	dir = 1
 	},
-/obj/structure/table/wood/fancy,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/chapel{
+	dir = 8
+	},
 /area/security/prison)
 "arm" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
@@ -5555,6 +5542,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "arJ" = (
@@ -5609,6 +5597,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "arN" = (
@@ -5657,6 +5646,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "arR" = (
@@ -5725,6 +5715,7 @@
 /obj/item/flashlight,
 /obj/item/flashlight,
 /obj/item/flashlight,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/gateway)
 "asa" = (
@@ -6157,6 +6148,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "atA" = (
@@ -6172,6 +6164,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "atC" = (
@@ -6187,10 +6180,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "atE" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "innerbrig";
 	name = "Brig";
@@ -6204,6 +6197,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "atF" = (
@@ -6211,7 +6207,6 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "atG" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "innerbrig";
 	name = "Brig";
@@ -6224,6 +6219,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "atH" = (
@@ -6308,6 +6306,8 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "atT" = (
@@ -6317,6 +6317,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "atU" = (
@@ -6327,12 +6328,17 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "atV" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "atW" = (
@@ -6535,6 +6541,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "auB" = (
@@ -6903,6 +6910,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "avu" = (
@@ -6934,6 +6942,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "avx" = (
@@ -6965,6 +6974,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "avA" = (
@@ -7135,6 +7145,7 @@
 "avX" = (
 /obj/structure/table/glass,
 /obj/item/storage/toolbox/emergency,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "avY" = (
@@ -7372,9 +7383,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "awL" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "outerbrig";
 	name = "Brig";
@@ -7388,12 +7396,12 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "awN" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "outerbrig";
 	name = "Brig";
@@ -7407,6 +7415,9 @@
 /obj/machinery/navbeacon/wayfinding/sec,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "awO" = (
@@ -7583,6 +7594,7 @@
 /area/maintenance/department/security/brig)
 "axh" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/bridge)
 "axi" = (
@@ -7644,10 +7656,10 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Holodeck Door"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "holodeck"
+	},
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "axB" = (
@@ -7792,6 +7804,7 @@
 	req_one_access_txt = "19; 65"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "ayg" = (
@@ -8158,6 +8171,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "azp" = (
@@ -8624,6 +8638,7 @@
 	id = "datboidetective";
 	name = "privacy shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/detectives_office)
 "aBf" = (
@@ -8765,12 +8780,14 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aBy" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
 	req_access_txt = "19"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "bridge-left"
+	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "aBz" = (
@@ -9501,6 +9518,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"aDL" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai_upload)
 "aDM" = (
 /obj/machinery/camera/motion{
 	c_tag = "AI Upload Center";
@@ -9508,6 +9531,12 @@
 	network = list("aiupload")
 	},
 /obj/machinery/holopad/secure,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
 /turf/open/floor/circuit,
@@ -10173,6 +10202,7 @@
 	name = "Privacy Shutters"
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/heads_quarters/hop)
 "aFB" = (
@@ -10584,9 +10614,6 @@
 	name = "bridge blast door"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
 	req_access_txt = "19"
@@ -10600,6 +10627,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "bridge-left"
+	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "aHe" = (
@@ -10607,15 +10637,15 @@
 	id = "bridge blast";
 	name = "bridge blast door"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
 	req_access_txt = "19"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "bridge-right"
+	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "aHg" = (
@@ -10624,9 +10654,6 @@
 	name = "bridge blast door"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
 	req_access_txt = "19"
@@ -10637,6 +10664,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "bridge-right"
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
@@ -10696,19 +10726,16 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aHu" = (
-/obj/structure/table,
-/obj/structure/window/reinforced{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/conveyor_switch/oneway{
-	dir = 8;
-	id = "ShuttleUnload";
-	name = "Shuttle Unload";
-	pixel_x = 6;
-	pixel_y = 9
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/cargo/storage)
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/execution/transfer)
 "aHz" = (
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
@@ -10970,19 +10997,9 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
 "aJx" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/grunge{
-	name = "Prison Forestry"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/security/prison)
 "aJD" = (
 /obj/structure/chair{
@@ -11305,6 +11322,7 @@
 /area/ai_monitored/command/storage/eva)
 "aKZ" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/command/storage/eva)
 "aLa" = (
@@ -11332,6 +11350,7 @@
 /area/ai_monitored/command/storage/eva)
 "aLc" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/teleporter)
 "aLd" = (
@@ -11645,6 +11664,7 @@
 "aMj" = (
 /obj/structure/closet/secure_closet/security/cargo,
 /obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "aMk" = (
@@ -12021,15 +12041,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aNT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/cargo/miningdock)
+/obj/structure/table/wood/fancy,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "aNU" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Cargo Bay Warehouse Maintenance";
@@ -12269,6 +12287,7 @@
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "aOT" = (
@@ -12299,6 +12318,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"aOX" = (
+/obj/structure/weightmachine/stacklifter,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "aPa" = (
 /obj/structure/sign/poster/random{
 	pixel_y = 32
@@ -13404,11 +13430,13 @@
 /turf/open/floor/plating,
 /area/cargo/storage)
 "aTz" = (
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/space/basic,
-/area/space)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "aTA" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
@@ -13423,6 +13451,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "aTH" = (
@@ -14603,6 +14632,7 @@
 	id = "papersplease";
 	name = "security shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/customs)
 "aXJ" = (
@@ -15178,6 +15208,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
 "aZJ" = (
@@ -15459,6 +15490,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
 "baS" = (
@@ -15479,6 +15511,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
 "baU" = (
@@ -15851,7 +15884,10 @@
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/obj/item/holosign_creator/robot_seat/restaurant,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	pixel_y = 6
+	},
+/obj/item/food/mint,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "bck" = (
@@ -15874,6 +15910,13 @@
 /obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/bar/atrium)
+"bcn" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "bco" = (
 /obj/structure/table/wood/fancy,
 /obj/item/gun/ballistic/revolver/russian{
@@ -15969,10 +16012,10 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "bcK" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/vacuum,
-/turf/open/floor/plating,
-/area/cargo/storage)
+/obj/effect/turf_decal/bot_white/left,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/command/gateway)
 "bcL" = (
 /obj/item/toy/plush/lizard_plushie,
 /turf/open/floor/plating,
@@ -16112,12 +16155,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "bdp" = (
-/obj/machinery/oven,
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker/large,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "bdq" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/beaker/large,
+/obj/machinery/oven,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "bdr" = (
@@ -16611,6 +16654,11 @@
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
+	},
+/obj/machinery/requests_console/directional/south{
+	department = "Mining";
+	departmentType = 2;
+	name = "Mining Bay Requests Console"
 	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
@@ -17130,14 +17178,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Mining Maintenance";
-	req_access_txt = "48"
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/closet/secure_closet/miner,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "bhs" = (
@@ -17145,12 +17190,7 @@
 	dir = 9
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/structure/closet/secure_closet/miner,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "bht" = (
@@ -18639,6 +18679,7 @@
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/iron/fifty,
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/item/stack/sheet/iron/fifty,
 /turf/open/floor/iron/dark,
 /area/science/robotics)
 "bmT" = (
@@ -18935,6 +18976,17 @@
 	},
 /turf/open/floor/engine,
 /area/science/explab)
+"bol" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "bon" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -19164,6 +19216,7 @@
 /area/science/server)
 "bpc" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/server)
 "bpe" = (
@@ -19267,6 +19320,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"bpN" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "bridgespace";
+	name = "bridge external shutters"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/command/bridge)
 "bpQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -19495,6 +19557,7 @@
 	network = list("ss13","rd");
 	pixel_x = 22
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/server)
 "bqo" = (
@@ -19622,11 +19685,13 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "9;55"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci-gene-passthrough"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
@@ -19721,8 +19786,10 @@
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "12; 55"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci-maint-passthrough"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "bqV" = (
@@ -20263,6 +20330,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
+"bsw" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "bsy" = (
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 8
@@ -20547,9 +20621,6 @@
 /turf/open/floor/iron/white,
 /area/science/explab)
 "btt" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
 /obj/machinery/door/airlock/research{
 	name = "Xenobiology Lab";
 	req_one_access_txt = "9;55"
@@ -20562,16 +20633,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci-gene-passthrough"
+	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "btA" = (
-/obj/structure/closet/crate,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
-	},
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron,
 /area/security/prison)
 "btB" = (
@@ -20701,6 +20770,7 @@
 	id = "cmoprivacy";
 	name = "CMO Office"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/heads_quarters/cmo)
 "bug" = (
@@ -21297,11 +21367,11 @@
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "12; 55"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci-maint-passthrough"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "bwq" = (
@@ -22275,9 +22345,9 @@
 /turf/open/floor/iron/dark,
 /area/science/explab)
 "bzd" = (
-/obj/item/integrated_circuit/loaded/hello_world,
-/obj/item/integrated_circuit/loaded/speech_relay,
-/obj/structure/rack,
+/obj/structure/table,
+/obj/item/stock_parts/cell/high,
+/obj/machinery/cell_charger,
 /turf/open/floor/iron/dark,
 /area/science/explab)
 "bzg" = (
@@ -22300,7 +22370,6 @@
 	dir = 1;
 	network = list("ss13","rd")
 	},
-/obj/machinery/module_duplicator,
 /turf/open/floor/iron/dark,
 /area/science/explab)
 "bzi" = (
@@ -22309,8 +22378,8 @@
 /area/science/explab)
 "bzj" = (
 /obj/structure/table,
-/obj/item/stock_parts/cell/high,
-/obj/machinery/cell_charger,
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/open/floor/iron/dark,
 /area/science/explab)
 "bzk" = (
@@ -22624,6 +22693,7 @@
 	id = "rdprivacy";
 	name = "Privacy shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/heads_quarters/rd)
 "bAp" = (
@@ -22650,6 +22720,7 @@
 /area/command/heads_quarters/rd)
 "bAt" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/science)
 "bAu" = (
@@ -22934,6 +23005,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/rd)
 "bBw" = (
@@ -22971,6 +23043,7 @@
 	departmentType = 5;
 	name = "Science Post Requests Console"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
 "bBB" = (
@@ -23311,6 +23384,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/rd)
 "bCK" = (
@@ -23348,6 +23422,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
 "bCN" = (
@@ -23604,6 +23679,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
 "bDK" = (
@@ -23637,7 +23713,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/research{
-	name = "Ordnance Storage";
+	name = "Toxins Storage";
 	req_access_txt = "71"
 	},
 /obj/machinery/door/firedoor,
@@ -23683,7 +23759,7 @@
 "bDU" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/research/glass{
-	name = "Ordnance Lab";
+	name = "Toxins Lab";
 	req_access_txt = "8"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -23943,18 +24019,9 @@
 	pixel_x = -8;
 	pixel_y = 14
 	},
-/obj/item/cartridge/signal/ordnance{
-	pixel_x = -9;
-	pixel_y = 4
-	},
-/obj/item/cartridge/signal/ordnance{
-	pixel_x = -5;
-	pixel_y = 1
-	},
-/obj/item/cartridge/signal/ordnance{
-	pixel_x = -9;
-	pixel_y = -1
-	},
+/obj/item/cartridge/signal/ordnance,
+/obj/item/cartridge/signal/ordnance,
+/obj/item/cartridge/signal/ordnance,
 /obj/item/paper_bin{
 	pixel_x = 7;
 	pixel_y = 3
@@ -24128,9 +24195,10 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/computer/pod/old/mass_driver_controller/ordnancedriver/longrange{
-	pixel_x = 24
-	},
+/obj/machinery/computer/pod/old/mass_driver_controller/ordnancedriver/longrange,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/structure/table,
 /turf/open/floor/iron,
 /area/science/mixing)
 "bFx" = (
@@ -24500,7 +24568,7 @@
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/machinery/door/airlock/research{
-	name = "Ordnance Launch Room";
+	name = "Toxins Launch Room";
 	req_access_txt = "8"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -24706,7 +24774,7 @@
 /area/science/mixing)
 "bHz" = (
 /obj/machinery/button/door/incinerator_vent_ordmix{
-	pixel_y = -24
+	pixel_y = -25
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -24716,15 +24784,15 @@
 /area/science/mixing)
 "bHA" = (
 /obj/machinery/embedded_controller/radio/airlock_controller/incinerator_ordmix{
-	pixel_x = 6;
-	pixel_y = -26
+	pixel_x = 4;
+	pixel_y = -28
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/machinery/button/ignition/incinerator/ordmix{
-	pixel_x = -6;
-	pixel_y = -24
+	pixel_x = -7;
+	pixel_y = -25
 	},
 /obj/machinery/atmospherics/components/binary/valve,
 /turf/open/floor/iron/dark,
@@ -24749,6 +24817,9 @@
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
+	},
+/obj/machinery/computer/pod/old/mass_driver_controller/ordnancedriver{
+	pixel_x = 25
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
@@ -25226,7 +25297,7 @@
 	dir = 8
 	},
 /obj/machinery/airlock_sensor/incinerator_ordmix{
-	pixel_x = -24
+	pixel_x = -25
 	},
 /obj/machinery/atmospherics/components/binary/pump/on,
 /obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/hidden{
@@ -25235,9 +25306,7 @@
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "bJR" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_ordmix{
-	dir = 8
-	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_ordmix,
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "bJS" = (
@@ -25697,6 +25766,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "bLS" = (
@@ -26023,6 +26093,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "bMW" = (
@@ -27634,6 +27705,7 @@
 	pixel_y = -32
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/lobby)
 "bSP" = (
@@ -27960,6 +28032,7 @@
 /area/engineering/storage/tech)
 "bTC" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/engineering)
 "bTD" = (
@@ -27969,7 +28042,6 @@
 /turf/closed/wall,
 /area/engineering/main)
 "bTF" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/navbeacon/wayfinding/engineering,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering{
@@ -27980,6 +28052,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "Engineering-passthrough"
 	},
 /turf/open/floor/iron,
 /area/engineering/break_room)
@@ -28724,6 +28799,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "bVQ" = (
@@ -28979,6 +29055,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "bWC" = (
@@ -29087,6 +29164,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/department/engine)
+"bXe" = (
+/obj/machinery/camera/preset/ordnance{
+	dir = 10
+	},
+/turf/open/floor/plating/asteroid/airless,
+/area/asteroid/nearstation/bomb_site)
 "bXf" = (
 /obj/machinery/suit_storage_unit/ce,
 /obj/effect/turf_decal/tile/yellow{
@@ -29179,9 +29262,6 @@
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
 "bXp" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering{
@@ -29192,6 +29272,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "Engineering-passthrough"
 	},
 /turf/open/floor/iron,
 /area/engineering/break_room)
@@ -29208,6 +29291,18 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"bXu" = (
+/obj/structure/sign/warning/electricshock{
+	pixel_x = -31
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/rack,
+/obj/item/card/id/advanced/prisoner/chef,
+/turf/open/floor/iron/white,
+/area/security/prison/upper)
 "bXx" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
@@ -29315,6 +29410,7 @@
 	id = "ce_privacy";
 	name = "Privacy shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/heads_quarters/ce)
 "bYa" = (
@@ -31473,6 +31569,9 @@
 /obj/item/bikehorn/rubberducky,
 /turf/open/floor/iron/showroomfloor,
 /area/service/chapel/monastery)
+"cja" = (
+/turf/closed/wall,
+/area/security/prison/upper)
 "cjl" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Monastery Cemetary"
@@ -31836,8 +31935,9 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/structure/weightmachine/stacklifter,
-/turf/open/floor/iron,
+/obj/structure/table/wood,
+/obj/machinery/computer/bookmanagement,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "clF" = (
 /obj/effect/spawner/lootdrop/maintenance,
@@ -31866,15 +31966,16 @@
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "clK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
-/obj/structure/cable,
-/obj/structure/table,
-/obj/item/pen,
-/obj/item/instrument/harmonica,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/iron,
+/obj/machinery/light/directional/north,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/trophy{
+	pixel_y = 8
+	},
+/obj/item/storage/book/bible,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "clL" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -31922,7 +32023,7 @@
 "clU" = (
 /obj/item/wrench,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "clV" = (
@@ -31932,8 +32033,8 @@
 /area/tcommsat/computer)
 "clY" = (
 /obj/item/beacon,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "cma" = (
@@ -31941,8 +32042,8 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "cmb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "cmc" = (
@@ -31994,8 +32095,8 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "cmj" = (
@@ -32010,8 +32111,8 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "cml" = (
@@ -32290,13 +32391,6 @@
 /obj/machinery/telecomms/processor/preset_two,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
-"cnp" = (
-/obj/machinery/camera/preset/ordnance{
-	c_tag = "Bomb Testing Asteroid Aft";
-	dir = 1
-	},
-/turf/open/floor/plating/asteroid/airless,
-/area/asteroid/nearstation/bomb_site)
 "cnq" = (
 /turf/closed/indestructible/riveted{
 	desc = "A wall impregnated with Fixium, able to withstand massive explosions with ease";
@@ -32421,6 +32515,7 @@
 "cnP" = (
 /obj/machinery/vending/security,
 /obj/effect/turf_decal/bot,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security)
 "cnQ" = (
@@ -32664,10 +32759,8 @@
 /area/service/kitchen)
 "cpn" = (
 /obj/structure/table,
-/obj/item/reagent_containers/food/condiment/enzyme{
-	pixel_y = 6
-	},
-/obj/item/food/mint,
+/obj/item/food/spaghetti,
+/obj/item/holosign_creator/robot_seat/restaurant,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "cpo" = (
@@ -32693,6 +32786,15 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
+"cpv" = (
+/obj/effect/turf_decal/siding/red{
+	color = "#FF0000";
+	dir = 4;
+	name = "security red"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison)
 "cpw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33037,16 +33139,12 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/dock)
 "cqI" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/cargo/miningdock)
+/obj/structure/table/wood/fancy,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "cqS" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
@@ -34002,6 +34100,12 @@
 /obj/machinery/computer/libraryconsole,
 /turf/open/floor/iron/dark,
 /area/service/library/lounge)
+"cxa" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "cxg" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -34321,12 +34425,14 @@
 /turf/open/floor/carpet,
 /area/service/library)
 "czK" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
 "czN" = (
@@ -34670,6 +34776,12 @@
 "cBU" = (
 /turf/closed/wall/r_wall,
 /area/command/gateway)
+"cCc" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "cCl" = (
 /turf/closed/wall/r_wall,
 /area/science/lab)
@@ -34679,6 +34791,10 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"cCs" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall,
+/area/maintenance/department/cargo)
 "cCt" = (
 /turf/open/floor/iron/white,
 /area/science/lab)
@@ -35054,8 +35170,12 @@
 /turf/open/floor/iron/dark,
 /area/science/lab)
 "cTq" = (
+/obj/effect/spawner/lootdrop/prison_contraband,
+/obj/structure/closet/crate,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/seed_extractor,
 /turf/open/floor/iron,
 /area/security/prison)
 "cTr" = (
@@ -35071,6 +35191,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security)
 "cUb" = (
@@ -35084,6 +35205,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"cZu" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron/white,
+/area/security/prison/upper)
 "daO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -35131,6 +35260,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/gateway)
 "dej" = (
@@ -35149,16 +35279,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
-"dfu" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/microwave,
-/obj/machinery/light/no_nightlight/directional/north,
-/turf/open/floor/iron/white,
-/area/security/prison)
 "dfw" = (
 /obj/machinery/camera/motion{
 	c_tag = "Armory Motion Sensor"
@@ -35262,9 +35382,13 @@
 /turf/open/floor/iron/white,
 /area/science/explab)
 "dkU" = (
-/obj/effect/turf_decal/stripes/white/line,
-/obj/effect/landmark/start/prisoner,
-/turf/open/floor/iron,
+/obj/item/kirbyplants{
+	icon_state = "plant-08"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "dlS" = (
 /obj/structure/reagent_dispensers/water_cooler,
@@ -35315,6 +35439,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/engineering/gravity_generator)
+"dof" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/prison)
 "dok" = (
 /obj/effect/turf_decal/trimline/green/line{
 	dir = 4
@@ -35377,14 +35506,11 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "dpV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "dqw" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /obj/machinery/door/airlock/research/glass{
 	name = "Genetics";
 	req_access_txt = "9"
@@ -35396,6 +35522,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci-gene-passthrough"
 	},
 /turf/open/floor/plating,
 /area/science/genetics)
@@ -35458,8 +35587,10 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "dtj" = (
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/structure/cable,
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "dtK" = (
@@ -35506,16 +35637,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/lab)
-"duH" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/grunge{
-	name = "Prison Monastery"
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "duQ" = (
 /obj/machinery/camera{
 	c_tag = "Departure Lounge Aft";
@@ -35527,9 +35648,13 @@
 /turf/open/floor/iron/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
 "dvY" = (
-/turf/open/floor/iron/dark/side{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
+/obj/structure/sign/painting/library{
+	pixel_x = -32
+	},
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "dxo" = (
 /obj/machinery/igniter/incinerator_ordmix,
@@ -35604,12 +35729,9 @@
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
 "dCu" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/turf/open/floor/iron/chapel{
 	dir = 1
 	},
-/obj/structure/table,
-/obj/item/toy/cards/deck,
-/turf/open/floor/iron,
 /area/security/prison)
 "dDZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35628,11 +35750,13 @@
 /obj/machinery/door/airlock/grunge{
 	name = "Library"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "Library-passthrough"
 	},
 /turf/open/floor/iron/dark,
 /area/service/library/lounge)
@@ -35697,17 +35821,20 @@
 	},
 /turf/open/floor/wood,
 /area/service/bar)
+"dGV" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/light/no_nightlight/directional/north,
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/iron,
+/area/security/prison)
 "dGY" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
+	dir = 8
 	},
-/obj/structure/sink{
-	pixel_y = 29
-	},
-/obj/structure/closet/crate/trashcart/laundry,
-/obj/effect/spawner/lootdrop/prison_contraband,
 /turf/open/floor/iron,
-/area/security/prison/safe)
+/area/security/prison)
 "dHc" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -35718,16 +35845,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"dIy" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/machinery/light/no_nightlight/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "dJm" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Research Pit";
@@ -35735,18 +35852,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"dJp" = (
-/obj/structure/chair/stool/bar/directional/south,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron/white,
-/area/security/prison)
 "dJP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security)
 "dKA" = (
@@ -35768,6 +35878,7 @@
 /area/engineering/storage_shared)
 "dMB" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/supply)
 "dMI" = (
@@ -35862,6 +35973,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible/layer2,
 /turf/open/floor/plating/airless,
 /area/maintenance/department/engine)
+"dRI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/cargo/miningdock)
 "dRU" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/structure/window/reinforced/spawner/west,
@@ -35963,14 +36087,30 @@
 /obj/item/food/meat/slab/monkey,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"dWo" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/turf/open/space/basic,
+/area/space)
 "dWp" = (
 /turf/open/floor/iron/dark,
 /area/engineering/transit_tube)
 "dWw" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
-/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
 "dWO" = (
@@ -36005,13 +36145,15 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "eaA" = (
-/obj/structure/table,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/vending/sustenance,
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/security/prison)
+/area/security/prison/upper)
 "eaB" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -36217,6 +36359,11 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
+"elj" = (
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison)
 "elk" = (
 /obj/structure/chair/office,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -36234,6 +36381,14 @@
 /obj/structure/plasticflaps/opaque,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"emp" = (
+/obj/effect/turf_decal/siding/red{
+	color = "#FF0000";
+	dir = 4;
+	name = "security red"
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "emB" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -36427,13 +36582,10 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/kitchen/fork/plastic,
 /turf/open/floor/iron/white,
-/area/security/prison)
+/area/security/prison/upper)
 "evU" = (
 /obj/effect/turf_decal/bot/left,
 /turf/open/floor/iron,
@@ -36486,14 +36638,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "eAF" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
-/obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
@@ -36791,6 +36944,15 @@
 /obj/structure/lattice,
 /turf/closed/wall,
 /area/space/nearstation)
+"eNW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/chair/stool/directional/west,
+/turf/open/floor/iron,
+/area/security/prison)
 "eOe" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -36832,7 +36994,9 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
-/obj/machinery/biogenerator,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "eQN" = (
@@ -36843,6 +37007,12 @@
 /obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"eQT" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "eQZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -36856,6 +37026,14 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/security/brig)
+"eRV" = (
+/obj/structure/chair/stool/bar/directional/south,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron/white,
+/area/security/prison/upper)
 "eSL" = (
 /turf/closed/wall/r_wall,
 /area/science/breakroom)
@@ -36864,17 +37042,6 @@
 /obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/iron,
 /area/engineering/main)
-"eTi" = (
-/obj/structure/table,
-/obj/item/storage/fancy/egg_box,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/item/book/manual/chef_recipes,
-/turf/open/floor/iron/white,
-/area/security/prison)
 "eTt" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
@@ -36904,31 +37071,19 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal)
 "eTI" = (
-/obj/structure/chair{
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/camera{
-	c_tag = "Permabrig - Kitchen";
-	dir = 1;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron,
 /area/security/prison)
 "eTW" = (
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bottle/ammonia,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/chapel{
+	dir = 4
 	},
-/obj/structure/closet/crate/trashcart,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/turf/open/floor/iron,
-/area/security/prison/safe)
+/area/security/prison)
 "eTZ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -36940,13 +37095,11 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "eUa" = (
-/obj/machinery/requests_console/directional/south{
-	department = "Mining";
-	departmentType = 2;
-	name = "Mining Bay Requests Console"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/chapel{
+	dir = 1
 	},
-/turf/open/floor/iron,
-/area/cargo/miningdock)
+/area/security/prison)
 "eUb" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron,
@@ -36989,6 +37142,15 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"eVE" = (
+/obj/structure/chair/stool/bar/directional/south,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/security/prison/upper)
 "eVW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37001,9 +37163,9 @@
 /turf/open/floor/iron,
 /area/maintenance/department/engine)
 "eXa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "eXo" = (
@@ -37139,10 +37301,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/tank/plasma{
-	dir = 4;
-	initialize_directions = 4
-	},
+/obj/machinery/atmospherics/components/tank/plasma,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
@@ -37288,6 +37447,13 @@
 	},
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
+"ffL" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "fgs" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -37428,24 +37594,32 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "flR" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron,
-/area/security/prison/safe)
+/area/security/prison)
 "fmh" = (
 /turf/open/floor/wood,
 /area/maintenance/department/engine)
 "fmp" = (
-/obj/structure/table,
-/obj/structure/reagent_dispensers/servingdish,
+/obj/structure/chair{
+	dir = 8
+	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/camera{
+	c_tag = "Permabrig - Kitchen";
+	dir = 1;
+	network = list("ss13","prison")
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/security/prison)
+/area/security/prison/upper)
 "fmD" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -37503,6 +37677,13 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "frn" = (
@@ -37658,6 +37839,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "fwx" = (
@@ -37803,6 +37985,7 @@
 "fGa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/server)
 "fGd" = (
@@ -37818,6 +38001,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"fGk" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/command/bridge)
 "fGo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -37892,15 +38082,9 @@
 /turf/open/floor/plating,
 /area/service/chapel/monastery)
 "fJd" = (
-/obj/structure/rack,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/clothing/mask/breath,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
-	},
-/obj/machinery/light/small/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
-/area/security/prison/safe)
+/area/security/prison)
 "fJw" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -38053,7 +38237,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/structure/closet/secure_closet/miner,
+/turf/open/floor/iron,
 /area/cargo/miningdock)
 "fQN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -38069,12 +38254,17 @@
 "fRs" = (
 /turf/closed/wall,
 /area/command/heads_quarters/rd)
+"fRJ" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/command/bridge)
 "fSx" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "fTp" = (
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron,
 /area/security/prison)
 "fTY" = (
@@ -38195,6 +38385,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/service/kitchen)
+"gaW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/table,
+/obj/item/storage/pill_bottle/dice,
+/turf/open/floor/iron,
+/area/security/prison)
 "gbu" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -38437,8 +38636,8 @@
 /area/science/mixing)
 "gmH" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "gmO" = (
@@ -38469,11 +38668,9 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "gnM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/turf/open/floor/iron/chapel{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/iron,
 /area/security/prison)
 "gnQ" = (
 /obj/structure/disposalpipe/segment,
@@ -38515,11 +38712,10 @@
 	},
 /area/hallway/secondary/exit/departure_lounge)
 "gqx" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/table,
-/obj/item/shovel/spade,
-/obj/item/shovel/spade,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "gsB" = (
 /obj/structure/disposalpipe/segment{
@@ -38539,6 +38735,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "gtl" = (
@@ -38620,6 +38817,12 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "guS" = (
@@ -38708,6 +38911,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/green,
 /obj/structure/sign/warning/vacuum{
 	pixel_x = -32;
 	pixel_y = -32
@@ -38860,6 +39064,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"gEA" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "gEI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -39053,6 +39263,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
+"gMF" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/item/radio/intercom/directional/north{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	prison_radio = 1
+	},
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/iron,
+/area/security/prison)
 "gMG" = (
 /obj/structure/table/wood,
 /obj/item/newspaper,
@@ -39186,6 +39408,18 @@
 	icon_state = "wood-broken4"
 	},
 /area/maintenance/department/engine)
+"gVg" = (
+/obj/effect/turf_decal/siding/red{
+	color = "#FF0000";
+	name = "security red"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/light/no_nightlight/directional/south,
+/turf/open/floor/iron,
+/area/security/prison)
 "gVk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -39698,6 +39932,18 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/iron/dark,
 /area/maintenance/department/engine)
+"hCd" = (
+/obj/effect/turf_decal/siding/red{
+	color = "#FF0000";
+	dir = 8;
+	name = "security red"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison)
 "hCg" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -39730,10 +39976,11 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
 "hDg" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
+/obj/structure/chair/stool/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
 "hDG" = (
@@ -39994,6 +40241,16 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
+"hQc" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron/white,
+/area/security/prison/upper)
 "hQd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -40163,10 +40420,10 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "hWS" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/iron/dark/corner{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
 	},
+/turf/open/floor/iron,
 /area/security/prison)
 "hXt" = (
 /obj/structure/girder,
@@ -40186,6 +40443,7 @@
 	id = "executionfireblast"
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "iab" = (
@@ -40301,7 +40559,6 @@
 /turf/open/floor/iron,
 /area/command/teleporter)
 "igs" = (
-/obj/effect/landmark/start/prisoner,
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/security/prison)
@@ -40430,14 +40687,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall,
 /area/maintenance/department/engine)
-"inG" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/security/prison)
 "ioj" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -40541,11 +40790,13 @@
 	name = "Test Chamber";
 	req_access_txt = "55"
 	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
-	dir = 4
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "ivp" = (
@@ -40639,6 +40890,11 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"iAC" = (
+/obj/structure/table,
+/obj/item/toy/cards/deck,
+/turf/open/floor/iron,
+/area/security/prison)
 "iBk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -40668,7 +40924,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "iBw" = (
-/obj/effect/turf_decal/stripes/white/line{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
 /turf/open/floor/iron,
@@ -40746,10 +41002,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "iFG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/machinery/light/no_nightlight/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
 "iFI" = (
@@ -40781,14 +41040,19 @@
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "iIB" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/table,
+/obj/machinery/conveyor_switch/oneway{
+	dir = 8;
+	id = "ShuttleUnload";
+	name = "Shuttle Unload";
+	pixel_x = 6;
+	pixel_y = 9
 	},
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 4
 	},
-/turf/open/space/basic,
-/area/space)
+/turf/open/floor/iron,
+/area/cargo/storage)
 "iIY" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40845,8 +41109,15 @@
 	name = "Brig Control Desk";
 	req_access_txt = "63"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
+"iKi" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "iLl" = (
 /obj/structure/sink{
 	pixel_y = 29
@@ -40993,6 +41264,24 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/plating/airless,
 /area/engineering/atmos)
+"iWD" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge";
+	req_access_txt = "19"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "bridge-right"
+	},
+/turf/open/floor/iron/dark,
+/area/command/bridge)
 "iWV" = (
 /obj/machinery/light{
 	dir = 4
@@ -41006,14 +41295,8 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "iXt" = (
-/obj/structure/chair/stool/bar/directional/south,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/landmark/start/prisoner,
-/turf/open/floor/iron/white,
-/area/security/prison)
+/turf/closed/wall/r_wall,
+/area/security/prison/upper)
 "iYH" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay";
@@ -41026,6 +41309,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "cargo-maint-passthrough"
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
@@ -41053,6 +41339,17 @@
 "jaJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance{
+	name = "Mining Maintenance";
+	req_access_txt = "48"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
@@ -41114,12 +41411,12 @@
 /obj/machinery/door/airlock/grunge{
 	name = "Library"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "Library-passthrough"
 	},
 /turf/open/floor/iron/dark,
 /area/service/library)
@@ -41207,6 +41504,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/closed/wall/r_wall,
 /area/tcommsat/computer)
+"jlA" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/warning/vacuum,
+/turf/open/floor/plating,
+/area/cargo/storage)
 "jng" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -41338,6 +41640,9 @@
 "jtf" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -41423,6 +41728,17 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/structure/closet/firecloset{
+	name = "fire extinguishers"
+	},
+/obj/item/extinguisher{
+	pixel_x = 6;
+	pixel_y = 7
+	},
+/obj/item/extinguisher{
+	pixel_x = 6;
+	pixel_y = 7
+	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "jze" = (
@@ -41452,6 +41768,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
+"jzI" = (
+/obj/structure/chair/stool/directional/north,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron,
+/area/security/prison)
 "jAx" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -41627,15 +41948,10 @@
 /turf/closed/wall,
 /area/commons/fitness/recreation)
 "jNt" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/machinery/hydroponics/soil,
-/obj/item/radio/intercom/directional/north{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "prison intercom";
-	prison_radio = 1
-	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/table,
+/obj/item/shovel/spade,
+/obj/item/shovel/spade,
 /turf/open/floor/iron,
 /area/security/prison)
 "jOe" = (
@@ -41731,29 +42047,16 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "jTV" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	layer = 3.1;
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
-	pixel_x = -8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/food/condiment/enzyme{
-	pixel_x = 9;
-	pixel_y = 3
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/effect/spawner/lootdrop/prison_contraband,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/security/prison)
+/area/security/prison/upper)
 "jUF" = (
 /obj/structure/grille/broken,
 /obj/structure/cable,
@@ -41848,13 +42151,10 @@
 	},
 /area/maintenance/department/engine)
 "jYn" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 6
-	},
-/obj/item/radio/intercom/directional/north{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "prison intercom";
-	prison_radio = 1
+/obj/structure/bedsheetbin,
+/obj/structure/table,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/security/prison)
@@ -41864,19 +42164,51 @@
 	},
 /turf/closed/wall,
 /area/maintenance/department/cargo)
+"jZL" = (
+/obj/machinery/door/window/westleft{
+	dir = 2;
+	name = "Conveyor Access";
+	req_access_txt = "31"
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
 "kaA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/iron/dark/side{
-	dir = 4
-	},
+/obj/structure/chair/stool/directional/east,
+/turf/open/floor/iron,
 /area/security/prison)
 "kbi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/storage)
+"kbB" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = 6;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/syringe{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/holosign_creator/robot_seat/restaurant/prison{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	dir = 1;
+	name = "Security red corner"
+	},
+/obj/effect/turf_decal/tile{
+	color = "#FF6700";
+	name = "Prison Orange"
+	},
+/turf/open/floor/iron,
+/area/security/prison/upper)
 "kbV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -41896,6 +42228,17 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"kdk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/table,
+/obj/item/pen,
+/obj/item/instrument/harmonica,
+/turf/open/floor/iron,
+/area/security/prison)
 "keN" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -42078,6 +42421,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"kmV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison)
 "knx" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -42197,12 +42548,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"kso" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "ksv" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
@@ -42386,12 +42731,7 @@
 /turf/open/floor/iron/freezer,
 /area/security/prison/toilet)
 "kBD" = (
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/structure/closet/crate,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/iron,
 /area/security/prison)
 "kCc" = (
@@ -42406,6 +42746,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
+"kCY" = (
+/obj/effect/turf_decal/siding/red{
+	color = "#FF0000";
+	dir = 6;
+	name = "security red"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "kDf" = (
 /obj/machinery/light/small,
 /turf/open/floor/carpet/black,
@@ -42571,8 +42922,20 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/structure/lattice,
 /turf/open/space/basic,
-/area/cargo/storage)
+/area/space/nearstation)
+"kLp" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge";
+	req_access_txt = "19"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "bridge-right"
+	},
+/turf/open/floor/iron/dark,
+/area/command/bridge)
 "kLJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -42640,13 +43003,26 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "kPM" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/obj/structure/table,
+/obj/item/kitchen/fork/plastic,
+/obj/item/kitchen/fork/plastic,
+/obj/item/kitchen/fork/plastic,
+/obj/item/kitchen/fork/plastic,
+/obj/item/kitchen/spoon/plastic,
+/obj/item/kitchen/spoon/plastic,
+/obj/item/kitchen/spoon/plastic,
+/obj/item/kitchen/spoon/plastic,
+/obj/item/kitchen/knife/plastic,
+/obj/item/kitchen/knife/plastic,
+/obj/item/kitchen/knife/plastic,
+/obj/item/kitchen/knife/plastic,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/security/prison)
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/iron/white,
+/area/security/prison/upper)
 "kPP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
@@ -42698,6 +43074,7 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "kSD" = (
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "kSG" = (
@@ -42949,6 +43326,7 @@
 /area/maintenance/department/security/brig)
 "lcZ" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/gateway)
 "ldb" = (
@@ -42960,9 +43338,6 @@
 /obj/item/paper_bin,
 /obj/item/folder/blue,
 /obj/item/pen,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "lem" = (
@@ -43197,10 +43572,12 @@
 /obj/machinery/door/airlock/grunge{
 	name = "Library"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "Library-passthrough"
 	},
 /turf/open/floor/iron/dark,
 /area/service/library/lounge)
@@ -43222,6 +43599,18 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"lsj" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/obj/machinery/camera{
+	c_tag = "Permabrig - Garden";
+	dir = 8;
+	network = list("ss13","prison")
+	},
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/iron,
+/area/security/prison)
 "lsq" = (
 /obj/structure/transit_tube/curved{
 	dir = 1
@@ -43302,6 +43691,11 @@
 "lvq" = (
 /turf/closed/wall,
 /area/security/prison/toilet)
+"lwM" = (
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "lwT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -43330,6 +43724,11 @@
 /obj/machinery/atmospherics/components/binary/thermomachine/heater,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"lyF" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "lzJ" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/carpet,
@@ -43386,8 +43785,36 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/gateway)
+"lDj" = (
+/obj/machinery/button/flasher{
+	id = "wardenpermaoffice";
+	name = "Prisoner Flash";
+	pixel_x = 5;
+	pixel_y = 8
+	},
+/obj/machinery/button/door/directional/north{
+	id = "Warden Perma Office";
+	name = "Privacy Shutters";
+	normaldoorcontrol = 1;
+	pixel_x = -6;
+	pixel_y = 8;
+	specialfunctions = 4
+	},
+/obj/machinery/computer/security/telescreen{
+	network = list("ss13");
+	pixel_y = -6
+	},
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/siding/red{
+	color = "#FF0000";
+	dir = 9;
+	name = "security red"
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "lDw" = (
 /obj/structure/flora/grass/jungle,
 /mob/living/carbon/human/species/monkey,
@@ -43436,14 +43863,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
-"lGp" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/turf/open/floor/iron/chapel{
-	dir = 8
-	},
-/area/security/prison)
 "lGq" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -43476,9 +43895,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/green{
-	dir = 4
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "lHX" = (
@@ -43496,19 +43914,20 @@
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "lKk" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 10
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/machinery/camera{
-	c_tag = "Permabrig - Monastery";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/obj/structure/sign/painting/library{
-	pixel_x = -32
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable,
+/obj/structure/table,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria,
+/turf/open/floor/iron/white,
+/area/security/prison/upper)
 "lKL" = (
 /obj/machinery/door/airlock{
 	name = "Starboard Emergency Storage"
@@ -43581,11 +44000,20 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "lPO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/effect/landmark/start/prisoner,
-/turf/open/floor/iron/chapel{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/griddle,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/white,
+/area/security/prison/upper)
+"lQl" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
+/obj/machinery/plate_press,
+/turf/open/floor/iron,
 /area/security/prison)
 "lQn" = (
 /obj/machinery/light/small{
@@ -43645,11 +44073,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "lTW" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/ai_upload)
+/turf/closed/wall/r_wall,
+/area/space/nearstation)
 "lUC" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -43913,6 +44338,15 @@
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/iron,
 /area/medical/cryo)
+"mhw" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space)
 "mhL" = (
 /obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/north,
@@ -43936,11 +44370,13 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "mjO" = (
-/obj/machinery/status_display/ai{
-	pixel_y = -32
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
-/area/cargo/miningdock)
+/area/security/prison)
 "mkf" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating/airless,
@@ -43983,6 +44419,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "mmv" = (
@@ -43994,6 +44431,14 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/engineering/storage_shared)
+"mmC" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/obj/structure/cable,
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/iron,
+/area/security/prison)
 "mnw" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -44113,11 +44558,12 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "mrR" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron/white,
+/area/security/prison/upper)
 "mse" = (
 /obj/machinery/holopad,
 /turf/open/floor/wood,
@@ -44137,6 +44583,7 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "mtu" = (
@@ -44149,11 +44596,9 @@
 /turf/closed/wall,
 /area/maintenance/department/security/brig)
 "mtB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/ai_upload)
+/obj/structure/sign/warning/biohazard,
+/turf/closed/wall/r_wall,
+/area/space)
 "mtC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -44242,8 +44687,11 @@
 	},
 /area/maintenance/department/crew_quarters/bar)
 "myn" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/security/prison)
@@ -44251,9 +44699,6 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
 	name = "bridge blast door"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
 	},
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
@@ -44270,6 +44715,9 @@
 	pixel_y = 8
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "bridge-left"
+	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "mzl" = (
@@ -44372,6 +44820,7 @@
 	id = "Engineering";
 	name = "engineering security door"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/engineering)
 "mDo" = (
@@ -44471,8 +44920,7 @@
 /turf/open/floor/grass,
 /area/science/genetics)
 "mKa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/effect/landmark/start/prisoner,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
 "mKc" = (
@@ -44487,8 +44935,14 @@
 /turf/closed/wall,
 /area/medical/medbay/lobby)
 "mLY" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 10
+/obj/effect/spawner/randomarcade{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/machinery/flasher/directional/east{
+	id = "wardenpermaoffice"
 	},
 /turf/open/floor/iron,
 /area/security/prison)
@@ -44516,7 +44970,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "mNN" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
 	req_access_txt = "19"
@@ -44529,17 +44982,23 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "bridge-left"
+	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "mOg" = (
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
+	},
+/obj/machinery/door/airlock{
+	name = "Cleaning Closet"
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/security/prison/safe)
+/area/security/prison)
 "mOt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -44575,6 +45034,16 @@
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /turf/open/space,
 /area/space/nearstation)
+"mPn" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/computer/chef_order{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/security/prison/upper)
 "mPP" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -44681,6 +45150,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "mWQ" = (
@@ -44690,6 +45160,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security)
 "mXc" = (
@@ -44919,39 +45390,6 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
-"nfc" = (
-/obj/structure/closet/crate,
-/obj/item/reagent_containers/glass/bowl,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/kitchen/fork/plastic,
-/obj/item/kitchen/fork/plastic,
-/obj/item/kitchen/fork/plastic,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/kitchen/knife/plastic,
-/obj/item/kitchen/knife/plastic,
-/obj/item/kitchen/knife/plastic,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/box/drinkingglasses,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron/white,
-/area/security/prison)
 "nfj" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -44978,10 +45416,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "holodeck"
+	},
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "nih" = (
@@ -45031,6 +45469,16 @@
 "njS" = (
 /turf/closed/wall/r_wall,
 /area/engineering/transit_tube)
+"njW" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/space)
 "nku" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Crematorium";
@@ -45092,7 +45540,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/structure/disposalpipe/segment{
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/disposaloutlet{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -45243,13 +45694,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"nud" = (
-/obj/item/toy/beach_ball/holoball,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "nvG" = (
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/iron/dark,
@@ -45277,10 +45721,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/chapel/monastery)
 "nwJ" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
 	},
-/obj/machinery/plate_press,
+/obj/machinery/light/no_nightlight/directional/north,
+/obj/item/toy/beach_ball/holoball,
 /turf/open/floor/iron,
 /area/security/prison)
 "nwK" = (
@@ -45347,6 +45792,28 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"nAV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/security/prison)
+"nBc" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/item/skillchip/job/chef,
+/obj/structure/closet/crate/secure/gear{
+	desc = "Contains the most important part of any Chef.";
+	name = "chef crate";
+	req_access_txt = "3"
+	},
+/turf/open/floor/iron/white,
+/area/security/prison/upper)
 "nBt" = (
 /obj/structure/disposaloutlet{
 	dir = 8
@@ -45477,11 +45944,7 @@
 	pixel_y = 2
 	},
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/science/xenobiology)
 "nIt" = (
 /obj/structure/disposalpipe/segment{
@@ -45557,6 +46020,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"nLW" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space)
 "nMG" = (
 /obj/machinery/camera/motion{
 	c_tag = "Telecomms Monitoring";
@@ -45570,8 +46039,8 @@
 	},
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "nNk" = (
@@ -45757,10 +46226,12 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "nVs" = (
+/obj/machinery/power/apc/auto_name/south,
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/table,
-/obj/item/plant_analyzer,
-/obj/item/plant_analyzer,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
 "nVz" = (
@@ -45927,6 +46398,12 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
+"ofe" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "ofj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -45948,17 +46425,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/closet/firecloset{
-	name = "fire extinguishers"
-	},
-/obj/item/extinguisher{
-	pixel_x = 6;
-	pixel_y = 7
-	},
-/obj/item/extinguisher{
-	pixel_x = 6;
-	pixel_y = 7
-	},
+/obj/machinery/chem_master,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "ofR" = (
@@ -46010,6 +46477,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
+"ohQ" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
+/obj/machinery/vending/games,
+/turf/open/floor/iron,
+/area/security/prison)
 "ohR" = (
 /obj/item/chair,
 /turf/open/floor/plating,
@@ -46154,6 +46628,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"ooI" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/hallway/primary/central)
 "ops" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -46244,11 +46723,9 @@
 "osv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/disposaloutlet{
-	dir = 4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "garbage"
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -46312,6 +46789,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/explab)
+"ovC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "ovM" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals Port Fore"
@@ -46349,6 +46833,7 @@
 "oxC" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/start/hangover,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "oxM" = (
@@ -46375,6 +46860,13 @@
 	},
 /turf/open/floor/carpet,
 /area/service/library/artgallery)
+"oyk" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/iron,
+/area/security/prison)
 "oyF" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -46603,6 +47095,14 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"oId" = (
+/obj/effect/turf_decal/siding/red{
+	color = "#FF0000";
+	dir = 8;
+	name = "security red"
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "oJp" = (
 /obj/machinery/light/no_nightlight/directional/north,
 /turf/open/floor/iron,
@@ -46617,6 +47117,15 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/engine)
+"oKE" = (
+/obj/structure/chair/stool/bar/directional/south,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron/white,
+/area/security/prison/upper)
 "oKI" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -46801,30 +47310,25 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "oSC" = (
-/obj/structure/table,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/conveyor_switch/oneway{
-	id = "ShuttleLoad";
-	name = "Shuttle Load";
-	pixel_x = -8;
-	pixel_y = 10
-	},
-/turf/open/floor/iron,
-/area/cargo/storage)
+/obj/effect/turf_decal/bot_white,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/command/gateway)
 "oSI" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/machinery/door/airlock{
-	name = "Cleaning Closet"
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/grunge{
+	name = "Prison Forestry"
 	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
-/area/security/prison/safe)
+/area/security/prison)
 "oTl" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8;
@@ -47114,17 +47618,13 @@
 /turf/open/floor/plating,
 /area/medical/abandoned)
 "pif" = (
-/obj/structure/holohoop{
+/obj/effect/spawner/randomarcade{
 	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "Permabrig - Yard";
-	dir = 8;
-	network = list("ss13","prison")
-	},
-/obj/effect/turf_decal/stripes/white/line{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
+/obj/machinery/light/no_nightlight/directional/east,
 /turf/open/floor/iron,
 /area/security/prison)
 "piI" = (
@@ -47272,11 +47772,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/rice,
-/obj/item/reagent_containers/food/condiment/flour,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/security/prison)
+/area/security/prison/upper)
 "pqw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -47432,6 +47930,27 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"pAv" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "Warden Perma Office";
+	name = "Warden's Office";
+	req_access_txt = "3"
+	},
+/obj/effect/turf_decal/siding/red{
+	color = "#FF0000";
+	name = "security red"
+	},
+/obj/effect/turf_decal/siding/red{
+	color = "#FF0000";
+	dir = 1;
+	name = "security red"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/prison)
 "pBm" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -47472,10 +47991,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/machinery/light/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/security/prison)
 "pEh" = (
@@ -47488,10 +48003,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"pEp" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "pEv" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1
@@ -47522,14 +48033,13 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "pFE" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/item/kitchen/fork/plastic,
-/turf/open/floor/iron/white,
+/obj/machinery/light/no_nightlight/directional/south,
+/turf/open/floor/iron,
 /area/security/prison)
 "pFG" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
@@ -47556,6 +48066,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "pGF" = (
@@ -47587,6 +48098,11 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"pHh" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/brig)
 "pHo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -47728,16 +48244,18 @@
 /turf/open/floor/iron/freezer,
 /area/medical/virology)
 "pOd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/effect/landmark/start/prisoner,
+/obj/machinery/plate_press,
 /turf/open/floor/iron,
 /area/security/prison)
 "pOs" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 9
+/obj/effect/spawner/randomarcade{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
 	},
 /turf/open/floor/iron,
 /area/security/prison)
@@ -47823,6 +48341,14 @@
 /obj/machinery/newscaster/security_unit/directional/south,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"pUx" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/processor,
+/turf/open/floor/iron/white,
+/area/security/prison/upper)
 "pVr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48244,11 +48770,7 @@
 /obj/item/clothing/glasses/science,
 /obj/structure/table,
 /obj/item/wrench,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/science/xenobiology)
 "qlz" = (
 /obj/structure/window/reinforced/spawner/east,
@@ -48370,6 +48892,19 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"qpG" = (
+/obj/item/radio/intercom/directional/north{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	prison_radio = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/closet/secure_closet/freezer/fridge,
+/turf/open/floor/iron/white,
+/area/security/prison/upper)
 "qpT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -48499,15 +49034,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
-"quw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/turf/open/floor/iron/chapel,
-/area/security/prison)
 "qux" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -48643,10 +49169,14 @@
 /turf/open/floor/grass,
 /area/medical/medbay/lobby)
 "qEk" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 6
 	},
-/obj/machinery/plate_press,
+/obj/item/radio/intercom/directional/north{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	prison_radio = 1
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "qEm" = (
@@ -48812,6 +49342,11 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
+"qKN" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "qLo" = (
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
@@ -48890,6 +49425,20 @@
 /obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/abandoned_gambling_den)
+"qQe" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/donut_box,
+/obj/effect/turf_decal/siding/red{
+	color = "#FF0000";
+	dir = 5;
+	name = "security red"
+	},
+/obj/machinery/camera{
+	c_tag = "Permabrig - Warden Office";
+	network = list("ss13","prison")
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "qQl" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -49039,6 +49588,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"qYF" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/command/bridge)
 "qZa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -49051,7 +49607,7 @@
 	dir = 4
 	},
 /turf/open/space/basic,
-/area/cargo/storage)
+/area/space)
 "raF" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
@@ -49099,15 +49655,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/open/floor/plating/airless,
 /area/tcommsat/computer)
-"rcR" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "reH" = (
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
 /obj/structure/disposalpipe/segment{
@@ -49188,24 +49735,18 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "rka" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron/white,
+/area/security/prison/upper)
 "rkv" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/grunge{
-	name = "Prison Monastery"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/security/prison)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison/upper)
 "rle" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -49261,10 +49802,13 @@
 	c_tag = "Cargo Docking Arm";
 	dir = 8
 	},
+/obj/structure/lattice,
 /turf/open/space/basic,
-/area/cargo/storage)
+/area/space/nearstation)
 "rnm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/security/prison)
 "rnE" = (
@@ -49372,20 +49916,13 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "rqQ" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/paper/guides/jobs/hydroponics,
-/obj/item/seeds/onion,
-/obj/item/seeds/garlic,
-/obj/item/seeds/potato,
-/obj/item/seeds/tomato,
-/obj/item/seeds/carrot,
-/obj/item/seeds/grass,
-/obj/item/seeds/ambrosia,
-/obj/item/seeds/wheat,
-/obj/item/seeds/pumpkin,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/light/no_nightlight/directional/south,
+/obj/structure/closet/crate,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "rrt" = (
@@ -49476,6 +50013,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/psychology)
+"rtm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/security/prison)
 "rtC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -49564,6 +50110,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
+"ruW" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable,
+/obj/structure/sink/kitchen{
+	dir = 4;
+	pixel_x = -11
+	},
+/turf/open/floor/iron/white,
+/area/security/prison/upper)
 "rvA" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
@@ -49726,14 +50284,14 @@
 /area/hallway/primary/central)
 "rBL" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
+	dir = 6
 	},
-/obj/machinery/hydroponics/soil,
-/obj/machinery/camera{
-	c_tag = "Permabrig - Garden";
-	dir = 8;
-	network = list("ss13","prison")
+/obj/structure/sign/warning/electricshock{
+	pixel_x = 32
 	},
+/obj/structure/table,
+/obj/item/cultivator,
+/obj/item/cultivator,
 /turf/open/floor/iron,
 /area/security/prison)
 "rBP" = (
@@ -49904,13 +50462,15 @@
 	},
 /area/maintenance/department/engine)
 "rJS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
-/turf/open/floor/iron/chapel{
-	dir = 4
-	},
-/area/security/prison)
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/microwave,
+/obj/machinery/light/no_nightlight/directional/north,
+/turf/open/floor/iron/white,
+/area/security/prison/upper)
 "rJT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50238,6 +50798,21 @@
 	},
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/service)
+"saw" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/grunge{
+	name = "Prison Workshop"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/prison)
 "saR" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -50258,9 +50833,9 @@
 /area/maintenance/department/crew_quarters/dorms)
 "sbt" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
+	dir = 6
 	},
-/obj/machinery/hydroponics/soil,
+/obj/machinery/washing_machine,
 /turf/open/floor/iron,
 /area/security/prison)
 "sbI" = (
@@ -50280,16 +50855,12 @@
 /turf/open/floor/iron/dark,
 /area/service/kitchen)
 "sbU" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/structure/sign/warning/electricshock{
-	pixel_x = 32
+/turf/open/floor/iron/chapel{
+	dir = 4
 	},
-/obj/structure/table,
-/obj/item/cultivator,
-/obj/item/cultivator,
-/turf/open/floor/iron,
 /area/security/prison)
 "sbY" = (
 /obj/machinery/vending/coffee,
@@ -50329,15 +50900,6 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"sdk" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/iron/chapel{
-	dir = 8
-	},
-/area/security/prison)
 "sdE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
@@ -50383,6 +50945,19 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
+"sfX" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock{
+	name = "Dining Room"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison/upper)
 "sgc" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron/dark,
@@ -51088,15 +51663,8 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "sQP" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/science/xenobiology)
+/turf/closed/wall/r_wall,
+/area/space)
 "sSj" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/item/radio/intercom/directional/south,
@@ -51196,12 +51764,11 @@
 	},
 /area/maintenance/department/engine)
 "sVF" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron/chapel{
+	dir = 1
 	},
-/obj/machinery/hydroponics/soil,
-/obj/structure/cable,
-/turf/open/floor/iron,
 /area/security/prison)
 "sWj" = (
 /obj/effect/turf_decal/stripes/line,
@@ -51257,6 +51824,14 @@
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"sYW" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/closet/secure_closet/freezer/kitchen,
+/turf/open/floor/iron/white,
+/area/security/prison/upper)
 "sYY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -51340,9 +51915,6 @@
 /area/engineering/atmos)
 "taA" = (
 /obj/structure/chair/office/light,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "taF" = (
@@ -51430,6 +52002,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
 "tdp" = (
@@ -51699,22 +52272,17 @@
 /area/construction/mining/aux_base)
 "tot" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
+	dir = 4
 	},
-/obj/machinery/hydroponics/soil,
+/obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "toR" = (
-/obj/item/stack/sheet/cardboard{
-	amount = 14
-	},
-/obj/item/stack/package_wrap,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/stripes/white/line{
 	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig - Workroom";
-	network = list("ss13","prison")
 	},
 /turf/open/floor/iron,
 /area/security/prison)
@@ -51748,11 +52316,8 @@
 /turf/closed/wall,
 /area/medical/storage)
 "tqM" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/turf/open/floor/iron/chapel,
-/area/security/prison)
+/turf/closed/wall/mineral/iron,
+/area/security/prison/upper)
 "tqO" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
@@ -51778,6 +52343,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"trf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "trt" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -52021,9 +52596,9 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "tAK" = (
-/obj/machinery/modular_computer/console/preset/civilian{
-	dir = 1
-	},
+/obj/structure/rack,
+/obj/item/integrated_circuit/loaded/speech_relay,
+/obj/item/integrated_circuit/loaded/hello_world,
 /turf/open/floor/iron/dark,
 /area/science/explab)
 "tBb" = (
@@ -52039,13 +52614,13 @@
 /obj/machinery/door/airlock/grunge{
 	name = "Library"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "Library-passthrough"
 	},
 /turf/open/floor/iron/dark,
 /area/service/library)
@@ -52359,25 +52934,32 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "tTq" = (
-/obj/structure/closet/crate,
-/obj/item/food/breadslice/plain,
-/obj/item/food/breadslice/plain,
-/obj/item/food/breadslice/plain,
-/obj/item/food/grown/potato,
-/obj/item/food/grown/potato,
-/obj/item/food/grown/onion,
-/obj/item/food/grown/onion,
-/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/item/radio/intercom/directional/north{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "prison intercom";
-	prison_radio = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
+/area/security/prison/upper)
+"tTG" = (
+/obj/effect/turf_decal/siding/red{
+	color = "#FF0000";
+	name = "security red"
+	},
+/obj/effect/turf_decal/siding/red/corner{
+	color = "#FF0000";
+	dir = 1;
+	name = "security red"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron,
 /area/security/prison)
 "tUr" = (
 /obj/structure/table/optable,
@@ -52525,14 +53107,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "ubq" = (
-/obj/structure/table,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/item/food/energybar,
+/obj/machinery/light/no_nightlight/directional/south,
+/obj/machinery/restaurant_portal/restaurant/prison,
 /turf/open/floor/iron/white,
-/area/security/prison)
+/area/security/prison/upper)
 "ucd" = (
 /obj/machinery/light/dim{
 	dir = 8
@@ -52658,15 +53240,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "ueX" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/grunge{
+	name = "Prison Monastery"
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "ufa" = (
 /turf/open/floor/iron/dark,
@@ -52695,6 +53276,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/psychology)
+"uhk" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/space)
 "uhn" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
@@ -52805,6 +53396,18 @@
 	},
 /turf/open/floor/engine,
 /area/science/breakroom)
+"ukE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "ukM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -52872,9 +53475,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "ume" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
 /obj/machinery/door/airlock/research{
 	name = "Xenobiology Lab";
 	req_access_txt = "55"
@@ -52889,6 +53489,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci-gene-passthrough"
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
@@ -52958,6 +53561,7 @@
 /area/medical/psychology)
 "uqJ" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "urG" = (
@@ -52992,6 +53596,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
+"usD" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "usI" = (
 /obj/structure/chair/wood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -53136,14 +53744,11 @@
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "uxx" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
+/obj/effect/spawner/randomcolavend,
+/turf/open/floor/iron,
 /area/security/prison)
 "uxF" = (
 /obj/machinery/door/firedoor,
@@ -53185,8 +53790,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "uzr" = (
@@ -53226,6 +53831,7 @@
 	dir = 4
 	},
 /obj/machinery/holopad,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
 "uAh" = (
@@ -53383,15 +53989,14 @@
 	},
 /area/maintenance/department/crew_quarters/dorms)
 "uGE" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/light/no_nightlight/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron,
 /area/security/prison)
 "uHJ" = (
 /obj/structure/disposalpipe/segment{
@@ -53515,8 +54120,13 @@
 /area/medical/psychology)
 "uPl" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
+	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
 "uPz" = (
@@ -53536,6 +54146,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
@@ -53558,6 +54169,16 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"uQv" = (
+/obj/structure/holohoop{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison)
 "uQB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -53571,6 +54192,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"uQG" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/secure_data/laptop,
+/obj/effect/turf_decal/siding/red{
+	color = "#FF0000";
+	dir = 1;
+	name = "security red"
+	},
+/obj/machinery/light/no_nightlight/directional/north,
+/turf/open/floor/iron,
+/area/security/prison)
 "uQR" = (
 /obj/item/ammo_casing/shotgun/beanbag,
 /turf/open/floor/plating,
@@ -53588,6 +54220,11 @@
 	},
 /turf/open/floor/iron,
 /area/security)
+"uSE" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/engineering/lobby)
 "uSL" = (
 /obj/machinery/camera{
 	c_tag = "Holodeck - Fore";
@@ -53664,6 +54301,7 @@
 	name = "brig shutters"
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/brig)
 "uVf" = (
@@ -53780,9 +54418,6 @@
 	name = "Containment Pen Access";
 	req_access_txt = "55"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobiomain";
 	name = "containment blast door"
@@ -53799,6 +54434,9 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci-maint-passthrough"
+	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "uXX" = (
@@ -53991,9 +54629,6 @@
 /turf/open/floor/carpet,
 /area/medical/psychology)
 "vgp" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
 /obj/machinery/door/airlock/research{
 	name = "Containment Pen";
 	req_access_txt = "55"
@@ -54007,6 +54642,9 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci-maint-passthrough"
+	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "vgR" = (
@@ -54069,6 +54707,16 @@
 /obj/structure/reagent_dispensers/fueltank/large,
 /turf/open/floor/iron,
 /area/engineering/main)
+"vjY" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Permabrig - Yard";
+	network = list("ss13","prison")
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "vkd" = (
 /obj/structure/lattice,
 /turf/closed/wall,
@@ -54430,10 +55078,8 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "vEU" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/machinery/hydroponics/soil,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/seed_extractor,
 /turf/open/floor/iron,
 /area/security/prison)
 "vFs" = (
@@ -54463,6 +55109,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "cargo-maint-passthrough"
 	},
 /turf/open/floor/plating,
 /area/cargo/storage)
@@ -54576,7 +55225,7 @@
 "vMt" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/atmos{
-	name = "Ordnance Storage";
+	name = "Toxins Storage";
 	req_access_txt = "24"
 	},
 /obj/structure/cable,
@@ -54693,12 +55342,18 @@
 	},
 /area/maintenance/department/science)
 "vRk" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/table,
+/obj/machinery/conveyor_switch/oneway{
+	id = "ShuttleLoad";
+	name = "Shuttle Load";
+	pixel_x = -8;
+	pixel_y = 10
 	},
-/obj/structure/window/reinforced,
-/turf/open/space/basic,
-/area/space)
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
 "vRm" = (
 /obj/structure/table,
 /obj/effect/turf_decal/stripes/line{
@@ -54754,6 +55409,18 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"vSh" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/grunge{
+	name = "Prison Monastery"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "vSB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -54773,11 +55440,11 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal)
 "vTg" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
+/obj/machinery/light/no_nightlight/directional/south,
+/obj/machinery/vending/hydroseeds{
+	slogan_delay = 700
 	},
-/obj/machinery/hydroponics/soil,
-/obj/machinery/light/no_nightlight/directional/north,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron,
 /area/security/prison)
 "vTL" = (
@@ -54787,7 +55454,7 @@
 "vTN" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/research{
-	name = "Ordnance Lab";
+	name = "Toxins Lab";
 	req_access_txt = "8"
 	},
 /turf/open/floor/iron/dark,
@@ -54853,6 +55520,40 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
+"vXu" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron/white,
+/area/security/prison/upper)
+"vXF" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	layer = 3.1;
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
+	pixel_x = -8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/condiment/enzyme{
+	pixel_x = 9;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/turf/open/floor/iron/white,
+/area/security/prison/upper)
 "vXW" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -54990,14 +55691,13 @@
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter/room)
 "wcP" = (
-/obj/structure/chair{
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron,
 /area/security/prison)
 "wdp" = (
 /obj/structure/disposalpipe/trunk{
@@ -55185,11 +55885,7 @@
 /turf/open/space,
 /area/space)
 "wkA" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/structure/punching_bag,
-/obj/machinery/light/no_nightlight/directional/north,
+/obj/structure/chair/stool/directional/west,
 /turf/open/floor/iron,
 /area/security/prison)
 "wkM" = (
@@ -55244,6 +55940,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
+"wlJ" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron,
+/area/security/prison)
 "wlK" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -55451,8 +56154,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/vending/cola/red,
 /turf/open/floor/iron/white,
-/area/security/prison)
+/area/security/prison/upper)
 "wxn" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -55707,6 +56411,9 @@
 /turf/open/floor/carpet,
 /area/service/chapel/monastery)
 "wEJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "wFr" = (
@@ -55716,6 +56423,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"wFz" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/table,
+/obj/item/plant_analyzer,
+/obj/item/plant_analyzer,
+/turf/open/floor/iron,
+/area/security/prison)
 "wFM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -55884,9 +56598,9 @@
 /area/medical/chemistry)
 "wNI" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
+	dir = 10
 	},
-/obj/machinery/hydroponics/soil,
+/obj/machinery/biogenerator,
 /turf/open/floor/iron,
 /area/security/prison)
 "wOf" = (
@@ -55931,22 +56645,21 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "wPo" = (
+/obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig - Upper Hall";
-	dir = 8;
-	network = list("ss13","prison")
 	},
 /turf/open/floor/iron,
 /area/security/prison)
 "wPr" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
 "wPw" = (
@@ -56133,8 +56846,9 @@
 /area/engineering/atmos)
 "wVS" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
+	dir = 9
 	},
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/iron,
 /area/security/prison)
 "wVV" = (
@@ -56200,7 +56914,7 @@
 /area/engineering/atmos)
 "wYr" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "wYu" = (
@@ -56225,6 +56939,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"wZB" = (
+/obj/structure/chair/comfy/black,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/command/bridge)
 "xan" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -56327,6 +57046,16 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/plating,
 /area/engineering/atmos)
+"xdb" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/open/space/basic,
+/area/space)
 "xdc" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -56355,6 +57084,13 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/engineering/atmos)
+"xdW" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/iron,
+/area/security/prison)
 "xdY" = (
 /obj/machinery/door/window/eastright{
 	name = "Danger: Conveyor Access";
@@ -56407,16 +57143,10 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "xga" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_x = -31
-	},
-/obj/structure/chair/stool/bar/directional/south,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron/white,
-/area/security/prison)
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/prison/upper)
 "xgt" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -56500,6 +57230,7 @@
 /area/security/detectives_office)
 "xjU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security)
 "xjZ" = (
@@ -56631,6 +57362,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"xnW" = (
+/obj/machinery/light/no_nightlight/directional/north,
+/obj/structure/weightmachine/weightlifter,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "xog" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -56649,7 +57388,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security)
 "xoD" = (
@@ -56758,6 +57498,9 @@
 	req_access_txt = "31"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "cargo-maint-passthrough"
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "xur" = (
@@ -56779,10 +57522,8 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
 "xuy" = (
-/obj/effect/spawner/randomarcade,
-/turf/open/floor/iron/dark/side{
-	dir = 4
-	},
+/obj/structure/chair/stool/directional/east,
+/turf/open/floor/iron,
 /area/security/prison)
 "xvx" = (
 /obj/structure/cable,
@@ -56859,6 +57600,20 @@
 	},
 /turf/open/floor/iron/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
+"xxJ" = (
+/obj/item/stack/sheet/cardboard{
+	amount = 14
+	},
+/obj/item/stack/package_wrap,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Permabrig - Workroom";
+	network = list("ss13","prison")
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "xxK" = (
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -56915,6 +57670,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"xyr" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space)
 "xyB" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating{
@@ -56955,6 +57717,17 @@
 	},
 /turf/closed/wall,
 /area/cargo/storage)
+"xAZ" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/prison)
 "xBB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -57185,6 +57958,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
+"xMS" = (
+/obj/machinery/door/window/westleft{
+	dir = 1;
+	name = "Conveyor Access";
+	req_access_txt = "31"
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
 "xNx" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/junction/flip,
@@ -57250,10 +58031,12 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "xPV" = (
-/obj/machinery/airalarm/directional/south,
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/iron,
-/area/security/prison/safe)
+/area/security/prison)
 "xQr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -57401,8 +58184,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
+"xYO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison)
 "yat" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/medical)
 "ybu" = (
@@ -57520,6 +58312,7 @@
 /area/engineering/atmos)
 "yeL" = (
 /obj/machinery/holopad,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "yfO" = (
@@ -75969,15 +76762,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aOn
+iXt
+iXt
+rkv
+xga
+iXt
+rkv
+rkv
+iXt
+iXt
 fzz
 ygc
 vDq
@@ -75990,7 +76783,7 @@ sJp
 hZL
 mWI
 ahU
-ahU
+aHu
 aiw
 afU
 ajH
@@ -76219,10 +77012,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 adE
 adE
 adE
@@ -76230,11 +77019,15 @@ adE
 adE
 adE
 adE
-adE
-aem
-acM
-acM
-aOn
+tqM
+pUx
+ruW
+mPn
+bXu
+pqq
+mrR
+hQc
+iXt
 lvq
 lvq
 lvq
@@ -76476,23 +77269,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 adE
+afs
+dvY
+aeE
+dvY
 aeE
 ahG
-kso
-ahG
-kso
-lKk
-adE
+tqM
+kbB
 pqq
-inG
+lKk
+eVE
+pqq
+mrR
 evP
 xga
-wxa
+ohQ
 wcP
 lvq
 sAN
@@ -76733,23 +77526,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 adE
+aNT
+dCu
+arl
+dCu
 arl
 aij
-lGp
-aij
-lGp
-pEp
-adE
-eTi
-inG
+tqM
+vXF
+cZu
+rka
+eRV
+pqq
+pqq
 fmp
-dJp
-wxa
+xga
+wlJ
 pFE
 lvq
 woO
@@ -76990,22 +77783,22 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 adE
+clE
+eTW
+aeW
+sbU
 aeW
 aik
-quw
+tqM
 rJS
-quw
+mrR
 rka
-adE
+eRV
 jTV
-inG
-fmp
-dJp
+mrR
+nBc
+xga
 uxx
 eTI
 lvq
@@ -77247,25 +78040,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 adE
+clK
+eUa
+aeX
+sVF
 aeX
 akN
-sdk
+tqM
 lPO
-sdk
-rcR
-adE
-dfu
-inG
+mrR
+rka
+oKE
+tTq
+vXu
 ubq
 iXt
 aep
 uGE
-agy
+afn
 afn
 guO
 afZ
@@ -77504,26 +78297,26 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 adE
+cqI
+gnM
 aeT
-akP
+gnM
+aeT
+alA
 tqM
-akP
-tqM
+qpG
+mrR
 kPM
-adE
+eRV
 tTq
-inG
+pqq
 eaA
-dJp
-aep
-aeC
-agy
-clE
+iXt
+aOX
+aiF
+aiF
+aiF
 ahF
 aiF
 wbB
@@ -77761,27 +78554,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 adE
+dkU
+gqx
+gqx
+gqx
 afX
 alA
-alA
-alA
+tqM
+sYW
 mrR
-kPM
-adE
-nfc
-inG
+mrR
+mrR
+tTq
+mrR
 wxa
-wxa
-aep
-aeD
-agy
+iXt
+xnW
+aiF
+aiF
 wkA
-ahF
+eNW
 igs
 lYA
 ahp
@@ -78018,29 +78811,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 adE
 adE
 adE
 aen
 aen
-duH
+ueX
+vSh
+tqM
+cja
 rkv
-adE
-agy
-acM
-acM
-acM
+rkv
+rkv
+sfX
+xga
+xga
+iXt
 aeq
-acM
-agy
+aiF
+jzI
 afp
 afE
-dCu
-wbB
+wFM
+agp
 ahp
 ahp
 ahp
@@ -78273,30 +79066,30 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 pDW
+fon
 aht
 aem
+hWS
+mjO
+wPr
+uPl
+xAZ
 wPr
 aeF
-afq
-ueX
-aeF
+wPr
+afZ
+afZ
 eAF
-aeF
 afZ
-afZ
+ukE
+bol
 aer
-aeF
+kmV
 aeV
-afq
+kdk
 afF
-clK
+ahF
 bvC
 eIJ
 iVP
@@ -78318,7 +79111,7 @@ avB
 lUY
 ojJ
 asu
-apE
+pHh
 auy
 avs
 uUY
@@ -78529,30 +79322,30 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-fon
+pDW
+aht
 aht
 aht
 aem
+iBw
+myn
+tot
+act
+pEg
 czK
 pEg
 act
 aeG
-aes
-aeG
-act
+pEg
+czK
+pEg
 wPo
-aeG
-aes
-aeG
-hDg
 aiF
-wHD
+mKa
+aiF
+hDg
+iAC
+gaW
 kLJ
 wbB
 ahp
@@ -78574,7 +79367,7 @@ hdB
 hdB
 hdB
 hdB
-aoN
+hdB
 atw
 gta
 avt
@@ -78786,32 +79579,32 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-pDW
+fon
 aht
-ahC
-ahC
+aem
+aem
+aem
+aem
+mOg
+agy
+acM
+acM
 oSI
-ahp
+lyF
 acM
-acM
+agy
 aJx
-acM
-acM
-agy
+saw
 aen
+aem
+lwM
 aga
-aen
-agy
+lwM
+rtm
 xuy
 kaA
-dvY
-hWS
+aiF
+wbB
 ahp
 agM
 fRl
@@ -78832,7 +79625,7 @@ wcf
 aqn
 wbs
 mJe
-apE
+pHh
 auz
 avu
 uUY
@@ -79043,31 +79836,31 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-pDW
+fon
 aht
-ahC
+aem
+aeC
+dtj
 dGY
-mOg
-ahp
-wNI
+nVs
+agy
 wVS
+dGY
 afZ
+bcn
+wNI
+agy
+lQl
 dWw
 ePM
-agy
+aem
 qEk
 aeu
 aeI
-agy
-jYn
-afI
-iBw
+nAV
+aiF
+agc
+aiF
 agp
 ahp
 ahp
@@ -79300,30 +80093,30 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-pDW
+fon
 aht
-ahC
-eTW
+aem
+aeD
+aiF
+aiF
+rnm
+agy
 xPV
-ahp
-vEU
 aiF
 wHD
+usD
+vEU
+agy
+xxJ
 fTp
 cTq
-agy
+aem
 toR
 mKa
 kBD
-agy
-afr
-wHD
+nAV
+aiF
+agc
 agc
 ago
 ekm
@@ -79346,7 +80139,7 @@ amh
 aqz
 wbs
 mJe
-apE
+pHh
 auy
 avv
 uUY
@@ -79557,32 +80350,32 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-pDW
+fon
 aht
-ahC
+aem
+afr
+pEg
+jYn
+sbt
+agy
+dGV
 fJd
 flR
-ahp
+ovC
 vTg
-rnm
+agy
 pOd
 iFG
 rqQ
-agy
+aem
 nwJ
-dIy
+mKa
 btA
-agy
-afs
+nAV
 aiF
-dkU
-agp
+aiF
+aiF
+wbB
 ahp
 sKL
 agZ
@@ -79602,7 +80395,7 @@ aoS
 amh
 aqq
 wbs
-aoN
+hdB
 atA
 auA
 avw
@@ -79814,32 +80607,32 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-pDW
+fon
 aht
-ahC
-ahC
-ahC
-ahC
+aem
+aem
+aem
+aem
+aem
+aem
+gMF
+iKi
+aiF
+ffL
 jNt
-myn
-aiF
-gnM
-gqx
 aem
 aem
 aem
 aem
 aem
-nud
-aiF
+vjY
+mKa
+kBD
+nAV
+wkA
+wkA
 agd
-agp
+ofe
 ahp
 agM
 asA
@@ -79860,7 +80653,7 @@ apK
 ark
 wbs
 mJe
-apE
+pHh
 auz
 avx
 uUY
@@ -80071,28 +80864,28 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-pDW
+fon
+aht
+aht
 aht
 aht
 aht
 aht
 aem
-vEU
+xPV
 aiF
 aiF
-fTp
-nVs
+mKa
+wFz
 aem
 aht
 aht
 aht
 aem
+eQT
+uQv
+cxa
+nAV
 mLY
 pif
 pOs
@@ -80328,28 +81121,28 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+fon
+fon
+fon
 pDW
 pDW
 pDW
 aht
 aem
-rBL
-uPl
+lsj
+gEA
 aiF
-dtj
-sbU
+elj
+rBL
 aem
 aht
 pDW
 aht
 aem
+acM
+dof
+acM
+pAv
 aem
 aem
 aem
@@ -80374,7 +81167,7 @@ amh
 aqz
 wbs
 mJe
-apE
+pHh
 auy
 avy
 uUY
@@ -80590,24 +81383,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 pDW
 aht
 aem
 aem
-tot
-sbt
-sVF
+xdW
+oyk
+mmC
 aem
 aem
 aht
 pDW
 aaa
-aaa
-aaa
+aem
+lDj
+oId
+hCd
+tTG
+aem
 aaa
 aaa
 aaa
@@ -80630,7 +81423,7 @@ aoW
 apM
 aqy
 arn
-aoN
+hdB
 atC
 auA
 avz
@@ -80847,10 +81640,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 pDW
 aht
 aht
@@ -80863,8 +81652,12 @@ aht
 aht
 pDW
 aaa
-aaa
-aaa
+aem
+uQG
+cCc
+xYO
+gVg
+aem
 aaa
 aaa
 aaa
@@ -80882,13 +81675,13 @@ rEZ
 amk
 piI
 piI
-tla
+aTz
 aoX
 amh
 aqz
 vao
 mJe
-apE
+pHh
 auz
 avA
 uUY
@@ -81105,10 +81898,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 pDW
 aht
 aht
@@ -81120,8 +81909,12 @@ aht
 fon
 aaa
 aaa
-aaa
-aaa
+aem
+qQe
+emp
+cpv
+kCY
+aem
 aaa
 aaa
 aaa
@@ -81139,7 +81932,7 @@ afH
 amh
 amZ
 anJ
-tla
+aTz
 aoY
 amg
 sBA
@@ -81363,10 +82156,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 pDW
 pDW
 pDW
@@ -81377,8 +82166,12 @@ pDW
 aaa
 aaa
 aaa
-aaa
-aaa
+aem
+aem
+acM
+acM
+acM
+aem
 aaa
 aby
 abI
@@ -81659,7 +82452,7 @@ agP
 aqz
 vao
 mJe
-apE
+pHh
 ark
 ark
 uUY
@@ -82154,7 +82947,7 @@ aaa
 aby
 aaa
 agQ
-ahd
+adU
 xou
 cnT
 aiq
@@ -82412,7 +83205,7 @@ aby
 aaa
 agQ
 ahd
-xou
+aeB
 aiq
 aiq
 ahd
@@ -82669,7 +83462,7 @@ aby
 abI
 agP
 cnN
-xou
+aeB
 cnT
 aiq
 ahd
@@ -82926,7 +83719,7 @@ aby
 aaa
 agQ
 ahd
-xou
+aeB
 aiq
 fQN
 aip
@@ -83183,7 +83976,7 @@ aby
 aaa
 agQ
 cnP
-xou
+aeB
 xjU
 xjU
 xjU
@@ -83191,7 +83984,7 @@ cTC
 ajq
 ajZ
 akR
-anf
+dcn
 amr
 dcn
 anO
@@ -83440,7 +84233,7 @@ aby
 aaa
 agQ
 cnQ
-fcK
+ahN
 cnV
 aiq
 air
@@ -83697,7 +84490,7 @@ aby
 aaa
 agP
 wtp
-aiq
+anf
 aiq
 ahQ
 ais
@@ -87312,7 +88105,7 @@ aaa
 aaa
 aqI
 arI
-asR
+qYF
 atS
 syK
 syK
@@ -87570,7 +88363,7 @@ aaa
 aqI
 arJ
 asR
-ayg
+fRJ
 fNn
 ayg
 qsk
@@ -88092,8 +88885,8 @@ ayb
 juf
 aAB
 aLv
-lTW
-wEJ
+aCK
+aDL
 aEF
 aAB
 aGp
@@ -88340,11 +89133,11 @@ aaa
 aaa
 aqI
 arM
-asR
+qYF
 atU
-auR
+wZB
 avX
-axb
+fGk
 yeL
 azj
 aAC
@@ -88606,7 +89399,7 @@ ayb
 azk
 aAB
 aBu
-mtB
+aCK
 wEJ
 aEH
 aAB
@@ -89112,7 +89905,7 @@ aaa
 aqI
 arP
 asR
-ayg
+fRJ
 dch
 ayg
 hpp
@@ -89368,7 +90161,7 @@ aaa
 aaa
 aqI
 arQ
-asR
+qYF
 atV
 axc
 axc
@@ -89633,7 +90426,7 @@ ayg
 ayg
 wyP
 ayg
-aBy
+kLp
 vRN
 vRN
 aEJ
@@ -89890,7 +90683,7 @@ axe
 azo
 aAD
 aAE
-mNN
+iWD
 wyP
 aDP
 aEK
@@ -90401,7 +91194,7 @@ atY
 auU
 atY
 iNH
-auK
+bpN
 auK
 aAH
 aBz
@@ -90658,7 +91451,7 @@ atZ
 auV
 awc
 ayg
-ayg
+fRJ
 azp
 aAH
 aBA
@@ -90724,7 +91517,7 @@ qXH
 jez
 jez
 qOx
-qzm
+uSE
 xGi
 bSN
 bTD
@@ -90923,8 +91716,8 @@ aCR
 aDU
 aEM
 aFA
-aGw
-awd
+qKN
+ooI
 aaf
 xPQ
 fei
@@ -90974,7 +91767,7 @@ bBp
 bvD
 bIx
 cqz
-qzm
+uSE
 bLR
 bMV
 bOd
@@ -91181,7 +91974,7 @@ aDU
 aEN
 aAH
 aGw
-awd
+ooI
 aHV
 xPQ
 aJW
@@ -91231,7 +92024,7 @@ bBp
 bHh
 bIx
 cqz
-qzm
+uSE
 bLS
 rnQ
 bSa
@@ -91438,7 +92231,7 @@ aDV
 aEO
 aAH
 aGw
-awd
+ooI
 aHV
 xPQ
 aJR
@@ -91488,7 +92281,7 @@ bBp
 bHi
 bIx
 cqz
-qzm
+uSE
 bLT
 rnQ
 fUc
@@ -91695,9 +92488,9 @@ bAB
 aEP
 aFA
 oxC
-awd
-aHV
-xPQ
+ooI
+bsw
+trf
 fei
 aLc
 aNx
@@ -91745,7 +92538,7 @@ bBp
 bHj
 bIx
 cqz
-qzm
+uSE
 bLU
 bMW
 bOe
@@ -93477,7 +94270,7 @@ aaa
 cBU
 aoB
 apr
-apq
+oSC
 lCb
 arY
 dda
@@ -93732,7 +94525,7 @@ ljT
 aJc
 aaa
 lcZ
-aoC
+bcK
 apq
 hOY
 aqS
@@ -97118,7 +97911,7 @@ amb
 bfB
 bbI
 jaJ
-xba
+cCs
 dSK
 eSL
 cBN
@@ -97372,9 +98165,9 @@ bbI
 bcB
 hgV
 hgV
-mjO
-bbI
-nts
+hgV
+hgV
+dRI
 bbI
 lru
 eSL
@@ -97630,9 +98423,9 @@ bcC
 qfZ
 xPf
 hgV
-bbI
+hgV
 fQD
-aNT
+bbI
 lru
 eSL
 bkA
@@ -97886,8 +98679,8 @@ qXb
 udR
 dma
 lGJ
-eUa
-bbI
+lGJ
+lGJ
 bhr
 bbI
 lru
@@ -98142,9 +98935,9 @@ baD
 jbo
 xkk
 xkk
-cqI
-cqI
-cqI
+xkk
+xkk
+xkk
 bhs
 bbI
 lru
@@ -101840,7 +102633,7 @@ ckK
 ckK
 cju
 cjx
-cnp
+bXe
 cnq
 cju
 cju
@@ -102244,7 +103037,7 @@ aet
 afj
 ecR
 tko
-ahN
+dUZ
 aVI
 dUZ
 aaa
@@ -103527,13 +104320,13 @@ aco
 lao
 ndd
 sZh
-sut
-aTy
+dWo
+jlA
 qof
 cCB
 mRD
 aTy
-aYF
+uhk
 baG
 sut
 aaa
@@ -103784,13 +104577,13 @@ aco
 adO
 nkE
 sZh
-sut
-bcK
-oSC
+xMS
 cCB
-aHu
-aTy
-aYF
+cCB
+cCB
+cCB
+cCB
+jZL
 baG
 sut
 aaa
@@ -104041,13 +104834,13 @@ uOe
 uOe
 ovf
 sZh
-sut
-aTz
+xdb
+aTy
 vRk
-aVI
+cCB
 iIB
-aTz
-aYF
+aTy
+njW
 baG
 sut
 aaa
@@ -104292,19 +105085,19 @@ aaa
 aaa
 aht
 cdm
-adU
-adU
-adU
-adU
-aeB
+aaa
+aaa
+aaa
+aaa
+aYF
 sZh
-rWE
-aht
-aYE
+sut
+nLW
+xyr
 aVI
-rWE
-aht
-aYE
+mhw
+nLW
+aYF
 baG
 rWE
 aht
@@ -104549,19 +105342,19 @@ aaa
 aaa
 aht
 cdm
-adU
-adU
-adU
-adU
-aeB
-sZh
-sut
 aaa
+aaa
+aaa
+aaa
+aYF
+sZh
+kKz
+aht
 rng
 aVI
 kKz
-aaa
-aYF
+aht
+aqG
 baG
 sut
 aaa
@@ -108696,7 +109489,7 @@ oEW
 iuM
 wXu
 qlk
-sQP
+lGS
 bnd
 aaa
 aaa
@@ -110231,15 +111024,15 @@ aaa
 aaa
 aaa
 aaa
-bkF
-bkF
-bkF
-xKc
-bkF
-xKc
-bkF
-bkF
-bkF
+sQP
+lTW
+sQP
+mtB
+lTW
+mtB
+sQP
+lTW
+sQP
 aaa
 aby
 aaa

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -15851,6 +15851,7 @@
 	pixel_x = 4;
 	pixel_y = 4
 	},
+/obj/item/holosign_creator/robot_seat/restaurant,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "bck" = (
@@ -16111,16 +16112,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "bdp" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/beaker/large,
+/obj/machinery/oven,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "bdq" = (
 /obj/structure/table,
-/obj/item/reagent_containers/food/condiment/enzyme{
-	pixel_y = 6
-	},
-/obj/item/food/mint,
+/obj/item/reagent_containers/glass/beaker/large,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "bdr" = (
@@ -32666,8 +32663,10 @@
 /area/service/kitchen)
 "cpn" = (
 /obj/structure/table,
-/obj/item/food/spaghetti,
-/obj/item/holosign_creator/robot_seat/restaurant,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	pixel_y = 6
+	},
+/obj/item/food/mint,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "cpo" = (

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -23639,7 +23639,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/research{
-	name = "Toxins Storage";
+	name = "Ordnance Storage";
 	req_access_txt = "71"
 	},
 /obj/machinery/door/firedoor,
@@ -23685,7 +23685,7 @@
 "bDU" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/research/glass{
-	name = "Toxins Lab";
+	name = "Ordnance Lab";
 	req_access_txt = "8"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -24502,7 +24502,7 @@
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/machinery/door/airlock/research{
-	name = "Toxins Launch Room";
+	name = "Ordnance Launch Room";
 	req_access_txt = "8"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -54576,7 +54576,7 @@
 "vMt" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/atmos{
-	name = "Toxins Storage";
+	name = "Ordnance Storage";
 	req_access_txt = "24"
 	},
 /obj/structure/cable,
@@ -54787,7 +54787,7 @@
 "vTN" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/research{
-	name = "Toxins Lab";
+	name = "Ordnance Lab";
 	req_access_txt = "8"
 	},
 /turf/open/floor/iron/dark,

--- a/Station Maps/PubbyStation/information.txt
+++ b/Station Maps/PubbyStation/information.txt
@@ -17,4 +17,4 @@
 }
 
 
-// Latest commit since update: https://github.com/tgstation/tgstation/commit/3d15be634c5a69b6fe1a5de5868024764aa9d3c9
+// Latest commit since update: https://github.com/tgstation/tgstation/commit/4e789c4920469c0b2df1fbf5887426a973baa894

--- a/Station Maps/PubbyStation/information.txt
+++ b/Station Maps/PubbyStation/information.txt
@@ -17,4 +17,4 @@
 }
 
 
-// Latest commit since update: https://github.com/tgstation/tgstation/commit/4e789c4920469c0b2df1fbf5887426a973baa894
+// Latest commit since update: https://github.com/tgstation/tgstation/commit/4a7a9f04583823e20408668f3ee7236fcdd4ed5e


### PR DESCRIPTION
Toxins was renamed to Ordnance, toxin canisters relabelled to Plasma, and chapel/main/monastery is now chapel/monastery, adds an oven to the kitchen

I also fixed a few things that I missed the first time around, specifically xenobiology's decals/areas and some unwanted pipes being visible.

From @aaaa1023 -
- Adds electrified grilles to most of security, all head of staff offices, EVA, Teleporter, Gateway, outside of bridge, all the security posts, and outside engineering. The areas I added wire to was mostly based off if those areas had electrified grilles on Metastation.
- Added a Chem Master to science inside Xenobiology. Every other map has one and they're pretty important for Cytology. I remember Pubby having one way back but I think it was lost when the circuits area was added in.
- Added Windoors to the cargo Conveyors because I kept seeing people get trapped inside them.
- Moved a bomb camera at the back of the toxins test area so it's connected to the wall and not floating.
- Added multi cycle link helpers to a lot of doors on the station. I mostly referenced Metastation when looking for where I should place them.
- Removed some area tiles that were in space near cargo because I'm pretty sure they can cause things like anomalies to spawn outside
- Moved a disposals outlet one tile backwards in disposals because it would cause items sent through to be instantly destroyed, or if the recycler was emagged, instantly kill anyone that went through disposals.