### PR TITLE
Pubbystation Returns (after lacking in updates)

### DIFF
--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -7271,7 +7271,6 @@
 	name = "Brig Desk";
 	req_access_txt = "1"
 	},
-/obj/item/food/donut,
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
 	name = "brig shutters"
@@ -7280,6 +7279,7 @@
 /obj/item/folder/red{
 	layer = 2.9
 	},
+/obj/item/food/donut/plain,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "awQ" = (
@@ -35952,6 +35952,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage_shared)
+"etk" = (
+/obj/machinery/light/directional/east,
+/turf/closed/wall,
+/area/cargo/storage)
 "eus" = (
 /turf/open/floor/iron/white,
 /area/medical/paramedic)
@@ -44777,10 +44781,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"njf" = (
-/obj/machinery/light/directional/east,
-/turf/closed/wall,
-/area/cargo/storage)
 "njg" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -100769,7 +100769,7 @@ cDa
 aTy
 iYH
 aTy
-njf
+etk
 xEt
 idl
 aTy

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -10,7 +10,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/security)
+/area/security/office)
 "aad" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -380,7 +380,7 @@
 /obj/structure/tank_dispenser/oxygen,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/showroomfloor,
-/area/security)
+/area/security/office)
 "aby" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -463,13 +463,13 @@
 /area/ai_monitored/turret_protected/ai)
 "ach" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/ai_monitored/turret_protected/ai)
 "aci" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/iron/white{
 	heat_capacity = 1e+006
@@ -965,7 +965,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "adM" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1000,7 +1000,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
-/area/security)
+/area/security/office)
 "adV" = (
 /turf/open/space,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -1167,7 +1167,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
-/area/security)
+/area/security/office)
 "aeC" = (
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/mop,
@@ -1892,14 +1892,11 @@
 /obj/item/radio/intercom/prison/directional/east,
 /turf/open/floor/iron,
 /area/security/prison/safe)
-"agP" = (
-/turf/closed/wall,
-/area/security)
 "agQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/security)
+/area/security/office)
 "agR" = (
 /obj/machinery/door/airlock/external{
 	name = "MiniSat External Access";
@@ -1940,7 +1937,7 @@
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/showroomfloor,
-/area/security)
+/area/security/office)
 "ahh" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/showcase/cyborg/old{
@@ -2148,21 +2145,18 @@
 	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/security)
+/area/security/office)
 "ahN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
-/area/security)
+/area/security/office)
 "ahP" = (
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/bar)
-"ahQ" = (
-/turf/closed/wall,
-/area/space)
 "ahR" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/transit_tube/crossing,
@@ -2296,32 +2290,32 @@
 	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/security)
+/area/security/office)
 "aio" = (
 /obj/structure/closet/l3closet/security,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/showroomfloor,
-/area/security)
+/area/security/office)
 "aip" = (
 /obj/structure/closet/bombcloset/security,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/showroomfloor,
-/area/security)
+/area/security/office)
 "aiq" = (
 /turf/open/floor/iron/showroomfloor,
-/area/security)
+/area/security/office)
 "air" = (
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/showroomfloor,
-/area/security)
+/area/security/office)
 "ais" = (
 /obj/effect/turf_decal/bot,
 /obj/item/radio/intercom/directional/east,
 /obj/vehicle/ridden/secway,
 /obj/item/key/security,
 /turf/open/floor/iron/showroomfloor,
-/area/security)
+/area/security/office)
 "ait" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -2644,7 +2638,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "ajl" = (
 /obj/structure/filingcabinet,
 /obj/effect/turf_decal/tile/red{
@@ -2654,7 +2648,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "ajm" = (
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box{
@@ -2670,7 +2664,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "ajn" = (
 /obj/structure/table,
 /obj/structure/plaque/static_plaque/golden{
@@ -2688,7 +2682,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "ajo" = (
 /obj/machinery/vending/coffee,
 /obj/effect/turf_decal/tile/red{
@@ -2699,7 +2693,7 @@
 	},
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "ajp" = (
 /obj/machinery/photocopier,
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -2712,7 +2706,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "ajq" = (
 /obj/effect/landmark/start/security_officer,
 /obj/effect/turf_decal/tile/red{
@@ -2729,7 +2723,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "ajr" = (
 /obj/item/food/donut/chaos,
 /turf/open/floor/plating,
@@ -2931,14 +2925,14 @@
 /obj/effect/landmark/start/security_officer,
 /obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "ajX" = (
 /turf/closed/wall,
 /area/service/bar/atrium)
 "ajY" = (
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "ajZ" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/red,
@@ -2949,7 +2943,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "aka" = (
 /obj/machinery/suit_storage_unit/hos,
 /obj/machinery/requests_console/directional/north{
@@ -3313,7 +3307,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "akR" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -3325,7 +3319,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "akT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -3435,12 +3429,12 @@
 /area/maintenance/department/security/brig)
 "alj" = (
 /obj/item/wrench,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/layer_manifold/general/visible,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "alk" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/plating,
@@ -3537,7 +3531,7 @@
 	},
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "alC" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -3550,18 +3544,18 @@
 	pixel_x = 8
 	},
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "alD" = (
 /obj/machinery/computer/secure_data,
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "alF" = (
 /obj/machinery/computer/security,
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "alH" = (
 /turf/open/floor/iron/dark,
-/area/security)
+/area/security/office)
 "alJ" = (
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
@@ -3606,8 +3600,10 @@
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "alT" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/components/binary/pump/layer4{
+	dir = 1;
+	name = "Distro to Brig"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "alY" = (
@@ -3671,6 +3667,9 @@
 /area/security/brig)
 "amd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "ame" = (
@@ -3727,10 +3726,10 @@
 	},
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "amn" = (
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "amp" = (
 /obj/machinery/holopad/secure,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -3738,7 +3737,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "amq" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -3752,7 +3751,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "amr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3767,7 +3766,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "ams" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3778,7 +3777,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/security)
+/area/security/office)
 "amt" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Head of Security";
@@ -4025,22 +4024,22 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "anc" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "ane" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "anf" = (
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
-/area/security)
+/area/security/office)
 "ani" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -4110,7 +4109,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "anw" = (
@@ -4207,14 +4205,14 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "anM" = (
 /obj/structure/chair/office{
 	dir = 1
 	},
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "anN" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -4222,7 +4220,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "anO" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -4233,7 +4231,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "anP" = (
 /obj/machinery/modular_computer/console/preset/cargochat/security{
 	dir = 8
@@ -4242,7 +4240,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron/dark,
-/area/security)
+/area/security/office)
 "anQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4352,6 +4350,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "aoj" = (
@@ -4424,7 +4425,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "aov" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -4434,20 +4435,20 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "aow" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "aox" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4;
 	sortType = 8
 	},
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "aoy" = (
 /obj/machinery/light/directional/east,
 /obj/structure/disposalpipe/segment{
@@ -4464,7 +4465,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "aoz" = (
 /turf/closed/wall,
 /area/maintenance/fore)
@@ -4617,7 +4618,7 @@
 	},
 /obj/structure/reagent_dispensers/wall/peppertank/directional/south,
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "apb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4627,7 +4628,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "apc" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1;
@@ -4639,7 +4640,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "apd" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -4650,7 +4651,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "ape" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -4682,7 +4683,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "apg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4837,7 +4838,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "apK" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor{
@@ -4898,7 +4899,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "apQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/sign/warning/vacuum/external{
@@ -6463,7 +6464,7 @@
 "auI" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "auJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/small{
@@ -7415,6 +7416,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -7770,7 +7774,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "ayI" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=BrigS2";
@@ -7989,7 +7993,7 @@
 "azm" = (
 /obj/effect/turf_decal/bot/right,
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "azo" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -8091,7 +8095,7 @@
 	color = "#52B4E9"
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "azR" = (
 /obj/machinery/door/airlock/command{
 	id_tag = "CMOCell";
@@ -9833,6 +9837,7 @@
 /area/commons/toilet/restrooms)
 "aFc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "aFe" = (
@@ -10693,6 +10698,16 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"aIU" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "aIX" = (
 /obj/effect/landmark/observer_start,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -19943,10 +19958,10 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bsD" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "bsF" = (
@@ -30514,9 +30529,6 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "cgv" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
@@ -31917,32 +31929,32 @@
 	c_tag = "Brig Equipment Room"
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/security)
+/area/security/office)
 "cnN" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/showroomfloor,
-/area/security)
+/area/security/office)
 "cnP" = (
 /obj/machinery/vending/security,
 /obj/effect/turf_decal/bot,
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
-/area/security)
+/area/security/office)
 "cnQ" = (
 /obj/machinery/suit_storage_unit/security,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/showroomfloor,
-/area/security)
+/area/security/office)
 "cnT" = (
 /obj/structure/weightmachine/weightlifter,
 /turf/open/floor/iron/showroomfloor,
-/area/security)
+/area/security/office)
 "cnV" = (
 /obj/structure/punching_bag,
 /turf/open/floor/iron/showroomfloor,
-/area/security)
+/area/security/office)
 "cnX" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -34244,7 +34256,7 @@
 "cCS" = (
 /obj/machinery/rnd/production/techfab/department/security,
 /turf/open/floor/iron/dark,
-/area/security)
+/area/security/office)
 "cCT" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/disposalpipe/segment{
@@ -34283,10 +34295,10 @@
 /turf/closed/wall,
 /area/cargo/warehouse)
 "cDy" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "cDB" = (
@@ -34601,7 +34613,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "cUb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom/directional/west,
@@ -34653,7 +34665,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "dcL" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
@@ -35293,7 +35305,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
-/area/security)
+/area/security/office)
 "dKA" = (
 /obj/machinery/atmospherics/components/trinary/filter/critical{
 	dir = 1
@@ -35666,6 +35678,10 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"eeE" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating/airless,
+/area/engineering/atmospherics_engine)
 "eeF" = (
 /obj/structure/chair{
 	dir = 8
@@ -36017,7 +36033,7 @@
 "evU" = (
 /obj/effect/turf_decal/bot/left,
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "ewb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -36788,7 +36804,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/security)
+/area/security/office)
 "fcQ" = (
 /obj/machinery/door/firedoor,
 /obj/effect/landmark/start/hangover,
@@ -37138,6 +37154,12 @@
 /obj/machinery/atmospherics/components/trinary/mixer/airmix,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"frV" = (
+/obj/machinery/space_heater,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/meter,
+/turf/open/floor/plating,
+/area/maintenance/department/security/brig)
 "frX" = (
 /obj/structure/chair{
 	dir = 1
@@ -37695,7 +37717,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/security)
+/area/security/office)
 "fRl" = (
 /obj/item/bedsheet,
 /obj/structure/bed,
@@ -37892,12 +37914,11 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "gfi" = (
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 2
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "gfC" = (
 /obj/structure/table,
 /obj/machinery/conveyor_switch/oneway{
@@ -37934,7 +37955,7 @@
 /obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "gif" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -39010,6 +39031,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"hjq" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "hju" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39357,7 +39384,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "hCj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -39538,6 +39565,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
+"hLv" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "hLC" = (
 /obj/structure/table/glass,
 /obj/item/clothing/gloves/color/latex,
@@ -39610,12 +39644,12 @@
 /turf/open/floor/iron/dark,
 /area/command/gateway)
 "hPG" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/trinary/filter/critical{
 	dir = 1;
 	filter_type = list(/datum/gas/nitrogen)
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
@@ -39681,10 +39715,10 @@
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "hQC" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "hQV" = (
@@ -39951,7 +39985,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "iea" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
@@ -40062,7 +40096,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "ijU" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/medical/memeorgans,
@@ -40678,7 +40712,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating/airless,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "iWD" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
@@ -40893,11 +40927,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Chamber Inject"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
@@ -41194,7 +41228,7 @@
 "jzI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/security)
+/area/security/office)
 "jAx" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -41285,11 +41319,11 @@
 /turf/open/floor/plating,
 /area/service/abandoned_gambling_den)
 "jHZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/turf/closed/wall,
-/area/maintenance/department/cargo)
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "jII" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -42181,6 +42215,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"kCo" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "kCI" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -42343,7 +42387,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "kKz" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -42503,7 +42547,7 @@
 /area/medical/cryo)
 "kTl" = (
 /turf/closed/wall,
-/area/space/nearstation)
+/area/security/office)
 "kTn" = (
 /obj/structure/grille/broken,
 /obj/structure/cable,
@@ -43129,7 +43173,7 @@
 /obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "lyB" = (
 /obj/machinery/atmospherics/components/binary/thermomachine/heater,
 /turf/open/floor/iron,
@@ -43916,7 +43960,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "mrR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -44322,7 +44366,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "mNN" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
@@ -44494,7 +44538,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
-/area/security)
+/area/security/office)
 "mXc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -44856,9 +44900,6 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "nkY" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
@@ -44897,6 +44938,16 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
+"nlI" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "nmF" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/effect/turf_decal/tile/blue,
@@ -45050,10 +45101,10 @@
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "nwg" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "nww" = (
@@ -45690,6 +45741,15 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"ocO" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmospherics_engine)
 "odh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -45829,7 +45889,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "olc" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Bedroom";
@@ -46263,7 +46323,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "oCn" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -46379,7 +46439,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "oGm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46443,9 +46503,11 @@
 /turf/open/floor/iron/grimy,
 /area/service/chapel/monastery)
 "oMH" = (
-/obj/machinery/suit_storage_unit/industrial/loader,
-/turf/open/floor/iron,
-/area/cargo/warehouse)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "oMN" = (
 /turf/open/floor/iron/stairs/left,
 /area/service/abandoned_gambling_den)
@@ -46714,7 +46776,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/effect/landmark/secequipment,
 /turf/open/floor/iron/showroomfloor,
-/area/security)
+/area/security/office)
 "oWL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -47114,7 +47176,7 @@
 /area/security/brig)
 "pth" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
@@ -47136,6 +47198,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"puR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "puW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -47355,7 +47423,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "pGZ" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lantern{
@@ -47552,6 +47620,9 @@
 "pQA" = (
 /turf/open/floor/carpet,
 /area/service/library/artgallery)
+"pRk" = (
+/turf/open/floor/iron,
+/area/engineering/atmospherics_engine)
 "pRE" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -48368,7 +48439,7 @@
 	pixel_x = -4
 	},
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "qAF" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -48915,7 +48986,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "rgs" = (
 /obj/structure/table,
 /obj/item/instrument/eguitar,
@@ -48957,7 +49028,7 @@
 "rjl" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "rka" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/dark,
@@ -49194,7 +49265,7 @@
 	color = "#9FED58"
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "rsK" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -49820,7 +49891,7 @@
 /area/medical/medbay/central)
 "rOV" = (
 /turf/closed/wall/r_wall,
-/area/security)
+/area/security/office)
 "rPu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -49989,10 +50060,10 @@
 /turf/open/floor/plating,
 /area/commons/storage/emergency/starboard)
 "rYH" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "rYY" = (
@@ -50184,7 +50255,9 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "skw" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/closed/wall,
 /area/maintenance/department/security/brig)
 "skS" = (
@@ -50324,7 +50397,7 @@
 	color = "#EFB341"
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "stc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/iron/white,
@@ -50451,7 +50524,7 @@
 	c_tag = "HFR Room"
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "sxT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -50465,6 +50538,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -50476,7 +50552,7 @@
 	pixel_y = 15
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "syA" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/start/hangover,
@@ -50941,7 +51017,7 @@
 /area/engineering/supermatter/room)
 "sWM" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/ai_monitored/turret_protected/ai)
@@ -51412,7 +51488,7 @@
 /obj/item/stack/sheet/plasteel/twenty,
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "tna" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
@@ -51973,7 +52049,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "tLN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/closed/wall/r_wall,
@@ -52076,6 +52152,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -52122,7 +52201,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "tTq" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -52849,6 +52928,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
+"uwu" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "uwF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -53090,6 +53180,9 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
+"uEM" = (
+/turf/closed/wall/r_wall,
+/area/engineering/atmospherics_engine)
 "uEY" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -53170,6 +53263,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
+"uJo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "uKD" = (
 /obj/structure/chair,
 /obj/machinery/light/directional/north,
@@ -53324,7 +53423,7 @@
 	pixel_x = -4
 	},
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "uSE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -53489,7 +53588,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "uWC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -53807,6 +53906,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -54021,6 +54123,14 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"vta" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "vtl" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -54050,6 +54160,10 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"vvf" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/cyan/visible,
+/turf/closed/wall,
+/area/maintenance/department/security/brig)
 "vvn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -54127,7 +54241,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/stasis,
+/obj/machinery/stasis{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "vzg" = (
@@ -54506,7 +54622,7 @@
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/space/nearstation)
+/area/security/office)
 "vRq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -54651,6 +54767,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
+"vYj" = (
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 2
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "vYH" = (
 /obj/structure/table/wood,
 /obj/machinery/camera/directional/east{
@@ -54696,7 +54819,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/stasis,
+/obj/machinery/stasis{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "vZJ" = (
@@ -54843,7 +54968,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "wfr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -55176,7 +55301,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/newscaster/security_unit/directional/north,
 /turf/open/floor/iron/showroomfloor,
-/area/security)
+/area/security/office)
 "wtZ" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/west,
@@ -55646,7 +55771,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "wMn" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/structure/disposalpipe/segment,
@@ -55757,7 +55882,7 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "wQU" = (
 /obj/effect/spawner/random/maintenance,
 /obj/structure/cable,
@@ -56137,7 +56262,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "xdY" = (
 /obj/machinery/door/window/eastright{
 	name = "Danger: Conveyor Access";
@@ -56308,7 +56433,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
-/area/security)
+/area/security/office)
 "xjZ" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -56461,7 +56586,7 @@
 /obj/structure/cable,
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
-/area/security)
+/area/security/office)
 "xoD" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -56532,6 +56657,14 @@
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/service/chapel/monastery)
+"xsa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "xsr" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -56622,9 +56755,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
@@ -56640,7 +56770,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "xxk" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -56680,7 +56810,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/security)
+/area/security/office)
 "xxO" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio2";
@@ -56871,7 +57001,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/security)
+/area/security/office)
 "xHe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -56923,7 +57053,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "xJy" = (
 /obj/structure/chair/comfy/black,
 /obj/structure/sign/plaques/kiddie{
@@ -57135,12 +57265,11 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "xTe" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "xTf" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -57482,6 +57611,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"yli" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "ylS" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -74281,11 +74418,11 @@ aiu
 ait
 ait
 aiu
-xTe
-xTe
-xTe
-xTe
-xTe
+tlB
+tlB
+tlB
+tlB
+tlB
 tSq
 axg
 viq
@@ -74538,7 +74675,7 @@ aiu
 aaa
 aaa
 aiu
-xTe
+tlB
 aiu
 aiu
 aiu
@@ -74795,7 +74932,7 @@ aiu
 aiu
 aiu
 aiu
-xTe
+tlB
 aiu
 coG
 cIt
@@ -75051,7 +75188,7 @@ akv
 alj
 alT
 skw
-ueU
+tlB
 aof
 aiu
 aqh
@@ -75060,15 +75197,15 @@ ajD
 atq
 aut
 aiu
-xTe
-xTe
-xTe
-xTe
-xTe
-xTe
-xTe
-xTe
-xTe
+tlB
+tlB
+tlB
+tlB
+tlB
+tlB
+tlB
+tlB
+tlB
 syn
 wUz
 ait
@@ -75562,9 +75699,9 @@ aiv
 aiu
 ajG
 akw
-ajD
-aiH
-aiu
+akv
+frV
+vvf
 ueU
 apB
 aiu
@@ -75583,7 +75720,7 @@ aiu
 aiu
 aiu
 aiu
-xTe
+tlB
 aiu
 aiu
 aiu
@@ -75840,7 +75977,7 @@ aiu
 aCd
 hHr
 hHr
-xTe
+tlB
 ezF
 aod
 aqg
@@ -81206,7 +81343,7 @@ aaa
 aaa
 aby
 abI
-agP
+kTl
 jzI
 jzI
 rOV
@@ -81463,7 +81600,7 @@ aaa
 aaa
 aby
 aaa
-agP
+kTl
 cnJ
 dJP
 xxK
@@ -81479,7 +81616,7 @@ anb
 anL
 aot
 apa
-agP
+kTl
 aqz
 vao
 mJe
@@ -81726,7 +81863,7 @@ mWQ
 aiq
 fcK
 aio
-agP
+kTl
 ajl
 ajY
 idZ
@@ -81736,7 +81873,7 @@ qzW
 amn
 tLA
 apb
-agP
+kTl
 avE
 arq
 asD
@@ -81983,7 +82120,7 @@ xou
 cnT
 aiq
 oWx
-agP
+kTl
 ajm
 oCi
 idZ
@@ -82231,7 +82368,7 @@ aaa
 aaa
 aaa
 aaa
-cFB
+aaa
 aby
 aaa
 agQ
@@ -82240,7 +82377,7 @@ aeB
 aiq
 aiq
 oWx
-agP
+kTl
 ajn
 ajW
 oFO
@@ -82484,20 +82621,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cFB
 aaa
 aaa
 aaa
 aaa
 aby
 abI
-agP
+kTl
 cnN
 aeB
 cnT
 aiq
 oWx
-agP
+kTl
 ajo
 ghx
 lyd
@@ -82754,7 +82891,7 @@ aeB
 aiq
 fQN
 aip
-agP
+kTl
 ajp
 ajY
 lyd
@@ -82764,7 +82901,7 @@ ane
 anN
 aox
 apH
-agP
+kTl
 aqA
 hWq
 aad
@@ -83268,9 +83405,9 @@ ahN
 cnV
 aiq
 aiq
-agP
-agP
-agP
+kTl
+kTl
+kTl
 cCS
 alH
 ams
@@ -83519,13 +83656,13 @@ aaa
 aaa
 aby
 aaa
-agP
+kTl
 wtp
 anf
 aiq
 aiq
 ais
-agP
+kTl
 ajr
 aiR
 akT
@@ -83776,13 +83913,13 @@ aaa
 aaa
 aby
 abI
-agP
+kTl
 air
 anf
 aiq
 abx
-agP
-agP
+kTl
+kTl
 ajs
 aiR
 akU
@@ -84033,7 +84170,7 @@ aaa
 aaa
 aaa
 aaa
-ahQ
+kTl
 vRp
 vRp
 vRp
@@ -89404,14 +89541,14 @@ aaa
 abO
 abW
 acd
-ace
+oMH
 ace
 ace
 amd
+kCo
+aIU
 acC
-acC
-acC
-acC
+vta
 acd
 acw
 acP
@@ -89660,16 +89797,16 @@ aby
 aaa
 abO
 ach
-ace
-ace
+gfi
+xTe
 abO
 abO
 abO
 bhU
 abO
 abO
-acC
-acC
+nlI
+kCo
 aci
 acP
 acP
@@ -91202,16 +91339,16 @@ aby
 aaa
 abO
 abV
-ace
-ace
+jHZ
+hjq
 abO
 abO
 abO
 bhU
 abO
 abO
-adT
-adT
+puR
+xsa
 sWM
 acU
 acU
@@ -91460,14 +91597,14 @@ aaa
 abO
 abW
 acd
-ace
+oMH
 ace
 ace
 aFc
+xsa
+yli
 adT
-adT
-adT
-adT
+uJo
 acd
 acw
 acU
@@ -94420,13 +94557,13 @@ bJP
 bJP
 bJP
 bJP
-fBp
+uEM
 auI
 auI
 auI
 auI
 auI
-fBp
+uEM
 aaa
 aaa
 aaa
@@ -94935,7 +95072,7 @@ cco
 lag
 bJP
 auI
-bUp
+ocO
 azm
 azN
 evU
@@ -95192,7 +95329,7 @@ cby
 cby
 bJP
 auI
-bUp
+ocO
 rsy
 rjl
 syt
@@ -95449,7 +95586,7 @@ bJP
 bJP
 bJP
 auI
-bUp
+ocO
 evU
 ssU
 azm
@@ -95705,11 +95842,11 @@ fBp
 fBp
 fBp
 fBp
-fBp
+uEM
 ayG
-bWO
-bWO
-bWO
+pRk
+pRk
+pRk
 hCg
 auI
 aaa
@@ -95965,8 +96102,8 @@ cRm
 iVT
 mrH
 pGV
-bWO
-bWO
+pRk
+pRk
 wfp
 wQE
 xdQ
@@ -96220,10 +96357,10 @@ yeD
 yeD
 yeD
 iiP
-bUp
-bWO
-bWO
-bWO
+ocO
+pRk
+pRk
+pRk
 uWA
 auI
 aaa
@@ -96476,7 +96613,7 @@ yeD
 yeD
 yeD
 yeD
-mkf
+eeE
 mNv
 rfm
 sxs
@@ -96736,10 +96873,10 @@ bYw
 bYw
 bYw
 bYw
-fBp
-fBp
-fBp
-fBp
+uEM
+uEM
+uEM
+uEM
 aaa
 aaa
 aaa
@@ -100010,7 +100147,7 @@ aSd
 bbO
 aTv
 bfC
-oMH
+aTv
 bcV
 aUz
 wkM
@@ -101309,9 +101446,9 @@ uXX
 tfz
 mdx
 kjA
-mdx
 dSK
 tfz
+uwu
 mdx
 fGd
 aKq
@@ -101566,9 +101703,9 @@ vaa
 mri
 aEj
 uSW
+vYj
+mri
 aEj
-gfi
-jHZ
 iSi
 iSi
 iSi
@@ -101823,8 +101960,8 @@ aEl
 aEj
 aEj
 tBP
-aEj
-uSW
+wAI
+hLv
 lEn
 pnU
 pnU

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -2244,7 +2244,7 @@
 "aif" = (
 /obj/machinery/door/airlock{
 	name = "Service Access";
-	req_one_access_txt = "22;25;26;28;35;37;38;46;70"
+	req_one_access_txt = "73"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
@@ -13481,7 +13481,7 @@
 "aVc" = (
 /obj/machinery/door/window/southleft{
 	name = "Bar Delivery";
-	req_access_txt = "25"
+	req_access_txt = "73"
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
@@ -16982,7 +16982,6 @@
 /obj/structure/table,
 /obj/item/stack/sheet/iron/five,
 /obj/item/stack/cable_coil/five,
-/obj/item/circuitboard/machine/paystand,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "bic" = (
@@ -46444,8 +46443,7 @@
 /turf/open/floor/iron/grimy,
 /area/service/chapel/monastery)
 "oMH" = (
-/obj/structure/table,
-/obj/item/airlock_painter/decal,
+/obj/machinery/suit_storage_unit/industrial/loader,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "oMN" = (

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -9477,7 +9477,6 @@
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
 "aEi" = (
-/obj/effect/landmark/blobstart,
 /obj/item/toy/beach_ball/holoball,
 /turf/open/floor/plating,
 /area/commons/toilet/restrooms)
@@ -18259,6 +18258,13 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"bmI" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Chapel Access"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "bmL" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/electrical{
@@ -21544,7 +21550,6 @@
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/west,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "bye" = (
@@ -22734,6 +22739,8 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/suit_storage_unit/medical,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "bCa" = (
@@ -29014,11 +29021,11 @@
 /turf/open/floor/iron/chapel{
 	dir = 8
 	},
-/area/service/chapel/monastery)
+/area/service/chapel)
 "bYB" = (
 /obj/structure/chair/wood,
 /turf/open/floor/iron/chapel,
-/area/service/chapel/monastery)
+/area/service/chapel)
 "bYI" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21";
@@ -29245,13 +29252,13 @@
 /turf/open/floor/iron/chapel{
 	dir = 1
 	},
-/area/service/chapel/monastery)
+/area/service/chapel)
 "bZm" = (
 /obj/structure/chair/wood,
 /turf/open/floor/iron/chapel{
 	dir = 4
 	},
-/area/service/chapel/monastery)
+/area/service/chapel)
 "bZr" = (
 /obj/item/trash/tray,
 /obj/structure/disposalpipe/segment{
@@ -29554,7 +29561,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/chapel,
-/area/service/chapel/monastery)
+/area/service/chapel)
 "caW" = (
 /obj/item/flashlight/lantern,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -29563,7 +29570,7 @@
 /turf/open/floor/iron/chapel{
 	dir = 8
 	},
-/area/service/chapel/monastery)
+/area/service/chapel)
 "caZ" = (
 /obj/structure/table,
 /obj/item/wirecutters,
@@ -29704,12 +29711,12 @@
 /turf/open/floor/iron/chapel{
 	dir = 4
 	},
-/area/service/chapel/monastery)
+/area/service/chapel)
 "cbN" = (
 /obj/item/storage/book/bible,
 /obj/structure/altar_of_gods,
 /turf/open/floor/carpet,
-/area/service/chapel/monastery)
+/area/service/chapel)
 "cbO" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/trophy{
@@ -29723,12 +29730,12 @@
 	dir = 8
 	},
 /turf/open/floor/carpet,
-/area/service/chapel/monastery)
+/area/service/chapel)
 "cbP" = (
 /turf/open/floor/iron/chapel{
 	dir = 1
 	},
-/area/service/chapel/monastery)
+/area/service/chapel)
 "cbQ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -29889,10 +29896,10 @@
 	dir = 8
 	},
 /turf/open/floor/carpet,
-/area/service/chapel/monastery)
+/area/service/chapel)
 "ccH" = (
 /turf/open/floor/iron/chapel,
-/area/service/chapel/monastery)
+/area/service/chapel)
 "ccJ" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -29993,7 +30000,7 @@
 /turf/open/floor/iron/chapel{
 	dir = 8
 	},
-/area/service/chapel/monastery)
+/area/service/chapel)
 "cdD" = (
 /obj/structure/table,
 /obj/item/trash/waffles,
@@ -30277,7 +30284,7 @@
 	icon_state = "plant-08"
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/chapel)
 "ceL" = (
 /obj/structure/table/wood/fancy,
 /obj/item/storage/box/matches{
@@ -30286,7 +30293,7 @@
 	},
 /obj/machinery/light/small,
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/chapel)
 "ceT" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/closet/emcloset,
@@ -32670,7 +32677,7 @@
 /obj/structure/table/wood,
 /obj/item/food/grown/harebell,
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/chapel)
 "cry" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -32729,7 +32736,7 @@
 /obj/structure/table/wood,
 /obj/item/food/grown/poppy,
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/chapel)
 "crK" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -32739,7 +32746,7 @@
 	network = list("ss13","monastery")
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/chapel)
 "crN" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -32750,7 +32757,7 @@
 	},
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/chapel)
 "crO" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -32778,7 +32785,7 @@
 	pixel_y = 8
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/chapel)
 "csd" = (
 /turf/open/floor/carpet/black,
 /area/service/chapel/office)
@@ -32799,7 +32806,7 @@
 	pixel_y = 8
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/chapel)
 "csn" = (
 /obj/structure/closet,
 /obj/item/storage/backpack/cultpack,
@@ -32926,7 +32933,7 @@
 /obj/item/storage/fancy/candle_box,
 /obj/machinery/light/small,
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/chapel)
 "ctr" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -38844,6 +38851,16 @@
 /obj/item/toy/cards/deck,
 /turf/open/floor/iron,
 /area/security/prison)
+"gVi" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "gVk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -39079,6 +39096,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"hkR" = (
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "hlQ" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -39160,7 +39181,7 @@
 /obj/structure/chair/wood,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/chapel,
-/area/service/chapel/monastery)
+/area/service/chapel)
 "hoR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -39788,11 +39809,11 @@
 "hTw" = (
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/chapel)
 "hTW" = (
 /obj/structure/table/wood/fancy,
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/chapel)
 "hUx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -40126,6 +40147,12 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engineering/supermatter/room)
+"imV" = (
+/obj/machinery/door/morgue{
+	name = "Confession Booth"
+	},
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "int" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall,
@@ -41152,6 +41179,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"jvV" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "jwq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41236,7 +41269,7 @@
 	name = "Chapel"
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/chapel)
 "jAy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -42459,7 +42492,7 @@
 "kOF" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/chapel,
-/area/service/chapel/monastery)
+/area/service/chapel)
 "kPA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43178,6 +43211,15 @@
 /obj/machinery/atmospherics/components/binary/thermomachine/heater,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"lza" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "lzJ" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/carpet,
@@ -44898,7 +44940,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/chapel)
 "nkY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
@@ -45088,6 +45130,9 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"nvp" = (
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "nvG" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/iron/dark,
@@ -46259,7 +46304,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/chapel)
 "oAk" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/lizard/wags_his_tail,
@@ -46815,6 +46860,10 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
+"oZS" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "oZX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -48043,7 +48092,7 @@
 	},
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/chapel)
 "qjx" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/yellow,
@@ -48187,7 +48236,6 @@
 	dir = 8
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "qoK" = (
@@ -48448,6 +48496,9 @@
 /obj/item/clothing/head/ushanka,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"qCB" = (
+/turf/closed/wall,
+/area/service/chapel)
 "qCG" = (
 /obj/structure/grille/broken,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -49988,7 +50039,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/chapel,
-/area/service/chapel/monastery)
+/area/service/chapel)
 "rVA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -50979,6 +51030,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"sTK" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "sTY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51762,7 +51819,7 @@
 	icon_state = "plant-05"
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/chapel)
 "txK" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -52257,7 +52314,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/chapel)
 "tWt" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
@@ -52364,6 +52421,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"ubj" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "ubq" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/red{
@@ -52503,6 +52568,12 @@
 "ufo" = (
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"ugi" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "ugv" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -52836,7 +52907,7 @@
 /turf/open/floor/iron/chapel{
 	dir = 8
 	},
-/area/service/chapel/monastery)
+/area/service/chapel)
 "ute" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -53838,6 +53909,7 @@
 /obj/machinery/disposal/bin{
 	name = "Corpse Disposal"
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "vgg" = (
@@ -54118,7 +54190,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
+/area/service/chapel)
 "vsJ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /turf/open/floor/iron,
@@ -55335,6 +55407,9 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
+"wvE" = (
+/turf/open/floor/carpet,
+/area/service/chapel)
 "wwp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -55613,7 +55688,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet,
-/area/service/chapel/monastery)
+/area/service/chapel)
 "wEJ" = (
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -55691,7 +55766,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet,
-/area/service/chapel/monastery)
+/area/service/chapel)
 "wIX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -56656,7 +56731,7 @@
 "xrO" = (
 /obj/structure/cable,
 /turf/open/floor/carpet,
-/area/service/chapel/monastery)
+/area/service/chapel)
 "xsa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -57358,6 +57433,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
+"xYS" = (
+/turf/closed/wall/mineral/iron,
+/area/service/chapel)
 "yat" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -71168,17 +71246,17 @@ bOw
 bOw
 bOw
 bOw
-bWV
-bWV
-bWV
-bYz
-bWV
-bWV
-bWV
-bWV
+qCB
+qCB
+qCB
+imV
+qCB
+qCB
+qCB
+qCB
 vsq
-bWV
-cfm
+qCB
+xYS
 qGk
 cvy
 bWV
@@ -71425,17 +71503,17 @@ fOq
 bOw
 bOw
 bOw
-bWV
-csv
-csS
-csS
+qCB
+ugi
+nvp
+nvp
 crK
 tWk
 hTw
-csv
-yiF
+ubj
+gVi
 txC
-cfm
+xYS
 csS
 udr
 cgG
@@ -71681,18 +71759,18 @@ bOw
 bQd
 bOw
 bQd
-bWV
-bWV
-csS
+qCB
+qCB
+nvp
 bZl
 bYA
 bZl
 usI
 cbP
 cdu
-yiF
+gVi
 hTW
-cfm
+xYS
 fnN
 ykY
 cgG
@@ -71938,18 +72016,18 @@ bOw
 bOw
 bOw
 bQe
-bWV
-csS
-csS
+qCB
+nvp
+nvp
 bZm
 bYB
 bZm
 caV
 cbM
 kOF
-yiF
+gVi
 ceL
-cfm
+xYS
 ccJ
 ykY
 bWV
@@ -72196,16 +72274,16 @@ bQg
 bQg
 bQg
 ozR
-csS
-cwk
-cwk
-cwk
-cwk
+nvp
+wvE
+wvE
+wvE
+wvE
 wIt
-cwk
+wvE
 cbN
 wEz
-csS
+nvp
 ozR
 csS
 ykY
@@ -72453,7 +72531,7 @@ dUh
 dUh
 dUh
 jAx
-qFp
+oZS
 xrO
 xrO
 xrO
@@ -72462,7 +72540,7 @@ wEz
 wEz
 cbO
 ccF
-oaM
+lza
 nkK
 oaM
 ykY
@@ -72709,18 +72787,18 @@ bOw
 bOw
 bOw
 bQe
-bWV
-csS
-csS
+qCB
+nvp
+nvp
 bZl
 bYA
 bZl
 caW
 cbP
 cdu
-csS
+nvp
 cth
-cfm
+xYS
 ctN
 ykY
 bWV
@@ -72966,18 +73044,18 @@ bOw
 bQd
 bOw
 bWi
-bWV
-bWV
-csS
+qCB
+qCB
+nvp
 bZm
 hoP
 bZm
 rUW
 cbM
 ccH
-csS
+nvp
 hTW
-cfm
+xYS
 csS
 ykY
 cgG
@@ -73224,17 +73302,17 @@ bOw
 bOw
 bOw
 bOw
-bWV
-crk
-csS
-csS
+qCB
+jvV
+nvp
+nvp
 crN
-vFs
-csS
+sTK
+nvp
 qiF
-csS
+nvp
 ceK
-cfm
+xYS
 csS
 ykY
 cgG
@@ -73481,17 +73559,17 @@ bOw
 bOw
 bOw
 bOw
-bWV
-bWV
+qCB
+qCB
 crx
 crH
-bWV
+qCB
 crY
 csk
-bWV
-cfl
-bWV
-cfm
+qCB
+bmI
+qCB
+xYS
 csS
 ykY
 bWV
@@ -73739,12 +73817,12 @@ bOw
 bOw
 bOw
 bOw
-bWV
-bWV
-bWV
-bWV
-bWV
-bWV
+qCB
+qCB
+qCB
+qCB
+qCB
+qCB
 bWV
 vDX
 ykY
@@ -81418,7 +81496,7 @@ feU
 bwv
 bAQ
 bzG
-bye
+hkR
 bBZ
 tqC
 xne

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -1551,6 +1551,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "afA" = (
@@ -1748,6 +1749,7 @@
 	department = "AI";
 	name = "AI Satellite Requests Console"
 	},
+/obj/structure/cable/multilayer/connected,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "agh" = (
@@ -5328,6 +5330,7 @@
 /obj/machinery/camera/directional/west{
 	c_tag = "Bridge MiniSat Access"
 	},
+/obj/structure/cable/multilayer/connected,
 /turf/open/floor/plating,
 /area/command/bridge)
 "arC" = (
@@ -5777,6 +5780,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/bridge)
 "asO" = (
@@ -5784,6 +5788,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/bridge)
 "asQ" = (
@@ -6100,6 +6105,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "atN" = (
@@ -6906,6 +6912,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "avN" = (
@@ -6921,6 +6928,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "avP" = (
@@ -6929,6 +6937,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "avQ" = (
@@ -6944,6 +6953,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "avR" = (
@@ -6958,6 +6968,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "avV" = (
@@ -35160,6 +35171,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "dEd" = (
@@ -35952,10 +35964,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage_shared)
-"etk" = (
-/obj/machinery/light/directional/east,
-/turf/closed/wall,
-/area/cargo/storage)
 "eus" = (
 /turf/open/floor/iron/white,
 /area/medical/paramedic)
@@ -43857,6 +43865,10 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"mqj" = (
+/obj/machinery/light/directional/east,
+/turf/closed/wall,
+/area/cargo/storage)
 "mql" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -47132,6 +47144,7 @@
 /area/hallway/primary/central)
 "puW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "pvc" = (
@@ -50489,6 +50502,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "syO" = (
@@ -50824,6 +50838,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "sRn" = (
@@ -57271,6 +57286,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "ycT" = (
@@ -100769,7 +100785,7 @@ cDa
 aTy
 iYH
 aTy
-etk
+mqj
 xEt
 idl
 aTy

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -118,7 +118,7 @@
 	id = "telelab";
 	name = "test chamber blast door"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plating,
 /area/science/explab)
 "aaq" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on,
@@ -39589,10 +39589,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"hNW" = (
-/obj/machinery/light/directional/east,
-/turf/closed/wall,
-/area/cargo/storage)
 "hOz" = (
 /obj/item/weldingtool,
 /turf/open/floor/plating,
@@ -41221,7 +41217,7 @@
 	name = "test chamber blast door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/engine,
+/turf/open/floor/plating,
 /area/science/explab)
 "jCr" = (
 /obj/machinery/light/small{
@@ -44781,6 +44777,10 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"njf" = (
+/obj/machinery/light/directional/east,
+/turf/closed/wall,
+/area/cargo/storage)
 "njg" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -47984,7 +47984,7 @@
 	id = "telelab";
 	name = "test chamber blast door"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plating,
 /area/science/explab)
 "qkk" = (
 /obj/effect/turf_decal/tile/yellow,
@@ -52546,7 +52546,7 @@
 	id = "telelab";
 	name = "test chamber blast door"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plating,
 /area/science/breakroom)
 "ukM" = (
 /obj/structure/disposalpipe/segment{
@@ -55363,7 +55363,7 @@
 	name = "test chamber blast door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/engine,
+/turf/open/floor/plating,
 /area/science/breakroom)
 "wDm" = (
 /obj/effect/turf_decal/stripes/line,
@@ -100769,7 +100769,7 @@ cDa
 aTy
 iYH
 aTy
-hNW
+njf
 xEt
 idl
 aTy

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -383,6 +383,13 @@
 	},
 /turf/open/floor/wood,
 /area/cargo/qm)
+"abx" = (
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/light/directional/south,
+/obj/structure/tank_dispenser/oxygen,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/showroomfloor,
+/area/security)
 "aby" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -2177,12 +2184,8 @@
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "ahQ" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron/showroomfloor,
-/area/security)
+/turf/closed/wall,
+/area/space)
 "ahR" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/transit_tube/crossing,
@@ -2304,8 +2307,6 @@
 /area/ai_monitored/security/armory)
 "aim" = (
 /obj/structure/table,
-/obj/item/storage/box/firingpins,
-/obj/item/storage/box/firingpins,
 /obj/item/key/security,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
@@ -2333,15 +2334,15 @@
 /turf/open/floor/iron/showroomfloor,
 /area/security)
 "air" = (
-/obj/vehicle/ridden/secway,
-/obj/item/key/security,
+/obj/machinery/recharge_station,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/showroomfloor,
 /area/security)
 "ais" = (
-/obj/structure/tank_dispenser/oxygen,
 /obj/effect/turf_decal/bot,
 /obj/item/radio/intercom/directional/east,
+/obj/vehicle/ridden/secway,
+/obj/item/key/security,
 /turf/open/floor/iron/showroomfloor,
 /area/security)
 "ait" = (
@@ -3692,9 +3693,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "amc" = (
@@ -12101,6 +12100,7 @@
 "aOG" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/chair/stool/bar/directional/south,
+/obj/machinery/bluespace_beacon,
 /turf/open/floor/iron,
 /area/command/teleporter)
 "aOH" = (
@@ -15792,6 +15792,7 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "bcC" = (
@@ -16481,7 +16482,6 @@
 /obj/item/shovel{
 	pixel_x = -5
 	},
-/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "bfC" = (
@@ -16696,7 +16696,7 @@
 /area/maintenance/department/crew_quarters/bar)
 "bgs" = (
 /obj/structure/table,
-/obj/item/food/donut,
+/obj/item/food/donut/plain,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bgt" = (
@@ -17017,7 +17017,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "bhu" = (
@@ -17676,13 +17675,15 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "bkf" = (
-/obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
+	},
+/obj/machinery/disposal/bin{
+	name = "Corpse Disposal"
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
@@ -18587,10 +18588,6 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "bny" = (
-/obj/item/reagent_containers/glass/bottle/epinephrine,
-/obj/item/reagent_containers/glass/bottle/multiver{
-	pixel_x = 6
-	},
 /obj/item/reagent_containers/syringe,
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/blue{
@@ -19343,6 +19340,16 @@
 /turf/open/floor/iron,
 /area/science/robotics)
 "bqk" = (
+/obj/item/mod/core/standard{
+	pixel_x = -4
+	},
+/obj/item/mod/core/standard{
+	pixel_y = 4
+	},
+/obj/item/mod/core/standard{
+	pixel_x = 4
+	},
+/obj/structure/table,
 /turf/open/floor/iron/dark,
 /area/science/robotics)
 "bql" = (
@@ -22631,6 +22638,7 @@
 	dir = 1
 	},
 /obj/item/radio/intercom/directional/south,
+/obj/machinery/recharge_station,
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "bAP" = (
@@ -22948,12 +22956,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bBZ" = (
-/obj/structure/bedsheetbin,
-/obj/structure/table/glass,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/suit_storage_unit/medical,
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "bCa" = (
@@ -23620,7 +23627,6 @@
 /turf/open/floor/plating,
 /area/medical/surgery)
 "bEt" = (
-/obj/machinery/disposal/bin,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -23631,6 +23637,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin{
+	name = "Corpse Disposal"
+	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "bEu" = (
@@ -25846,8 +25855,8 @@
 /area/engineering/lobby)
 "bMW" = (
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/rnd/production/circuit_imprinter,
 /obj/item/radio/intercom/directional/east,
+/obj/machinery/recharge_station,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "bMX" = (
@@ -26130,8 +26139,8 @@
 /area/engineering/lobby)
 "bOe" = (
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/rnd/production/protolathe/department/engineering,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/rnd/production/circuit_imprinter,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "bOf" = (
@@ -26291,11 +26300,9 @@
 /area/hallway/primary/aft)
 "bOM" = (
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/modular_computer/console/preset/civilian{
-	dir = 8
-	},
 /obj/machinery/newscaster/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/rnd/production/protolathe/department/engineering,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "bON" = (
@@ -26524,11 +26531,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/modular_computer/console/preset/cargochat/engineering{
+/obj/machinery/modular_computer/console/preset/civilian{
 	dir = 8
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 9
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
@@ -26993,12 +26997,7 @@
 /area/engineering/lobby)
 "bRq" = (
 /obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 10
-	},
-/obj/machinery/computer/department_orders/engineering{
-	dir = 8
-	},
+/obj/machinery/recharge_station,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "bRr" = (
@@ -27319,9 +27318,11 @@
 /turf/open/space,
 /area/space/nearstation)
 "bSo" = (
-/obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
+	},
+/obj/machinery/disposal/bin{
+	name = "Disposal To Space"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
@@ -33220,6 +33221,17 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
 /area/service/chapel/monastery)
+"csV" = (
+/obj/structure/rack,
+/obj/item/pickaxe{
+	pixel_x = 5
+	},
+/obj/item/shovel{
+	pixel_x = -5
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/cargo/miningdock)
 "csY" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/iron/dark,
@@ -34303,7 +34315,7 @@
 /turf/open/floor/iron/dark,
 /area/service/library)
 "cAT" = (
-/obj/structure/destructible/cult/tome,
+/obj/structure/destructible/cult/item_dispenser/archives/library,
 /turf/open/floor/iron/dark,
 /area/service/library)
 "cAU" = (
@@ -35135,6 +35147,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "dmI" = (
@@ -40724,6 +40737,7 @@
 	dir = 8
 	},
 /obj/structure/closet/secure_closet/medical2,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "iDV" = (
@@ -42566,7 +42580,6 @@
 /area/engineering/storage_shared)
 "kDS" = (
 /obj/structure/window/reinforced/spawner/east,
-/obj/machinery/disposal/bin,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -42579,6 +42592,9 @@
 	},
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/disposal/bin{
+	name = "Corpse Disposal"
+	},
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "kDY" = (
@@ -42866,6 +42882,9 @@
 	},
 /turf/open/floor/plating,
 /area/medical/cryo)
+"kTl" = (
+/turf/closed/wall,
+/area/space/nearstation)
 "kTn" = (
 /obj/structure/grille/broken,
 /obj/structure/cable,
@@ -42883,7 +42902,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/requests_console/directional/south{
 	department = "Virology";
@@ -42891,6 +42909,9 @@
 	name = "Virology Requests Console";
 	pixel_y = 30;
 	receive_ore_updates = 1
+	},
+/obj/machinery/disposal/bin{
+	name = "Disposal To Space"
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
@@ -43086,7 +43107,6 @@
 /turf/closed/wall/r_wall,
 /area/science/server)
 "lcH" = (
-/obj/machinery/newscaster/directional/north,
 /obj/machinery/camera/directional/west{
 	c_tag = "Cargo Mining Dock"
 	},
@@ -43636,6 +43656,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "lGS" = (
@@ -46177,6 +46198,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
+"ohH" = (
+/obj/machinery/disposal/bin{
+	name = "Disposal To Space"
+	},
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "ohR" = (
 /obj/item/chair,
 /turf/open/floor/plating,
@@ -46828,7 +46855,6 @@
 /turf/open/floor/iron/stairs/left,
 /area/service/abandoned_gambling_den)
 "oNE" = (
-/obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/light{
 	dir = 8
@@ -46843,6 +46869,9 @@
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
+	},
+/obj/machinery/disposal/bin{
+	name = "Disposal To Space"
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
@@ -47088,6 +47117,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"oWx" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/landmark/secequipment,
+/turf/open/floor/iron/showroomfloor,
+/area/security)
 "oWL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -47335,9 +47369,11 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/computer/crew{
-	dir = 8
+/obj/structure/table/glass,
+/obj/item/reagent_containers/glass/bottle/multiver{
+	pixel_x = 6
 	},
+/obj/item/reagent_containers/glass/bottle/epinephrine,
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "pkM" = (
@@ -48049,35 +48085,9 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "pWo" = (
-/obj/structure/closet/crate/secure/weapon{
-	desc = "A secure clothing crate.";
-	name = "formal uniform crate";
-	req_access_txt = "3"
-	},
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/suit/security/officer,
-/obj/item/clothing/suit/security/officer,
-/obj/item/clothing/suit/security/officer,
-/obj/item/clothing/suit/security/officer,
-/obj/item/clothing/suit/security/officer,
-/obj/item/clothing/suit/security/officer,
-/obj/item/clothing/under/rank/security/warden/formal,
-/obj/item/clothing/suit/security/warden,
-/obj/item/clothing/under/rank/security/head_of_security/formal,
-/obj/item/clothing/suit/security/hos,
-/obj/item/clothing/head/beret/sec/navyofficer,
-/obj/item/clothing/head/beret/sec/navyofficer,
-/obj/item/clothing/head/beret/sec/navyofficer,
-/obj/item/clothing/head/beret/sec/navyofficer,
-/obj/item/clothing/head/beret/sec/navyofficer,
-/obj/item/clothing/head/beret/sec/navyofficer,
-/obj/item/clothing/head/beret/sec/navywarden,
-/obj/item/clothing/head/hos/beret/navyhos,
+/obj/structure/table,
+/obj/item/storage/box/firingpins,
+/obj/item/storage/box/firingpins,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "pWK" = (
@@ -48776,6 +48786,9 @@
 /obj/structure/table/wood,
 /obj/item/inspector{
 	pixel_x = 4
+	},
+/obj/item/inspector{
+	pixel_x = -4
 	},
 /turf/open/floor/iron,
 /area/security)
@@ -50234,6 +50247,9 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/grass,
 /area/medical/medbay/central)
+"rOV" = (
+/turf/closed/wall/r_wall,
+/area/security)
 "rPu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -51864,6 +51880,15 @@
 /obj/machinery/power/energy_accumulator/grounding_rod/anchored,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
+"toE" = (
+/obj/machinery/modular_computer/console/preset/cargochat/engineering{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/engineering/main)
 "toR" = (
 /obj/item/stack/sheet/cardboard{
 	amount = 14
@@ -52241,7 +52266,9 @@
 /area/maintenance/department/cargo)
 "tCi" = (
 /obj/structure/window/reinforced/spawner/west,
-/obj/machinery/disposal/bin,
+/obj/machinery/disposal/bin{
+	name = "Corpse Disposal"
+	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -53737,9 +53764,6 @@
 /obj/item/inspector{
 	pixel_x = -4
 	},
-/obj/item/inspector{
-	pixel_x = 4
-	},
 /turf/open/floor/iron,
 /area/security)
 "uSE" = (
@@ -53996,13 +54020,15 @@
 /turf/open/floor/iron/white,
 /area/medical/psychology)
 "uYT" = (
-/obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
 /obj/machinery/light/small,
 /obj/machinery/status_display/ai{
 	pixel_x = -32
+	},
+/obj/machinery/disposal/bin{
+	name = "Corpse Disposal"
 	},
 /turf/open/floor/iron/white,
 /area/medical/cryo)
@@ -54141,7 +54167,6 @@
 /turf/open/floor/iron/white,
 /area/science/explab)
 "vfw" = (
-/obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
@@ -54151,6 +54176,9 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
+	},
+/obj/machinery/disposal/bin{
+	name = "Corpse Disposal"
 	},
 /turf/open/floor/iron/white,
 /area/medical/storage)
@@ -54261,7 +54289,6 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "vmo" = (
-/obj/machinery/disposal/bin,
 /obj/machinery/camera/directional/west{
 	c_tag = "Medbay Psychology Office";
 	network = list("ss13","medbay")
@@ -54274,6 +54301,9 @@
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 4
+	},
+/obj/machinery/disposal/bin{
+	name = "Corpse Disposal"
 	},
 /turf/open/floor/iron/white,
 /area/medical/psychology)
@@ -54541,7 +54571,6 @@
 	dir = 8
 	},
 /obj/machinery/stasis,
-/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "vzg" = (
@@ -54920,6 +54949,11 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
+"vRp" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "vRq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -55110,7 +55144,6 @@
 	dir = 8
 	},
 /obj/machinery/stasis,
-/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "vZJ" = (
@@ -56299,6 +56332,7 @@
 	dir = 8
 	},
 /obj/structure/closet/secure_closet/medical2,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "wUz" = (
@@ -56688,6 +56722,15 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
+"xiD" = (
+/obj/machinery/computer/department_orders/engineering{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/engineering/main)
 "xja" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -56740,7 +56783,6 @@
 /area/service/library/artgallery)
 "xkk" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "xkB" = (
@@ -57178,9 +57220,11 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/machinery/disposal/bin,
 /obj/structure/sign/warning/vacuum{
 	pixel_x = -32
+	},
+/obj/machinery/disposal/bin{
+	name = "Disposal To Space"
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
@@ -80168,7 +80212,7 @@ olY
 olY
 bBX
 qIl
-sEN
+ohH
 jJN
 iaj
 ksP
@@ -81629,7 +81673,7 @@ abI
 agP
 jzI
 jzI
-agP
+rOV
 ahL
 ahL
 ahL
@@ -82402,7 +82446,7 @@ adU
 xou
 cnT
 aiq
-ahd
+oWx
 agP
 ajm
 oCi
@@ -82659,7 +82703,7 @@ ahd
 aeB
 aiq
 aiq
-ahd
+oWx
 agP
 ajn
 ajW
@@ -82916,7 +82960,7 @@ cnN
 aeB
 cnT
 aiq
-ahd
+oWx
 agP
 ajo
 ghx
@@ -83687,7 +83731,7 @@ cnQ
 ahN
 cnV
 aiq
-air
+aiq
 agP
 agP
 agP
@@ -83943,7 +83987,7 @@ agP
 wtp
 anf
 aiq
-ahQ
+aiq
 ais
 agP
 ajr
@@ -84197,10 +84241,10 @@ aaa
 aby
 abI
 agP
-agQ
-agQ
-agQ
-agP
+air
+anf
+aiq
+abx
 agP
 agP
 ajs
@@ -84453,12 +84497,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-abI
-abI
-abI
-abI
-abI
+ahQ
+vRp
+vRp
+vRp
+kTl
+kTl
 abI
 ajs
 aka
@@ -92008,8 +92052,8 @@ qoK
 aoq
 bZc
 bZJ
-cbW
-cbW
+toE
+xiD
 cbW
 jPo
 ory
@@ -97616,7 +97660,7 @@ bbI
 bcB
 hgV
 hgV
-hgV
+csV
 aEj
 dRI
 aFi

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -71,9 +71,7 @@
 	c_tag = "Toxins Lab Starboard";
 	network = list("ss13","rd")
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
@@ -157,14 +155,11 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "aaw" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#d1dfff"
-	},
 /obj/machinery/requests_console/directional/north{
 	department = "Nanite Lab";
 	name = "Nanite Lab Requests Console"
 	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/engine,
 /area/science/explab)
 "aax" = (
@@ -218,9 +213,7 @@
 /obj/item/exodrone{
 	pixel_y = 8
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/cargo/warehouse/upper)
@@ -366,9 +359,7 @@
 /turf/open/floor/wood,
 /area/cargo/qm)
 "abh" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/filingcabinet,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/wood,
@@ -472,13 +463,13 @@
 /area/ai_monitored/turret_protected/ai)
 "ach" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/ai_monitored/turret_protected/ai)
 "aci" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/iron/white{
 	heat_capacity = 1e+006
@@ -514,9 +505,7 @@
 	c_tag = "MiniSat AI Chamber West";
 	network = list("minisat")
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "aco" = (
@@ -580,9 +569,7 @@
 	c_tag = "MiniSat AI Chamber East";
 	network = list("minisat")
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "acv" = (
@@ -629,9 +616,7 @@
 	c_tag = "MiniSat AI Chamber South";
 	network = list("minisat")
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/flasher{
 	id = "AI";
 	pixel_y = 20
@@ -849,9 +834,7 @@
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
 "ads" = (
 /obj/machinery/suit_storage_unit/standard_unit,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/camera/directional/west{
 	c_tag = "EVA Storage"
 	},
@@ -2119,9 +2102,7 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "ahI" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/security/prison)
 "ahJ" = (
@@ -2159,9 +2140,7 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/security/armory)
 "ahM" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/requests_console/directional/west{
 	department = "Security";
 	departmentType = 5;
@@ -2480,10 +2459,7 @@
 /obj/item/gun/energy/ionrifle,
 /obj/item/gun/energy/temperature/security,
 /obj/item/clothing/suit/hooded/ablative,
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "aiO" = (
@@ -2506,13 +2482,10 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
 /obj/structure/sign/warning/nosmoking{
 	pixel_x = 32
 	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "aiR" = (
@@ -2705,9 +2678,7 @@
 /obj/structure/plaque/static_plaque/golden{
 	pixel_y = 32
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/item/storage/box/handcuffs{
 	pixel_x = 1;
 	pixel_y = 3
@@ -2971,9 +2942,7 @@
 /turf/open/floor/iron,
 /area/security)
 "ajZ" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -3006,11 +2975,8 @@
 "akc" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
 /obj/machinery/status_display/evac/directional/north,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "akd" = (
@@ -3102,12 +3068,9 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/door/firedoor,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "akp" = (
@@ -3502,9 +3465,7 @@
 /area/service/bar/atrium)
 "alq" = (
 /obj/item/storage/box/bodybags,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/table/glass,
 /obj/item/reagent_containers/syringe{
 	name = "steel point"
@@ -3756,9 +3717,7 @@
 /turf/open/floor/iron/dark,
 /area/security/warden)
 "amm" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/camera/directional/west{
 	c_tag = "Security Office"
 	},
@@ -4036,9 +3995,7 @@
 /area/security/warden)
 "amU" = (
 /obj/machinery/computer/security,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/camera/directional/north{
 	c_tag = "Brig Control Room"
 	},
@@ -4175,9 +4132,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "any" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/sign/map{
 	icon_state = "map-pubby";
 	pixel_x = -32
@@ -4496,9 +4451,7 @@
 /turf/open/floor/iron,
 /area/security)
 "aoy" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -4523,9 +4476,7 @@
 /turf/open/floor/iron/dark,
 /area/command/gateway)
 "aoB" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/bot_white,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -4564,9 +4515,7 @@
 /obj/machinery/camera/directional/west{
 	c_tag = "Brig Gulag Teleporter"
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/table,
 /obj/item/storage/box/prisoner,
 /obj/item/razor{
@@ -4764,9 +4713,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -5184,9 +5131,7 @@
 	},
 /area/ai_monitored/command/nuke_storage)
 "aqN" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/circuit/green{
 	luminosity = 2
@@ -5471,10 +5416,6 @@
 	pixel_y = 4
 	},
 /obj/structure/table/glass,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#e8eaff"
-	},
 /obj/item/pen,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -5482,6 +5423,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "arL" = (
@@ -5523,10 +5465,6 @@
 	pixel_y = 32
 	},
 /obj/structure/table/glass,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#e8eaff"
-	},
 /obj/machinery/recharger,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -5534,6 +5472,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "arP" = (
@@ -5649,7 +5588,7 @@
 /area/command/gateway)
 "asb" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = -32
@@ -5834,9 +5773,7 @@
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "asM" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
@@ -6355,9 +6292,7 @@
 /turf/open/floor/iron,
 /area/command/gateway)
 "aui" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/structure/closet/secure_closet/exile,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -6450,9 +6385,7 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "auB" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/flasher{
 	id = "brigentry";
 	pixel_x = -28
@@ -6748,9 +6681,7 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Dormitories Fore"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the monastery.";
 	name = "Monastery Monitor";
@@ -6949,9 +6880,7 @@
 /turf/open/floor/iron/freezer,
 /area/command/heads_quarters/captain)
 "avJ" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/freezer,
 /area/command/heads_quarters/captain)
 "avK" = (
@@ -7099,9 +7028,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "awg" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/item/kirbyplants{
 	icon_state = "plant-08"
 	},
@@ -7129,7 +7056,7 @@
 /area/security/interrogation)
 "awk" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -7149,11 +7076,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "awm" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/iron,
@@ -7243,9 +7168,7 @@
 /area/commons/fitness/recreation)
 "awA" = (
 /obj/machinery/disposal/bin,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
@@ -7431,10 +7354,6 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "awY" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -7445,6 +7364,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "axb" = (
@@ -7466,10 +7386,6 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "axe" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
 /obj/machinery/computer/rdconsole{
 	dir = 8
 	},
@@ -7483,6 +7399,7 @@
 	departmentType = 5;
 	name = "Bridge Requests Console"
 	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "axg" = (
@@ -7592,9 +7509,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "axI" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "axJ" = (
@@ -7629,9 +7544,7 @@
 /area/maintenance/disposal/incinerator)
 "axP" = (
 /obj/structure/closet/secure_closet/captains,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/camera/directional/north{
 	c_tag = "Captain's Quarters"
 	},
@@ -7842,9 +7755,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "ayG" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -8360,9 +8271,7 @@
 /obj/structure/table/wood,
 /obj/item/folder/blue,
 /obj/item/stamp/captain,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/keycard_auth{
 	pixel_x = 28;
 	pixel_y = 8
@@ -8734,9 +8643,7 @@
 /obj/structure/filingcabinet/chestdrawer{
 	pixel_y = 2
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/camera/directional/north{
 	c_tag = "Head of Personnel's Office"
 	},
@@ -8773,9 +8680,7 @@
 /area/service/bar/atrium)
 "aBK" = (
 /obj/structure/table,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/item/crowbar,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -9046,7 +8951,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /obj/machinery/vending/drugs,
 /turf/open/floor/iron/white,
@@ -9263,9 +9168,7 @@
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "aDv" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
@@ -9636,9 +9539,7 @@
 /obj/item/storage/toolbox/electrical{
 	pixel_x = -2
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/light_switch{
 	dir = 9;
 	pixel_x = -22
@@ -9656,18 +9557,14 @@
 /obj/item/storage/toolbox/mechanical{
 	pixel_x = -2
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "aEx" = (
 /obj/structure/table/wood,
 /obj/item/pinpointer/nuke,
 /obj/item/disk/nuclear,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "aEy" = (
@@ -9695,9 +9592,7 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "aEC" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/camera/directional/east{
 	c_tag = "Bridge Port Entrance"
 	},
@@ -9794,9 +9689,7 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aEJ" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/camera/directional/west{
 	c_tag = "Bridge Starboard Entrance"
 	},
@@ -9936,9 +9829,7 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "aFe" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -10106,9 +9997,7 @@
 /area/hallway/primary/central)
 "aFD" = (
 /obj/structure/table,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/item/taperecorder,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -10134,9 +10023,7 @@
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
 "aFL" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -10655,9 +10542,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aHK" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/sign/map{
 	icon_state = "map-pubby";
 	pixel_y = 32
@@ -10725,9 +10610,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aIa" = (
@@ -10766,9 +10649,7 @@
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aIg" = (
@@ -11482,9 +11363,7 @@
 /obj/machinery/microwave{
 	pixel_y = 6
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -11836,7 +11715,7 @@
 /area/command/teleporter)
 "aNv" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -11934,14 +11813,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aNX" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aOf" = (
@@ -11959,9 +11835,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "aOh" = (
 /obj/structure/chair,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/landmark/start/assistant,
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron{
@@ -12063,9 +11937,7 @@
 /area/maintenance/department/crew_quarters/bar)
 "aOD" = (
 /obj/machinery/suit_storage_unit/standard_unit,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -12074,9 +11946,7 @@
 "aOE" = (
 /obj/structure/table,
 /obj/item/hand_tele,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/camera/directional/west{
 	c_tag = "Teleporter"
 	},
@@ -12265,9 +12135,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/hallway/secondary/exit/departure_lounge)
 "aPq" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/camera/directional/east{
 	c_tag = "Departure Lounge Starboard"
 	},
@@ -12691,9 +12559,7 @@
 /area/service/bar)
 "aQT" = (
 /obj/machinery/vending/cigarette,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/wood{
 	icon_state = "wood-broken6"
 	},
@@ -12771,9 +12637,7 @@
 /area/hallway/primary/central)
 "aRf" = (
 /obj/item/banner/cargo/mundane,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aRi" = (
@@ -12873,9 +12737,7 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Auxiliary Base Construction"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/computer/security/telescreen/auxbase{
 	dir = 8;
 	pixel_x = 30
@@ -12887,9 +12749,7 @@
 /turf/closed/wall,
 /area/hallway/primary/central)
 "aRI" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron/dark,
 /area/hallway/primary/central)
@@ -13164,9 +13024,7 @@
 /obj/item/storage/box/beanbag,
 /obj/item/assembly/mousetrap,
 /obj/item/storage/box/mousetraps,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/wood,
 /area/service/bar)
 "aSR" = (
@@ -13496,9 +13354,7 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "aUv" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -13519,9 +13375,7 @@
 /area/cargo/storage)
 "aUA" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/status_display/supply{
 	dir = 4;
 	layer = 4;
@@ -13597,9 +13451,7 @@
 /area/service/hydroponics)
 "aUX" = (
 /obj/machinery/icecream_vat,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen/coldroom)
 "aUZ" = (
@@ -13615,9 +13467,7 @@
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen/coldroom)
 "aVb" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen/coldroom)
@@ -13742,9 +13592,7 @@
 /area/service/theater)
 "aVl" = (
 /obj/structure/dresser,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/sign/poster/contraband/clown{
 	pixel_y = 32
 	},
@@ -13771,9 +13619,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aVo" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/sign/directions/engineering{
 	pixel_x = -32;
 	pixel_y = -8
@@ -14395,10 +14241,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aXs" = (
@@ -14547,16 +14390,13 @@
 /obj/structure/sign/departments/botany{
 	pixel_y = 32
 	},
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#e8eaff"
-	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "aXZ" = (
@@ -14795,9 +14635,7 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
 "aYL" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -14857,9 +14695,7 @@
 /area/service/kitchen)
 "aYU" = (
 /obj/machinery/processor,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
@@ -15015,9 +14851,7 @@
 /obj/machinery/modular_computer/console/preset/id{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/camera/directional/west{
 	c_tag = "Security Checkpoint"
 	},
@@ -15272,9 +15106,7 @@
 /turf/open/floor/plating,
 /area/cargo/storage)
 "baJ" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "baL" = (
@@ -15376,9 +15208,7 @@
 "baX" = (
 /obj/vehicle/ridden/janicart,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/button/door{
 	id = "jangarage";
 	name = "Custodial Closet Shutters Control";
@@ -15393,9 +15223,7 @@
 "baZ" = (
 /obj/structure/closet/l3closet/janitor,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/service/janitor)
 "bba" = (
@@ -15545,7 +15373,7 @@
 /area/cargo/sorting)
 "bbE" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /obj/machinery/conveyor{
 	dir = 10;
@@ -15650,9 +15478,7 @@
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "bca" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/camera/directional/east{
 	c_tag = "Hydroponics South"
 	},
@@ -15913,9 +15739,7 @@
 	},
 /area/hallway/secondary/entry)
 "bdd" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
@@ -16022,11 +15846,8 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "bdM" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
 /obj/item/radio/intercom/directional/east,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "bdR" = (
@@ -16039,9 +15860,7 @@
 /area/hallway/primary/central)
 "bdS" = (
 /obj/machinery/vending/coffee,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
 	},
@@ -16061,9 +15880,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "beb" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/structure/sign/departments/custodian{
 	pixel_x = 32
 	},
@@ -16773,7 +16590,7 @@
 /area/science/robotics/mechbay)
 "bgF" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
@@ -16788,11 +16605,8 @@
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
 "bgJ" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/light/directional/east,
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
 "bgS" = (
@@ -16866,9 +16680,7 @@
 /area/commons/vacant_room/commissary)
 "bgX" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
@@ -17101,9 +16913,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bhQ" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/button/door{
 	id = "Skynet_launch";
 	name = "Mech Bay Door Control";
@@ -17114,9 +16924,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bhR" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/button/door{
 	id = "Skynet_launch";
 	name = "Mech Bay Door Control";
@@ -17149,10 +16957,7 @@
 /turf/open/floor/iron/white,
 /area/ai_monitored/turret_protected/ai)
 "bhV" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
 "bib" = (
@@ -17162,9 +16967,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/table,
 /obj/item/stack/sheet/iron/five,
 /obj/item/stack/cable_coil/five,
@@ -17490,9 +17293,7 @@
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/flora/grass/jungle,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/grass,
 /area/medical/medbay/central)
 "bjR" = (
@@ -17506,9 +17307,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/iv_drip,
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
@@ -17586,9 +17385,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -17625,9 +17422,7 @@
 	pixel_y = 3
 	},
 /obj/item/storage/firstaid/regular,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -17652,9 +17447,7 @@
 /turf/open/floor/iron/white,
 /area/medical/paramedic)
 "bke" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/shower{
 	dir = 4;
 	pixel_y = 1
@@ -17859,9 +17652,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "bkR" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -17947,10 +17738,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/plating,
 /area/medical/cryo)
 "blc" = (
@@ -18086,9 +17874,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "blx" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -18479,7 +18265,7 @@
 "bmP" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/science/robotics)
@@ -18501,13 +18287,10 @@
 /turf/open/floor/iron/dark,
 /area/science/robotics)
 "bmT" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#c1caff"
-	},
 /obj/structure/sign/poster/random{
 	pixel_y = 32
 	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark/telecomms,
 /area/science/server)
 "bmU" = (
@@ -18541,10 +18324,7 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "bnh" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#d1dfff"
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bni" = (
@@ -18661,9 +18441,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "bnO" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/rnd/production/circuit_imprinter/department/science,
 /turf/open/floor/iron/dark,
 /area/science/robotics)
@@ -19005,9 +18783,7 @@
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high/plus,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/ecto_sniffer{
 	pixel_x = 4;
@@ -19071,9 +18847,7 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "bpy" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -19163,9 +18937,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
@@ -19640,10 +19412,10 @@
 /area/medical/cryo)
 "bqZ" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8;
@@ -19788,9 +19560,7 @@
 /area/science/lab)
 "brr" = (
 /obj/machinery/disposal/bin,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
@@ -19940,6 +19710,10 @@
 /obj/structure/table,
 /obj/item/folder/white,
 /obj/item/pen,
+/obj/machinery/airalarm/server{
+	dir = 4;
+	pixel_x = 24
+	},
 /turf/open/floor/iron/dark,
 /area/science/server)
 "brG" = (
@@ -19974,9 +19748,7 @@
 /turf/closed/wall,
 /area/science/xenobiology)
 "brT" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -20082,9 +19854,7 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Arrivals Starboard Aft"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -20164,7 +19934,7 @@
 /area/medical/medbay/central)
 "bsD" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -20672,9 +20442,7 @@
 	c_tag = "Research and Development Lab";
 	network = list("ss13","rd")
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/requests_console{
 	department = "Science";
 	departmentType = 2;
@@ -20685,9 +20453,7 @@
 /turf/open/floor/iron/white,
 /area/science/lab)
 "but" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -20837,9 +20603,7 @@
 /area/medical/medbay/central)
 "bvk" = (
 /obj/machinery/computer/crew,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -20935,10 +20699,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -20952,6 +20712,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "bvw" = (
@@ -21056,9 +20817,7 @@
 /area/hallway/primary/aft)
 "bvI" = (
 /obj/structure/closet/emcloset,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/camera/directional/north{
 	c_tag = "Science Access Airlock";
@@ -21234,9 +20993,7 @@
 "bwx" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/item/screwdriver,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -22374,11 +22131,8 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bzO" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bzX" = (
@@ -22538,7 +22292,7 @@
 /area/hallway/primary/aft)
 "bAx" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -22701,9 +22455,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "bBi" = (
@@ -22801,9 +22553,7 @@
 /area/command/heads_quarters/rd)
 "bBw" = (
 /obj/machinery/computer/security,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -22854,9 +22604,7 @@
 "bBE" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
 /obj/effect/turf_decal/delivery,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -23165,15 +22913,12 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/rd)
 "bCK" = (
@@ -23272,7 +23017,7 @@
 /area/science/mixing)
 "bCX" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
@@ -23468,9 +23213,7 @@
 /obj/structure/sign/poster/random{
 	pixel_x = 32
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/hallway/primary/aft)
 "bDL" = (
@@ -23569,9 +23312,7 @@
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "bEd" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -23654,9 +23395,7 @@
 /area/medical/surgery)
 "bEv" = (
 /obj/structure/table/optable,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -24409,9 +24148,7 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "bHh" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -24700,13 +24437,10 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
 "bIt" = (
@@ -24983,7 +24717,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/bluespace_vendor/directional/south,
 /turf/open/floor/iron,
@@ -25259,9 +24993,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bKK" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -25613,9 +25345,7 @@
 	dir = 8;
 	name = "Distro to Waste"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -25844,9 +25574,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/hallway/primary/aft)
 "bMV" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -26194,9 +25922,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bOn" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Air to Port"
 	},
@@ -26483,9 +26209,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bPG" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -26527,9 +26251,7 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "bPM" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 8
@@ -26537,9 +26259,7 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "bPN" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -26656,7 +26376,7 @@
 /area/engineering/gravity_generator)
 "bQq" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -26681,9 +26401,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
@@ -26726,10 +26444,6 @@
 /area/engineering/storage/tech)
 "bQw" = (
 /obj/structure/rack,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
 /obj/machinery/camera/directional/north{
 	c_tag = "Tech Storage"
 	},
@@ -26745,6 +26459,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "bQx" = (
@@ -26926,7 +26641,7 @@
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -26959,7 +26674,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -27258,9 +26973,7 @@
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
 "bSd" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/computer/atmos_alert{
 	dir = 8
 	},
@@ -27272,9 +26985,7 @@
 /area/engineering/atmos)
 "bSe" = (
 /obj/machinery/pipedispenser/disposal,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/camera/directional/west{
 	c_tag = "Atmospherics Central"
 	},
@@ -27290,9 +27001,7 @@
 /turf/open/space,
 /area/space/nearstation)
 "bSh" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -27391,7 +27100,7 @@
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
@@ -27405,7 +27114,7 @@
 /area/engineering/storage/tech)
 "bSG" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -27422,7 +27131,7 @@
 "bSI" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
@@ -27582,7 +27291,7 @@
 /area/maintenance/department/engine)
 "bTm" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
@@ -27601,7 +27310,7 @@
 /area/engineering/gravity_generator)
 "bTq" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -27947,9 +27656,7 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "bUl" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
@@ -27983,9 +27690,7 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Engineering Access"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -28087,9 +27792,7 @@
 /area/command/heads_quarters/ce)
 "bUJ" = (
 /obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/camera/directional/north{
 	c_tag = "Chief Engineer's Office"
 	},
@@ -28181,9 +27884,7 @@
 "bUV" = (
 /obj/structure/table,
 /obj/item/pen,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/item/paper_bin{
 	layer = 2.9
 	},
@@ -28718,9 +28419,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/cable,
 /obj/structure/tank_dispenser,
 /turf/open/floor/iron/dark,
@@ -28764,9 +28463,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/item/stock_parts/cell/emproof{
 	pixel_x = -4;
 	pixel_y = -2
@@ -28854,9 +28551,7 @@
 /obj/structure/plaque/static_plaque/atmos{
 	pixel_y = 32
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/camera/directional/north{
 	c_tag = "Atmospherics Entrance"
 	},
@@ -28909,7 +28604,7 @@
 /area/maintenance/department/engine)
 "bXe" = (
 /obj/machinery/camera/preset/ordnance{
-	dir = 10
+	dir = 5
 	},
 /turf/open/floor/plating/asteroid/airless,
 /area/asteroid/nearstation/bomb_site)
@@ -29313,9 +29008,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/engineering/main)
@@ -29395,7 +29088,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
@@ -29448,7 +29141,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
@@ -29519,9 +29212,7 @@
 /area/engineering/atmos)
 "bZh" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "bZl" = (
@@ -29739,7 +29430,7 @@
 /area/engineering/main)
 "cav" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
@@ -29906,9 +29597,7 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "cbi" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -29921,9 +29610,7 @@
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter/room)
 "cbl" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/closet/secure_closet/engineering_welding,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -30085,9 +29772,7 @@
 /obj/machinery/power/emitter/welded{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
@@ -30110,9 +29795,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
@@ -30408,9 +30091,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
@@ -30424,15 +30105,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
 /obj/machinery/camera/directional/east{
 	c_tag = "Engineering Center";
 	network = list("ss13","engine")
 	},
 /obj/structure/cable,
+/obj/machinery/light/directional/east,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
 "cdX" = (
@@ -30622,9 +30300,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "cfb" = (
@@ -30648,9 +30324,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
@@ -30831,7 +30505,7 @@
 /area/engineering/supermatter/room)
 "cgv" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
@@ -32058,15 +31732,11 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "cmR" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "cmU" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "cmV" = (
@@ -32241,9 +31911,7 @@
 "cnN" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/delivery,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/security)
 "cnP" = (
@@ -32393,9 +32061,7 @@
 	},
 /area/maintenance/department/crew_quarters/bar)
 "coL" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/button/door{
 	id = "qm_warehouse";
 	name = "Warehouse Door Control";
@@ -32507,12 +32173,9 @@
 /area/service/bar/atrium)
 "cpq" = (
 /obj/machinery/deepfryer,
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "cpt" = (
@@ -33917,7 +33580,7 @@
 /area/hallway/primary/central)
 "cxC" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -33994,7 +33657,7 @@
 /area/service/library/lounge)
 "cyz" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /obj/effect/landmark/start/hangover,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -34004,7 +33667,7 @@
 /area/service/library/lounge)
 "cyA" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -34611,7 +34274,7 @@
 /area/cargo/warehouse)
 "cDy" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
@@ -34769,9 +34432,7 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "cPy" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
@@ -35091,9 +34752,7 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "diM" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -35216,9 +34875,7 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "dpa" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/sign/directions/evac{
 	dir = 1;
 	pixel_y = 32
@@ -35882,9 +35539,7 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "dXU" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -36213,11 +35868,8 @@
 /turf/open/floor/carpet,
 /area/service/abandoned_gambling_den)
 "eqf" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#c1caff"
-	},
 /obj/machinery/firealarm/directional/north,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron{
 	heat_capacity = 1e+006
 	},
@@ -36491,9 +36143,7 @@
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
 "eDR" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -36507,9 +36157,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "eER" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -36575,9 +36223,7 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/department/engine)
 "eHq" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "eHK" = (
@@ -36996,9 +36642,7 @@
 	c_tag = "Experimentation Lab Central";
 	network = list("ss13","rd")
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/button/door{
 	id = "telelab";
 	name = "Test Chamber Blast Door";
@@ -37012,7 +36656,7 @@
 	pixel_y = 26
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/science/explab)
@@ -37236,7 +36880,7 @@
 /area/medical/storage)
 "ffJ" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -37295,9 +36939,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/cable,
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37349,9 +36991,7 @@
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "fjs" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -37413,14 +37053,11 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "fno" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/bodycontainer/morgue{
 	dir = 8
 	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "fnN" = (
@@ -37754,7 +37391,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
@@ -38124,9 +37761,7 @@
 /turf/open/floor/iron/dark,
 /area/service/library/lounge)
 "fWL" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
@@ -38353,7 +37988,7 @@
 	pixel_x = 22
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/green,
 /obj/machinery/camera/directional/east{
@@ -38433,7 +38068,7 @@
 /area/service/abandoned_gambling_den)
 "gnq" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38489,9 +38124,7 @@
 /area/hallway/primary/central)
 "gpC" = (
 /obj/structure/chair,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron{
 	heat_capacity = 1e+006
@@ -39298,9 +38931,7 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "hfi" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Port to Filter"
 	},
@@ -39404,9 +39035,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "hkQ" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
@@ -39560,7 +39189,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -39884,9 +39513,7 @@
 /obj/item/hemostat,
 /obj/item/cautery,
 /obj/structure/table/glass,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -39962,6 +39589,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"hNW" = (
+/obj/machinery/light/directional/east,
+/turf/closed/wall,
+/area/cargo/storage)
 "hOz" = (
 /obj/item/weldingtool,
 /turf/open/floor/plating,
@@ -39973,7 +39604,7 @@
 /area/command/gateway)
 "hPG" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/trinary/filter/critical{
 	dir = 1;
@@ -39993,9 +39624,7 @@
 	pixel_x = 3;
 	pixel_y = 4
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/item/reagent_containers/glass/beaker{
 	pixel_x = -6
 	},
@@ -40046,7 +39675,7 @@
 /area/tcommsat/computer)
 "hQC" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
@@ -40289,7 +39918,7 @@
 /area/medical/medbay/central)
 "idl" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /obj/machinery/conveyor{
 	dir = 10;
@@ -40367,10 +39996,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#d1dfff"
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "igX" = (
@@ -41065,9 +40691,7 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "iWV" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -41263,7 +40887,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Chamber Inject"
@@ -41382,7 +41006,7 @@
 /area/maintenance/department/chapel/monastery)
 "jrG" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/shower{
@@ -41543,11 +41167,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/light/directional/east,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "jzz" = (
@@ -41725,10 +41346,7 @@
 /area/engineering/supermatter)
 "jMD" = (
 /obj/structure/bodycontainer/morgue,
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "jMS" = (
@@ -41809,9 +41427,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "jRZ" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
@@ -42263,9 +41879,7 @@
 /turf/open/floor/iron/stairs/left,
 /area/service/abandoned_gambling_den)
 "kqc" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/camera/directional/west{
 	c_tag = "Incinerator"
 	},
@@ -42569,9 +42183,7 @@
 /turf/open/floor/carpet/black,
 /area/service/chapel/office)
 "kDJ" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/conveyor_switch/oneway{
 	id = "EngLoad"
 	},
@@ -42767,7 +42379,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
@@ -42899,9 +42511,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/requests_console/directional/south{
 	department = "Virology";
@@ -42919,9 +42529,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
@@ -42942,9 +42550,7 @@
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "kVc" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -43208,10 +42814,7 @@
 /area/maintenance/department/cargo)
 "lhu" = (
 /obj/machinery/shieldgen,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/plating,
 /area/engineering/storage_shared)
 "lhO" = (
@@ -43750,15 +43353,12 @@
 /turf/open/floor/iron/dark,
 /area/science/genetics)
 "lOK" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/door/firedoor,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "lPe" = (
@@ -44254,10 +43854,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "mql" = (
@@ -44494,9 +44091,7 @@
 /obj/item/hemostat,
 /obj/item/cautery,
 /obj/structure/table/glass,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -44522,7 +44117,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
@@ -44755,9 +44350,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45257,7 +44850,7 @@
 /area/service/chapel/monastery)
 "nkY" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
@@ -45451,7 +45044,7 @@
 /area/commons/fitness/recreation)
 "nwg" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/engine,
@@ -45927,9 +45520,7 @@
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/junglebush/b,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/grass,
 /area/medical/medbay/central)
 "nUg" = (
@@ -46403,9 +45994,7 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "ory" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/structure/table,
 /obj/item/stack/sheet/glass/fifty{
 	layer = 4
@@ -46856,9 +46445,7 @@
 /area/service/abandoned_gambling_den)
 "oNE" = (
 /obj/structure/disposalpipe/trunk,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/camera/directional/west{
 	c_tag = "Xenobiology Test Lab";
 	network = list("xeno","rd")
@@ -47463,10 +47050,7 @@
 /area/engineering/break_room)
 "ppx" = (
 /obj/effect/decal/remains/human,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/plating,
 /area/medical/abandoned)
 "ppQ" = (
@@ -47524,7 +47108,7 @@
 /area/security/brig)
 "pth" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
@@ -47618,11 +47202,8 @@
 	},
 /area/maintenance/department/security/brig)
 "pAb" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
 /obj/machinery/power/energy_accumulator/tesla_coil,
+/obj/machinery/light/directional/west,
 /turf/open/floor/plating,
 /area/engineering/storage_shared)
 "pAo" = (
@@ -47908,10 +47489,7 @@
 /turf/open/floor/iron/dark,
 /area/service/library)
 "pNf" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/science/genetics)
 "pNy" = (
@@ -47923,9 +47501,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "pOc" = (
@@ -48254,9 +47830,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "qdO" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -48519,9 +48093,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "qoh" = (
@@ -48547,9 +48119,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
@@ -48836,10 +48406,7 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "qEm" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "qEN" = (
@@ -49878,14 +49445,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "rAP" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
 /obj/machinery/light_switch{
 	pixel_x = 25;
 	pixel_y = -9
 	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "rBh" = (
@@ -50419,7 +49983,7 @@
 /area/commons/storage/emergency/starboard)
 "rYH" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
@@ -51126,10 +50690,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "sHy" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#c1caff"
-	},
 /obj/machinery/camera/directional/north{
 	c_tag = "Holodeck Control";
 	name = "holodeck camera"
@@ -51139,6 +50699,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "sHH" = (
@@ -51287,13 +50848,10 @@
 	dir = 1
 	},
 /obj/structure/closet/l3closet/virology,
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "sSs" = (
@@ -51374,7 +50932,7 @@
 /area/engineering/supermatter/room)
 "sWM" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/ai_monitored/turret_protected/ai)
@@ -51605,9 +51163,7 @@
 /obj/structure/rack,
 /obj/item/stack/package_wrap,
 /obj/item/hand_labeler,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -51840,15 +51396,12 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/item/stack/sheet/plasteel/twenty,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "tna" = (
@@ -52020,9 +51573,7 @@
 	c_tag = "Xenobiology Test Chamber";
 	network = list("xeno","rd")
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "tuL" = (
@@ -52134,9 +51685,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -52681,7 +52230,7 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/unlocked{
-	dir = 4;
+	dir = 8;
 	pixel_x = -23
 	},
 /turf/open/floor/iron/white,
@@ -53014,9 +52563,7 @@
 "ulf" = (
 /obj/structure/table/glass,
 /obj/effect/spawner/random/food_or_drink/donkpockets,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -53609,9 +53156,7 @@
 /area/service/library/artgallery)
 "uKD" = (
 /obj/structure/chair,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -53686,9 +53231,7 @@
 /turf/open/floor/plating,
 /area/cargo/warehouse/upper)
 "uOA" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -54332,9 +53875,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "voI" = (
@@ -54717,9 +54258,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
@@ -54932,9 +54471,7 @@
 	pixel_y = 3
 	},
 /obj/item/clothing/gloves/color/yellow,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/camera/directional/north{
 	c_tag = "Engineering Port Storage"
 	},
@@ -55077,7 +54614,7 @@
 	},
 /obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
@@ -55311,9 +54848,7 @@
 	pixel_x = 129;
 	pixel_y = 60
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/machinery/reagentgrinder,
 /obj/structure/cable,
@@ -55561,9 +55096,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "wqu" = (
@@ -55630,9 +55163,7 @@
 /area/security)
 "wtZ" = (
 /obj/structure/cable,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "wun" = (
@@ -56072,7 +55603,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
@@ -56316,7 +55847,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
@@ -56581,10 +56112,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#d1dfff"
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "xdQ" = (
@@ -57079,7 +56607,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
@@ -57488,10 +57016,7 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "xOq" = (
@@ -57723,9 +57248,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "ycl" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/landmark/start/hangover,
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/freezer,
@@ -57798,9 +57321,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "yeD" = (
@@ -57940,7 +57461,7 @@
 /area/service/chapel/monastery)
 "ylb" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
@@ -57953,9 +57474,7 @@
 	c_tag = "Engineering Telecomms Access";
 	network = list("tcomms")
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/structure/chair{
 	dir = 8
 	},
@@ -101250,7 +100769,7 @@ cDa
 aTy
 iYH
 aTy
-bbG
+hNW
 xEt
 idl
 aTy

--- a/Station Maps/PubbyStation/PubbyStation.dmm
+++ b/Station Maps/PubbyStation/PubbyStation.dmm
@@ -533,10 +533,6 @@
 /obj/machinery/ai_slipper{
 	uses = 8
 	},
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/ai_monitored/turret_protected/ai)
 "acs" = (
@@ -16842,6 +16838,10 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"bht" = (
+/obj/machinery/light/directional/east,
+/turf/closed/wall,
+/area/cargo/storage)
 "bhu" = (
 /obj/machinery/light,
 /obj/structure/closet/secure_closet/miner,
@@ -43865,10 +43865,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"mqj" = (
-/obj/machinery/light/directional/east,
-/turf/closed/wall,
-/area/cargo/storage)
 "mql" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -52261,6 +52257,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"uau" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "uaC" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -90177,7 +90180,7 @@ ace
 abO
 abO
 acF
-ace
+uau
 acq
 abO
 abO
@@ -100785,7 +100788,7 @@ cDa
 aTy
 iYH
 aTy
-mqj
+bht
 xEt
 idl
 aTy


### PR DESCRIPTION
- Updates library cult tome's path
- Makes lights use directionals (this wasn't in an updatepath thing so I had to add it in)
- There were also some lights with varedited colors for some reason? Those were removed now anyway
- Adds a borg recharger to Medical, Engineering and Security (Engineering's Cargo consoles were moved out of the Foyer and into Engineering to make room)
- Adds a Medical MODsuit to Medical storage, and Cargo MODsuit to Cargo warehouse.
- Removes a formal uniform crate I previously added to the armory (order it from cargo instead, lazy bastards)
- Replaces reinforced floors under windows in Sciences' testing room with platings
- Removes a crew monitoring console from Medical (they had 2 next to eachother)
- Labels Medical/Xenobio disposal units to show where they lead to (viro/xenobio to space, medical to morgue)
- Adds MODsuit cores to Robotics
- Updates donut paths (they currently are all errors)
- Connects the AI sat to the power grid, because they do not have their own power source and their SMES couldn't power their SAT at once, nor last an entire round. Also fixes the AI sat's SMES, as its input was connected to it's output on the same tile.
- Removes paystand (https://github.com/tgstation/tgstation/pull/63889)
- Makes Service hall use Service access (which includes the Bar deliveries windoor that uses it
- If I'm missing anything let me know, yeah?