### PR TITLE
adds more areas to pubby

### DIFF
--- a/StationMaps/PubbyStation/PubbyStation.dmm
+++ b/StationMaps/PubbyStation/PubbyStation.dmm
@@ -93,7 +93,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "aan" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -138,7 +138,7 @@
 "aat" = (
 /obj/structure/sign/warning,
 /turf/closed/wall/r_wall,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "aau" = (
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/rnd/experimentor,
@@ -862,6 +862,10 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
+"ady" = (
+/obj/structure/chair,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "adz" = (
 /obj/machinery/light/small,
 /obj/machinery/camera/motion/directional/south{
@@ -2870,7 +2874,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "ajT" = (
 /obj/structure/rack,
 /obj/item/gun/ballistic/shotgun/riot{
@@ -6416,7 +6420,7 @@
 "auI" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
-/area/engineering/atmos)
+/area/engineering/atmos/hfr_room)
 "auJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/small{
@@ -7411,7 +7415,7 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/open/floor/iron/dark,
-/area/engineering/atmos)
+/area/engineering/atmos/hfr_room)
 "axy" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Holodeck Door"
@@ -7703,7 +7707,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/hfr_room)
 "ayI" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=BrigS2";
@@ -7727,7 +7731,7 @@
 	name = "Atmos RC"
 	},
 /turf/open/floor/iron/dark,
-/area/engineering/atmos)
+/area/engineering/atmos/hfr_room)
 "ayN" = (
 /obj/machinery/holopad,
 /obj/structure/disposalpipe/segment{
@@ -7921,7 +7925,7 @@
 "azm" = (
 /obj/effect/turf_decal/bot/right,
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/hfr_room)
 "azo" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -7965,7 +7969,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/engineering/atmos)
+/area/engineering/atmos/hfr_room)
 "azu" = (
 /obj/machinery/door/airlock{
 	id_tag = "Dorm2";
@@ -8025,7 +8029,7 @@
 	color = "#52B4E9"
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/hfr_room)
 "azR" = (
 /obj/machinery/door/airlock/command{
 	id_tag = "CMOCell";
@@ -8034,7 +8038,7 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/medical/cmo,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "azS" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Port Solar Access"
@@ -16075,7 +16079,7 @@
 "beS" = (
 /obj/structure/sign/warning,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "beY" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Arrivals Central"
@@ -16274,7 +16278,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "bfN" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -16287,11 +16291,11 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "bfP" = (
 /obj/machinery/power/shieldwallgen,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "bfQ" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16731,7 +16735,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/science/robotics,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "bhr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17008,7 +17012,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "biy" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17030,7 +17034,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "biD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 4
@@ -17206,9 +17210,6 @@
 "bjK" = (
 /turf/closed/wall,
 /area/commons/vacant_room/commissary)
-"bjL" = (
-/turf/closed/wall,
-/area/medical/cryo)
 "bjM" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -17554,7 +17555,7 @@
 /obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "bkF" = (
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
@@ -17611,7 +17612,7 @@
 /obj/item/clothing/gloves/color/latex/nitrile,
 /obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/plating,
-/area/medical/cryo)
+/area/maintenance/department/medical/central)
 "bkY" = (
 /obj/structure/table,
 /obj/item/storage/box/gloves{
@@ -17625,7 +17626,7 @@
 	pixel_x = -4
 	},
 /turf/open/floor/plating,
-/area/medical/cryo)
+/area/maintenance/department/medical/central)
 "bkZ" = (
 /obj/structure/table,
 /obj/item/circuitboard/machine/smartfridge{
@@ -17641,7 +17642,7 @@
 	},
 /obj/item/stack/cable_coil,
 /turf/open/floor/plating,
-/area/medical/cryo)
+/area/maintenance/department/medical/central)
 "bla" = (
 /obj/structure/closet/crate/medical,
 /obj/item/storage/box/rxglasses{
@@ -17655,8 +17656,10 @@
 /obj/item/reagent_containers/chem_pack,
 /obj/item/reagent_containers/chem_pack,
 /obj/item/storage/box/syringes,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/medical/cryo)
+/area/maintenance/department/medical/central)
 "blb" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -17664,7 +17667,7 @@
 /obj/machinery/light/directional/east,
 /obj/machinery/portable_atmospherics/canister/anesthetic_mix,
 /turf/open/floor/plating,
-/area/medical/cryo)
+/area/maintenance/department/medical/central)
 "blc" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -18043,17 +18046,17 @@
 	},
 /obj/item/wrench/medical,
 /turf/open/floor/plating,
-/area/medical/cryo)
+/area/maintenance/department/medical/central)
 "bmi" = (
 /turf/open/floor/plating,
-/area/medical/cryo)
+/area/maintenance/department/medical/central)
 "bml" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/anesthetic_mix,
 /turf/open/floor/plating,
-/area/medical/cryo)
+/area/maintenance/department/medical/central)
 "bmn" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -18244,7 +18247,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "bnq" = (
 /obj/item/beacon,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -18453,8 +18456,8 @@
 /turf/open/floor/iron,
 /area/science/breakroom)
 "boc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/science/explab)
@@ -18466,12 +18469,6 @@
 /turf/open/floor/engine{
 	name = "Holodeck Projector Floor"
 	},
-/area/science/explab)
-"boh" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 8
-	},
-/turf/open/floor/engine,
 /area/science/explab)
 "bol" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -18539,8 +18536,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/effect/mapping_helpers/airlock/access/any/medical/general,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/medical/cryo)
+/area/maintenance/department/medical/central)
 "boB" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner/north,
@@ -18716,18 +18714,17 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "bpo" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/science/explab)
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "bpq" = (
 /obj/effect/spawner/random/maintenance,
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "bpr" = (
 /obj/structure/disposaloutlet{
 	dir = 1
@@ -19138,7 +19135,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
 /obj/effect/mapping_helpers/airlock/access/any/science/genetics,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "bqC" = (
 /obj/machinery/monkey_recycler,
 /obj/structure/window/reinforced,
@@ -19226,6 +19223,9 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"bqN" = (
+/turf/open/floor/plating,
+/area/maintenance/department/science/central)
 "bqO" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
@@ -19235,7 +19235,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "bqV" = (
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 1
@@ -19353,7 +19353,7 @@
 /obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "brp" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -20738,7 +20738,7 @@
 /obj/item/stack/cable_coil,
 /obj/item/electronics/airalarm,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical/morgue)
 "bwu" = (
 /obj/structure/table,
 /obj/item/storage/medkit/fire{
@@ -21269,7 +21269,7 @@
 /obj/effect/spawner/random/maintenance,
 /obj/item/clothing/shoes/winterboots,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical/morgue)
 "byd" = (
 /obj/structure/table,
 /obj/item/storage/box/rxglasses{
@@ -21783,7 +21783,7 @@
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical/morgue)
 "bzD" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -21797,7 +21797,7 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/maintenance/department/engine)
+/area/maintenance/department/medical/morgue)
 "bzF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -21949,7 +21949,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/science/general,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "bAo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -22071,7 +22071,7 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/maintenance/department/engine)
+/area/maintenance/department/medical/morgue)
 "bAN" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -22372,7 +22372,7 @@
 /obj/item/stack/medical/mesh,
 /obj/item/stack/medical/suture,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical/morgue)
 "bBZ" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -22746,11 +22746,11 @@
 "bDg" = (
 /obj/machinery/atmospherics/components/tank/air,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical/morgue)
 "bDh" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical/morgue)
 "bDi" = (
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
@@ -22761,8 +22761,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical/morgue)
 "bDs" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/medical/glass{
@@ -22805,7 +22806,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "bDB" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -23003,7 +23004,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold/general/visible,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical/morgue)
 "bEl" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
@@ -23011,7 +23012,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical/morgue)
 "bEm" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Maintenance";
@@ -23022,7 +23023,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical/morgue)
 "bEr" = (
 /turf/closed/wall/r_wall,
 /area/medical/virology)
@@ -23030,7 +23031,7 @@
 /obj/structure/closet/crate/medical,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "bEE" = (
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 1
@@ -23297,7 +23298,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "bFr" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -23363,7 +23364,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical/morgue)
 "bFI" = (
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/iron/freezer,
@@ -24173,7 +24174,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "bJc" = (
 /obj/structure/chair/comfy/black,
 /obj/item/trash/pistachios,
@@ -24318,7 +24319,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "bJO" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
@@ -24567,7 +24568,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/office)
 "bKY" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/atmos/glass{
@@ -24582,7 +24583,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/office)
 "bLb" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -24719,7 +24720,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "bLL" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -24801,7 +24802,7 @@
 	req_access_txt = "24"
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/office)
 "bLY" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hazardvest,
@@ -25093,11 +25094,11 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/office)
 "bMZ" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/office)
 "bNa" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -25109,7 +25110,7 @@
 	req_access_txt = "24"
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/office)
 "bNb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /turf/open/floor/iron,
@@ -25288,7 +25289,7 @@
 /obj/item/cigbutt/cigarbutt,
 /obj/item/trash/chips,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "bNQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -25302,7 +25303,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "bNS" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -25314,7 +25315,7 @@
 "bNV" = (
 /obj/item/wrench/medical,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "bNW" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -25322,7 +25323,7 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "bNX" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
@@ -25383,7 +25384,7 @@
 	name = "External to Filter"
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/office)
 "bOh" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/chair/office{
@@ -25394,7 +25395,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/office)
 "bOj" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/atmos/glass{
@@ -25405,7 +25406,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/office)
 "bOk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -25483,7 +25484,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "bOG" = (
 /obj/structure/water_source/puddle,
 /obj/structure/flora/ausbushes/reedbush{
@@ -25499,7 +25500,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "bOI" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -25530,7 +25531,7 @@
 	req_access_txt = "24"
 	},
 /turf/open/floor/plating,
-/area/engineering/atmos)
+/area/engineering/atmos/office)
 "bOO" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -25543,7 +25544,7 @@
 	name = "Air to External"
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/office)
 "bOQ" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -25557,7 +25558,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/office)
 "bOS" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
@@ -25683,7 +25684,7 @@
 /obj/structure/table,
 /obj/item/trash/chips,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "bPE" = (
 /turf/closed/wall,
 /area/engineering/storage/tech)
@@ -25698,7 +25699,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/tech_storage,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "bPG" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/yellow{
@@ -25722,7 +25723,7 @@
 	id = "atmosdelivery"
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/office)
 "bPK" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -25760,7 +25761,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/office)
 "bPP" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -25775,7 +25776,7 @@
 	name = "Atmospherics Requests Console"
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/office)
 "bPQ" = (
 /turf/closed/wall,
 /area/engineering/atmos)
@@ -26017,7 +26018,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/office)
 "bQH" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -26134,10 +26135,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"bRn" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/engineering/atmos)
 "bRp" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -26174,7 +26171,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/office)
 "bRt" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -26194,7 +26191,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/office)
 "bRv" = (
 /obj/machinery/atmospherics/components/unary/bluespace_sender,
 /turf/open/floor/iron,
@@ -26420,7 +26417,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/office)
 "bSe" = (
 /obj/machinery/pipedispenser/disposal,
 /obj/machinery/light/directional/west,
@@ -26587,7 +26584,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/office)
 "bSR" = (
 /obj/item/wrench,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
@@ -26603,7 +26600,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/office)
 "bST" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/iron,
@@ -26912,7 +26909,7 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/office)
 "bTK" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
 	dir = 1;
@@ -27683,7 +27680,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/science/general,
 /obj/effect/mapping_helpers/airlock/access/any/medical/general,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "bWb" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -28138,7 +28135,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical/morgue)
 "bXz" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
 	dir = 1
@@ -28549,12 +28546,12 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engineering/atmos)
+/area/engineering/atmos/hfr_room)
 "bZh" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
-/area/engineering/atmos)
+/area/engineering/atmos/hfr_room)
 "bZr" = (
 /obj/item/trash/tray,
 /obj/structure/disposalpipe/segment{
@@ -29614,7 +29611,6 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "cfU" = (
@@ -33239,7 +33235,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/medical/chemistry,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "cBM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -33455,7 +33451,7 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "cKA" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -33606,7 +33602,7 @@
 "cRm" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron/dark,
-/area/engineering/atmos)
+/area/engineering/atmos/hfr_room)
 "cRA" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -33686,7 +33682,16 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
+"cYx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "cZu" = (
 /obj/structure/chair{
 	dir = 1
@@ -33745,12 +33750,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/gateway)
+"ddf" = (
+/obj/effect/spawner/random/trash/mess,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "dej" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 10
 	},
 /turf/open/floor/iron/dark,
-/area/engineering/atmos)
+/area/engineering/atmos/hfr_room)
 "dfm" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -33767,6 +33776,10 @@
 /obj/effect/spawner/random/contraband/armory,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"dfP" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "dfU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -33960,6 +33973,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"doA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "dpa" = (
 /obj/machinery/light/directional/north,
 /obj/structure/sign/directions/evac{
@@ -34043,7 +34067,7 @@
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "dsM" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room"
@@ -34246,7 +34270,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "dCh" = (
 /obj/structure/sign/painting/library_private{
 	pixel_x = -32
@@ -34305,7 +34329,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/engineering/atmos)
+/area/engineering/atmos/hfr_room)
 "dFU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -34401,7 +34425,7 @@
 /obj/structure/table,
 /obj/item/assembly/igniter,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "dMA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -34469,7 +34493,20 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/medical/general,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical/morgue)
+"dOB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science/central)
 "dPk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -34537,7 +34574,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "dRU" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/structure/window/reinforced/spawner/west,
@@ -34587,7 +34624,7 @@
 /obj/item/cautery,
 /obj/item/hemostat,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "dSK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -34600,12 +34637,12 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "dTR" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "dTT" = (
 /turf/open/floor/iron,
 /area/cargo/office)
@@ -34710,6 +34747,10 @@
 /obj/machinery/atmospherics/components/binary/pump,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"dZG" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/central)
 "eaA" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -34894,6 +34935,14 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse/upper)
+"ekl" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "ekm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -34956,7 +35005,7 @@
 "ema" = (
 /obj/structure/plasticflaps/opaque,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical/morgue)
 "emp" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/table,
@@ -35194,7 +35243,7 @@
 "evU" = (
 /obj/effect/turf_decal/bot/left,
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/hfr_room)
 "ewb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -35515,8 +35564,8 @@
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "eNo" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 9
+/obj/machinery/atmospherics/components/unary/thermomachine/heater{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/science/explab)
@@ -35868,7 +35917,7 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "eZE" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -35930,7 +35979,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/office)
 "fby" = (
 /obj/structure/bed,
 /obj/item/bedsheet/cmo,
@@ -35947,8 +35996,9 @@
 /area/medical/abandoned)
 "fca" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/medical/cryo)
+/area/maintenance/department/medical/central)
 "fcK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -36029,7 +36079,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "feN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
@@ -36066,7 +36116,7 @@
 "fgl" = (
 /obj/machinery/drone_dispenser,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "fgs" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -36158,6 +36208,19 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
+"fiP" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/department/medical/morgue)
+"fiZ" = (
+/turf/open/floor/iron/dark,
+/area/engineering/atmos/hfr_room)
 "fjs" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/purple{
@@ -36304,6 +36367,16 @@
 /obj/machinery/bluespace_vendor/directional/south,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"frh" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/atmos/hfr_room)
 "frn" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -36515,7 +36588,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "fAL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -36626,7 +36699,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "fGk" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -36722,9 +36795,8 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "fJU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall,
-/area/engineering/supermatter/room)
+/turf/closed/wall,
+/area/maintenance/department/science/central)
 "fKa" = (
 /obj/item/radio/intercom/directional/north{
 	desc = "A station intercom. It looks like it has been modified to not broadcast.";
@@ -36817,7 +36889,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "fNX" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -36889,7 +36961,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/supply/mining,
 /turf/open/floor/iron,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "fQN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -36957,6 +37029,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
+"fWa" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos/hfr_room)
 "fWh" = (
 /obj/structure/table/wood/fancy,
 /turf/open/floor/iron/dark,
@@ -37105,7 +37184,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "gfC" = (
 /obj/structure/table,
 /obj/machinery/conveyor_switch/oneway{
@@ -37425,13 +37504,12 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/office)
 "guE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -37679,8 +37757,10 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/office)
 "gEA" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
@@ -37698,6 +37778,10 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"gEL" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "gEZ" = (
 /turf/closed/wall,
 /area/security/medical)
@@ -37977,8 +38061,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "gRJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
@@ -38001,7 +38086,7 @@
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "gTR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -38014,7 +38099,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "gUJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -38026,6 +38111,19 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"gUM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science/central)
 "gVc" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken4"
@@ -38048,7 +38146,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "gVy" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -38296,6 +38394,9 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"hjQ" = (
+/turf/closed/wall,
+/area/maintenance/department/medical/morgue)
 "hkc" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -38411,8 +38512,11 @@
 "hop" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "hoR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -38616,7 +38720,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/hfr_room)
 "hCj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -38827,7 +38931,7 @@
 "hOz" = (
 /obj/item/weldingtool,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "hOY" = (
 /obj/effect/turf_decal/bot_white/right,
 /obj/item/radio/intercom/directional/east,
@@ -39097,6 +39201,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
+"icI" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science/central)
 "icK" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -39241,7 +39355,7 @@
 "iiy" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "iiJ" = (
 /obj/machinery/door/window/right/directional/north{
 	base_state = "left";
@@ -39257,8 +39371,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/engineering/atmos)
+/area/engineering/atmos/hfr_room)
 "ijU" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/medical/memeorgans,
@@ -39362,7 +39477,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "iqc" = (
 /turf/open/floor/iron/stairs/right,
 /area/service/abandoned_gambling_den)
@@ -39435,6 +39550,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
+"ivf" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/department/medical/morgue)
 "ivp" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -39585,7 +39710,7 @@
 	target_pressure = 4500
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "iCV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -39625,7 +39750,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter/room)
 "iEQ" = (
@@ -39676,7 +39800,6 @@
 	},
 /obj/structure/table/glass,
 /obj/item/stack/medical/gauze,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "iIB" = (
@@ -39799,6 +39922,19 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"iMj" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science/central)
 "iMH" = (
 /obj/machinery/door/window/left/directional/south{
 	base_state = "right";
@@ -39870,7 +40006,7 @@
 /area/engineering/atmos)
 "iSi" = (
 /turf/closed/wall/r_wall,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "iSl" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -39913,7 +40049,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating/airless,
-/area/engineering/atmos)
+/area/engineering/atmos/hfr_room)
 "iWD" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -40013,7 +40149,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "jaS" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
 	dir = 1
@@ -40089,6 +40225,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"jfT" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "jgr" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Library"
@@ -40549,6 +40689,16 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark,
 /area/service/chapel)
+"jHF" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "jHP" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/bottle/vodka/badminka{
@@ -40566,7 +40716,7 @@
 	dir = 9
 	},
 /turf/closed/wall,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "jII" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -40731,7 +40881,7 @@
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
-/area/engineering/atmos)
+/area/engineering/atmos/hfr_room)
 "jOw" = (
 /obj/structure/table/wood/fancy,
 /obj/structure/sign/painting/library_secure{
@@ -40779,7 +40929,7 @@
 "jSA" = (
 /obj/structure/sign/departments/science,
 /turf/closed/wall,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "jSP" = (
 /obj/machinery/conveyor{
 	dir = 10;
@@ -40936,7 +41086,7 @@
 	dir = 4
 	},
 /turf/closed/wall,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "jZL" = (
 /obj/machinery/door/window/left/directional/west{
 	dir = 2;
@@ -41103,7 +41253,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "kjI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -41428,10 +41578,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"kvj" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/closed/wall,
-/area/maintenance/department/engine)
 "kvq" = (
 /obj/machinery/door/window/left/directional/east{
 	dir = 1;
@@ -41497,11 +41643,8 @@
 /turf/open/floor/iron,
 /area/science/breakroom)
 "kxJ" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
-	dir = 4
-	},
 /turf/closed/wall,
-/area/medical/medbay/central)
+/area/maintenance/department/medical/central)
 "kya" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -41624,7 +41767,6 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/trunk,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/disposal/bin{
 	name = "Corpse Disposal"
 	},
@@ -41717,7 +41859,7 @@
 	layer = 2.9
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "kJm" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/fyellow,
@@ -41733,6 +41875,18 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/security/brig)
+"kJJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "kJU" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -41744,7 +41898,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/hfr_room)
 "kKf" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-08"
@@ -41806,17 +41960,24 @@
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
 "kPA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Docking Arm Maintenance"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/engineering/main)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "cargo-maint-passthrough"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/department/science/central)
 "kPM" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -41829,7 +41990,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
 /turf/open/floor/plating,
-/area/engineering/atmos)
+/area/engineering/atmos/office)
 "kQy" = (
 /obj/machinery/computer/med_data,
 /obj/effect/turf_decal/tile/blue{
@@ -41886,14 +42047,14 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "kSO" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 6
 	},
 /obj/machinery/portable_atmospherics/canister/anesthetic_mix,
 /turf/open/floor/plating,
-/area/medical/cryo)
+/area/maintenance/department/medical/central)
 "kTl" = (
 /turf/closed/wall,
 /area/security/lockers)
@@ -42019,7 +42180,7 @@
 "kXZ" = (
 /obj/structure/easel,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "kYt" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/grass,
@@ -42155,6 +42316,9 @@
 /obj/item/pen,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
+"ldy" = (
+/turf/closed/wall/r_wall,
+/area/engineering/atmos/office)
 "lem" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -42222,7 +42386,7 @@
 	},
 /obj/structure/cable,
 /turf/closed/wall,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "lhu" = (
 /obj/machinery/shieldgen,
 /obj/machinery/light/directional/east,
@@ -42558,7 +42722,7 @@
 "ltJ" = (
 /obj/structure/statue/petrified,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "lug" = (
 /obj/effect/decal/cleanable/ash,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -42876,7 +43040,7 @@
 	dir = 5
 	},
 /turf/closed/wall,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "lQQ" = (
 /obj/machinery/computer/atmos_control/carbon_tank{
 	dir = 8
@@ -42917,6 +43081,17 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/genetics)
+"lSc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "lTf" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -43304,8 +43479,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/office)
 "mlI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -43443,7 +43619,7 @@
 	dir = 9
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "mrk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -43471,7 +43647,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/hfr_room)
 "mrR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -43733,7 +43909,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "mDW" = (
@@ -43877,8 +44052,10 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/hfr_room)
 "mNN" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -43905,7 +44082,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "mOx" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -44150,6 +44327,11 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"mZZ" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/department/medical)
 "naq" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -44549,6 +44731,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "nrD" = (
@@ -44588,13 +44771,16 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical/morgue)
 "nts" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/closed/wall,
 /area/cargo/miningdock)
+"ntz" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/department/medical/morgue)
 "ntO" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -44602,6 +44788,9 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"nuk" = (
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "nvG" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/iron/dark,
@@ -44661,8 +44850,9 @@
 /obj/machinery/light_switch{
 	pixel_y = -24
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/medical/cryo)
+/area/maintenance/department/medical/central)
 "nyB" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -44822,6 +45012,15 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/engine)
+"nHT" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos/hfr_room)
 "nIm" = (
 /obj/machinery/computer/security/telescreen{
 	dir = 8;
@@ -45013,6 +45212,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
+"nSg" = (
+/obj/structure/chair/stool/bar/directional/west,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "nSz" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
@@ -45054,7 +45257,7 @@
 	},
 /obj/item/light/bulb,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "nTx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -45158,6 +45361,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
+"nXq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "nXC" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Xenobiology Slime Pen #1";
@@ -45197,7 +45411,7 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "nZX" = (
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter/room)
@@ -45242,7 +45456,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "ocd" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
@@ -45284,7 +45498,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/medical/surgery,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "ofe" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/dark/side{
@@ -45469,7 +45683,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "onJ" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -45521,7 +45735,7 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "opz" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -46152,8 +46366,8 @@
 	},
 /area/hallway/secondary/entry)
 "oPr" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/science/explab)
@@ -46188,7 +46402,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "oQr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -46219,7 +46433,7 @@
 "oRX" = (
 /obj/structure/closet,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "oSa" = (
 /obj/effect/turf_decal/trimline/blue/corner{
 	dir = 4
@@ -46278,7 +46492,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "oTp" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -46361,6 +46575,9 @@
 /obj/effect/landmark/secequipment,
 /turf/open/floor/iron/showroomfloor,
 /area/security/lockers)
+"oWB" = (
+/turf/open/floor/iron,
+/area/engineering/atmos/hfr_room)
 "oWL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -46372,7 +46589,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "oXe" = (
 /obj/structure/table/glass,
 /obj/item/mmi,
@@ -46398,7 +46615,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "oYc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -46439,6 +46656,10 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"pca" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "pcg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -46464,7 +46685,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "pdq" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
@@ -46845,7 +47066,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "pvK" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -47092,7 +47313,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/hfr_room)
 "pGZ" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lantern{
@@ -47130,7 +47351,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "pIa" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay"
@@ -47193,7 +47414,7 @@
 "pKd" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "pKf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -47381,7 +47602,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "pTG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -47531,6 +47752,14 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/department/engine)
+"qah" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "qaQ" = (
 /turf/closed/wall,
 /area/hallway/secondary/service)
@@ -48118,7 +48347,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/medical/cryo)
+/area/maintenance/department/medical/central)
 "qwJ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -48266,7 +48495,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "qHu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -48375,7 +48604,7 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "qJI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -48761,7 +48990,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical/morgue)
 "rbx" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
@@ -48845,7 +49074,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/hfr_room)
 "rgs" = (
 /obj/structure/table,
 /obj/item/instrument/eguitar,
@@ -48887,7 +49116,11 @@
 "rjl" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/hfr_room)
+"rjw" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/maintenance/department/science/central)
 "rjL" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/shower{
@@ -48948,7 +49181,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "rng" = (
 /obj/structure/window/reinforced,
 /obj/machinery/camera/directional/east{
@@ -49010,7 +49243,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "rpc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -49122,7 +49355,7 @@
 	color = "#9FED58"
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/hfr_room)
 "rsK" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -49299,7 +49532,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "rxQ" = (
 /obj/machinery/door/airlock{
 	id_tag = "PottySci";
@@ -49379,7 +49612,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "rAP" = (
 /obj/machinery/light_switch{
 	pixel_x = 25;
@@ -49496,7 +49729,11 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/office)
+"rDV" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/science/central)
 "rEh" = (
 /obj/structure/table/glass,
 /obj/item/restraints/handcuffs/cable/zipties,
@@ -49743,6 +49980,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"rNF" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "rNJ" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner/north,
@@ -49911,6 +50152,9 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"rXs" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/department/medical)
 "rXH" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -50031,6 +50275,9 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/service/kitchen)
+"sbK" = (
+/turf/closed/wall/r_wall,
+/area/engineering/atmos/hfr_room)
 "sbY" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/wood,
@@ -50242,7 +50489,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "snY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -50263,6 +50510,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"soN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "spo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -50274,6 +50530,7 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "sqh" = (
@@ -50320,7 +50577,7 @@
 	color = "#EFB341"
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/hfr_room)
 "stc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/iron/white,
@@ -50398,6 +50655,9 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"swm" = (
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "sww" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/item/food/meat/slab/monkey,
@@ -50447,7 +50707,7 @@
 	c_tag = "HFR Room"
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/hfr_room)
 "sxT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -50472,7 +50732,7 @@
 	pixel_y = 15
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/hfr_room)
 "syA" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/start/hangover,
@@ -50954,12 +51214,16 @@
 /turf/open/floor/iron/chapel,
 /area/service/chapel)
 "sTF" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/turf/open/floor/engine,
-/area/engineering/supermatter/room)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science/central)
 "sTY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50991,7 +51255,7 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "sWj" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
@@ -51241,6 +51505,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/explab)
+"tdr" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engineering/atmos/office)
 "tdB" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/purple{
@@ -51371,7 +51639,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/access/any/science/research,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "tir" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -51393,7 +51661,7 @@
 	dir = 9
 	},
 /turf/closed/wall/r_wall,
-/area/engineering/atmos)
+/area/engineering/atmos/hfr_room)
 "tiI" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -51489,7 +51757,7 @@
 /obj/item/stack/sheet/plasteel/twenty,
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/hfr_room)
 "tnY" = (
 /obj/machinery/button/door{
 	id = "aux_base_shutters";
@@ -51697,6 +51965,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"tva" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating/airless,
+/area/engineering/atmos/hfr_room)
 "tvj" = (
 /obj/structure/festivus{
 	anchored = 1;
@@ -51930,7 +52202,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "tCi" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/machinery/disposal/bin{
@@ -51992,7 +52264,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "tDz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -52154,6 +52426,10 @@
 	},
 /turf/closed/wall,
 /area/engineering/storage_shared)
+"tPs" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "tQi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -52242,7 +52518,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/hfr_room)
 "tTq" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -52385,7 +52661,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "ubq" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/red{
@@ -53141,7 +53417,7 @@
 	dir = 10
 	},
 /turf/closed/wall,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "uAq" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -53463,7 +53739,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/medical/morgue,
 /turf/open/floor/iron/dark,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical/morgue)
 "uQu" = (
 /obj/machinery/door/firedoor,
 /obj/effect/landmark/start/hangover,
@@ -53481,7 +53757,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "uQR" = (
 /obj/item/ammo_casing/shotgun/beanbag,
 /turf/open/floor/plating,
@@ -53536,7 +53812,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "uTt" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -53820,7 +54096,7 @@
 /obj/item/storage/crayons,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "vao" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54218,7 +54494,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/medical/cryo)
+/area/maintenance/department/medical/central)
 "vuq" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -54322,6 +54598,10 @@
 /obj/machinery/stasis,
 /turf/open/floor/iron,
 /area/medical/medbay/central)
+"vyQ" = (
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "vzg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -54351,7 +54631,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "vAa" = (
 /obj/structure/chair/wood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -54598,7 +54878,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "vNu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
@@ -54667,7 +54947,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/supply/mail_sorting,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "vQz" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay"
@@ -54807,7 +55087,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/medical/pharmacy,
 /turf/open/floor/iron/white,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "vTg" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -54858,7 +55138,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/office)
 "vWY" = (
 /obj/structure/closet/crate,
 /obj/item/storage/bag/ore,
@@ -55128,7 +55408,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/hfr_room)
 "wfr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -55333,7 +55613,7 @@
 "wns" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
 /turf/open/floor/plating,
-/area/medical/cryo)
+/area/maintenance/department/medical/central)
 "wnJ" = (
 /obj/structure/sign/warning,
 /turf/closed/wall,
@@ -55612,7 +55892,7 @@
 	dir = 10
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "wBg" = (
 /obj/machinery/door/airlock/maintenance{
 	id_tag = "Potty1"
@@ -55913,7 +56193,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/hfr_room)
 "wMn" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/structure/disposalpipe/segment,
@@ -55951,7 +56231,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "wOF" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio8";
@@ -56024,14 +56304,14 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
-/area/engineering/atmos)
+/area/engineering/atmos/hfr_room)
 "wQU" = (
 /obj/effect/spawner/random/maintenance,
 /obj/structure/cable,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "wRe" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/freezer,
@@ -56083,8 +56363,8 @@
 /area/service/bar/atrium)
 "wSR" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -56251,6 +56531,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/atmos)
+"wYr" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/department/science/central)
 "wYu" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "shootshut"
@@ -56319,7 +56603,7 @@
 "xba" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "xbu" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -56420,7 +56704,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/engineering/atmos)
+/area/engineering/atmos/hfr_room)
 "xdY" = (
 /obj/machinery/door/window/right/directional/east{
 	name = "Danger: Conveyor Access";
@@ -56561,7 +56845,7 @@
 "xhT" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "xiw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -56592,7 +56876,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "xjl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
@@ -56856,9 +57140,9 @@
 /turf/open/floor/carpet,
 /area/service/bar/atrium)
 "xst" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/turf/closed/wall/r_wall,
-/area/engineering/supermatter/room)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/department/science/central)
 "xsO" = (
 /obj/item/ectoplasm,
 /turf/open/floor/plating{
@@ -56932,7 +57216,7 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "xvO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -56979,6 +57263,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"xxr" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/maintenance/department/science/central)
 "xxw" = (
 /obj/machinery/atmospherics/components/binary/pump,
 /turf/open/floor/iron/dark,
@@ -57037,12 +57325,12 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/supply/mail_sorting,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "xyl" = (
 /obj/structure/table,
 /obj/item/assembly/timer,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "xyp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57071,11 +57359,11 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/medical/cmo,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/department/medical)
 "xyK" = (
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/plating,
-/area/medical/cryo)
+/area/maintenance/department/medical/central)
 "xzp" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -57114,14 +57402,8 @@
 /turf/open/floor/iron/dark,
 /area/service/library)
 "xDj" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/turf/closed/wall,
+/area/maintenance/department/medical)
 "xEt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -57275,7 +57557,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/hfr_room)
 "xJy" = (
 /obj/structure/chair/comfy/black,
 /obj/structure/sign/plaques/kiddie{
@@ -57439,6 +57721,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/medbay/lobby)
+"xQH" = (
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "xQM" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/donkpockets,
@@ -57661,7 +57947,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/department/science/central)
 "ycl" = (
 /obj/machinery/light/directional/east,
 /obj/effect/landmark/start/hangover,
@@ -57741,8 +58027,9 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "yeD" = (
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/engineering/atmos)
+/area/engineering/atmos/hfr_room)
 "yeL" = (
 /obj/machinery/holopad,
 /obj/structure/cable,
@@ -78848,10 +79135,10 @@ aYG
 aZx
 aYG
 bAJ
-bBX
-bBX
-bBX
-bBX
+ntz
+ntz
+ntz
+ntz
 bva
 xtI
 olY
@@ -79105,12 +79392,12 @@ aYG
 bxY
 bzz
 bAK
-bBX
+ntz
 bDg
 bXy
 bFF
-bva
-olY
+hjQ
+jHF
 bva
 bHT
 bJi
@@ -79362,12 +79649,12 @@ bwq
 bxZ
 bzA
 bAK
-bBX
+ntz
 bDg
 bEk
-bva
-bva
-xtI
+hjQ
+hjQ
+soN
 bBX
 bBX
 bBX
@@ -79619,13 +79906,13 @@ bwr
 bya
 bzB
 bAL
-bBX
+ntz
 bDh
 bEl
-bva
-bVC
-xtI
-bBX
+hjQ
+rNF
+soN
+ntz
 doo
 hRH
 nCe
@@ -79869,20 +80156,20 @@ bnt
 sKe
 aYG
 aYG
-bBX
+ntz
 nta
-bBX
-bBX
-bBX
-bBX
-bBX
-bBX
-bva
+ntz
+ntz
+ntz
+ntz
+ntz
+ntz
+hjQ
 bEm
-bva
-bTl
-olY
-bBX
+hjQ
+jfT
+qah
+ntz
 erQ
 oat
 sEN
@@ -80126,20 +80413,20 @@ aYG
 aYG
 aYG
 eUe
-bva
+hjQ
 rbu
-bsn
+tPs
 bws
 byb
 bzC
 bzC
 bBY
-olY
-xtI
-olY
-olY
-olY
-bBX
+qah
+soN
+qah
+qah
+qah
+ntz
 qIl
 ohH
 jJN
@@ -80384,19 +80671,19 @@ bnu
 bpu
 uHJ
 uPG
-xtI
-olY
-tAh
-kkF
+soN
+qah
+fiP
+ivf
 bzD
 bAM
-olY
+qah
 bDj
-bBX
-bBX
-bBX
-bBX
-bBX
+ntz
+ntz
+ntz
+ntz
+ntz
 kTU
 wMn
 rsd
@@ -80640,16 +80927,16 @@ dmI
 oyH
 oyH
 uok
-bva
-bva
-bva
-bva
-bva
+hjQ
+hjQ
+hjQ
+hjQ
+hjQ
 dOo
-bva
-bva
-bDi
-bBX
+hjQ
+hjQ
+nuk
+ntz
 uko
 sSl
 bHS
@@ -80906,7 +81193,7 @@ juh
 bAN
 kvq
 ema
-bBX
+ntz
 gld
 ybu
 tuM
@@ -81162,8 +81449,8 @@ kbi
 fDf
 bAO
 tqC
-bva
-bBX
+hjQ
+ntz
 tak
 dok
 rus
@@ -81661,11 +81948,11 @@ ptL
 ptL
 ptL
 biO
-biY
-biY
-biY
-biY
-biY
+kxJ
+kxJ
+kxJ
+kxJ
+kxJ
 vIa
 bou
 biY
@@ -81918,11 +82205,11 @@ bgZ
 ugM
 pkj
 biP
-bjL
+kxJ
 bkX
 bmh
 xyK
-bjL
+kxJ
 bpy
 biv
 bsr
@@ -82175,11 +82462,11 @@ xvO
 bhL
 jcT
 sSj
-bjL
+kxJ
 bkY
 bmi
 wns
-bjL
+kxJ
 mgW
 bCd
 bvL
@@ -82432,11 +82719,11 @@ bhb
 xPQ
 piM
 bij
-bjL
+kxJ
 bkZ
 bmi
 xyK
-bjL
+kxJ
 mgW
 srf
 bFJ
@@ -82689,11 +82976,11 @@ coy
 xPQ
 jcT
 bik
-bjL
+kxJ
 bla
-bmi
+dZG
 nyl
-bjL
+kxJ
 bvc
 bqY
 mEo
@@ -82722,7 +83009,7 @@ rHh
 sOB
 aht
 bva
-xbD
+kJJ
 ewb
 lPe
 lug
@@ -82946,7 +83233,7 @@ jcT
 xPQ
 bik
 biT
-bjL
+kxJ
 kSO
 qvR
 fca
@@ -83203,11 +83490,11 @@ jcT
 xPQ
 bik
 nmF
-bjL
+kxJ
 blb
 bml
 vtX
-bjL
+kxJ
 ryC
 bqX
 mEo
@@ -83460,11 +83747,11 @@ qbP
 qve
 amL
 bjc
-bjc
-bjc
-bjc
 kxJ
-bjc
+kxJ
+kxJ
+kxJ
+kxJ
 bpD
 brb
 btZ
@@ -83483,11 +83770,11 @@ xIZ
 sOB
 sOB
 sOB
-bva
-bva
-bva
-bva
-bva
+xDj
+xDj
+xDj
+xDj
+xDj
 snZ
 bva
 bva
@@ -83740,11 +84027,11 @@ pJc
 lig
 xBk
 uwS
-bva
+xDj
 bNP
 bOE
 dSI
-umd
+ddf
 bDi
 bva
 bsn
@@ -83998,10 +84285,10 @@ iyl
 iyl
 sCA
 oeU
-xtI
+cYx
 omS
-xtI
-xtI
+cYx
+cYx
 olY
 bva
 gcn
@@ -84254,11 +84541,11 @@ ptR
 tir
 haB
 cCd
-bva
+xDj
 bNR
 pHN
 fAE
-bsn
+dfP
 kTn
 bva
 sZP
@@ -84511,11 +84798,11 @@ mKg
 mKg
 mKg
 wcx
-bva
-bva
-bva
-bva
-bva
+xDj
+xDj
+xDj
+xDj
+xDj
 sWN
 iOl
 iOl
@@ -84768,9 +85055,9 @@ fMs
 hkF
 ufk
 eKa
-bva
+xDj
 xhT
-sWN
+lSc
 bVZ
 iOl
 nqB
@@ -85017,18 +85304,18 @@ rHG
 dZb
 uEY
 bEE
-bBX
-bva
-bva
-bva
-bva
-bva
-bva
-bva
-bva
+rXs
+xDj
+xDj
+xDj
+xDj
+xDj
+xDj
+xDj
+xDj
 snT
-xbD
-bBX
+doA
+rXs
 bBX
 bBX
 bBX
@@ -85284,8 +85571,8 @@ bJb
 bLG
 bpi
 bJb
-nqB
-bBX
+nXq
+rXs
 bQm
 bQZ
 bQZ
@@ -85531,18 +85818,18 @@ lsr
 hHJ
 bDw
 bEF
-bBX
+rXs
 bEz
-bTl
-bNX
-bsn
-bsn
-bSw
-bSw
-bDi
-bNU
-olY
-bBX
+pca
+xQH
+dfP
+dfP
+mZZ
+mZZ
+swm
+ady
+ekl
+rXs
 pQm
 doe
 cCF
@@ -85788,18 +86075,18 @@ bub
 byo
 bub
 bub
-bBX
-bva
-bva
-bva
-bva
-bva
-bva
-bva
-bva
-bBX
-olY
-bBX
+rXs
+xDj
+xDj
+xDj
+xDj
+xDj
+xDj
+xDj
+xDj
+rXs
+ekl
+rXs
 bQo
 fWq
 bRa
@@ -86054,9 +86341,9 @@ lFb
 uik
 txK
 bMK
-bBX
-olY
-bBX
+rXs
+ekl
+rXs
 bQp
 ptK
 bfQ
@@ -86312,8 +86599,8 @@ bsK
 bsK
 ygx
 cBL
-olY
-bBX
+ekl
+rXs
 wVE
 bRG
 iBk
@@ -86568,10 +86855,10 @@ bum
 bsK
 bwV
 bMM
-bBX
-olY
-bBX
-bBX
+rXs
+ekl
+rXs
+rXs
 bPB
 bRH
 bPB
@@ -86824,11 +87111,11 @@ dMR
 abz
 bsK
 eeb
-bBX
-bBX
-olY
-bPC
-bBX
+rXs
+rXs
+ekl
+nSg
+rXs
 bRd
 bRI
 bSB
@@ -86845,11 +87132,11 @@ cai
 cbe
 cca
 pyA
-kPA
-fJU
+orZ
+nZX
 iEJ
-xst
-xst
+nZX
+nZX
 nZX
 nZX
 nZX
@@ -87081,11 +87368,11 @@ dMR
 abz
 bsK
 bAg
-bBX
+rXs
 bNV
-olY
+ekl
 bPD
-bBX
+rXs
 bRe
 bRJ
 bSC
@@ -87107,7 +87394,7 @@ cbj
 ceX
 wdp
 cfS
-sTF
+eoo
 eoo
 bCk
 xqI
@@ -87338,11 +87625,11 @@ dMR
 abz
 bsK
 bLL
-bBX
+rXs
 bNW
 bOH
-bva
-bBX
+xDj
+rXs
 bQr
 bRK
 bQr
@@ -87595,10 +87882,10 @@ dMR
 rLd
 bsK
 anH
-bBX
-bNX
-olY
-bva
+rXs
+xQH
+ekl
+xDj
 bQs
 vsv
 bRL
@@ -87852,9 +88139,9 @@ dMR
 gFf
 bsK
 prD
-bBX
-bBX
-olY
+rXs
+rXs
+ekl
 bPF
 bTu
 bTu
@@ -88110,9 +88397,9 @@ gFf
 bsK
 bLM
 bMN
-bBX
-olY
-bva
+rXs
+ekl
+xDj
 rYk
 bRi
 bRN
@@ -88367,9 +88654,9 @@ gFf
 bsK
 ezC
 jCw
-bBX
-olY
-bva
+rXs
+ekl
+xDj
 bQv
 bRj
 bRO
@@ -88624,9 +88911,9 @@ eRX
 bwV
 bLO
 bAh
-bBX
-olY
-bva
+rXs
+ekl
+xDj
 bQw
 bRj
 bRP
@@ -88881,9 +89168,9 @@ bsK
 nnf
 byz
 ooh
-bBX
-olY
-bva
+rXs
+ekl
+xDj
 bQx
 bRj
 bRQ
@@ -89138,9 +89425,9 @@ mqg
 bKG
 byA
 bAi
-bBX
-olY
-bva
+rXs
+ekl
+xDj
 bQy
 xff
 bRR
@@ -89385,19 +89672,19 @@ dRj
 hEC
 hEC
 hEC
-bBX
-bBX
-bBX
-bBX
-bBX
-bBX
-bBX
-bBX
-bBX
-bBX
-bBX
-olY
-bva
+rXs
+rXs
+rXs
+rXs
+rXs
+rXs
+rXs
+rXs
+rXs
+rXs
+rXs
+ekl
+xDj
 bQz
 bRl
 rpu
@@ -89652,9 +89939,9 @@ vNl
 vNl
 vNl
 vNl
-olY
-olY
-bva
+ekl
+ekl
+xDj
 bQA
 bRm
 vyx
@@ -89890,28 +90177,28 @@ cQN
 xOq
 bmA
 cQN
-bva
-bBX
-bBX
-bBX
+xDj
+rXs
+rXs
+rXs
 vSL
-bva
+xDj
 hEC
 cIe
 fby
-bva
+xDj
 vNl
 oXV
-bva
-bva
-bva
-bva
-bva
-bva
-bva
+xDj
+xDj
+xDj
+xDj
+xDj
+xDj
+xDj
 xje
-bva
-bva
+xDj
+xDj
 bPE
 bPE
 bRU
@@ -90147,22 +90434,22 @@ bls
 aDm
 dhy
 bmB
-bva
-bDi
-bDi
-bDi
-olY
-bDi
-bva
-bva
-bva
-kvj
+xDj
+swm
+swm
+swm
+ekl
+swm
+xDj
+xDj
+xDj
+xDj
 hop
 xDj
-bva
+xDj
 jCv
 bOK
-bEN
+bRV
 ery
 bEN
 bRV
@@ -90415,7 +90702,7 @@ gVk
 gVk
 uQB
 oWN
-bRD
+gEL
 bFq
 tWh
 bIt
@@ -90661,19 +90948,19 @@ blu
 aDm
 rLQ
 eeF
-bBX
-bBX
-bBX
+rXs
+rXs
+rXs
 bro
-bBX
-bBX
-bBX
-bBX
-bva
+rXs
+rXs
+rXs
+rXs
+xDj
 gRb
-bDi
-bTl
-bva
+swm
+pca
+xDj
 bAl
 bIu
 bmD
@@ -90929,7 +91216,7 @@ bAm
 uaY
 oQi
 bDA
-ccN
+vyQ
 jSA
 wdv
 voL
@@ -91182,12 +91469,12 @@ tiI
 byF
 tiI
 byE
-bBX
-bBX
-bBX
-bBX
-bBX
-bBX
+rXs
+rXs
+rXs
+rXs
+rXs
+rXs
 bvD
 bIx
 cqz
@@ -92229,7 +92516,7 @@ qzm
 bRr
 yhO
 qOx
-fBp
+ldy
 fBp
 bVd
 fBp
@@ -92486,7 +92773,7 @@ bRs
 mlD
 gur
 bSS
-vzg
+tdr
 bUp
 bVe
 bVV
@@ -93247,17 +93534,17 @@ bGb
 laB
 xbB
 tqU
-fBp
-fBp
-fBp
+ldy
+ldy
+ldy
 bOj
 bKY
-fBp
-fBp
-fBp
-fBp
-fBp
-fBp
+ldy
+ldy
+ldy
+ldy
+ldy
+ldy
 bWP
 fuR
 bWO
@@ -94759,9 +95046,9 @@ prO
 ajQ
 pvZ
 gYW
-aEj
+fJU
 pTF
-aEj
+fJU
 beI
 lot
 lot
@@ -94813,13 +95100,13 @@ bJP
 bJP
 bJP
 bJP
-fBp
+sbK
 auI
 auI
 auI
 auI
 auI
-fBp
+sbK
 aaa
 aaa
 aaa
@@ -95016,9 +95303,9 @@ odh
 aZn
 bav
 cuL
-aEj
-uXX
-aEj
+fJU
+icI
+fJU
 bfv
 bgE
 lZc
@@ -95273,9 +95560,9 @@ aYr
 aZn
 baw
 bbA
-aEj
-uXX
-aEj
+fJU
+icI
+fJU
 fkd
 sgZ
 bhl
@@ -95328,11 +95615,11 @@ cco
 lag
 bJP
 auI
-bUp
+nHT
 azm
 azN
 evU
-uWA
+fWa
 auI
 aaa
 aaa
@@ -95530,9 +95817,9 @@ nwK
 aZn
 bat
 syO
-aEj
-uXX
-aEj
+fJU
+icI
+fJU
 bfx
 bgG
 bhm
@@ -95585,11 +95872,11 @@ cby
 cby
 bJP
 auI
-bUp
+nHT
 rsy
 rjl
 syt
-uWA
+fWa
 auI
 aaa
 aaa
@@ -95787,9 +96074,9 @@ tQi
 hNd
 tYn
 nBt
-aEj
-uXX
-aEj
+fJU
+icI
+fJU
 bfy
 bgI
 bhn
@@ -95842,11 +96129,11 @@ bJP
 bJP
 bJP
 auI
-bUp
+nHT
 evU
 ssU
 azm
-uWA
+fWa
 auI
 aaa
 aaa
@@ -96046,13 +96333,13 @@ rJT
 sLD
 vQo
 dSK
-aEj
+fJU
 bfz
 bgI
 bhn
 bgI
 bfz
-aEj
+fJU
 iSi
 iSi
 bkt
@@ -96093,16 +96380,16 @@ bWO
 bYt
 bZf
 jOl
-fBp
-fBp
-fBp
-fBp
-fBp
-fBp
+sbK
+sbK
+sbK
+sbK
+sbK
+sbK
 ayG
-bWO
-bWO
-bWO
+oWB
+oWB
+oWB
 hCg
 auI
 aaa
@@ -96302,14 +96589,14 @@ aZn
 krI
 bbC
 lQr
-lru
-aEj
+iMj
+fJU
 bfA
 bgJ
 bhn
 bhV
 vyn
-aEj
+fJU
 ltJ
 iSi
 vDT
@@ -96358,8 +96645,8 @@ cRm
 iVT
 mrH
 pGV
-bWO
-bWO
+oWB
+oWB
 wfp
 wQE
 xdQ
@@ -96559,15 +96846,15 @@ aZn
 aZn
 bbD
 jYA
-lru
-aEj
-aEj
-aEj
+iMj
+fJU
+fJU
+fJU
 bhp
-aEj
-aEj
-aEj
-aEj
+fJU
+fJU
+fJU
+fJU
 iSi
 bmT
 bnU
@@ -96606,18 +96893,18 @@ lQQ
 auW
 tvr
 axx
-bRn
+yeD
 dFK
 yeD
 yeD
 yeD
 yeD
 iiP
-bUp
-bWO
-bWO
-bWO
-uWA
+frh
+oWB
+oWB
+oWB
+fWa
 auI
 aaa
 aaa
@@ -96816,14 +97103,14 @@ aZn
 baz
 uwF
 jYA
-set
-mdx
-mdx
-mdx
+gUM
+sTF
+sTF
+sTF
 fGd
 aam
 bix
-aFi
+bqN
 fgl
 iSi
 bmU
@@ -96862,14 +97149,14 @@ pFG
 rGo
 eGT
 vLx
-fBp
+sbK
 ayJ
 dFK
-yeD
-yeD
-yeD
-yeD
-mkf
+fiZ
+fiZ
+fiZ
+fiZ
+tva
 mNv
 rfm
 sxs
@@ -97073,12 +97360,12 @@ aZo
 rWb
 bwD
 jYA
-aEj
-aEj
-aEj
-aEj
+fJU
+fJU
+fJU
+fJU
 aam
-aFi
+bqN
 aam
 iSi
 iSi
@@ -97129,10 +97416,10 @@ bYw
 bYw
 bYw
 bYw
-fBp
-fBp
-fBp
-fBp
+sbK
+sbK
+sbK
+sbK
 aaa
 aaa
 aaa
@@ -97333,7 +97620,7 @@ nts
 lcH
 amb
 bfB
-aEj
+fJU
 jaJ
 xba
 dSK
@@ -97590,10 +97877,10 @@ bcB
 hgV
 hgV
 csV
-aEj
+fJU
 dRI
-aFi
-lru
+bqN
+iMj
 iSi
 bkz
 fGH
@@ -97847,10 +98134,10 @@ bcC
 qfZ
 xPf
 iXt
-aEj
+fJU
 fQD
-aEj
-lru
+fJU
+iMj
 iSi
 bkA
 blR
@@ -98106,8 +98393,8 @@ lGJ
 lGJ
 lGJ
 bhr
-aEj
-lru
+fJU
+iMj
 iSi
 vYH
 xQM
@@ -98363,8 +98650,8 @@ xkk
 xkk
 xkk
 bhs
-aEj
-lru
+fJU
+iMj
 iSi
 iSi
 wDf
@@ -98620,7 +98907,7 @@ hgV
 hgV
 pXH
 jYn
-aEj
+fJU
 biC
 dSK
 iSi
@@ -98877,9 +99164,9 @@ beO
 hgV
 pXH
 bhu
-aEj
-aFi
-lru
+fJU
+bqN
+iMj
 iSi
 aau
 aan
@@ -99134,9 +99421,9 @@ beP
 hgV
 pXH
 bhv
-aEj
-aEj
-lru
+fJU
+fJU
+iMj
 iSi
 aaw
 pJU
@@ -99391,9 +99678,9 @@ bdI
 bfI
 bdI
 bbI
-aEj
-aGP
-lru
+fJU
+xxr
+iMj
 aat
 aay
 hTq
@@ -99648,9 +99935,9 @@ bdI
 bfJ
 bdI
 aaa
-aEj
+fJU
 pKd
-lru
+iMj
 iSi
 aaA
 aao
@@ -99905,9 +100192,9 @@ bdI
 oPy
 bdI
 aht
-aEj
-aEj
-lru
+fJU
+fJU
+iMj
 iSi
 iSi
 aap
@@ -100163,7 +100450,7 @@ bfK
 aaa
 aaa
 aaa
-aEj
+fJU
 obj
 xba
 tim
@@ -100420,13 +100707,13 @@ aaa
 aaa
 aaa
 aaa
-aEj
-lru
-aFi
+fJU
+iMj
+bqN
 iSi
 nJI
-bpo
-bpo
+bky
+bky
 lAR
 bqs
 vfp
@@ -100677,12 +100964,12 @@ aaa
 aaa
 aaa
 aaa
-aEj
-lru
-aEj
+fJU
+iMj
+fJU
 iSi
 bky
-boh
+oPr
 oPr
 bqx
 bqs
@@ -100934,9 +101221,9 @@ aaa
 aaa
 aaa
 aaa
-aEj
-lru
-aFi
+fJU
+iMj
+bqN
 bkD
 vxp
 boc
@@ -101191,12 +101478,12 @@ aaa
 aaa
 aaa
 aaa
-aEj
-lru
-aEj
+fJU
+iMj
+fJU
 iSi
 iSi
-pdf
+iSi
 iSi
 iSi
 brR
@@ -101436,26 +101723,26 @@ cDa
 mZS
 myc
 sAD
-aEj
+fJU
 uAh
 lQr
-aEj
-aEj
-aEj
-aEj
-aEj
-aEj
-aEj
-aEj
-aEj
-aEj
+fJU
+fJU
+fJU
+fJU
+fJU
+fJU
+fJU
+fJU
+fJU
+fJU
 oTl
 rpa
 rpa
 ipI
 rmP
 bpq
-aEj
+fJU
 brT
 eOJ
 wkZ
@@ -101693,21 +101980,21 @@ rbx
 nNk
 myc
 uzX
-aEj
+fJU
 nTv
 kSG
 kXZ
-uXX
-uXX
-tfz
-mdx
+icI
+icI
+dOB
+sTF
 kjA
-mdx
+sTF
 dSK
-tfz
-mdx
+dOB
+sTF
 fGd
-aKq
+rjw
 cYn
 wAI
 rpa
@@ -101934,7 +102221,7 @@ aur
 aur
 aEj
 odG
-aFi
+bpo
 yiL
 yiL
 set
@@ -101950,16 +102237,16 @@ tAm
 tvy
 eCB
 ahW
-vHj
-mdx
+kPA
+sTF
 ajS
-mdx
-mdx
+sTF
+sTF
 vaa
 mri
-aEj
+fJU
 uSW
-aEj
+fJU
 gfi
 jHZ
 iSi
@@ -102207,16 +102494,16 @@ tko
 bbG
 xud
 bbG
-aEj
-aEl
+fJU
+xst
 jYA
-aEl
-aEl
-aEl
-aEj
-aEj
+xst
+xst
+xst
+fJU
+fJU
 tBP
-aEj
+fJU
 uSW
 lEn
 pnU
@@ -102470,10 +102757,10 @@ rax
 aaa
 aaa
 aaa
-aEj
+fJU
 iiy
 uSW
-aEj
+fJU
 uSW
 lEn
 uwb
@@ -102727,10 +103014,10 @@ rax
 aaa
 aaa
 aaa
-aEj
+fJU
 beS
 uSW
-aEj
+fJU
 uSW
 lEn
 biD
@@ -102984,10 +103271,10 @@ oCX
 sut
 aaa
 aaa
-aEj
-bdo
+fJU
+wYr
 dBQ
-aEj
+fJU
 uSW
 lEn
 vYN
@@ -103241,12 +103528,12 @@ igX
 rWE
 aht
 aht
-aEj
+fJU
 kIo
 bfN
-aEj
+fJU
 uSW
-aEj
+fJU
 iSi
 iSi
 iSi
@@ -103498,10 +103785,10 @@ baG
 sut
 aaa
 aaa
-aEj
-aEj
+fJU
+fJU
 lhf
-aEj
+fJU
 qHf
 dTR
 dTR
@@ -103755,13 +104042,13 @@ baG
 sut
 aaa
 aaa
-aEj
+fJU
 bfP
 fer
-aEj
-aEj
-aEj
-aKq
+fJU
+fJU
+fJU
+rjw
 uSW
 iSi
 blX
@@ -104012,13 +104299,13 @@ baG
 sut
 aaa
 aaa
-aEj
+fJU
 pKd
 uSW
 hOz
-aEj
+fJU
 oRX
-aFi
+bqN
 uSW
 iSi
 bnh
@@ -104269,7 +104556,7 @@ baG
 sut
 aaa
 aaa
-aEj
+fJU
 eZA
 tDn
 dTR
@@ -104526,11 +104813,11 @@ baG
 rWE
 aht
 aht
-aEj
+fJU
 vzT
 gUb
-aFi
-aEj
+bqN
+fJU
 gSI
 uSW
 bfM
@@ -104783,12 +105070,12 @@ baG
 sut
 aaa
 aaa
-aEj
+fJU
 dsv
 dLY
 xyl
-aEj
-aKq
+fJU
+rjw
 uSW
 ybX
 iSi
@@ -105040,12 +105327,12 @@ baG
 sut
 aaa
 aaa
-aEj
-aEj
-aEj
-aEj
-aEj
-aEj
+fJU
+fJU
+fJU
+fJU
+fJU
+fJU
 rAE
 bfM
 iSi
@@ -105302,7 +105589,7 @@ aht
 cdm
 aaa
 aaa
-aEl
+xst
 uSW
 ybX
 iSi
@@ -105559,7 +105846,7 @@ aaa
 cdm
 aaa
 aaa
-aEl
+xst
 uSW
 fNv
 iSi
@@ -105816,7 +106103,7 @@ aaa
 cdm
 aaa
 aaa
-aEl
+xst
 uSW
 bfM
 iSi
@@ -106073,7 +106360,7 @@ aaa
 cdm
 aaa
 aaa
-aEl
+xst
 uSW
 ybX
 iSi
@@ -106328,9 +106615,9 @@ aht
 aht
 aht
 cdm
-aEj
-aEj
-aEj
+fJU
+fJU
+fJU
 rAE
 fNv
 iSi
@@ -106585,9 +106872,9 @@ aht
 aaa
 aaa
 cdm
-aEl
+xst
 bnl
-aFi
+bqN
 uSW
 kSG
 iSi
@@ -106842,7 +107129,7 @@ aht
 aaa
 aaa
 cdm
-aEl
+xst
 iCe
 rxa
 uSW
@@ -107099,16 +107386,16 @@ aht
 aaa
 aaa
 cdm
-aEl
+xst
 wOf
-aFi
+bqN
 uSW
 qHf
 pvc
 wQU
 xvx
-bjM
-bjM
+rDV
+rDV
 bqO
 btB
 btF
@@ -107356,13 +107643,13 @@ aht
 aht
 aht
 bbP
-aEj
-aEj
-aEj
+fJU
+fJU
+fJU
 xyh
-aEj
+fJU
 jYA
-aEj
+fJU
 cJo
 qJB
 ops
@@ -107619,7 +107906,7 @@ hMc
 vZV
 fEo
 qIH
-aEj
+fJU
 iSi
 iSi
 iSi


### PR DESCRIPTION
- splits north and south cargo maints into 2 separate areas (southern one is now science maints)
- Makes medbay central's maints a maintenance area rather than cryo
- Cuts off of Engineering maints by adding Medical maints and Morgue maints
- Cuts off of Atmos by adding HFR area

Other fixes:
- Adds missing APC to Engineering maints
- Fixes cables leading to Atmos
- Removes waste pipes leading to thermomachines, which I forgot to do when I updated their paths.