### PR TITLE
Pubby update

### DIFF
--- a/StationMaps/PubbyStation/PubbyStation.dmm
+++ b/StationMaps/PubbyStation/PubbyStation.dmm
@@ -47287,7 +47287,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "pTG" = (

--- a/StationMaps/PubbyStation/PubbyStation.dmm
+++ b/StationMaps/PubbyStation/PubbyStation.dmm
@@ -43,11 +43,24 @@
 	pixel_y = 4
 	},
 /obj/machinery/button/ticket_machine{
-	pixel_x = 28;
-	pixel_y = -12
+	pixel_x = 28
 	},
 /obj/item/paper_bin/carbon{
 	layer = 2.9
+	},
+/obj/machinery/button/door/directional/south{
+	id = "hop";
+	name = "Privacy Shutters Control";
+	req_access = list("hop");
+	pixel_x = -6;
+	pixel_y = -26
+	},
+/obj/machinery/button/door/directional/south{
+	id = "hopqueue";
+	name = "Queue Shutters Control";
+	req_access = list("hop");
+	pixel_x = -6;
+	pixel_y = -36
 	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
@@ -1939,14 +1952,6 @@
 	pixel_x = 6;
 	pixel_y = 27
 	},
-/obj/machinery/button/door{
-	id = "executionspaceblast";
-	name = "Vent to Space";
-	pixel_x = -6;
-	pixel_y = 32;
-	req_access_txt = "7";
-	silicon_access_disabled = 1
-	},
 /obj/machinery/button/ignition{
 	id = "secigniter";
 	pixel_x = 6;
@@ -1957,6 +1962,12 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/machinery/button/door/directional/north{
+	id = "executionspaceblast";
+	name = "Vent to Space";
+	req_access = list("armory");
+	pixel_x = -6
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
@@ -2022,20 +2033,8 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "ahz" = (
-/obj/machinery/button/door{
-	id = "executionfireblast";
-	name = "Transfer Area Lockdown";
-	pixel_x = 25;
-	pixel_y = -5;
-	req_access_txt = "2"
-	},
 /obj/machinery/light/small{
 	dir = 4
-	},
-/obj/machinery/light_switch{
-	dir = 9;
-	pixel_x = 24;
-	pixel_y = 4
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -2046,6 +2045,12 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/button/door/directional/east{
+	id = "executionfireblast";
+	name = "Transfer Area Lockdown";
+	req_access = list("armory");
+	silicon_access_disabled = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "ahB" = (
@@ -2249,18 +2254,13 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "ain" = (
-/obj/machinery/light_switch{
-	dir = 9;
-	pixel_x = -22
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/security/lockers)
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "aio" = (
 /obj/structure/closet/l3closet/security,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/lockers)
 "aip" = (
@@ -2514,6 +2514,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "ajc" = (
@@ -2951,11 +2952,10 @@
 /area/station/command/heads_quarters/hos)
 "ake" = (
 /obj/structure/closet/secure_closet/hos,
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/east{
 	id = "hos_spess_shutters";
 	name = "Space shutters";
-	pixel_x = 24;
-	req_access_txt = "1"
+	req_access = list("hos")
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
@@ -3072,15 +3072,15 @@
 /area/station/maintenance/department/security/brig)
 "akt" = (
 /obj/structure/bed,
-/obj/machinery/button/door{
-	id = "mainthideout";
-	name = "Door Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 25;
-	specialfunctions = 4
-	},
 /obj/item/bedsheet/dorms,
 /obj/item/radio/intercom/directional/south,
+/obj/machinery/button/door/directional/east{
+	id = "mainthideout";
+	name = "Door Bolt Control";
+	req_access = list("command");
+	specialfunctions = 4;
+	normaldoorcontrol = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
 "akv" = (
@@ -3985,16 +3985,13 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
 "anb" = (
-/obj/machinery/light_switch{
-	dir = 9;
-	pixel_x = -22
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron,
 /area/station/security/office)
 "anc" = (
@@ -4226,13 +4223,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "anR" = (
-/obj/machinery/light_switch{
-	pixel_y = -24
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "anS" = (
@@ -4515,19 +4510,6 @@
 /area/station/security/warden)
 "aoS" = (
 /obj/structure/table/reinforced,
-/obj/machinery/button/door{
-	id = "Secure Gate";
-	name = "Entrance Lockdown";
-	pixel_x = 5;
-	pixel_y = -2
-	},
-/obj/machinery/button/door{
-	id = "Prison Gate";
-	name = "Permabrig Lockdown";
-	pixel_x = 5;
-	pixel_y = 8;
-	req_access = list("armory")
-	},
 /obj/machinery/computer/security/telescreen/prison{
 	dir = 4;
 	pixel_x = -7
@@ -4537,6 +4519,18 @@
 "aoT" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/start/warden,
+/obj/machinery/button/door/directional/west{
+	id = "Prison Gate";
+	name = "Permabrig Lockdown";
+	req_access = list("armory");
+	pixel_y = 6
+	},
+/obj/machinery/button/door/directional/west{
+	id = "Secure Gate";
+	name = "Entrance Lockdown";
+	req_access = list("armory");
+	pixel_y = -6
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
 "aoU" = (
@@ -4571,9 +4565,7 @@
 /area/station/security/warden)
 "aoY" = (
 /obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/light_switch{
-	pixel_y = -22
-	},
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
 "apa" = (
@@ -5088,9 +5080,6 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "aqM" = (
-/obj/machinery/light_switch{
-	pixel_y = 28
-	},
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -5126,13 +5115,10 @@
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
 "aqS" = (
-/obj/machinery/door/window{
-	name = "Gateway Chamber";
-	req_access_txt = "62"
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/machinery/door/window/left/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
 "aqT" = (
@@ -5188,12 +5174,6 @@
 "arj" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Labor Camp Shuttle Airlock"
-	},
-/obj/machinery/button/door{
-	id = "prison release";
-	name = "Labor Camp Shuttle Lockdown";
-	pixel_y = -25;
-	req_access_txt = "2"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -5642,6 +5622,11 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/button/door/directional/west{
+	id = "prison release";
+	name = "Labor Camp Shuttle Lockdown";
+	req_access = list("brig")
+	},
 /turf/open/floor/iron,
 /area/station/security/brig)
 "asx" = (
@@ -5748,18 +5733,16 @@
 	pixel_x = -24;
 	pixel_y = 10
 	},
-/obj/machinery/button/door{
-	id = "bridgespace";
-	name = "Bridge Space Lockdown";
-	pixel_x = -24;
-	pixel_y = -2;
-	req_access_txt = "19"
-	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 8
+	},
+/obj/machinery/button/door/directional/west{
+	id = "bridgespace";
+	name = "Bridge Space Lockdown";
+	req_access = list("command")
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
@@ -5773,21 +5756,20 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/machinery/button/door{
-	id = "bridgespace";
-	name = "Bridge Space Lockdown";
-	pixel_x = 24;
-	pixel_y = -2;
-	req_access_txt = "19"
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/machinery/button/door/directional/east{
+	id = "bridgespace";
+	name = "Bridge Space Lockdown";
+	req_access = list("command")
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "asV" = (
 /obj/structure/closet/crate/goldcrate,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "asX" = (
@@ -5810,15 +5792,13 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "ata" = (
-/obj/machinery/light_switch{
-	pixel_x = -20
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "atb" = (
@@ -6229,17 +6209,15 @@
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "aug" = (
-/obj/machinery/button/door{
-	id = "stationawaygate";
-	name = "Gateway Access Shutter Control";
-	pixel_x = -1;
-	pixel_y = -24;
-	req_access_txt = "62"
-	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
+	},
+/obj/machinery/button/door/directional/south{
+	name = "Gateway Access Shutter Control";
+	id = "stationawaygate";
+	req_access = list("gateway")
 	},
 /turf/open/floor/iron,
 /area/station/command/gateway)
@@ -6380,28 +6358,25 @@
 /area/station/security/brig)
 "auE" = (
 /obj/machinery/computer/secure_data,
-/obj/machinery/button/door{
-	desc = "A remote control switch for the medbay foyer.";
-	id = "innerbrig";
-	name = "Brig Interior Doors Control";
-	normaldoorcontrol = 1;
-	pixel_x = -6;
-	pixel_y = 36;
-	req_access = list("brig_entrance")
-	},
-/obj/machinery/button/door{
-	desc = "A remote control switch for the medbay foyer.";
-	id = "outerbrig";
-	name = "Brig Exterior Doors Control";
-	normaldoorcontrol = 1;
-	pixel_x = -6;
-	pixel_y = 24;
-	req_access = list("brig_entrance")
-	},
 /obj/machinery/button/flasher{
 	id = "brigentry";
 	pixel_x = 6;
 	pixel_y = 24
+	},
+/obj/machinery/button/door/directional/north{
+	id = "outerbrig";
+	name = "Brig Exterior Doors Control";
+	req_access = list("brig_entrance");
+	pixel_x = -6;
+	normaldoorcontrol = 1
+	},
+/obj/machinery/button/door/directional/north{
+	id = "innerbrig";
+	name = "Brig Interior Doors Control";
+	req_access = list("brig_entrance");
+	pixel_x = -6;
+	normaldoorcontrol = 1;
+	pixel_y = 36
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
@@ -6571,12 +6546,11 @@
 /area/station/commons/dorms)
 "ave" = (
 /obj/structure/bed,
-/obj/machinery/button/door{
-	id = "Dorm3Shutters";
-	name = "Privacy Shutters Control";
-	pixel_y = 26
-	},
 /obj/item/bedsheet/dorms,
+/obj/machinery/button/door/directional/north{
+	id = "Dorm3Shutters";
+	name = "Privacy Shutters Control"
+	},
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "avf" = (
@@ -6590,14 +6564,13 @@
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "avg" = (
-/obj/machinery/button/door{
-	id = "Dorm3";
-	name = "Dorm Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 25;
-	specialfunctions = 4
-	},
 /obj/structure/closet/secure_closet/personal/cabinet,
+/obj/machinery/button/door/directional/east{
+	name = "Dorm Bolt Control";
+	id = "Dorm3";
+	specialfunctions = 4;
+	normaldoorcontrol = 1
+	},
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "avh" = (
@@ -6882,14 +6855,16 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "avP" = (
-/obj/machinery/firealarm/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron,
+/area/station/cargo/office)
 "avQ" = (
 /obj/machinery/door/airlock/command{
 	name = "MiniSat Access"
@@ -7519,11 +7494,11 @@
 "axT" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
-/obj/machinery/requests_console/directional/north{
-	announcementConsole = 1;
-	department = "Captain's Desk";
-	departmentType = 5;
-	name = "Captain's Requests Console"
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain)
@@ -7534,6 +7509,12 @@
 /area/station/command/heads_quarters/captain)
 "axV" = (
 /obj/machinery/computer/communications,
+/obj/machinery/requests_console/directional/north{
+	announcementConsole = 1;
+	department = "Captain's Desk";
+	departmentType = 5;
+	name = "Captain's Requests Console"
+	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain)
 "axW" = (
@@ -7592,12 +7573,11 @@
 /area/station/commons/dorms)
 "ayj" = (
 /obj/structure/bed,
-/obj/machinery/button/door{
-	id = "Dorm2Shutters";
-	name = "Privacy Shutters Control";
-	pixel_y = 26
-	},
 /obj/item/bedsheet/dorms,
+/obj/machinery/button/door/directional/north{
+	id = "Dorm2Shutters";
+	name = "Privacy Shutters Control"
+	},
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "ayk" = (
@@ -7611,14 +7591,13 @@
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "ayl" = (
-/obj/machinery/button/door{
-	id = "Dorm2";
-	name = "Dorm Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 25;
-	specialfunctions = 4
-	},
 /obj/structure/closet/secure_closet/personal/cabinet,
+/obj/machinery/button/door/directional/east{
+	name = "Dorm Bolt Control";
+	id = "Dorm2";
+	specialfunctions = 4;
+	normaldoorcontrol = 1
+	},
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "aym" = (
@@ -7670,17 +7649,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
 "ayE" = (
-/obj/machinery/button/door{
-	id = "prison release";
-	name = "Labor Camp Shuttle Lockdown";
-	pixel_x = -25;
-	req_access_txt = "2"
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/machinery/button/door/directional/west{
+	id = "prison release";
+	name = "Labor Camp Shuttle Lockdown";
+	req_access = list("brig")
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
@@ -7776,6 +7754,7 @@
 "ayS" = (
 /obj/structure/bed,
 /obj/item/bedsheet/captain,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/captain)
 "ayV" = (
@@ -7802,10 +7781,9 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
 "ayZ" = (
-/obj/machinery/door/window{
-	dir = 8;
+/obj/machinery/door/window/left/directional/west{
 	name = "Captain's Desk";
-	req_access_txt = "20"
+	req_access = list("captain")
 	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain)
@@ -7826,10 +7804,6 @@
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain)
 "azd" = (
-/obj/machinery/light_switch{
-	dir = 9;
-	pixel_x = -22
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -8142,10 +8116,6 @@
 "aAp" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
-/obj/machinery/light_switch{
-	dir = 9;
-	pixel_x = -22
-	},
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/captain)
 "aAq" = (
@@ -8225,13 +8195,6 @@
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain)
 "aAz" = (
-/obj/machinery/button/door{
-	id = "bridge blast";
-	name = "Bridge Entrance Lockdown";
-	pixel_x = -24;
-	pixel_y = -2;
-	req_access_txt = "19"
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -8244,6 +8207,11 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/button/door/directional/west{
+	id = "bridge blast";
+	name = "Bridge Entrance Lockdown";
+	req_access = list("command")
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
@@ -8291,13 +8259,6 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "aAE" = (
-/obj/machinery/button/door{
-	id = "bridge blast";
-	name = "Bridge Entrance Lockdown";
-	pixel_x = 24;
-	pixel_y = -2;
-	req_access_txt = "19"
-	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -8308,6 +8269,11 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/button/door/directional/east{
+	id = "bridge blast";
+	name = "Bridge Entrance Lockdown";
+	req_access = list("command")
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
@@ -8615,6 +8581,7 @@
 /obj/machinery/vending/cart{
 	req_access_txt = "57"
 	},
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "aBH" = (
@@ -8637,12 +8604,11 @@
 /area/station/commons/dorms)
 "aBM" = (
 /obj/structure/bed,
-/obj/machinery/button/door{
-	id = "Dorm1Shutters";
-	name = "Privacy Shutters Control";
-	pixel_y = 26
-	},
 /obj/item/bedsheet/dorms,
+/obj/machinery/button/door/directional/north{
+	id = "Dorm1Shutters";
+	name = "Privacy Shutters Control"
+	},
 /turf/open/floor/iron/grimy,
 /area/station/commons/dorms)
 "aBN" = (
@@ -8656,14 +8622,13 @@
 /turf/open/floor/iron/grimy,
 /area/station/commons/dorms)
 "aBO" = (
-/obj/machinery/button/door{
-	id = "Dorm1";
-	name = "Dorm Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 25;
-	specialfunctions = 4
-	},
 /obj/structure/closet/secure_closet/personal/cabinet,
+/obj/machinery/button/door/directional/east{
+	name = "Dorm Bolt Control";
+	id = "Dorm1";
+	specialfunctions = 4;
+	normaldoorcontrol = 1
+	},
 /turf/open/floor/iron/grimy,
 /area/station/commons/dorms)
 "aBR" = (
@@ -8748,6 +8713,7 @@
 	dir = 1
 	},
 /obj/machinery/holopad,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
 "aCl" = (
@@ -8761,18 +8727,12 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/button/door{
+/obj/machinery/vending/wardrobe/det_wardrobe,
+/obj/machinery/button/door/directional/north{
 	id = "datboidetective";
 	name = "Privacy Shutters";
-	pixel_x = 2;
-	pixel_y = 26;
-	req_access_txt = "4"
+	req_access = list("detective")
 	},
-/obj/machinery/light_switch{
-	pixel_x = -8;
-	pixel_y = 27
-	},
-/obj/machinery/vending/wardrobe/det_wardrobe,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
 "aCo" = (
@@ -8859,22 +8819,18 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Captain's Office"
 	},
-/obj/machinery/light_switch{
-	pixel_x = 25
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain)
 "aCG" = (
 /obj/structure/table,
-/obj/item/ai_module/supplied/quarantine,
 /obj/machinery/camera/motion/directional/west{
 	c_tag = "AI Upload Port";
 	network = list("aiupload")
 	},
-/obj/item/ai_module/reset,
 /obj/machinery/flasher{
 	id = "brigentry";
 	pixel_x = -28
@@ -8888,6 +8844,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/item/ai_module/reset,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "aCH" = (
@@ -8907,7 +8864,6 @@
 /area/station/ai_monitored/turret_protected/ai_upload)
 "aCM" = (
 /obj/structure/table,
-/obj/item/ai_module/supplied/freeform,
 /obj/machinery/camera/motion/directional/east{
 	c_tag = "AI Upload Starboard";
 	network = list("aiupload")
@@ -8923,6 +8879,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/effect/spawner/round_default_module,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "aCP" = (
@@ -9234,9 +9191,10 @@
 	c_tag = "AI Upload Center";
 	network = list("aiupload")
 	},
-/obj/machinery/holopad/secure,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
+/obj/structure/table/wood/fancy/green,
+/obj/effect/spawner/random/aimodule/harmless,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "aDN" = (
@@ -9451,10 +9409,7 @@
 	pixel_x = -2
 	},
 /obj/machinery/light/directional/west,
-/obj/machinery/light_switch{
-	dir = 9;
-	pixel_x = -22
-	},
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron{
 	heat_capacity = 1e+006
 	},
@@ -9513,22 +9468,8 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "aED" = (
-/obj/structure/table,
-/obj/item/ai_module/core/full/asimov,
-/obj/effect/spawner/random/aimodule/harmless,
-/obj/item/ai_module/core/freeformcore,
-/obj/machinery/door/window{
-	base_state = "right";
-	dir = 4;
-	icon_state = "right";
-	name = "Core Modules";
-	req_access_txt = "20"
-	},
-/obj/effect/spawner/random/aimodule/neutral,
-/obj/item/ai_module/core/full/custom,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/flasher{
 	id = "brigentry";
@@ -9541,6 +9482,12 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/door/window/right/directional/east{
+	name = "Core Modules";
+	req_access = list("ai_upload")
+	},
+/obj/structure/table/wood/fancy/blue,
+/obj/effect/spawner/random/aimodule/neutral,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "aEE" = (
@@ -9571,20 +9518,8 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "aEI" = (
-/obj/structure/table,
-/obj/item/ai_module/supplied/oxygen,
-/obj/item/ai_module/zeroth/onehuman,
-/obj/machinery/door/window{
-	dir = 8;
-	name = "High-Risk Modules";
-	req_access_txt = "20"
-	},
-/obj/item/ai_module/reset/purge,
-/obj/effect/spawner/random/aimodule/harmful,
-/obj/item/ai_module/supplied/protect_station,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/machinery/flasher{
 	id = "brigentry";
@@ -9597,6 +9532,12 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/door/window/left/directional/west{
+	name = "High-Risk Modules";
+	req_access = list("ai_upload")
+	},
+/obj/structure/table/wood/fancy/red,
+/obj/effect/spawner/random/aimodule/harmful,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "aEJ" = (
@@ -9661,24 +9602,6 @@
 	pixel_x = 38;
 	pixel_y = -25
 	},
-/obj/machinery/button/door{
-	id = "hop";
-	name = "Privacy Shutters Control";
-	pixel_x = 25;
-	pixel_y = -26;
-	req_access_txt = "28"
-	},
-/obj/machinery/button/door{
-	id = "hopqueue";
-	name = "Queue Shutters Control";
-	pixel_x = 25;
-	pixel_y = -36;
-	req_access_txt = "28"
-	},
-/obj/machinery/light_switch{
-	pixel_x = 38;
-	pixel_y = -35
-	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
 "aES" = (
@@ -9730,9 +9653,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aFb" = (
-/obj/machinery/light_switch{
-	pixel_y = 25
-	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "aFc" = (
@@ -10824,9 +10745,7 @@
 	},
 /area/station/hallway/primary/central)
 "aKh" = (
-/obj/machinery/light_switch{
-	pixel_x = -25
-	},
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "aKi" = (
@@ -11164,6 +11083,7 @@
 	pixel_y = 2
 	},
 /obj/effect/landmark/xeno_spawn,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/auxiliary)
 "aLF" = (
@@ -11179,20 +11099,14 @@
 /obj/structure/urinal{
 	pixel_y = 32
 	},
-/obj/machinery/button/door{
-	id = "Potty1";
-	name = "Bathroom Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 25;
-	pixel_y = 4;
-	specialfunctions = 4
-	},
-/obj/machinery/light_switch{
-	pixel_x = 36;
-	pixel_y = 6
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
+	},
+/obj/machinery/button/door/directional/east{
+	name = "Bathroom Bolt Control";
+	id = "Potty1";
+	specialfunctions = 4;
+	normaldoorcontrol = 1
 	},
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/auxiliary)
@@ -11266,17 +11180,13 @@
 /area/station/command/teleporter)
 "aMa" = (
 /obj/structure/closet/crate,
-/obj/machinery/button/door{
-	id = "teleshutter";
-	name = "Teleporter Shutters Control";
-	pixel_x = 25;
-	pixel_y = -5;
-	req_access_txt = "17"
-	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/machinery/button/door/directional/east{
+	req_access = list("teleporter")
+	},
 /turf/open/floor/iron,
 /area/station/command/teleporter)
 "aMd" = (
@@ -11378,9 +11288,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard)
 "aMt" = (
-/obj/effect/spawner/random/structure/crate,
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "aMw" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -11430,10 +11345,6 @@
 /obj/item/storage/toolbox/artistic{
 	pixel_x = -3
 	},
-/obj/machinery/light_switch{
-	dir = 9;
-	pixel_x = -22
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -11445,6 +11356,7 @@
 	dir = 8
 	},
 /obj/item/rcl/pre_loaded,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
 "aMW" = (
@@ -11486,11 +11398,8 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/machinery/light_switch{
-	dir = 9;
-	pixel_x = -22
-	},
 /obj/machinery/airalarm/directional/south,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
 "aMZ" = (
@@ -11912,7 +11821,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/item/radio/intercom/directional/north,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "aOQ" = (
@@ -11939,19 +11848,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "aOU" = (
-/obj/machinery/light_switch{
-	pixel_x = 25;
-	pixel_y = -3
-	},
 /obj/structure/cable,
-/obj/item/radio/intercom/directional/east{
-	pixel_x = 32;
-	pixel_y = 3
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
 "aOW" = (
@@ -12260,15 +12162,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "aQo" = (
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/west{
 	id = "qm_warehouse";
 	name = "Warehouse Door Control";
-	pixel_x = -24;
-	req_access_txt = "31"
-	},
-/obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = 9
+	req_access = list("cargo")
 	},
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
@@ -12589,8 +12486,7 @@
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/structure/flora/bush/pale/style_random,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -12604,8 +12500,7 @@
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/structure/flora/bush/pale/style_random,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
@@ -12616,8 +12511,7 @@
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/structure/flora/bush/pale/style_random,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -12970,10 +12864,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 10
 	},
-/obj/machinery/light_switch{
-	pixel_x = 22
-	},
-/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "aTc" = (
@@ -12992,10 +12883,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "aTk" = (
-/obj/machinery/light_switch{
-	pixel_x = 8;
-	pixel_y = -34
-	},
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/wood{
 	icon_state = "wood-broken6"
@@ -13003,6 +12890,7 @@
 /area/station/cargo/qm)
 "aTm" = (
 /obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/wood,
 /area/station/cargo/qm)
 "aTo" = (
@@ -13429,12 +13317,10 @@
 	pixel_x = 2;
 	pixel_y = 4
 	},
-/obj/machinery/light_switch{
-	pixel_y = 22
-	},
 /obj/item/holosign_creator/robot_seat/bar{
 	pixel_y = -10
 	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "aVi" = (
@@ -13479,11 +13365,10 @@
 "aVj" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/east{
 	id = "barshutters";
 	name = "Bar Lockdown";
-	pixel_x = 28;
-	req_access_txt = "25"
+	req_access = list("bar")
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
@@ -13561,10 +13446,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "aVy" = (
-/obj/machinery/light_switch{
-	pixel_x = -4;
-	pixel_y = -25
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -13572,6 +13453,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "aVz" = (
@@ -13741,7 +13623,6 @@
 "aWm" = (
 /obj/structure/disposalpipe/segment,
 /obj/item/storage/box/drinkingglasses,
-/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "aWo" = (
@@ -13792,10 +13673,6 @@
 /area/station/service/theater)
 "aWr" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/light_switch{
-	pixel_x = 24;
-	pixel_y = 24
-	},
 /obj/structure/mirror{
 	pixel_x = 28;
 	pixel_y = -2
@@ -13836,8 +13713,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
@@ -13845,16 +13721,14 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "aWu" = (
 /obj/machinery/computer/cargo,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -13876,10 +13750,6 @@
 	pixel_x = 8;
 	pixel_y = 22;
 	req_access_txt = "39"
-	},
-/obj/machinery/light_switch{
-	pixel_x = -4;
-	pixel_y = 24
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -13937,9 +13807,6 @@
 /obj/structure/bed,
 /obj/effect/landmark/start/janitor,
 /obj/item/bedsheet/purple,
-/obj/machinery/light_switch{
-	pixel_x = 24
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/janitor)
@@ -13986,10 +13853,6 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "aWT" = (
-/obj/machinery/light_switch{
-	pixel_x = -6;
-	pixel_y = 38
-	},
 /obj/structure/sink/kitchen{
 	name = "utility sink";
 	pixel_y = 28
@@ -14436,6 +14299,7 @@
 	dir = 1
 	},
 /obj/machinery/disposal/bin,
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/service/theater)
 "aYl" = (
@@ -14660,12 +14524,6 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-05"
 	},
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "Bar Lockdown";
-	pixel_y = 26;
-	req_access_txt = "28"
-	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar/atrium)
 "aYZ" = (
@@ -14845,6 +14703,8 @@
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "aZP" = (
@@ -15048,13 +14908,6 @@
 /obj/machinery/computer/secure_data{
 	dir = 4
 	},
-/obj/machinery/button/door{
-	id = "papersplease";
-	name = "Shutters Control Button";
-	pixel_x = -26;
-	pixel_y = 6;
-	req_access_txt = "1"
-	},
 /obj/machinery/button/flasher{
 	id = "brigentry";
 	pixel_x = -26;
@@ -15066,6 +14919,12 @@
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/machinery/button/door/directional/west{
+	id = "papersplease";
+	name = "Shutters Control Button";
+	req_access = list("brig");
+	pixel_y = 6
 	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/customs)
@@ -15128,11 +14987,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "baW" = (
-/obj/machinery/button/door{
-	id = "jangarage";
+/obj/machinery/button/door/directional/east{
 	name = "Custodial Closet Shutters Control";
-	pixel_x = 25;
-	req_access_txt = "26"
+	req_access = list("janitor");
+	id = "jangarage"
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
@@ -15140,21 +14998,19 @@
 /obj/vehicle/ridden/janicart,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/directional/west,
-/obj/machinery/button/door{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door/directional/west{
 	id = "jangarage";
 	name = "Custodial Closet Shutters Control";
-	pixel_x = -25;
-	req_access_txt = "26"
+	req_access = list("janitor")
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "baZ" = (
 /obj/structure/closet/l3closet/janitor,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/directional/east,
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "bba" = (
@@ -15673,10 +15529,6 @@
 	dir = 8;
 	pixel_x = 11
 	},
-/obj/machinery/light_switch{
-	dir = 9;
-	pixel_x = 22
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
@@ -15975,11 +15827,10 @@
 /obj/machinery/light{
 	light_color = "#c9d3e8"
 	},
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/south{
 	id = "barshutters";
 	name = "Bar Lockdown";
-	pixel_y = -28;
-	req_access_txt = "25"
+	req_access = list("bar")
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar/atrium)
@@ -15993,11 +15844,10 @@
 /obj/machinery/light{
 	light_color = "#c9d3e8"
 	},
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/south{
 	id = "barshutters";
 	name = "Bar Lockdown";
-	pixel_y = -28;
-	req_access_txt = "25"
+	req_access = list("bar")
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar/atrium)
@@ -16111,6 +15961,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "bfk" = (
@@ -16139,12 +15990,10 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
 	},
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/west{
 	id = "kitchenwindowshutters";
 	name = "Kitchen Window Shutters Control";
-	pixel_x = -26;
-	pixel_y = 5;
-	req_access_txt = "28"
+	req_access = list("kitchen")
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
@@ -16569,17 +16418,14 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Vacant Commissary"
 	},
-/obj/machinery/button/door{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/button/door/directional/north{
 	id = "commissarydoor";
 	name = "Commissary Door Lock";
 	normaldoorcontrol = 1;
-	pixel_x = -5;
-	pixel_y = 27;
 	specialfunctions = 4
-	},
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
@@ -16592,14 +16438,12 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
-/obj/machinery/light_switch{
-	pixel_x = 25
-	},
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/brown,
 /obj/machinery/requests_console/directional/north{
 	name = "Commissary Requests Console"
 	},
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "bgZ" = (
@@ -16737,9 +16581,16 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bht" = (
-/obj/machinery/light/directional/east,
-/turf/closed/wall,
-/area/station/cargo/storage)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "bhu" = (
 /obj/machinery/light,
 /obj/structure/closet/secure_closet/miner,
@@ -16823,28 +16674,26 @@
 /area/station/hallway/primary/central)
 "bhQ" = (
 /obj/machinery/light/directional/east,
-/obj/machinery/button/door{
-	id = "Skynet_launch";
-	name = "Mech Bay Door Control";
-	pixel_x = 25;
-	req_access_txt = "29"
-	},
 /obj/effect/turf_decal/tile/purple,
+/obj/machinery/button/door/directional/east{
+	name = "Mech Bay Door Control";
+	req_access = list("robotics");
+	id = "Skynet_launch"
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bhR" = (
 /obj/machinery/light/directional/west,
-/obj/machinery/button/door{
-	id = "Skynet_launch";
-	name = "Mech Bay Door Control";
-	pixel_x = -25;
-	req_access_txt = "29"
-	},
 /obj/machinery/camera/directional/west{
 	c_tag = "Robotics Mech Bay"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
+	},
+/obj/machinery/button/door/directional/west{
+	req_access = list("robotics");
+	name = "Mech Bay Door Control";
+	id = "Skynet_launch"
 	},
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
@@ -17814,6 +17663,9 @@
 	dir = 4
 	},
 /obj/structure/chair/stool/bar/directional/north,
+/obj/structure/sign/directions/engineering{
+	pixel_x = 32
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "blE" = (
@@ -18643,19 +18495,13 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/aft)
 "boX" = (
-/obj/machinery/button/door{
-	id = "robotics";
-	name = "Shutters Control Button";
-	pixel_x = -26;
-	pixel_y = 8;
-	req_access_txt = "29"
-	},
-/obj/machinery/light_switch{
-	pixel_x = -25;
-	pixel_y = -8
-	},
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 4
+	},
+/obj/machinery/button/door/directional/west{
+	req_access = list("robotics");
+	name = "Shutters Control Button";
+	id = "robotics"
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/robotics)
@@ -19402,9 +19248,6 @@
 /area/station/science/lab)
 "bru" = (
 /obj/machinery/holopad,
-/obj/machinery/light_switch{
-	pixel_x = 25
-	},
 /obj/item/reagent_containers/glass/bucket,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -19412,6 +19255,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "brw" = (
@@ -19435,8 +19279,7 @@
 	pixel_y = 12
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/item/razor{
 	pixel_y = 5
@@ -19473,8 +19316,7 @@
 /obj/item/clothing/gloves/color/latex,
 /obj/item/surgical_drapes,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/table,
 /obj/effect/turf_decal/stripes/line{
@@ -19493,15 +19335,13 @@
 /turf/open/floor/iron/dark,
 /area/station/science/server)
 "brG" = (
-/obj/machinery/light_switch{
-	pixel_x = -25
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/white,
 /area/station/science/explab)
 "brJ" = (
@@ -19656,6 +19496,7 @@
 	},
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/pushbroom,
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "bsr" = (
@@ -20049,9 +19890,6 @@
 /obj/structure/table,
 /obj/item/clothing/gloves/color/latex,
 /obj/item/clothing/mask/surgical,
-/obj/machinery/light_switch{
-	pixel_y = -24
-	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "btV" = (
@@ -22167,37 +22005,35 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/button/door{
-	desc = "A switch that controls privacy shutters.";
-	id = "rdprivacy";
-	name = "Privacy Shutters";
-	pixel_x = 40;
-	pixel_y = -5;
-	req_access_txt = "30"
-	},
 /obj/machinery/keycard_auth{
-	pixel_x = 28;
+	pixel_x = 24;
 	pixel_y = 6
-	},
-/obj/machinery/button/door{
-	id = "rndshutters";
-	name = "Research Lockdown";
-	pixel_x = 28;
-	pixel_y = -5;
-	req_access_txt = "47"
-	},
-/obj/machinery/button/door{
-	id = "research_shutters_2";
-	name = "RnD Shutters";
-	pixel_x = 40;
-	pixel_y = 5;
-	req_access_txt = "47"
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/button/door/directional/east{
+	id = "rndshutters";
+	name = "Research Lockdown";
+	req_access = list("research");
+	pixel_y = -5
+	},
+/obj/machinery/button/door/directional/east{
+	id = "research_shutters_2";
+	name = "Techfab Shutters";
+	req_access = list("research");
+	pixel_x = 38;
+	pixel_y = 5
+	},
+/obj/machinery/button/door/directional/east{
+	id = "rdprivacy";
+	name = "Privacy Shutters";
+	req_access = list("rd");
+	pixel_x = 38;
+	pixel_y = -5
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "bBw" = (
@@ -22387,9 +22223,6 @@
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/glasses/hud/health,
-/obj/machinery/light_switch{
-	pixel_y = -24
-	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -22406,6 +22239,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "bCc" = (
@@ -23048,10 +22882,6 @@
 /obj/machinery/computer/mecha{
 	dir = 4
 	},
-/obj/machinery/light_switch{
-	dir = 9;
-	pixel_x = -22
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -23060,6 +22890,7 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/south,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "bES" = (
@@ -23289,13 +23120,11 @@
 /area/station/maintenance/department/science)
 "bFC" = (
 /obj/item/wallframe/camera,
-/obj/machinery/button/door{
-	id = "PottySci";
+/obj/machinery/button/door/directional/east{
 	name = "Bathroom Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 25;
-	pixel_y = 4;
-	specialfunctions = 4
+	specialfunctions = 4;
+	id = "PottySci"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
@@ -23455,11 +23284,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
 "bGm" = (
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = 8
-	},
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
@@ -23468,6 +23292,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/white,
 /area/station/science/mixing)
 "bGn" = (
@@ -26080,13 +25905,11 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "bRm" = (
-/obj/machinery/light_switch{
-	pixel_x = 25
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "bRp" = (
@@ -27426,28 +27249,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bVD" = (
-/obj/machinery/button/door{
-	desc = "A remote control-switch for the engineering security doors.";
-	id = "Engineering";
-	name = "Engineering Lockdown";
-	pixel_x = -24;
-	pixel_y = -10;
-	req_access_txt = "10"
-	},
-/obj/machinery/button/door{
-	desc = "A remote control-switch for secure storage.";
-	id = "Secure Storage";
-	name = "Engineering Secure Storage";
-	pixel_x = -24;
-	req_access_txt = "11"
-	},
-/obj/machinery/button/door{
-	id = "atmos";
-	name = "Atmospherics Lockdown";
-	pixel_x = -24;
-	pixel_y = 10;
-	req_access_txt = "24"
-	},
 /obj/structure/table/reinforced,
 /obj/item/folder/yellow,
 /obj/item/paper/monitorkey,
@@ -27459,6 +27260,23 @@
 	dir = 8
 	},
 /mob/living/simple_animal/parrot/poly,
+/obj/machinery/button/door/directional/west{
+	id = "Secure Storage";
+	name = "Engineering Secure Storage";
+	req_access = list("engineering")
+	},
+/obj/machinery/button/door/directional/west{
+	id = "atmos";
+	name = "Atmospherics Lockdown";
+	req_access = list("atmospherics");
+	pixel_y = 10
+	},
+/obj/machinery/button/door/directional/west{
+	id = "Engineering";
+	name = "Engineering Lockdown";
+	req_access = list("engineering");
+	pixel_y = -10
+	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "bVG" = (
@@ -27663,9 +27481,6 @@
 "bWr" = (
 /obj/machinery/modular_computer/console/preset/engineering{
 	dir = 8
-	},
-/obj/machinery/light_switch{
-	pixel_x = 22
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -27961,21 +27776,17 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/machinery/light_switch{
-	pixel_x = 25
-	},
-/obj/machinery/button/door{
-	desc = "A remote control-switch for secure storage.";
-	id = "ce_privacy";
-	name = "Privacy Shutters";
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
+	},
+/obj/machinery/button/door/directional/east{
+	name = "Privacy Shutters";
+	req_access = list("ce");
+	id = "ce_privacy"
 	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
@@ -29190,12 +29001,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cdR" = (
-/obj/machinery/button/door{
-	id = "SupermatterExternal";
-	name = "Shutters Control";
-	pixel_x = 25;
-	req_access_txt = "11"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -29206,29 +29011,27 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/machinery/button/door/directional/east{
+	id = "SupermatterExternal";
+	name = "Shutters Control";
+	req_access = list("engineering")
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cdS" = (
-/obj/machinery/button/door{
-	id = "SupermatterExternal";
-	name = "Shutters Control";
-	pixel_x = -25;
-	req_access_txt = "11"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/light/directional/west,
 /obj/structure/cable,
+/obj/machinery/button/door/directional/west{
+	id = "SupermatterExternal";
+	name = "Shutters Control";
+	req_access = list("engineering")
+	},
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "cdW" = (
-/obj/machinery/button/door{
-	id = "SupermatterExternal";
-	name = "Shutters Control";
-	pixel_x = 25;
-	req_access_txt = "11"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -29238,15 +29041,14 @@
 	},
 /obj/structure/cable,
 /obj/machinery/light/directional/east,
+/obj/machinery/button/door/directional/east{
+	id = "SupermatterExternal";
+	name = "Shutters Control";
+	req_access = list("engineering")
+	},
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "cdX" = (
-/obj/machinery/button/door{
-	id = "SupermatterExternal";
-	name = "Shutters Control";
-	pixel_x = -25;
-	req_access_txt = "11"
-	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -29254,6 +29056,11 @@
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
+	},
+/obj/machinery/button/door/directional/west{
+	id = "SupermatterExternal";
+	name = "Shutters Control";
+	req_access = list("engineering")
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
@@ -29669,11 +29476,10 @@
 /obj/item/clothing/suit/chaplainsuit/holidaypriest,
 /obj/item/clothing/suit/chaplainsuit/nun,
 /obj/item/clothing/head/nun_hood,
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/west{
 	id = "Cell1";
 	name = "Cell Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = -25;
 	specialfunctions = 4
 	},
 /turf/open/floor/iron/grimy,
@@ -29948,11 +29754,10 @@
 /obj/item/clothing/suit/chaplainsuit/holidaypriest,
 /obj/item/clothing/suit/chaplainsuit/nun,
 /obj/item/clothing/head/nun_hood,
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/west{
 	id = "Cell2";
 	name = "Cell Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = -25;
 	specialfunctions = 4
 	},
 /turf/open/floor/iron/grimy,
@@ -31177,12 +30982,10 @@
 /area/station/maintenance/department/crew_quarters/bar)
 "coL" = (
 /obj/machinery/light/directional/north,
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/north{
 	id = "qm_warehouse";
 	name = "Warehouse Door Control";
-	pixel_x = 7;
-	pixel_y = 23;
-	req_access_txt = "31"
+	req_access = list("cargo")
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
@@ -31231,6 +31034,7 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Bar Drinks"
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "cpf" = (
@@ -31319,19 +31123,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/button/door{
-	id = "kitchenshutters";
-	name = "Kitchen Shutters Control";
-	pixel_x = 5;
-	pixel_y = -24;
-	req_access_txt = "28"
-	},
-/obj/machinery/light_switch{
-	pixel_x = -6;
-	pixel_y = -24
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
+	},
+/obj/machinery/button/door/directional/south{
+	id = "kitchenshutters";
+	name = "Kitchen Shutters Control";
+	req_access = list("kitchen")
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
@@ -31356,6 +31154,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "cpC" = (
@@ -32568,15 +32367,13 @@
 /area/station/security/prison)
 "cxg" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
 "cxh" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -32586,8 +32383,7 @@
 /area/space/nearstation)
 "cxk" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -33096,15 +32892,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/button/door{
-	id = "supplybridge";
-	name = "Space Bridge Control";
-	pixel_y = 27
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/button/door/directional/north{
+	id = "supplybridge";
+	name = "Space Bridge Control"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
@@ -33112,15 +32907,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/button/door{
-	id = "supplybridge";
-	name = "Space Bridge Control";
-	pixel_y = 27
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/button/door/directional/north{
+	id = "supplybridge";
+	name = "Space Bridge Control"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
@@ -35321,14 +35115,11 @@
 	network = list("ss13","medbay");
 	pixel_y = -22
 	},
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = -25
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "eFj" = (
@@ -35619,13 +35410,6 @@
 /turf/open/space,
 /area/space/nearstation)
 "eTw" = (
-/obj/machinery/button/door{
-	id = "Disposal Exit";
-	name = "Disposal Vent Control";
-	pixel_x = -25;
-	pixel_y = 6;
-	req_access_txt = "12"
-	},
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -35639,6 +35423,12 @@
 	pixel_y = -5
 	},
 /obj/structure/chair/stool/bar/directional/south,
+/obj/machinery/button/door/directional/west{
+	id = "Disposal Exit";
+	name = "Disposal Vent Control";
+	req_access = list("mail_sorting");
+	pixel_y = 6
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
 "eTI" = (
@@ -35890,15 +35680,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "fby" = (
-/obj/machinery/light_switch{
-	pixel_y = -22
-	},
 /obj/structure/sign/poster/official/no_erp{
 	pixel_x = 29
 	},
 /obj/structure/chair/office{
 	dir = 1
 	},
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/medical/abandoned)
 "fca" = (
@@ -37599,16 +37387,11 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/door/window{
-	base_state = "right";
-	dir = 4;
-	icon_state = "right";
-	layer = 3
-	},
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/left/directional/east,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
 "gDq" = (
@@ -37708,13 +37491,6 @@
 "gFo" = (
 /obj/structure/window/reinforced,
 /obj/structure/table/glass,
-/obj/machinery/button/door{
-	id = "research_shutters_2";
-	name = "Shutters Control Button";
-	pixel_x = -28;
-	pixel_y = -7;
-	req_access_txt = "47"
-	},
 /obj/item/stack/sheet/glass/fifty{
 	pixel_x = 3;
 	pixel_y = 3
@@ -37725,6 +37501,11 @@
 /obj/item/clothing/glasses/welding,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/stack/cable_coil,
+/obj/machinery/button/door/directional/west{
+	id = "research_shutters_2";
+	name = "Shutters Control Button";
+	req_access = list("research")
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
 "gFw" = (
@@ -37900,13 +37681,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/button/door{
+/obj/structure/cable,
+/obj/machinery/button/door/directional/north{
 	id = "assistantshutters";
 	name = "Tool Storage Shutters Control";
-	pixel_y = 24;
-	req_access_txt = "10"
+	req_access = list("engineering")
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "gOS" = (
@@ -38457,13 +38237,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel/monastery)
 "hqo" = (
-/obj/machinery/button/door{
+/obj/structure/cable,
+/obj/machinery/button/door/directional/north{
 	id = "assistantshutters";
 	name = "Tool Storage Shutters Control";
-	pixel_y = 24;
-	req_access_txt = "10"
+	req_access = list("engineering")
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "htK" = (
@@ -38846,12 +38625,6 @@
 /area/station/command/gateway)
 "hPN" = (
 /obj/structure/table/glass,
-/obj/machinery/button/door{
-	id = "xenobiomain";
-	name = "Containment Blast Doors";
-	pixel_x = 28;
-	req_access_txt = "55"
-	},
 /obj/item/storage/box/monkeycubes{
 	pixel_x = 3;
 	pixel_y = 4
@@ -38859,6 +38632,11 @@
 /obj/machinery/light/directional/east,
 /obj/item/reagent_containers/glass/beaker{
 	pixel_x = -6
+	},
+/obj/machinery/button/door/directional/east{
+	name = "Containment Blast Doors";
+	req_access = list("xenobiology");
+	id = "xenobiomain"
 	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
@@ -39311,23 +39089,22 @@
 /turf/open/floor/plating/airless,
 /area/station/engineering/supermatter/room)
 "inm" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/table/reinforced,
-/obj/item/computer_hardware/hard_drive/portable/atmos{
-	pixel_x = 5;
-	pixel_y = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/item/computer_hardware/hard_drive/portable/engineering,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron,
-/area/station/command/heads_quarters/ce)
+/area/station/science/robotics)
 "int" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall,
@@ -40683,20 +40460,18 @@
 	network = list("ss13","rd")
 	},
 /obj/machinery/light/directional/north,
-/obj/machinery/button/door{
-	id = "telelab";
-	name = "Test Chamber Blast Door";
-	pixel_x = 6;
-	pixel_y = 26
-	},
-/obj/machinery/button/door{
-	id = "testlab";
-	name = "Window Blast Doors";
-	pixel_x = -6;
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
+	},
+/obj/machinery/button/door/directional/north{
+	id = "testlab";
+	name = "Test Chamber Blast Door";
+	pixel_x = -6
+	},
+/obj/machinery/button/door/directional/north{
+	id = "telelab";
+	name = "Test Chamber Blast Door";
+	pixel_x = 6
 	},
 /turf/open/floor/iron/white,
 /area/station/science/explab)
@@ -40922,8 +40697,7 @@
 /area/station/maintenance/department/crew_quarters/dorms)
 "jVS" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/open/floor/iron/freezer,
 /area/station/medical/virology)
@@ -41130,19 +40904,17 @@
 /area/station/science/mixing/launch)
 "khJ" = (
 /obj/machinery/chem_master,
-/obj/machinery/button/door{
-	id = "chemistry_shutters";
-	name = "Shutters Control";
-	pixel_x = 26;
-	pixel_y = 4;
-	req_one_access_txt = "5;69"
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
+	},
+/obj/machinery/button/door/directional/east{
+	name = "Shutters Control";
+	req_access = list("pharmacy");
+	id = "chemistry_shutters"
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
@@ -42094,6 +41866,10 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"kXo" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/service/janitor)
 "kXZ" = (
 /obj/structure/easel,
 /turf/open/floor/plating,
@@ -42469,11 +42245,10 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/west{
 	id = "plumbing_shutters";
 	name = "Plumbing Shutter Control";
-	pixel_x = -25;
-	req_access_txt = "33"
+	req_access = list("plumbing")
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -42586,27 +42361,31 @@
 	dir = 8
 	},
 /obj/machinery/keycard_auth{
-	pixel_x = 26
-	},
-/obj/machinery/button/door{
-	id = "cmoprivacy";
-	name = "CMO Shutter Control";
 	pixel_x = 25;
-	pixel_y = 9;
-	req_access_txt = "40"
+	pixel_y = 10
+	},
+/obj/machinery/button/door/directional/east{
+	name = "CMO Shutter Control";
+	req_access = list("cmo");
+	id = "cmoprivacy"
 	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "lsI" = (
-/obj/structure/sign/directions/engineering{
-	pixel_x = 32
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/obj/structure/table/glass,
+/obj/item/computer_hardware/hard_drive/portable/medical,
+/obj/item/computer_hardware/hard_drive/portable/chemistry{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/cmo)
 "ltk" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "misclab";
@@ -44763,12 +44542,23 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "nyl" = (
-/obj/machinery/light_switch{
-	pixel_y = -24
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical/central)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/computer_hardware/hard_drive/portable/atmos{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/computer_hardware/hard_drive/portable/engineering,
+/turf/open/floor/iron,
+/area/station/command/heads_quarters/ce)
 "nyB" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -45575,6 +45365,12 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/obj/machinery/button/door{
+	id = "commissaryshutters";
+	name = "Commissary Shutters Control";
+	pixel_x = 28;
+	pixel_y = 5
+	},
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "omS" = (
@@ -45777,13 +45573,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "ous" = (
-/obj/machinery/button/door{
-	desc = "A remote control-switch for secure storage.";
-	id = "Secure Storage";
-	name = "Engineering Secure Storage";
-	pixel_y = -24;
-	req_access_txt = "11"
-	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -45791,6 +45580,11 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/loading_area{
 	dir = 8
+	},
+/obj/machinery/button/door/directional/south{
+	id = "Secure Storage";
+	name = "Engineering Secure Storage";
+	req_access = list("engineering")
 	},
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
@@ -46140,9 +45934,6 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/machinery/light_switch{
-	pixel_x = 22
-	},
 /obj/effect/turf_decal/tile/green,
 /obj/machinery/camera/directional/east{
 	c_tag = "Virology Lab";
@@ -46153,6 +45944,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "oGZ" = (
@@ -47298,10 +47090,10 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/west{
 	id = "surgerya";
 	name = "Privacy Shutters Control";
-	pixel_x = -26
+	req_access = list("surgery")
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
@@ -48717,14 +48509,13 @@
 /obj/item/pen{
 	pixel_y = 5
 	},
-/obj/machinery/button/door{
-	id = "commissaryshutters";
-	name = "Commissary Shutters Control";
-	pixel_x = 28;
-	pixel_y = 5
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
+	},
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/button/door/directional/east{
+	id = "commissaryshutters";
+	name = "Commissary Shutters Control"
 	},
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
@@ -49525,11 +49316,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "rAP" = (
-/obj/machinery/light_switch{
-	pixel_x = 25;
-	pixel_y = -9
-	},
 /obj/machinery/light/directional/east,
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "rBh" = (
@@ -49817,12 +49605,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "rLi" = (
-/obj/machinery/button/door{
-	id = "shootshut";
-	name = "shutters control";
-	pixel_x = 28
-	},
 /obj/item/ammo_casing/shotgun/improvised,
+/obj/machinery/button/door/directional/east{
+	id = "shootshut";
+	name = "shutters control"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
 "rLJ" = (
@@ -50278,6 +50065,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "sgc" = (
@@ -50364,11 +50152,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/button/door{
-	id = "Supermatter";
-	pixel_y = 24
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/button/door/directional/north{
+	id = "Supermatter"
+	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "smW" = (
@@ -51658,12 +51445,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "tnY" = (
-/obj/machinery/button/door{
-	id = "aux_base_shutters";
-	name = "Public Shutters Control";
-	pixel_x = -26;
-	req_one_access_txt = "32;47;48"
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -51671,6 +51452,11 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
+	},
+/obj/machinery/button/door/directional/west{
+	id = "aux_base_shutters";
+	name = "Public Shutters Control";
+	req_access = list("aux_base")
 	},
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
@@ -52696,18 +52482,17 @@
 /area/station/service/kitchen/coldroom)
 "ueP" = (
 /obj/structure/table/glass,
-/obj/machinery/button/door{
-	id = "xenobiomain";
-	name = "Containment Blast Doors";
-	pixel_x = 28;
-	req_access_txt = "55"
-	},
 /obj/item/storage/box/monkeycubes{
 	pixel_x = 3;
 	pixel_y = 4
 	},
 /obj/item/reagent_containers/glass/beaker{
 	pixel_x = -6
+	},
+/obj/machinery/button/door/directional/east{
+	name = "Containment Blast Doors";
+	req_access = list("xenobiology");
+	id = "xenobiomain"
 	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
@@ -53781,12 +53566,10 @@
 /obj/item/pen/fountain,
 /obj/item/stamp/law,
 /obj/machinery/newscaster/directional/east,
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/south{
 	id = "lawyer_shutters";
 	name = "Privacy Shutters";
-	pixel_x = 2;
-	pixel_y = -26;
-	req_access_txt = "38"
+	req_access = list("lawyer")
 	},
 /turf/open/floor/carpet,
 /area/station/service/lawoffice)
@@ -54040,8 +53823,7 @@
 /area/station/service/chapel)
 "vbv" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/iron/freezer,
@@ -54822,12 +54604,11 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/paramedic,
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/west{
 	id = "MedbayFoyer";
 	name = "Medbay Foyer Doors";
 	normaldoorcontrol = 1;
-	pixel_x = -23;
-	req_access_txt = "5"
+	req_access = list("medical")
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
@@ -55289,6 +55070,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/holopad/secure,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "weL" = (
@@ -55648,21 +55430,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"wvg" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/table/glass,
-/obj/item/computer_hardware/hard_drive/portable/medical,
-/obj/item/computer_hardware/hard_drive/portable/chemistry{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/cmo)
 "wvk" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Chapel Access"
@@ -56205,12 +55972,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "wQy" = (
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 25
-	},
 /obj/structure/chair/sofa/left,
 /obj/item/radio/intercom/directional/north,
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
 "wQE" = (
@@ -56897,10 +56661,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
 	},
-/obj/machinery/light_switch{
-	pixel_x = 7;
-	pixel_y = 32
-	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "xne" = (
@@ -57291,11 +57052,8 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = -25
-	},
 /obj/machinery/iv_drip,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "xBB" = (
@@ -81336,7 +81094,7 @@ bjK
 biN
 bie
 bie
-biN
+bjK
 bjK
 iOj
 efC
@@ -82051,7 +81809,7 @@ cnJ
 ais
 xxK
 ahM
-ain
+ahM
 xwX
 ajk
 adK
@@ -82882,7 +82640,7 @@ bik
 kxJ
 bla
 dZG
-nyl
+dZG
 kxJ
 bvc
 bqY
@@ -83126,7 +82884,7 @@ aWN
 aXO
 aYM
 vOW
-vOW
+kXo
 oAk
 aZP
 bed
@@ -85720,7 +85478,7 @@ cSJ
 lsr
 hHJ
 bDw
-wvg
+lsI
 rXs
 bEz
 pca
@@ -85923,7 +85681,7 @@ arB
 asM
 atN
 aaZ
-dDZ
+aMt
 awR
 axT
 ayZ
@@ -86253,7 +86011,7 @@ bfQ
 cCP
 bTp
 bPB
-inm
+nyl
 bVD
 bWn
 bXf
@@ -86437,7 +86195,7 @@ arD
 gif
 atN
 hmL
-avP
+dDZ
 awR
 axV
 azb
@@ -87725,7 +87483,7 @@ syK
 syK
 vLp
 aDO
-wyP
+bht
 aAB
 aAB
 aAB
@@ -93677,7 +93435,7 @@ bks
 blD
 nUL
 dbI
-lsI
+nUL
 bqf
 nUL
 bsV
@@ -95216,7 +94974,7 @@ bhR
 lZc
 bju
 bkt
-blG
+inm
 bmO
 bnQ
 boY
@@ -96721,7 +96479,7 @@ aws
 qXD
 qXD
 qXD
-qXD
+qkS
 gLn
 gLn
 cop
@@ -97255,7 +97013,7 @@ wDZ
 aTo
 wDZ
 aUu
-xIM
+avP
 pvZ
 aXw
 aYv
@@ -101369,7 +101127,7 @@ cDa
 aTy
 iYH
 aTy
-bht
+bbG
 xEt
 jSP
 aTy
@@ -101867,7 +101625,7 @@ aur
 aur
 aEj
 noT
-aMt
+ain
 aFi
 aFi
 lru

--- a/StationMaps/PubbyStation/PubbyStation.dmm
+++ b/StationMaps/PubbyStation/PubbyStation.dmm
@@ -513,7 +513,7 @@
 /area/station/cargo/warehouse/upper)
 "acq" = (
 /obj/machinery/turretid{
-	control_area = "/area/ai_monitored/turret_protected/ai";
+	control_area = "/area/station/ai_monitored/turret_protected/ai";
 	name = "AI Chamber turret control";
 	pixel_x = 5;
 	pixel_y = -24
@@ -7846,7 +7846,7 @@
 /area/station/command/bridge)
 "azk" = (
 /obj/machinery/turretid{
-	control_area = "/area/ai_monitored/turret_protected/ai_upload";
+	control_area = "/area/station/ai_monitored/turret_protected/ai_upload";
 	name = "AI Upload turret control";
 	pixel_y = -25
 	},
@@ -18757,9 +18757,7 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
 	dir = 1
 	},
-/obj/machinery/power/apc/auto_name/directional/west{
-	dir = 1
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/server)
@@ -23814,7 +23812,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
 	},
-/obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "bII" = (
@@ -24632,7 +24629,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
-/obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "bMj" = (
@@ -26212,8 +26208,8 @@
 /turf/open/floor/plating,
 /area/station/medical/psychology)
 "bSt" = (
-/obj/machinery/meter/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/meter,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bSu" = (
@@ -28471,19 +28467,16 @@
 "caB" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "caC" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "caE" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
-/obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "caF" = (
@@ -28491,7 +28484,6 @@
 	name = "Mixed Air Tank In"
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "caH" = (
@@ -28499,7 +28491,6 @@
 	name = "Mixed Air Tank Out"
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "caQ" = (
@@ -30762,7 +30753,7 @@
 /area/space/nearstation)
 "cnC" = (
 /obj/machinery/turretid{
-	control_area = "/area/ai_monitored/turret_protected/aisat_interior";
+	control_area = "/area/station/ai_monitored/turret_protected/aisat_interior";
 	name = "AI Satellite turret control";
 	pixel_x = -5;
 	pixel_y = -24
@@ -52731,9 +52722,9 @@
 /area/station/medical/cryo)
 "umO" = (
 /obj/machinery/door/morgue{
-	name = "Private Exhibit"
+	name = "Private Exhibit";
+	req_access = list("library")
 	},
-/obj/effect/mapping_helpers/airlock/access/any/service/library,
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
 "und" = (

--- a/StationMaps/PubbyStation/PubbyStation.dmm
+++ b/StationMaps/PubbyStation/PubbyStation.dmm
@@ -15612,16 +15612,10 @@
 /area/station/maintenance/department/cargo)
 "bcN" = (
 /obj/structure/table,
-/obj/item/computer_hardware/hard_drive/role/quartermaster{
-	pixel_x = -4;
-	pixel_y = 7
-	},
+/obj/item/computer_hardware/hard_drive/portable/quartermaster,
 /obj/item/clipboard,
-/obj/item/computer_hardware/hard_drive/role/quartermaster{
-	pixel_x = 6;
-	pixel_y = 5
-	},
-/obj/item/computer_hardware/hard_drive/role/quartermaster,
+/obj/item/computer_hardware/hard_drive/portable/quartermaster,
+/obj/item/computer_hardware/hard_drive/portable/quartermaster,
 /obj/item/coin/silver,
 /obj/item/stamp/qm,
 /obj/machinery/requests_console/directional/west{
@@ -23044,33 +23038,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
-"bEF" = (
-/obj/item/computer_hardware/hard_drive/role/medical{
-	pixel_x = -2;
-	pixel_y = 6
-	},
-/obj/item/computer_hardware/hard_drive/role/medical{
-	pixel_x = 6;
-	pixel_y = 3
-	},
-/obj/item/computer_hardware/hard_drive/role/medical,
-/obj/item/computer_hardware/hard_drive/role/chemistry{
-	pixel_y = 2
-	},
-/obj/structure/table,
-/obj/machinery/light,
-/obj/item/wrench/medical,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/cmo)
 "bEI" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -23148,9 +23115,9 @@
 	pixel_x = -8;
 	pixel_y = 14
 	},
-/obj/item/computer_hardware/hard_drive/role/signal/ordnance,
-/obj/item/computer_hardware/hard_drive/role/signal/ordnance,
-/obj/item/computer_hardware/hard_drive/role/signal/ordnance,
+/obj/item/computer_hardware/hard_drive/portable/ordnance,
+/obj/item/computer_hardware/hard_drive/portable/ordnance,
+/obj/item/computer_hardware/hard_drive/portable/ordnance,
 /obj/item/paper_bin{
 	pixel_x = 7;
 	pixel_y = 3
@@ -27164,31 +27131,6 @@
 /area/station/maintenance/department/engine)
 "bUH" = (
 /turf/closed/wall/r_wall,
-/area/station/command/heads_quarters/ce)
-"bUI" = (
-/obj/item/computer_hardware/hard_drive/role/engineering{
-	pixel_x = 4;
-	pixel_y = 5
-	},
-/obj/item/computer_hardware/hard_drive/role/engineering{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/computer_hardware/hard_drive/role/engineering{
-	pixel_x = 3
-	},
-/obj/structure/table/reinforced,
-/obj/item/computer_hardware/hard_drive/role/atmos,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "bUJ" = (
 /obj/structure/filingcabinet/chestdrawer,
@@ -44234,7 +44176,6 @@
 /area/station/cargo/storage)
 "mXq" = (
 /obj/item/taperecorder,
-/obj/item/computer_hardware/hard_drive/role/lawyer,
 /obj/structure/table/wood,
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/wood,

--- a/StationMaps/PubbyStation/PubbyStation.dmm
+++ b/StationMaps/PubbyStation/PubbyStation.dmm
@@ -3208,7 +3208,7 @@
 /obj/machinery/door/window/left/directional/west{
 	dir = 2;
 	name = "Cargo Desk";
-	req_access_txt = "50"
+	req_access = list("mail_sorting")
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -3257,7 +3257,7 @@
 	},
 /obj/machinery/door/window/right/directional/south{
 	name = "Cargo Desk";
-	req_access_txt = "50"
+	req_access = list("mail_sorting")
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -3669,7 +3669,7 @@
 	base_state = "right";
 	icon_state = "right";
 	name = "Armory";
-	req_access_txt = "3"
+	req_access = list("armory")
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -3887,7 +3887,7 @@
 	dir = 1;
 	icon_state = "left";
 	name = "Security Delivery";
-	req_access_txt = "1"
+	req_access = list("armory")
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
@@ -4733,6 +4733,7 @@
 /obj/machinery/camera/directional/south{
 	c_tag = "Bridge Starboard Exterior"
 	},
+/obj/structure/lattice,
 /turf/open/space,
 /area/space/nearstation)
 "apq" = (
@@ -4811,11 +4812,11 @@
 /obj/machinery/door/window/brigdoor{
 	dir = 1;
 	name = "Armory Desk";
-	req_access_txt = "3"
+	req_access = list("armory")
 	},
 /obj/machinery/door/window/left/directional/south{
 	name = "Reception Desk";
-	req_access_txt = "63"
+	req_access = list("brig_entrance")
 	},
 /obj/item/paper_bin{
 	layer = 2.9
@@ -6348,7 +6349,7 @@
 /obj/machinery/door/window/left/directional/east{
 	dir = 8;
 	name = "Brig Desk";
-	req_access_txt = "1"
+	req_access = list("security")
 	},
 /obj/item/paper_bin,
 /obj/item/pen{
@@ -6766,7 +6767,7 @@
 /obj/machinery/door/window/left/directional/east{
 	dir = 8;
 	name = "Brig Desk";
-	req_access_txt = "1"
+	req_access = list("security")
 	},
 /obj/item/folder/red,
 /obj/item/restraints/handcuffs,
@@ -7170,7 +7171,7 @@
 	dir = 1;
 	icon_state = "right";
 	name = "Brig Desk";
-	req_access_txt = "1"
+	req_access = list("brig_entrance")
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
@@ -7185,7 +7186,7 @@
 	dir = 1;
 	icon_state = "right";
 	name = "Brig Desk";
-	req_access_txt = "1"
+	req_access = list("brig_entrance")
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
@@ -7210,7 +7211,7 @@
 	dir = 1;
 	icon_state = "right";
 	name = "Brig Desk";
-	req_access_txt = "1"
+	req_access = list("brig_entrance")
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
@@ -8578,9 +8579,7 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "aBG" = (
-/obj/machinery/vending/cart{
-	req_access_txt = "57"
-	},
+/obj/machinery/vending/cart,
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
@@ -9811,7 +9810,7 @@
 	dir = 1;
 	icon_state = "rightsecure";
 	name = "Head of Personnel's Desk";
-	req_access_txt = "57"
+	req_access = list("hop")
 	},
 /obj/machinery/door/window/left/directional/north{
 	dir = 2;
@@ -10996,6 +10995,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/external,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard)
 "aLo" = (
@@ -11007,6 +11007,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/external,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard)
 "aLu" = (
@@ -11288,14 +11289,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard)
 "aMt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
+/turf/open/floor/plating,
+/area/station/medical/medbay/central)
 "aMw" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -12373,9 +12368,7 @@
 /turf/open/floor/wood,
 /area/station/service/bar)
 "aQV" = (
-/obj/structure/closet/secure_closet/bar{
-	req_access_txt = "25"
-	},
+/obj/structure/closet/secure_closet/bar,
 /obj/item/stack/cable_coil,
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/sheet/iron/fifty,
@@ -12804,7 +12797,7 @@
 /obj/machinery/door/window/left/directional/south{
 	dir = 8;
 	name = "Kitchen Delivery";
-	req_access_txt = "28"
+	req_access = list("kitchen")
 	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/crew_quarters/bar)
@@ -13209,7 +13202,7 @@
 "aUR" = (
 /obj/machinery/door/window/right/directional/east{
 	name = "Hydroponics Delivery";
-	req_access_txt = "35"
+	req_access = list("hydroponics")
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
@@ -13267,7 +13260,7 @@
 "aVc" = (
 /obj/machinery/door/window/left/directional/south{
 	name = "Bar Delivery";
-	req_access_txt = "73"
+	req_access = list("service")
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
@@ -13539,7 +13532,7 @@
 /obj/machinery/door/window/right/directional/east{
 	dir = 2;
 	name = "Janitor Delivery";
-	req_access_txt = "26"
+	req_access = list("janitor")
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=1";
@@ -13749,7 +13742,7 @@
 	name = "Virology Access Console";
 	pixel_x = 8;
 	pixel_y = 22;
-	req_access_txt = "39"
+	req_access = list("virology")
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -14104,7 +14097,7 @@
 /obj/machinery/door/window/right/directional/west{
 	dir = 2;
 	name = "Security Checkpoint";
-	req_access_txt = "1"
+	req_access = list("brig_entrance")
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "papersplease";
@@ -15154,7 +15147,7 @@
 	},
 /obj/machinery/door/window/left/directional/west{
 	name = "Trash Chute";
-	req_access_txt = "50"
+	req_access = list("mail_sorting")
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
@@ -15214,7 +15207,7 @@
 /obj/machinery/door/window/right/directional/west{
 	dir = 1;
 	name = "Security Checkpoint";
-	req_access_txt = "1"
+	req_access = list("brig_entrance")
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "papersplease";
@@ -15273,7 +15266,7 @@
 	dir = 1;
 	icon_state = "left";
 	name = "Hydroponics Desk";
-	req_access_txt = "35"
+	req_access = list("hydroponics")
 	},
 /obj/item/reagent_containers/glass/bucket,
 /obj/machinery/door/firedoor,
@@ -15288,7 +15281,7 @@
 /obj/machinery/door/window/right/directional/west{
 	dir = 1;
 	name = "Hydroponics Desk";
-	req_access_txt = "35"
+	req_access = list("hydroponics")
 	},
 /obj/item/food/monkeycube,
 /obj/machinery/door/firedoor,
@@ -16581,14 +16574,12 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bht" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/light_switch/directional/south,
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "bhu" = (
@@ -17319,7 +17310,7 @@
 	dir = 2;
 	icon_state = "left";
 	name = "Robotics Desk";
-	req_access_txt = "29"
+	req_access = list("robotics")
 	},
 /obj/item/paper_bin,
 /obj/item/pen,
@@ -18646,7 +18637,7 @@
 /obj/machinery/door/window/right/directional/south{
 	dir = 1;
 	name = "Medbay Front Desk";
-	req_access_txt = "5"
+	req_access = list("medical")
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
@@ -18701,7 +18692,7 @@
 /obj/machinery/door/window/right/directional/east{
 	dir = 2;
 	name = "Research and Development Desk";
-	req_one_access_txt = "7"
+	req_access = list("science")
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "research_shutters_2";
@@ -18998,7 +18989,7 @@
 	base_state = "right";
 	icon_state = "right";
 	name = "Containment Pen #5";
-	req_access_txt = "55"
+	req_access = list("xenobiology")
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio5";
@@ -19031,7 +19022,7 @@
 	base_state = "right";
 	icon_state = "right";
 	name = "Containment Pen #6";
-	req_access_txt = "55"
+	req_access = list("xenobiology")
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio6";
@@ -19428,7 +19419,7 @@
 	dir = 2;
 	icon_state = "right";
 	name = "Containment Pen #5";
-	req_access_txt = "55"
+	req_access = list("xenobiology")
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -19439,7 +19430,7 @@
 	dir = 2;
 	icon_state = "right";
 	name = "Containment Pen #6";
-	req_access_txt = "55"
+	req_access = list("xenobiology")
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -19450,7 +19441,7 @@
 	id = "xenobio6";
 	name = "Containment Blast Doors";
 	pixel_y = 4;
-	req_access_txt = "55"
+	req_access = list("xenobiology")
 	},
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -19579,7 +19570,7 @@
 /obj/machinery/door/window/right/directional/south{
 	dir = 1;
 	name = "Medbay Front Desk";
-	req_access_txt = "5"
+	req_access = list("medical")
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
@@ -20568,7 +20559,7 @@
 	},
 /obj/machinery/door/window/left/directional/south{
 	name = "First-Aid Supplies";
-	req_access_txt = "5"
+	req_access = list("medical")
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -20979,7 +20970,7 @@
 	base_state = "right";
 	icon_state = "right";
 	name = "Containment Pen #1";
-	req_access_txt = "55"
+	req_access = list("xenobiology")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -20992,7 +20983,7 @@
 	id = "xenobio1";
 	name = "Containment Blast Doors";
 	pixel_y = 4;
-	req_access_txt = "55"
+	req_access = list("xenobiology")
 	},
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -21009,7 +21000,7 @@
 	base_state = "right";
 	icon_state = "right";
 	name = "Containment Pen #2";
-	req_access_txt = "55"
+	req_access = list("xenobiology")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -21022,7 +21013,7 @@
 	id = "xenobio2";
 	name = "Containment Blast Doors";
 	pixel_y = 4;
-	req_access_txt = "55"
+	req_access = list("xenobiology")
 	},
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -21038,7 +21029,7 @@
 	base_state = "right";
 	icon_state = "right";
 	name = "Containment Pen #3";
-	req_access_txt = "55"
+	req_access = list("xenobiology")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -21050,7 +21041,7 @@
 	base_state = "right";
 	icon_state = "right";
 	name = "Containment Pen #4";
-	req_access_txt = "55"
+	req_access = list("xenobiology")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -21191,7 +21182,7 @@
 /obj/machinery/door/window/right/directional/east{
 	dir = 1;
 	name = "Chemistry Testing";
-	req_access_txt = "5; 33"
+	req_access = list("plumbing")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -21494,7 +21485,7 @@
 	dir = 2;
 	icon_state = "right";
 	name = "Containment Pen #1";
-	req_access_txt = "55"
+	req_access = list("xenobiology")
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -21547,7 +21538,7 @@
 	dir = 2;
 	icon_state = "right";
 	name = "Containment Pen #3";
-	req_access_txt = "55"
+	req_access = list("xenobiology")
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -22830,13 +22821,13 @@
 /area/station/maintenance/department/medical/morgue)
 "bEm" = (
 /obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Maintenance";
-	req_access_txt = "12;24"
+	name = "Atmospherics Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/atmospherics/pipe/layer_manifold/supply{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
 "bEr" = (
@@ -23110,7 +23101,7 @@
 /obj/machinery/door/window/left/directional/east{
 	dir = 1;
 	name = "Monkey Pen";
-	req_one_access_txt = "9"
+	req_access = list("genetics")
 	},
 /turf/open/floor/grass,
 /area/station/science/genetics)
@@ -24156,7 +24147,7 @@
 /obj/machinery/door/window/left/directional/south{
 	dir = 8;
 	name = "Mass Driver Door";
-	req_access_txt = "8"
+	req_access = list("ordnance")
 	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
@@ -24578,7 +24569,7 @@
 /obj/machinery/door/window/left/directional/north{
 	dir = 2;
 	name = "Atmospherics Desk";
-	req_access_txt = "24"
+	req_access = list("atmospherics")
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
@@ -24886,7 +24877,7 @@
 /obj/machinery/door/window/left/directional/west{
 	dir = 1;
 	name = "Atmospherics Delivery";
-	req_access_txt = "24"
+	req_access = list("atmospherics")
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
@@ -25307,7 +25298,7 @@
 /obj/machinery/door/window/left/directional/north{
 	dir = 2;
 	name = "Atmospherics Desk";
-	req_access_txt = "24"
+	req_access = list("atmospherics")
 	},
 /turf/open/floor/plating,
 /area/station/engineering/atmos/office)
@@ -26775,8 +26766,7 @@
 /area/station/engineering/storage/tech)
 "bUg" = (
 /obj/machinery/door/airlock/highsecurity{
-	name = "Secure Tech Storage";
-	req_access_txt = "19;23"
+	name = "Secure Tech Storage"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -27367,7 +27357,6 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)
 "bVQ" = (
-/obj/structure/closet/wardrobe/red,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -30083,7 +30072,8 @@
 /obj/machinery/mass_driver/chapelgun,
 /obj/machinery/door/window/left/directional/east{
 	dir = 8;
-	name = "Mass Driver"
+	name = "Mass Driver";
+	req_access = list("chapel_office")
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
@@ -31994,7 +31984,7 @@
 	},
 /obj/machinery/door/window/left/directional/west{
 	name = "Deliveries";
-	req_access_txt = "50"
+	req_access = list("mail_sorting")
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
@@ -32696,7 +32686,7 @@
 	dir = 2;
 	icon_state = "left";
 	name = "Curator Desk Door";
-	req_access_txt = "37"
+	req_access = list("library")
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -32736,7 +32726,7 @@
 /obj/machinery/door/window/right/directional/north{
 	dir = 2;
 	name = "Curator Desk Door";
-	req_access_txt = "37"
+	req_access = list("library")
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -33359,7 +33349,7 @@
 	base_state = "left";
 	icon_state = "left";
 	name = "Research Division Delivery";
-	req_access_txt = "47"
+	req_access = list("science")
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
@@ -34320,7 +34310,7 @@
 	dir = 1;
 	icon_state = "left";
 	name = "Danger: Conveyor Access";
-	req_access_txt = "12"
+	req_access = list("maint_tunnels")
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
@@ -35489,7 +35479,7 @@
 /obj/machinery/door/window/right/directional/south{
 	dir = 4;
 	name = "Morgue Waste Chute";
-	req_access_txt = "5"
+	req_access = list("medical")
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -35732,7 +35722,7 @@
 /obj/machinery/door/window/left/directional/south{
 	dir = 4;
 	name = "Engineering Delivery";
-	req_access_txt = "10"
+	req_access = list("engineering")
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
@@ -36978,7 +36968,7 @@
 /obj/machinery/door/window/left/directional/north{
 	dir = 2;
 	name = "Chemistry Desk";
-	req_access_txt = "5; 69"
+	req_access = list("pharmacy")
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "chemistry_shutters";
@@ -38017,7 +38007,7 @@
 	dir = 2;
 	icon_state = "right";
 	name = "Containment Pen #4";
-	req_access_txt = "55"
+	req_access = list("xenobiology")
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -38345,6 +38335,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/external,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port)
 "hzn" = (
@@ -38996,7 +38987,7 @@
 	id = "xenobio5";
 	name = "Containment Blast Doors";
 	pixel_y = 4;
-	req_access_txt = "55"
+	req_access = list("xenobiology")
 	},
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -39046,7 +39037,7 @@
 	base_state = "left";
 	icon_state = "left";
 	name = "Secure Art Exhibit";
-	req_access_txt = "37"
+	req_access = list("library")
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
@@ -39089,12 +39080,6 @@
 /turf/open/floor/plating/airless,
 /area/station/engineering/supermatter/room)
 "inm" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -39102,9 +39087,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/light_switch/directional/north,
-/turf/open/floor/iron,
-/area/station/science/robotics)
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "int" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall,
@@ -39233,7 +39218,7 @@
 /obj/machinery/door/window/left/directional/south{
 	dir = 8;
 	name = "Test Chamber";
-	req_access_txt = "55"
+	req_access = list("xenobiology")
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -39578,7 +39563,7 @@
 /obj/machinery/door/window/brigdoor{
 	dir = 4;
 	name = "Brig Control Desk";
-	req_access_txt = "63"
+	req_access = list("brig_entrance")
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -39634,7 +39619,7 @@
 	base_state = "right";
 	icon_state = "right";
 	name = "Armory";
-	req_access_txt = "3"
+	req_access = list("armory")
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -40055,7 +40040,7 @@
 	idSelf = "virology_airlock_control";
 	name = "Virology Access Button";
 	pixel_y = 24;
-	req_access_txt = "39"
+	req_access = list("virology")
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -40092,7 +40077,7 @@
 	idSelf = "virology_airlock_control";
 	name = "Virology Access Button";
 	pixel_x = -24;
-	req_access_txt = "39"
+	req_access = list("virology")
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -40782,7 +40767,7 @@
 /obj/machinery/door/window/left/directional/west{
 	dir = 2;
 	name = "Conveyor Access";
-	req_access_txt = "31"
+	req_access = list("cargo")
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
@@ -41271,7 +41256,7 @@
 /obj/machinery/door/window/left/directional/east{
 	dir = 1;
 	name = "Medbay Delivery";
-	req_access_txt = "5"
+	req_access = list("medical")
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=1";
@@ -41523,7 +41508,7 @@
 	id = "xenobio3";
 	name = "Containment Blast Doors";
 	pixel_y = 4;
-	req_access_txt = "55"
+	req_access = list("xenobiology")
 	},
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -41866,10 +41851,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
-"kXo" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/service/janitor)
 "kXZ" = (
 /obj/structure/easel,
 /turf/open/floor/plating,
@@ -42291,6 +42272,23 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"lpI" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/iron,
+/area/station/science/robotics)
 "lpW" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -42440,7 +42438,7 @@
 /obj/machinery/door/window/right/directional/south{
 	dir = 8;
 	name = "Medbay Front Desk";
-	req_access_txt = "5"
+	req_access = list("medical")
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
@@ -42857,11 +42855,11 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/left/directional/east{
 	name = "armoury desk";
-	req_access_txt = "1"
+	req_access = list("brig")
 	},
 /obj/machinery/door/window/left/directional/west{
 	name = "armoury desk";
-	req_access_txt = "3"
+	req_access = list("armory")
 	},
 /obj/machinery/door/firedoor,
 /obj/item/storage/fancy/donut_box,
@@ -43086,7 +43084,7 @@
 	dir = 2;
 	icon_state = "right";
 	name = "Containment Pen #8";
-	req_access_txt = "55"
+	req_access = list("xenobiology")
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -43689,7 +43687,7 @@
 /obj/machinery/door/window/left/directional/east{
 	dir = 1;
 	name = "Monkey Pen";
-	req_one_access_txt = "9"
+	req_access = list("genetics")
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -43844,7 +43842,7 @@
 	id = "xenobio4";
 	name = "Containment Blast Doors";
 	pixel_y = 4;
-	req_access_txt = "55"
+	req_access = list("xenobiology")
 	},
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -44066,7 +44064,7 @@
 	id = "xenobio8";
 	name = "Containment Blast Doors";
 	pixel_y = 4;
-	req_access_txt = "55"
+	req_access = list("xenobiology")
 	},
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -44542,23 +44540,9 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "nyl" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/table/reinforced,
-/obj/item/computer_hardware/hard_drive/portable/atmos{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/computer_hardware/hard_drive/portable/engineering,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/station/command/heads_quarters/ce)
+/area/station/service/janitor)
 "nyB" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -45850,7 +45834,7 @@
 	id = "misclab";
 	name = "Test Chamber Blast Doors";
 	pixel_y = -2;
-	req_access_txt = "55"
+	req_access = list("xenobiology")
 	},
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
@@ -47353,7 +47337,7 @@
 /obj/machinery/door/window/left/directional/south{
 	dir = 4;
 	name = "Test Chamber";
-	req_access_txt = "55"
+	req_access = list("xenobiology")
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "misclab";
@@ -48369,7 +48353,7 @@
 /obj/machinery/door/window/left/directional/north{
 	dir = 2;
 	name = "Chemistry Desk";
-	req_access_txt = "5; 69"
+	req_access = list("pharmacy")
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "chemistry_shutters";
@@ -49401,7 +49385,7 @@
 	},
 /obj/machinery/door/window/left/directional/west{
 	name = "Deliveries Chute";
-	req_access_txt = "50"
+	req_access = list("mail_sorting")
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
@@ -49586,6 +49570,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/external,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port)
 "rLd" = (
@@ -49656,7 +49641,7 @@
 	},
 /obj/machinery/door/window/right/directional/south{
 	name = "First-Aid Supplies";
-	req_access_txt = "5"
+	req_access = list("medical")
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -49700,6 +49685,11 @@
 	pixel_x = -4
 	},
 /obj/structure/table,
+/obj/machinery/button/door/directional/east{
+	id = "armory";
+	name = "Armory Shutters";
+	req_access = list("armory")
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "rPu" = (
@@ -50164,7 +50154,7 @@
 	dir = 2;
 	icon_state = "right";
 	name = "Containment Pen #7";
-	req_access_txt = "55"
+	req_access = list("xenobiology")
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -51560,7 +51550,7 @@
 "tqW" = (
 /obj/machinery/door/window/right/directional/north{
 	name = "Secure Art Exhibit";
-	req_access_txt = "37"
+	req_access = list("library")
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
@@ -52709,7 +52699,7 @@
 /obj/machinery/door/window/right/directional/south{
 	dir = 8;
 	name = "Medbay Front Desk";
-	req_access_txt = "5"
+	req_access = list("medical")
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
@@ -52760,9 +52750,9 @@
 /area/station/medical/cryo)
 "umO" = (
 /obj/machinery/door/morgue{
-	name = "Private Exhibit";
-	req_access_txt = "37"
+	name = "Private Exhibit"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/service/library,
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
 "und" = (
@@ -53833,7 +53823,7 @@
 	base_state = "left";
 	icon_state = "left";
 	name = "Danger: Conveyor Access";
-	req_access_txt = "12"
+	req_access = list("maint_tunnels")
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -54237,7 +54227,7 @@
 	dir = 8;
 	icon_state = "left";
 	name = "Research Division Delivery";
-	req_access_txt = "47"
+	req_access = list("research")
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/window/reinforced,
@@ -54931,7 +54921,7 @@
 	dir = 1;
 	name = "Returns";
 	pixel_y = 7;
-	req_access_txt = "50"
+	req_access = list("mail_sorting")
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
@@ -55552,14 +55542,23 @@
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "wzP" = (
-/obj/machinery/button/door/directional/east{
-	id = "armory";
-	name = "Armory Shutters";
-	pixel_y = 26;
-	req_access = list("armory")
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/computer_hardware/hard_drive/portable/atmos{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/computer_hardware/hard_drive/portable/engineering,
+/turf/open/floor/iron,
+/area/station/command/heads_quarters/ce)
 "wAA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -56363,7 +56362,7 @@
 	id = "xenobio7";
 	name = "Containment Blast Doors";
 	pixel_y = 4;
-	req_access_txt = "55"
+	req_access = list("xenobiology")
 	},
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -56385,7 +56384,7 @@
 "xdY" = (
 /obj/machinery/door/window/right/directional/east{
 	name = "Danger: Conveyor Access";
-	req_access_txt = "12"
+	req_access = list("maint_tunnels")
 	},
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/machinery/conveyor/inverted{
@@ -56718,7 +56717,7 @@
 	base_state = "right";
 	icon_state = "right";
 	name = "Containment Pen #7";
-	req_access_txt = "55"
+	req_access = list("xenobiology")
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio7";
@@ -56856,7 +56855,7 @@
 	base_state = "right";
 	icon_state = "right";
 	name = "Containment Pen #8";
-	req_access_txt = "55"
+	req_access = list("xenobiology")
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio8";
@@ -56962,7 +56961,7 @@
 	dir = 2;
 	icon_state = "right";
 	name = "Containment Pen #2";
-	req_access_txt = "55"
+	req_access = list("xenobiology")
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -57317,7 +57316,7 @@
 /obj/machinery/door/window/left/directional/west{
 	dir = 1;
 	name = "Conveyor Access";
-	req_access_txt = "31"
+	req_access = list("cargo")
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
@@ -81294,7 +81293,7 @@ aby
 abI
 ahL
 rOV
-wzP
+akM
 aim
 aiO
 ajj
@@ -82884,7 +82883,7 @@ aWN
 aXO
 aYM
 vOW
-kXo
+nyl
 oAk
 aZP
 bed
@@ -82909,7 +82908,7 @@ tWt
 pPN
 cKQ
 cKQ
-suU
+aMt
 gZl
 uyg
 cKQ
@@ -83133,7 +83132,7 @@ aOv
 aKT
 mUt
 aLL
-aKT
+aLL
 aKT
 aUQ
 aVU
@@ -83390,7 +83389,7 @@ aKT
 aKT
 mUt
 aKT
-aRL
+aKT
 aKT
 aUR
 aKT
@@ -85681,7 +85680,7 @@ arB
 asM
 atN
 aaZ
-aMt
+bht
 awR
 axT
 ayZ
@@ -86011,7 +86010,7 @@ bfQ
 cCP
 bTp
 bPB
-nyl
+wzP
 bVD
 bWn
 bXf
@@ -87483,7 +87482,7 @@ syK
 syK
 vLp
 aDO
-bht
+inm
 aAB
 aAB
 aAB
@@ -91328,11 +91327,11 @@ aht
 aht
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aht
+aht
+aht
+aht
+aht
 aht
 aaa
 aaa
@@ -94974,7 +94973,7 @@ bhR
 lZc
 bju
 bkt
-inm
+lpI
 bmO
 bnQ
 boY

--- a/StationMaps/PubbyStation/PubbyStation.dmm
+++ b/StationMaps/PubbyStation/PubbyStation.dmm
@@ -125,7 +125,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "telelab";
-	name = "test chamber blast door"
+	name = "Test Chamber Blast Door"
 	},
 /turf/open/floor/plating,
 /area/station/science/explab)
@@ -135,7 +135,6 @@
 /turf/open/floor/engine,
 /area/station/science/explab)
 "aas" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -144,7 +143,7 @@
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "telelab";
-	name = "test chamber blast door"
+	name = "Test Chamber Blast Door"
 	},
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/engine,
@@ -308,7 +307,7 @@
 "aaZ" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridgespace";
-	name = "bridge external shutters"
+	name = "Bridge External Shutters"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -875,10 +874,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/ai_monitored/turret_protected/aisat_interior)
-"ady" = (
-/obj/structure/chair,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
 "adz" = (
 /obj/machinery/light/small,
 /obj/machinery/camera/motion/directional/south{
@@ -2253,10 +2248,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
-"ain" = (
-/obj/effect/spawner/random/structure/crate,
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
 "aio" = (
 /obj/structure/closet/l3closet/security,
 /obj/effect/turf_decal/delivery,
@@ -2795,7 +2786,7 @@
 "ajL" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Prison Gate";
-	name = "prison blast door"
+	name = "Prison Blast Door"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -2954,7 +2945,7 @@
 /obj/structure/closet/secure_closet/hos,
 /obj/machinery/button/door/directional/east{
 	id = "hos_spess_shutters";
-	name = "Space shutters";
+	name = "Space Shutters";
 	req_access = list("hos")
 	},
 /turf/open/floor/iron/dark,
@@ -2998,7 +2989,7 @@
 /area/station/maintenance/department/crew_quarters/dorms)
 "akl" = (
 /obj/machinery/door/airlock/public/glass{
-	name = "space-bridge access"
+	name = "Space-Bridge Access"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -3035,7 +3026,7 @@
 /area/station/hallway/primary/central)
 "akp" = (
 /obj/machinery/door/airlock/public/glass{
-	name = "space-bridge access"
+	name = "Space-Bridge Access"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -3329,7 +3320,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "hos_spess_shutters";
-	name = "Space shutters"
+	name = "Space Shutters"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -3678,12 +3669,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
-"aml" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/station/security/prison)
 "amm" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/camera/directional/west{
@@ -4373,7 +4358,6 @@
 /obj/machinery/door/airlock/security{
 	name = "Brig Control"
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -5071,7 +5055,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "bridgespace";
-	name = "bridge external shutters"
+	name = "Bridge External Shutters"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -6410,7 +6394,7 @@
 "auK" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridgespace";
-	name = "bridge external shutters"
+	name = "Bridge External Shutters"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark,
@@ -6855,17 +6839,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
-"avP" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron,
-/area/station/cargo/office)
 "avQ" = (
 /obj/machinery/door/airlock/command{
 	name = "MiniSat Access"
@@ -7175,7 +7148,7 @@
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
-	name = "brig shutters"
+	name = "Brig Shutters"
 	},
 /obj/item/radio,
 /turf/open/floor/iron/dark,
@@ -7190,7 +7163,7 @@
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
-	name = "brig shutters"
+	name = "Brig Shutters"
 	},
 /obj/structure/table/reinforced,
 /obj/item/folder/red{
@@ -7204,7 +7177,7 @@
 /obj/item/pen,
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
-	name = "brig shutters"
+	name = "Brig Shutters"
 	},
 /obj/machinery/door/window/left/directional/south{
 	base_state = "right";
@@ -7410,7 +7383,7 @@
 "axE" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "prison release";
-	name = "prisoner processing blast door"
+	name = "Prisoner Processing Blast Door"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -8359,7 +8332,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "datboidetective";
-	name = "privacy shutters"
+	name = "Privacy Shutters"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -9818,7 +9791,7 @@
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "hop";
-	name = "privacy shutters"
+	name = "Privacy Shutters"
 	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/hop)
@@ -10182,7 +10155,7 @@
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "assistantshutters";
-	name = "storage shutters"
+	name = "Storage Shutters"
 	},
 /turf/open/floor/plating,
 /area/station/commons/storage/primary)
@@ -10192,7 +10165,7 @@
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "assistantshutters";
-	name = "storage shutters"
+	name = "Storage Shutters"
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -10216,7 +10189,7 @@
 "aHd" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
-	name = "bridge blast door"
+	name = "Bridge Blast Door"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/delivery,
@@ -10240,7 +10213,7 @@
 "aHe" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
-	name = "bridge blast door"
+	name = "Bridge Blast Door"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
@@ -10256,7 +10229,7 @@
 "aHg" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
-	name = "bridge blast door"
+	name = "Bridge Blast Door"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/delivery,
@@ -11288,9 +11261,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard)
-"aMt" = (
-/turf/open/floor/plating,
-/area/station/medical/medbay/central)
 "aMw" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -14087,7 +14057,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "papersplease";
-	name = "security shutters"
+	name = "Security Shutters"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -14101,7 +14071,7 @@
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "papersplease";
-	name = "privacy shutters"
+	name = "Privacy Shutters"
 	},
 /obj/item/folder/red,
 /obj/item/pen,
@@ -14298,7 +14268,6 @@
 "aYl" = (
 /obj/structure/table/wood,
 /obj/item/soap,
-/obj/structure/table/wood,
 /obj/item/bikehorn,
 /obj/item/toy/cattoy,
 /turf/open/floor/iron/dark,
@@ -14491,7 +14460,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchenshutters";
-	name = "kitchen shutters"
+	name = "Kitchen Shutters"
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
@@ -14749,7 +14718,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchenshutters";
-	name = "kitchen shutters"
+	name = "Kitchen Shutters"
 	},
 /obj/item/storage/fancy/donut_box,
 /obj/effect/turf_decal/tile/red{
@@ -15048,7 +15017,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchenshutters";
-	name = "kitchen shutters"
+	name = "Kitchen Shutters"
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -15161,7 +15130,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/shutters{
 	id = "qm_warehouse";
-	name = "warehouse shutters"
+	name = "Warehouse Shutters"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -15211,7 +15180,7 @@
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "papersplease";
-	name = "privacy shutters"
+	name = "Privacy Shutters"
 	},
 /obj/item/crowbar,
 /obj/effect/turf_decal/delivery,
@@ -15378,7 +15347,7 @@
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "barshutters";
-	name = "bar shutters"
+	name = "Bar Shutters"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -15586,7 +15555,7 @@
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "barshutters";
-	name = "bar shutters"
+	name = "Bar Shutters"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -15753,7 +15722,7 @@
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchenwindowshutters";
-	name = "kitchen shutters"
+	name = "Kitchen Shutters"
 	},
 /obj/effect/landmark/navigate_destination/kitchen,
 /obj/machinery/door/firedoor,
@@ -15997,7 +15966,7 @@
 "bfs" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "barshutters";
-	name = "bar shutters"
+	name = "Bar Shutters"
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
@@ -16211,7 +16180,7 @@
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchenwindowshutters";
-	name = "kitchen shutters"
+	name = "Kitchen Shutters"
 	},
 /turf/open/floor/plating,
 /area/station/service/kitchen)
@@ -16573,15 +16542,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
-"bht" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
 "bhu" = (
 /obj/machinery/light,
 /obj/structure/closet/secure_closet/miner,
@@ -17298,7 +17258,7 @@
 "bku" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "robotics";
-	name = "robotics lab shutters"
+	name = "Robotics Lab Shutters"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -17316,7 +17276,7 @@
 /obj/item/pen,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "robotics";
-	name = "robotics lab shutters"
+	name = "Robotics Lab Shutters"
 	},
 /turf/open/floor/plating,
 /area/station/science/robotics)
@@ -17810,7 +17770,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchenshutters";
-	name = "kitchen shutters"
+	name = "Kitchen Shutters"
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -18533,10 +18493,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "bpo" = (
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/station/science/explab)
 "bpq" = (
 /obj/effect/spawner/random/maintenance,
 /obj/structure/closet/crate,
@@ -18613,7 +18574,7 @@
 "bpN" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridgespace";
-	name = "bridge external shutters"
+	name = "Bridge External Shutters"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable,
@@ -18680,7 +18641,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "research_shutters_2";
-	name = "research shutters"
+	name = "Research Shutters"
 	},
 /turf/open/floor/plating,
 /area/station/science/lab)
@@ -18696,7 +18657,7 @@
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "research_shutters_2";
-	name = "research shutters"
+	name = "Research Shutters"
 	},
 /obj/item/folder/white,
 /turf/open/floor/plating,
@@ -18993,7 +18954,7 @@
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio5";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -19001,7 +18962,7 @@
 "bqI" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio5";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -19010,7 +18971,7 @@
 "bqJ" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio6";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -19026,7 +18987,7 @@
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio6";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -19034,15 +18995,12 @@
 "bqL" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio6";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
-"bqN" = (
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/central)
 "bqO" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
@@ -19335,6 +19293,10 @@
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/white,
 /area/station/science/explab)
+"brI" = (
+/obj/effect/spawner/random/trash/mess,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "brJ" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -20395,7 +20357,7 @@
 "bvG" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "rndshutters";
-	name = "research shutters"
+	name = "Research Shutters"
 	},
 /obj/structure/sign/warning/secure_area{
 	pixel_x = 32
@@ -20622,7 +20584,7 @@
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "barshutters";
-	name = "bar shutters"
+	name = "Bar Shutters"
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -20833,7 +20795,7 @@
 "bxp" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "rndshutters";
-	name = "research shutters"
+	name = "Research Shutters"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment{
@@ -21326,7 +21288,7 @@
 "byO" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "rndshutters";
-	name = "research shutters"
+	name = "Research Shutters"
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/sign/warning/secure_area{
@@ -21468,7 +21430,7 @@
 "bzk" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio1";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -21478,7 +21440,7 @@
 "bzl" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio1";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/machinery/door/window/left/directional/north{
 	base_state = "right";
@@ -21493,7 +21455,7 @@
 "bzm" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio1";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -21502,7 +21464,7 @@
 "bzn" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio2";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -21512,7 +21474,7 @@
 "bzp" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio2";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -21521,7 +21483,7 @@
 "bzq" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio3";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -21531,7 +21493,7 @@
 "bzr" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio3";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/machinery/door/window/left/directional/north{
 	base_state = "right";
@@ -21546,7 +21508,7 @@
 "bzs" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio3";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -21761,7 +21723,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "rdprivacy";
-	name = "Privacy shutters"
+	name = "Privacy Shutters"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -22505,17 +22467,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/mixing)
-"bCY" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/cryo)
 "bDa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -22847,6 +22798,21 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/cmo)
+"bEF" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/table/glass,
+/obj/item/computer_hardware/hard_drive/portable/medical,
+/obj/item/computer_hardware/hard_drive/portable/chemistry{
+	pixel_x = 5;
+	pixel_y = 5
 	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
@@ -24299,7 +24265,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
-	name = "atmospherics security door"
+	name = "Atmospherics Security Door"
 	},
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron/dark,
@@ -24308,7 +24274,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
-	name = "atmospherics security door"
+	name = "Atmospherics Security Door"
 	},
 /obj/machinery/door/firedoor/heavy,
 /obj/structure/disposalpipe/segment,
@@ -26851,7 +26817,7 @@
 "bUo" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
-	name = "atmospherics security door"
+	name = "Atmospherics Security Door"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/camera/directional/north{
@@ -26931,6 +26897,24 @@
 /area/station/maintenance/department/engine)
 "bUH" = (
 /turf/closed/wall/r_wall,
+/area/station/command/heads_quarters/ce)
+"bUI" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/computer_hardware/hard_drive/portable/atmos{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/computer_hardware/hard_drive/portable/engineering,
+/turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "bUJ" = (
 /obj/structure/filingcabinet/chestdrawer,
@@ -27128,7 +27112,7 @@
 "bVc" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
-	name = "atmospherics security door"
+	name = "Atmospherics Security Door"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27631,7 +27615,7 @@
 "bWF" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
-	name = "engineering security door"
+	name = "Engineering Security Door"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/delivery,
@@ -27645,7 +27629,7 @@
 "bWG" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
-	name = "engineering security door"
+	name = "Engineering Security Door"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -27959,7 +27943,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "ce_privacy";
-	name = "Privacy shutters"
+	name = "Privacy Shutters"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -30912,7 +30896,7 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/external{
-	name = "public external airlock"
+	name = "Public External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/external,
 /turf/open/floor/plating,
@@ -31150,7 +31134,7 @@
 "cpC" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "barshutters";
-	name = "bar shutters"
+	name = "Bar Shutters"
 	},
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -31513,7 +31497,7 @@
 "cri" = (
 /obj/machinery/door/poddoor{
 	id = "Secure Storage";
-	name = "secure storage"
+	name = "Secure Storage"
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/delivery,
@@ -31733,17 +31717,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
 /area/station/service/chapel/monastery)
-"csV" = (
-/obj/structure/rack,
-/obj/item/pickaxe{
-	pixel_x = 5
-	},
-/obj/item/shovel{
-	pixel_x = -5
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "csY" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/iron/dark,
@@ -32590,7 +32563,7 @@
 "czw" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Prison Gate";
-	name = "prison blast door"
+	name = "Prison Blast Door"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable,
@@ -33160,6 +33133,10 @@
 	icon_state = "platingdmg1"
 	},
 /area/station/maintenance/department/science/central)
+"cJv" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/central)
 "cKA" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -33171,6 +33148,10 @@
 "cKQ" = (
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"cLB" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "cMa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -33391,15 +33372,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
-"cYx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
 "cZu" = (
 /obj/structure/chair{
 	dir = 1
@@ -33458,10 +33430,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/gateway)
-"ddf" = (
-/obj/effect/spawner/random/trash/mess,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
 "dej" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 10
@@ -33484,10 +33452,6 @@
 /obj/effect/spawner/random/contraband/armory,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
-"dfP" = (
-/obj/structure/girder,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
 "dfU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -33681,17 +33645,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"doA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
 "dpa" = (
 /obj/machinery/light/directional/north,
 /obj/structure/sign/directions/evac{
@@ -33895,11 +33848,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
-"dvY" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/security/prison)
 "dxo" = (
 /obj/machinery/igniter/incinerator_ordmix,
 /turf/open/floor/engine/vacuum,
@@ -34105,6 +34053,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"dIj" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "dJm" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Research Pit"
@@ -34126,6 +34082,10 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"dKH" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/central)
 "dLY" = (
 /obj/structure/table,
 /obj/item/assembly/igniter,
@@ -34196,35 +34156,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/obj/effect/mapping_helpers/airlock/access/any/medical/surgery,
 /turf/open/floor/plating,
-/area/station/maintenance/department/medical/morgue)
-"dOB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/central)
+/area/station/maintenance/department/medical)
 "dPk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/dock)
-"dPr" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/station/security/prison)
 "dPO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -34271,14 +34211,18 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/machinery/door/airlock/maintenance{
+	name = "Mining Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
+/turf/open/floor/iron,
 /area/station/maintenance/department/science/central)
 "dRU" = (
 /obj/structure/window/reinforced/spawner/east,
@@ -34362,6 +34306,9 @@
 "dUZ" = (
 /turf/closed/wall/r_wall,
 /area/station/cargo/storage)
+"dVg" = (
+/turf/closed/wall/r_wall,
+/area/station/security/medical)
 "dVI" = (
 /obj/item/wrench,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -34408,12 +34355,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"dWZ" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/station/security/prison/safe)
 "dXv" = (
 /obj/machinery/door/airlock/medical{
 	name = "Surgical Theatres"
@@ -34452,10 +34393,6 @@
 /obj/machinery/atmospherics/components/binary/pump,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"dZG" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical/central)
 "eaA" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -34494,14 +34431,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "lawyer_shutters";
-	name = "law office shutters"
+	name = "Law Office Shutters"
 	},
 /turf/open/floor/plating,
 /area/station/service/lawoffice)
 "eca" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio7";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -34640,14 +34577,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/warehouse/upper)
-"ekl" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
 "ekm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -34736,10 +34665,19 @@
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
-"enJ" = (
-/obj/structure/chair/stool/bar/directional/east,
+"enf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/area/station/maintenance/department/science/central)
 "eoo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -35179,7 +35117,7 @@
 	id = "permashut2"
 	},
 /obj/machinery/door/airlock/glass{
-	name = "cell 2"
+	name = "Cell 2"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "perma-cell-2-passthrough"
@@ -35234,6 +35172,15 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
+"eKj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "eKI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -35253,6 +35200,17 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
+"eLG" = (
+/turf/closed/wall,
+/area/station/maintenance/department/medical/morgue)
+"eMp" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "eNo" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
 	dir = 8
@@ -35541,6 +35499,12 @@
 /obj/machinery/power/energy_accumulator/grounding_rod/anchored,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
+"eWD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/central)
 "eXa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35669,6 +35633,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
+"fbb" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/station/maintenance/department/medical)
 "fby" = (
 /obj/structure/sign/poster/official/no_erp{
 	pixel_x = 29
@@ -35679,11 +35648,6 @@
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/medical/abandoned)
-"fca" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical/central)
 "fcK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -35893,19 +35857,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
-"fiP" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/station/maintenance/department/medical/morgue)
-"fiZ" = (
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/hfr_room)
 "fjs" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/purple{
@@ -36052,16 +36003,6 @@
 /obj/machinery/bluespace_vendor/directional/south,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"frh" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/engineering/atmos/hfr_room)
 "frn" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -36479,9 +36420,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"fJU" = (
-/turf/closed/wall,
-/area/station/maintenance/department/science/central)
 "fKa" = (
 /obj/item/radio/intercom/directional/north{
 	desc = "A station intercom. It looks like it has been modified to not broadcast.";
@@ -36631,22 +36569,18 @@
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
 "fQD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Mining Maintenance"
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
 /turf/open/floor/iron,
-/area/station/maintenance/department/science/central)
+/area/station/cargo/miningdock)
 "fQN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -36714,13 +36648,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
-"fWa" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos/hfr_room)
 "fWh" = (
 /obj/structure/table/wood/fancy,
 /turf/open/floor/iron/dark,
@@ -36780,7 +36707,7 @@
 "gam" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchenwindowshutters";
-	name = "kitchen shutters"
+	name = "Kitchen Shutters"
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -36972,7 +36899,7 @@
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "chemistry_shutters";
-	name = "chemistry shutters"
+	name = "Chemistry Shutters"
 	},
 /obj/item/folder/white,
 /obj/item/pen,
@@ -37051,6 +36978,10 @@
 /obj/machinery/light,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"gmP" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "gna" = (
 /turf/open/floor/iron/stairs/medium,
 /area/station/service/abandoned_gambling_den)
@@ -37151,6 +37082,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
+"gtR" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/security/prison)
 "gtW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -37246,6 +37184,9 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
+"gvM" = (
+/turf/closed/wall,
+/area/station/maintenance/department/science/central)
 "gwn" = (
 /obj/structure/sign/warning{
 	pixel_y = 32
@@ -37305,8 +37246,10 @@
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "gzf" = (
-/turf/closed/wall/r_wall,
-/area/station/security/medical)
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/security/prison)
 "gzy" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
@@ -37458,13 +37401,15 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"gEL" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
-"gEZ" = (
-/turf/closed/wall,
-/area/station/security/medical)
+"gEK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "gFf" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -37635,6 +37580,10 @@
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
+"gMf" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "gMF" = (
 /obj/item/toy/beach_ball/holoball,
 /obj/effect/turf_decal/stripes/white/line{
@@ -37711,6 +37660,9 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"gQI" = (
+/turf/closed/wall,
+/area/station/maintenance/department/medical/central)
 "gQU" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -37788,19 +37740,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"gUM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/central)
 "gVc" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken4"
@@ -37839,6 +37778,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
+"gVJ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/office)
 "gXg" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -38000,7 +37943,7 @@
 "hiN" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio4";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/machinery/door/window/left/directional/north{
 	base_state = "right";
@@ -38071,9 +38014,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"hjQ" = (
-/turf/closed/wall,
-/area/station/maintenance/department/medical/morgue)
 "hkc" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -38131,7 +38071,7 @@
 "hmL" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridgespace";
-	name = "bridge external shutters"
+	name = "Bridge External Shutters"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -38256,7 +38196,7 @@
 "hvW" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio4";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -38341,6 +38281,9 @@
 "hzn" = (
 /turf/closed/wall/r_wall,
 /area/station/science/mixing/launch)
+"hzr" = (
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/hfr_room)
 "hzy" = (
 /turf/open/floor/iron/chapel,
 /area/station/service/chapel)
@@ -38350,6 +38293,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
+"hBg" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "hBn" = (
 /obj/structure/table/glass,
 /obj/item/folder/white,
@@ -38788,6 +38735,10 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/captain)
+"hVZ" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/central)
 "hWo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -38877,16 +38828,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
-"icI" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/central)
 "icK" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -39050,6 +38991,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
+"ijt" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos/hfr_room)
 "ijU" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/medical/memeorgans,
@@ -39079,17 +39027,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/station/engineering/supermatter/room)
-"inm" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/light_switch/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
 "int" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall,
@@ -39189,13 +39126,17 @@
 "irZ" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "SupermatterExternal";
-	name = "radiation shutters"
+	name = "Radiation Shutters"
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"isg" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/central)
 "isC" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Dorms";
@@ -39229,16 +39170,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
-"ivf" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/station/maintenance/department/medical/morgue)
 "ivp" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -39306,7 +39237,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "SupermatterExternal";
-	name = "radiation shutters"
+	name = "Radiation Shutters"
 	},
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -39380,6 +39311,10 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"iBY" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "iCe" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
 	dir = 4;
@@ -39481,6 +39416,15 @@
 /obj/item/stack/medical/gauze,
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
+"iGR" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos/hfr_room)
 "iIB" = (
 /obj/structure/table,
 /obj/machinery/conveyor_switch/oneway{
@@ -39601,19 +39545,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"iMj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/central)
 "iMH" = (
 /obj/machinery/door/window/left/directional/south{
 	base_state = "right";
@@ -39640,7 +39571,7 @@
 "iNH" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridgespace";
-	name = "bridge external shutters"
+	name = "Bridge External Shutters"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/item/radio/intercom/directional/north,
@@ -39757,14 +39688,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"iXt" = (
-/obj/machinery/requests_console/directional/south{
-	department = "Mining";
-	departmentType = 2;
-	name = "Mining Bay Requests Console"
-	},
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "iYH" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay"
@@ -39816,6 +39739,15 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
+"jaB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "jaJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -39904,10 +39836,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
-"jfT" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical/morgue)
 "jgr" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Library"
@@ -40306,7 +40234,7 @@
 "jBx" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "telelab";
-	name = "test chamber blast door"
+	name = "Test Chamber Blast Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -40368,16 +40296,6 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
-"jHF" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical/morgue)
 "jHP" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/bottle/vodka/badminka{
@@ -40712,6 +40630,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/explab)
+"jWA" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating/airless,
+/area/station/engineering/atmos/hfr_room)
 "jWH" = (
 /obj/effect/turf_decal/trimline/blue/corner,
 /turf/open/floor/iron/white,
@@ -40903,6 +40825,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
+"khX" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/central)
 "kiw" = (
 /obj/machinery/door/airlock{
 	name = "Prison Restrooms"
@@ -41316,9 +41249,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/breakroom)
-"kxJ" = (
-/turf/closed/wall,
-/area/station/maintenance/department/medical/central)
 "kya" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -41372,7 +41302,7 @@
 "kAo" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
-	name = "atmospherics security door"
+	name = "Atmospherics Security Door"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/newscaster/directional/east,
@@ -41550,18 +41480,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/station/maintenance/department/security/brig)
-"kJJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "kJU" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -41634,24 +41552,6 @@
 /obj/machinery/holopad/secure,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hos)
-"kPA" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	name = "Docking Arm Maintenance"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "cargo-maint-passthrough"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/central)
 "kPM" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -41990,9 +41890,6 @@
 /obj/item/pen,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
-"ldy" = (
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/office)
 "lem" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -42117,7 +42014,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
-	name = "atmospherics security door"
+	name = "Atmospherics Security Door"
 	},
 /obj/machinery/door/firedoor/heavy,
 /obj/effect/landmark/start/hangover,
@@ -42152,6 +42049,22 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
+"lkH" = (
+/obj/structure/rack,
+/obj/item/pickaxe{
+	pixel_x = 5
+	},
+/obj/item/shovel{
+	pixel_x = -5
+	},
+/obj/machinery/light/directional/south,
+/obj/machinery/requests_console/directional/south{
+	department = "Mining";
+	departmentType = 2;
+	name = "Mining Bay Requests Console"
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "lkK" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -42258,7 +42171,7 @@
 "lot" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "Skynet_launch";
-	name = "mech bay"
+	name = "Mech Bay"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
@@ -42272,23 +42185,6 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
-"lpI" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/light_switch/directional/north,
-/turf/open/floor/iron,
-/area/station/science/robotics)
 "lpW" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -42369,25 +42265,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
-"lsI" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/table/glass,
-/obj/item/computer_hardware/hard_drive/portable/medical,
-/obj/item/computer_hardware/hard_drive/portable/chemistry{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/cmo)
 "ltk" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "misclab";
-	name = "test chamber blast door"
+	name = "Test Chamber Blast Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -42422,6 +42303,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"lvo" = (
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/airlock/command/glass{
+	name = "AI Core"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
+/turf/open/floor/iron/white,
+/area/station/ai_monitored/turret_protected/ai)
 "lvq" = (
 /turf/closed/wall,
 /area/station/security/prison/toilet)
@@ -42491,7 +42381,7 @@
 /obj/item/wrench,
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	id = "Supermatter";
-	name = "supermatter shielding"
+	name = "Supermatter Shielding"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -42755,7 +42645,7 @@
 "lRu" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "surgerya";
-	name = "privacy shutter"
+	name = "Privacy Shutter"
 	},
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -42771,21 +42661,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/janitor)
+"lRN" = (
+/turf/closed/wall/r_wall,
+/area/station/maintenance/department/medical)
 "lRW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/science/genetics)
-"lSc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
 "lTf" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -42854,11 +42736,11 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/left/directional/east{
-	name = "armoury desk";
+	name = "Armory Desk";
 	req_access = list("brig")
 	},
 /obj/machinery/door/window/left/directional/west{
-	name = "armoury desk";
+	name = "Armory Desk";
 	req_access = list("armory")
 	},
 /obj/machinery/door/firedoor,
@@ -43358,7 +43240,7 @@
 "msw" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio4";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -43486,7 +43368,7 @@
 "myu" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
-	name = "bridge blast door"
+	name = "Bridge Blast Door"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/sign/directions/evac{
@@ -43574,7 +43456,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
-	name = "engineering security door"
+	name = "Engineering Security Door"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -43819,7 +43701,7 @@
 "mQc" = (
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	id = "Supermatter";
-	name = "supermatter shielding"
+	name = "Supermatter Shielding"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -44020,11 +43902,6 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"mZZ" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/station/maintenance/department/medical)
 "naq" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -44041,6 +43918,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
+"nbo" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/station/maintenance/department/medical/morgue)
 "nbw" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -44465,15 +44352,16 @@
 /obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
+"ntb" = (
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "nts" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/closed/wall,
 /area/station/cargo/miningdock)
-"ntz" = (
-/turf/closed/wall/r_wall,
-/area/station/maintenance/department/medical/morgue)
 "ntO" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -44481,9 +44369,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
-"nuk" = (
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical/morgue)
 "nvG" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/iron/dark,
@@ -44539,10 +44424,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
-"nyl" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/service/janitor)
 "nyB" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -44550,6 +44431,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/primary/central)
+"nyN" = (
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "nyO" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
@@ -44656,7 +44541,7 @@
 "nEb" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "misclab";
-	name = "test chamber blast door"
+	name = "Test Chamber Blast Door"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /obj/effect/spawner/structure/window/reinforced,
@@ -44696,21 +44581,23 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
+"nGp" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "nGx" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/station/maintenance/department/engine)
-"nHT" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos/hfr_room)
 "nIm" = (
 /obj/machinery/computer/security/telescreen{
 	dir = 8;
@@ -44902,10 +44789,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
-"nSg" = (
-/obj/structure/chair/stool/bar/directional/west,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
 "nSz" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
@@ -45024,6 +44907,24 @@
 /obj/item/spear,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"nWl" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Docking Arm Maintenance"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "cargo-maint-passthrough"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "nWw" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -45049,9 +44950,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/closed/wall/r_wall,
 /area/station/science/mixing/chamber)
-"nXq" = (
+"nXy" = (
 /obj/structure/disposalpipe/segment{
-	dir = 9
+	dir = 6
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45157,6 +45058,9 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"odp" = (
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "odF" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/grunge{
@@ -45175,18 +45079,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
-"oeU" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Medbay Maintenance"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/any/medical/surgery,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
 "ofe" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/dark/side{
@@ -45395,7 +45287,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "assistantshutters";
-	name = "storage shutters"
+	name = "Storage Shutters"
 	},
 /obj/effect/landmark/navigate_destination/tools,
 /obj/machinery/door/firedoor,
@@ -45442,6 +45334,16 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
+"opJ" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/hfr_room)
 "oqh" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Chapel"
@@ -45645,6 +45547,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
+"oxA" = (
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "oxC" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/start/hangover,
@@ -45825,7 +45731,7 @@
 /obj/effect/landmark/event_spawn,
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	id = "Supermatter";
-	name = "supermatter shielding"
+	name = "Supermatter Shielding"
 	},
 /turf/open/floor/plating,
 /area/station/engineering/supermatter)
@@ -45935,19 +45841,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"oJj" = (
+/turf/closed/wall,
+/area/station/maintenance/department/medical)
 "oJp" = (
 /obj/machinery/light/no_nightlight/directional/north,
 /turf/open/floor/iron,
 /area/station/security/prison)
-"oKb" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/command/glass{
-	name = "AI Core"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
-/turf/open/floor/iron/white,
-/area/station/ai_monitored/turret_protected/ai)
 "oKD" = (
 /obj/structure/disposalpipe/junction,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -46055,12 +45955,6 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/entry)
-"oPr" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/station/science/explab)
 "oPy" = (
 /obj/machinery/door/airlock/external{
 	name = "Mining Dock Airlock"
@@ -46071,6 +45965,9 @@
 /obj/effect/mapping_helpers/airlock/access/any/supply/mining,
 /turf/open/floor/plating,
 /area/station/cargo/miningdock)
+"oPH" = (
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "oPV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -46143,7 +46040,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio5";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -46265,9 +46162,6 @@
 /obj/effect/landmark/secequipment,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/lockers)
-"oWB" = (
-/turf/open/floor/iron,
-/area/station/engineering/atmos/hfr_room)
 "oWL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -46340,16 +46234,24 @@
 	},
 /turf/open/floor/plating,
 /area/station/service/chapel/dock)
+"pbo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "pbR" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 8
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
-"pca" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
 "pcg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -46548,11 +46450,9 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
-"pjX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/chair/stool/bar/directional/east,
+"pjM" = (
 /turf/open/floor/iron,
-/area/station/engineering/main)
+/area/station/engineering/atmos/hfr_room)
 "pkj" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/start/hangover,
@@ -46584,7 +46484,7 @@
 "pkU" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio7";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -46649,6 +46549,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
+"pnn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "pnF" = (
 /obj/structure/flora/bush/large/style_random,
 /obj/structure/flora/grass/jungle/b,
@@ -46834,6 +46745,23 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"pAM" = (
+/obj/structure/chair/stool/bar/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
+"pBg" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/central)
 "pBm" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -46860,6 +46788,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"pCY" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Medbay Maintenance"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "pDe" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
@@ -46922,6 +46862,9 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"pEI" = (
+/turf/closed/wall/r_wall,
+/area/station/maintenance/department/medical/morgue)
 "pEK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -47018,6 +46961,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"pHf" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/central)
 "pHh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -47267,7 +47220,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "chemistry_shutters";
-	name = "chemistry shutters"
+	name = "Chemistry Shutters"
 	},
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
@@ -47341,7 +47294,7 @@
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "misclab";
-	name = "test chamber blast door"
+	name = "Test Chamber Blast Door"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -47439,14 +47392,6 @@
 	icon_state = "platingdmg2"
 	},
 /area/station/maintenance/department/engine)
-"qah" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical/morgue)
 "qaQ" = (
 /turf/closed/wall,
 /area/station/hallway/secondary/service)
@@ -47510,6 +47455,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"qdt" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/central)
 "qdO" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -47620,6 +47569,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"qhH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/central)
 "qhW" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -47693,12 +47655,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
+"qjT" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/service/janitor)
 "qkf" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /obj/machinery/door/poddoor/preopen{
 	id = "telelab";
-	name = "test chamber blast door"
+	name = "Test Chamber Blast Door"
 	},
 /turf/open/floor/plating,
 /area/station/science/explab)
@@ -47974,7 +47940,7 @@
 "qtF" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobiomain";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48030,9 +47996,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "qvR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "qwJ" = (
@@ -48152,7 +48117,7 @@
 "qFu" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "SupermatterExternal";
-	name = "radiation shutters"
+	name = "Radiation Shutters"
 	},
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -48357,7 +48322,7 @@
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "chemistry_shutters";
-	name = "chemistry shutters"
+	name = "Chemistry Shutters"
 	},
 /obj/item/folder/white,
 /obj/item/pen,
@@ -48524,10 +48489,16 @@
 "qVP" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobiomain";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
+"qWu" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/station/security/prison/safe)
 "qWG" = (
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plating,
@@ -48608,6 +48579,23 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"qYI" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/iron,
+/area/station/science/robotics)
 "qZa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -48803,10 +48791,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
-"rjw" = (
-/obj/structure/girder,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/central)
 "rjL" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/shower{
@@ -48915,6 +48899,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"rod" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "rof" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
@@ -49084,6 +49078,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
+"rtA" = (
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "rtC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -49413,10 +49412,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
-"rDV" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/central)
 "rEh" = (
 /obj/structure/table/glass,
 /obj/item/restraints/handcuffs/cable/zipties,
@@ -49663,10 +49658,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
-"rNF" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical/morgue)
 "rNJ" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner/north,
@@ -49840,9 +49831,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"rXs" = (
-/turf/closed/wall/r_wall,
-/area/station/maintenance/department/medical)
 "rXH" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -49895,7 +49883,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
-	name = "public external airlock"
+	name = "Public External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/external,
 /turf/open/floor/plating,
@@ -49951,7 +49939,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchenshutters";
-	name = "kitchen shutters"
+	name = "Kitchen Shutters"
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -49963,9 +49951,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/service/kitchen)
-"sbK" = (
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/hfr_room)
 "sbY" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/wood,
@@ -50058,6 +50043,12 @@
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
+"sfh" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/station/security/prison)
 "sgc" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron/dark,
@@ -50162,7 +50153,7 @@
 "snD" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "barshutters";
-	name = "bar shutters"
+	name = "Bar Shutters"
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -50198,15 +50189,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"soN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical/morgue)
 "spo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -50343,9 +50325,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"swm" = (
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
 "sww" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/item/food/meat/slab/monkey,
@@ -50775,6 +50754,9 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron/white,
 /area/station/security/prison)
+"sNt" = (
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "sOB" = (
 /turf/closed/wall,
 /area/station/medical/psychology)
@@ -50807,7 +50789,7 @@
 "sQx" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridgespace";
-	name = "bridge external shutters"
+	name = "Bridge External Shutters"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -50889,17 +50871,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/chapel,
 /area/station/service/chapel)
-"sTF" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/central)
 "sTY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51090,7 +51061,7 @@
 "tbC" = (
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	id = "Supermatter";
-	name = "supermatter shielding"
+	name = "Supermatter Shielding"
 	},
 /turf/open/floor/plating,
 /area/station/engineering/supermatter)
@@ -51181,10 +51152,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/explab)
-"tdr" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/atmos/office)
 "tdB" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/purple{
@@ -51414,7 +51381,7 @@
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "SupermatterExternal";
-	name = "radiation shutters"
+	name = "Radiation Shutters"
 	},
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -51558,7 +51525,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "misclab";
-	name = "test chamber blast door"
+	name = "Test Chamber Blast Door"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -51640,10 +51607,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"tva" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/turf/open/floor/plating/airless,
-/area/station/engineering/atmos/hfr_room)
 "tvj" = (
 /obj/structure/festivus{
 	anchored = 1;
@@ -51699,7 +51662,7 @@
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "SupermatterExternal";
-	name = "radiation shutters"
+	name = "Radiation Shutters"
 	},
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -51707,7 +51670,7 @@
 "twQ" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio8";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -52012,6 +51975,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"tHl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "tIx" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -52032,6 +52006,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"tJu" = (
+/turf/open/floor/plating,
+/area/station/medical/medbay/central)
 "tJX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -52095,16 +52072,23 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"tOy" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "tPm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/closed/wall,
 /area/station/engineering/storage_shared)
-"tPs" = (
-/obj/structure/girder,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical/morgue)
 "tQi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -52649,7 +52633,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "telelab";
-	name = "test chamber blast door"
+	name = "Test Chamber Blast Door"
 	},
 /turf/open/floor/plating,
 /area/station/science/breakroom)
@@ -52792,6 +52776,10 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"upW" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "uqf" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -52898,7 +52886,7 @@
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "misclab";
-	name = "test chamber blast door"
+	name = "Test Chamber Blast Door"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -53061,7 +53049,7 @@
 /area/station/medical/paramedic)
 "uzx" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "Genetics maintenance"
+	name = "Genetics Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/science/genetics,
 /turf/open/floor/plating,
@@ -53291,6 +53279,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
+"uIR" = (
+/obj/structure/chair/stool/bar/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "uKD" = (
 /obj/structure/chair,
 /obj/machinery/light/directional/north,
@@ -53510,7 +53502,7 @@
 "uUh" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "SupermatterExternal";
-	name = "radiation shutters"
+	name = "Radiation Shutters"
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/door/firedoor,
@@ -53544,7 +53536,7 @@
 "uUY" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
-	name = "brig shutters"
+	name = "Brig Shutters"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -53680,7 +53672,7 @@
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobiomain";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -53894,6 +53886,10 @@
 	},
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
+"vgm" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/central)
 "vgp" = (
 /obj/machinery/door/airlock/research{
 	name = "Containment Pen"
@@ -54269,10 +54265,6 @@
 /obj/machinery/stasis,
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
-"vyQ" = (
-/obj/effect/spawner/random/structure/crate,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
 "vzg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -54399,7 +54391,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
 /turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
+/area/station/maintenance/department/science/central)
 "vHR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -54602,6 +54594,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
+"vPF" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/station/maintenance/department/medical/morgue)
 "vQo" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Cargo Office Maintenance"
@@ -55493,7 +55495,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/preopen{
 	id = "prison release";
-	name = "prisoner processing blast door"
+	name = "Prisoner Processing Blast Door"
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
@@ -55541,24 +55543,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
-"wzP" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/table/reinforced,
-/obj/item/computer_hardware/hard_drive/portable/atmos{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/computer_hardware/hard_drive/portable/engineering,
-/turf/open/floor/iron,
-/area/station/command/heads_quarters/ce)
 "wAA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -55584,6 +55568,9 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
+"wBF" = (
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/office)
 "wBO" = (
 /obj/item/toy/crayon/spraycan{
 	pixel_x = 4;
@@ -55619,7 +55606,7 @@
 "wDf" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "telelab";
-	name = "test chamber blast door"
+	name = "Test Chamber Blast Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -55766,6 +55753,17 @@
 /obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
+"wGr" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron,
+/area/station/cargo/office)
 "wGM" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -55914,7 +55912,7 @@
 "wOF" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio8";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -56044,6 +56042,9 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"wTu" = (
+/turf/closed/wall,
+/area/station/security/medical)
 "wTD" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
@@ -56207,10 +56208,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
-"wYr" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/central)
 "wYu" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "shootshut"
@@ -56721,7 +56718,7 @@
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio7";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -56802,10 +56799,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/station/service/bar/atrium)
-"xst" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/central)
 "xsO" = (
 /obj/item/ectoplasm,
 /turf/open/floor/plating{
@@ -56820,6 +56813,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
+"xsZ" = (
+/obj/structure/chair,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "xte" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -56859,7 +56856,7 @@
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio8";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -56926,10 +56923,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"xxr" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/central)
 "xxw" = (
 /obj/machinery/atmospherics/components/binary/pump,
 /turf/open/floor/iron/dark,
@@ -56954,7 +56947,7 @@
 "xxO" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio2";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/machinery/door/window/left/directional/north{
 	base_state = "right";
@@ -57061,9 +57054,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/library)
-"xDj" = (
-/turf/closed/wall,
-/area/station/maintenance/department/medical)
 "xEt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -57381,10 +57371,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/medical/medbay/lobby)
-"xQH" = (
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
 "xQM" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/donkpockets,
@@ -57560,6 +57546,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"xYi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair/stool/bar/directional/east,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "xZT" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -57686,6 +57677,9 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"yet" = (
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/central)
 "yeD" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -76139,7 +76133,7 @@ aaa
 aaa
 adE
 adE
-dvY
+gzf
 acM
 aOn
 fzz
@@ -77185,11 +77179,11 @@ aiA
 ahY
 aiA
 aiA
-gzf
-gzf
-gzf
-gzf
-gzf
+dVg
+dVg
+dVg
+dVg
+dVg
 aDl
 ueU
 aiu
@@ -77442,7 +77436,7 @@ wHD
 sdE
 aiC
 ajc
-gEZ
+wTu
 akB
 alq
 alZ
@@ -77699,7 +77693,7 @@ yjF
 sdE
 aiC
 ajc
-gEZ
+wTu
 akC
 alr
 ama
@@ -77956,7 +77950,7 @@ dsP
 sdE
 aiC
 ajc
-gEZ
+wTu
 akD
 als
 maH
@@ -78213,7 +78207,7 @@ oJp
 sdE
 aiE
 agy
-gEZ
+wTu
 akE
 alt
 amc
@@ -78445,7 +78439,7 @@ aaa
 aht
 aht
 aem
-aml
+sfh
 wPr
 kmV
 kdk
@@ -78702,7 +78696,7 @@ aaa
 aaa
 aht
 aem
-dPr
+gtR
 czK
 pEg
 act
@@ -78795,10 +78789,10 @@ aYG
 aZx
 aYG
 bAJ
-ntz
-ntz
-ntz
-ntz
+pEI
+pEI
+pEI
+pEI
 bva
 xtI
 olY
@@ -79052,12 +79046,12 @@ aYG
 bxY
 bzz
 bAK
-ntz
+pEI
 bDg
 bXy
 bFF
-hjQ
-jHF
+eLG
+rod
 bva
 bHT
 bJi
@@ -79216,7 +79210,7 @@ aaa
 aaa
 aht
 ahC
-dWZ
+qWu
 afs
 ahp
 wNI
@@ -79309,12 +79303,12 @@ bwq
 bxZ
 bzA
 bAK
-ntz
+pEI
 bDg
 bEk
-hjQ
-hjQ
-soN
+eLG
+eLG
+eKj
 bBX
 bBX
 bBX
@@ -79566,13 +79560,13 @@ bwr
 bya
 bzB
 bAL
-ntz
+pEI
 bDh
 bEl
-hjQ
-rNF
-soN
-ntz
+eLG
+gMf
+eKj
+pEI
 doo
 hRH
 nCe
@@ -79816,20 +79810,20 @@ bnt
 sKe
 aYG
 aYG
-ntz
+pEI
 nta
-ntz
-ntz
-ntz
-ntz
-ntz
-ntz
-hjQ
+pEI
+pEI
+pEI
+pEI
+pEI
+pEI
+eLG
 bEm
-hjQ
-jfT
-qah
-ntz
+eLG
+iBY
+dIj
+pEI
 erQ
 oat
 sEN
@@ -80073,20 +80067,20 @@ aYG
 aYG
 aYG
 eUe
-hjQ
+eLG
 rbu
-tPs
+gmP
 bws
 byb
 bzC
 bzC
 bBY
-qah
-soN
-qah
-qah
-qah
-ntz
+dIj
+eKj
+dIj
+dIj
+dIj
+pEI
 qIl
 ohH
 jJN
@@ -80331,19 +80325,19 @@ bnu
 bpu
 uHJ
 uPG
-soN
-qah
-fiP
-ivf
+eKj
+dIj
+vPF
+nbo
 bzD
 bAM
-qah
+dIj
 bDj
-ntz
-ntz
-ntz
-ntz
-ntz
+pEI
+pEI
+pEI
+pEI
+pEI
 kTU
 wMn
 rsd
@@ -80587,16 +80581,16 @@ dmI
 oyH
 oyH
 uok
-hjQ
-hjQ
-hjQ
-hjQ
-hjQ
-dOo
-hjQ
-hjQ
-nuk
-ntz
+eLG
+eLG
+eLG
+eLG
+eLG
+pCY
+eLG
+eLG
+sNt
+pEI
 uko
 sSl
 bHS
@@ -80853,7 +80847,7 @@ juh
 bAN
 kvq
 ema
-ntz
+pEI
 gld
 ybu
 tuM
@@ -81109,8 +81103,8 @@ kbi
 fDf
 bAO
 tqC
-hjQ
-ntz
+eLG
+pEI
 tak
 dok
 rus
@@ -81608,11 +81602,11 @@ ptL
 ptL
 ptL
 biO
-kxJ
-kxJ
-kxJ
-kxJ
-kxJ
+gQI
+gQI
+gQI
+gQI
+gQI
 vIa
 bou
 biY
@@ -81865,11 +81859,11 @@ bgZ
 ugM
 pkj
 biP
-kxJ
+gQI
 bkX
 bmh
 xyK
-kxJ
+gQI
 bpy
 biv
 bsr
@@ -82122,11 +82116,11 @@ xvO
 bhL
 jcT
 sSj
-kxJ
+gQI
 bkY
 bmi
 wns
-kxJ
+gQI
 mgW
 bCd
 bvL
@@ -82379,11 +82373,11 @@ bhb
 xPQ
 piM
 bij
-kxJ
+gQI
 bkZ
 bmi
 xyK
-kxJ
+gQI
 mgW
 srf
 bFJ
@@ -82416,7 +82410,7 @@ qXx
 bDi
 bRF
 bDi
-enJ
+uIR
 ewb
 bva
 bPA
@@ -82636,15 +82630,15 @@ coy
 xPQ
 jcT
 bik
-kxJ
+gQI
 bla
-dZG
-dZG
-kxJ
+hVZ
+hVZ
+gQI
 bvc
 bqY
 mEo
-bCY
+tOy
 rtd
 koW
 koW
@@ -82669,7 +82663,7 @@ rHh
 sOB
 aht
 bva
-kJJ
+pbo
 ewb
 lPe
 lug
@@ -82883,7 +82877,7 @@ aWN
 aXO
 aYM
 vOW
-nyl
+qjT
 oAk
 aZP
 bed
@@ -82893,10 +82887,10 @@ jcT
 xPQ
 bik
 biT
-kxJ
+gQI
 kSO
+eWD
 qvR
-fca
 boz
 spo
 nrv
@@ -82908,7 +82902,7 @@ tWt
 pPN
 cKQ
 cKQ
-aMt
+tJu
 gZl
 uyg
 cKQ
@@ -83150,11 +83144,11 @@ jcT
 xPQ
 bik
 nmF
-kxJ
+gQI
 blb
 bml
 vtX
-kxJ
+gQI
 ryC
 bqX
 mEo
@@ -83407,11 +83401,11 @@ qbP
 qve
 amL
 bjc
-kxJ
-kxJ
-kxJ
-kxJ
-kxJ
+gQI
+gQI
+gQI
+gQI
+gQI
 bpD
 brb
 btZ
@@ -83430,11 +83424,11 @@ xIZ
 sOB
 sOB
 sOB
-xDj
-xDj
-xDj
-xDj
-xDj
+oJj
+oJj
+oJj
+oJj
+oJj
 snZ
 bva
 bva
@@ -83687,11 +83681,11 @@ pJc
 lig
 xBk
 uwS
-xDj
+oJj
 bNP
 bOE
 dSI
-ddf
+brI
 bDi
 bva
 bsn
@@ -83944,11 +83938,11 @@ iyl
 iyl
 iyl
 sCA
-oeU
-cYx
+dOo
+jaB
 omS
-cYx
-cYx
+jaB
+jaB
 olY
 bva
 gcn
@@ -84201,11 +84195,11 @@ ptR
 tir
 haB
 cCd
-xDj
+oJj
 bNR
 pHN
 fAE
-dfP
+hBg
 kTn
 bva
 sZP
@@ -84458,11 +84452,11 @@ mKg
 mKg
 mKg
 wcx
-xDj
-xDj
-xDj
-xDj
-xDj
+oJj
+oJj
+oJj
+oJj
+oJj
 sWN
 iOl
 iOl
@@ -84715,9 +84709,9 @@ fMs
 hkF
 ufk
 eKa
-xDj
+oJj
 xhT
-lSc
+nXy
 bVZ
 iOl
 nqB
@@ -84964,18 +84958,18 @@ rHG
 dZb
 uEY
 bEE
-rXs
-xDj
-xDj
-xDj
-xDj
-xDj
-xDj
-xDj
-xDj
+lRN
+oJj
+oJj
+oJj
+oJj
+oJj
+oJj
+oJj
+oJj
 snT
-doA
-rXs
+pnn
+lRN
 bBX
 bBX
 bBX
@@ -85231,8 +85225,8 @@ bJb
 bLG
 bpi
 bJb
-nXq
-rXs
+tHl
+lRN
 bQm
 bQZ
 bQZ
@@ -85477,19 +85471,19 @@ cSJ
 lsr
 hHJ
 bDw
-lsI
-rXs
+bEF
+lRN
 bEz
-pca
-xQH
-dfP
-dfP
-mZZ
-mZZ
-swm
-ady
-ekl
-rXs
+upW
+oxA
+hBg
+hBg
+fbb
+fbb
+oPH
+xsZ
+eMp
+lRN
 pQm
 doe
 cCF
@@ -85680,7 +85674,7 @@ arB
 asM
 atN
 aaZ
-bht
+gEK
 awR
 axT
 ayZ
@@ -85735,18 +85729,18 @@ bub
 byo
 bub
 bub
-rXs
-xDj
-xDj
-xDj
-xDj
-xDj
-xDj
-xDj
-xDj
-rXs
-ekl
-rXs
+lRN
+oJj
+oJj
+oJj
+oJj
+oJj
+oJj
+oJj
+oJj
+lRN
+eMp
+lRN
 bQo
 fWq
 bRa
@@ -86001,16 +85995,16 @@ lFb
 uik
 txK
 bMK
-rXs
-ekl
-rXs
+lRN
+eMp
+lRN
 bQp
 ptK
 bfQ
 cCP
 bTp
 bPB
-wzP
+bUI
 bVD
 bWn
 bXf
@@ -86259,8 +86253,8 @@ bsK
 bsK
 ygx
 cBL
-ekl
-rXs
+eMp
+lRN
 wVE
 bRG
 iBk
@@ -86515,10 +86509,10 @@ bum
 bsK
 bwV
 bMM
-rXs
-ekl
-rXs
-rXs
+lRN
+eMp
+lRN
+lRN
 bPB
 bRH
 bPB
@@ -86771,11 +86765,11 @@ dMR
 abz
 bsK
 eeb
-rXs
-rXs
-ekl
-nSg
-rXs
+lRN
+lRN
+eMp
+pAM
+lRN
 bRd
 bRI
 bSB
@@ -87028,11 +87022,11 @@ dMR
 abz
 bsK
 bAg
-rXs
+lRN
 bNV
-ekl
+eMp
 bPD
-rXs
+lRN
 bRe
 bRJ
 bSC
@@ -87285,11 +87279,11 @@ dMR
 abz
 bsK
 bLL
-rXs
+lRN
 bNW
 bOH
-xDj
-rXs
+oJj
+lRN
 bQr
 bRK
 bQr
@@ -87482,7 +87476,7 @@ syK
 syK
 vLp
 aDO
-inm
+nGp
 aAB
 aAB
 aAB
@@ -87542,10 +87536,10 @@ dMR
 rLd
 bsK
 anH
-rXs
-xQH
-ekl
-xDj
+lRN
+oxA
+eMp
+oJj
 bQs
 vsv
 bRL
@@ -87799,9 +87793,9 @@ dMR
 gFf
 bsK
 prD
-rXs
-rXs
-ekl
+lRN
+lRN
+eMp
 bPF
 bTu
 bTu
@@ -88057,9 +88051,9 @@ gFf
 bsK
 bLM
 bMN
-rXs
-ekl
-xDj
+lRN
+eMp
+oJj
 rYk
 bRi
 bRN
@@ -88314,9 +88308,9 @@ gFf
 bsK
 ezC
 jCw
-rXs
-ekl
-xDj
+lRN
+eMp
+oJj
 bQv
 bRj
 bRO
@@ -88571,9 +88565,9 @@ eRX
 bwV
 bLO
 bAh
-rXs
-ekl
-xDj
+lRN
+eMp
+oJj
 bQw
 bRj
 bRP
@@ -88828,9 +88822,9 @@ bsK
 nnf
 byz
 ooh
-rXs
-ekl
-xDj
+lRN
+eMp
+oJj
 bQx
 bRj
 bRQ
@@ -89085,9 +89079,9 @@ mqg
 bKG
 byA
 bAi
-rXs
-ekl
-xDj
+lRN
+eMp
+oJj
 bQy
 xff
 bRR
@@ -89332,19 +89326,19 @@ dRj
 hEC
 hEC
 hEC
-rXs
-rXs
-rXs
-rXs
-rXs
-rXs
-rXs
-rXs
-rXs
-rXs
-rXs
-ekl
-xDj
+lRN
+lRN
+lRN
+lRN
+lRN
+lRN
+lRN
+lRN
+lRN
+lRN
+lRN
+eMp
+oJj
 bQz
 bRl
 rpu
@@ -89599,9 +89593,9 @@ vNl
 vNl
 vNl
 vNl
-ekl
-ekl
-xDj
+eMp
+eMp
+oJj
 bQA
 bRm
 vyx
@@ -89837,28 +89831,28 @@ cQN
 xOq
 bmA
 cQN
-xDj
-rXs
-rXs
-rXs
+oJj
+lRN
+lRN
+lRN
 vSL
-xDj
+oJj
 hEC
 cIe
 fby
-xDj
+oJj
 vNl
 oXV
-xDj
-xDj
-xDj
-xDj
-xDj
-xDj
-xDj
+oJj
+oJj
+oJj
+oJj
+oJj
+oJj
+oJj
 xje
-xDj
-xDj
+oJj
+oJj
 bPE
 bPE
 bRU
@@ -90094,19 +90088,19 @@ bls
 aDm
 dhy
 bmB
-xDj
-swm
-swm
-swm
-ekl
-swm
-xDj
-xDj
-xDj
-xDj
+oJj
+oPH
+oPH
+oPH
+eMp
+oPH
+oJj
+oJj
+oJj
+oJj
 hop
-xDj
-xDj
+oJj
+oJj
 jCv
 bOK
 bRV
@@ -90362,7 +90356,7 @@ gVk
 gVk
 uQB
 oWN
-gEL
+cLB
 bFq
 tWh
 bIt
@@ -90608,19 +90602,19 @@ blu
 aDm
 rLQ
 eeF
-rXs
-rXs
-rXs
+lRN
+lRN
+lRN
 bro
-rXs
-rXs
-rXs
-rXs
-xDj
+lRN
+lRN
+lRN
+lRN
+oJj
 gRb
-swm
-pca
-xDj
+oPH
+upW
+oJj
 bAl
 bIu
 bmD
@@ -90643,7 +90637,7 @@ mCe
 bYl
 bYK
 pyA
-pjX
+xYi
 xpw
 cci
 vAE
@@ -90876,7 +90870,7 @@ bAm
 uaY
 oQi
 bDA
-vyQ
+nyN
 jSA
 wdv
 voL
@@ -91129,12 +91123,12 @@ tiI
 byF
 tiI
 byE
-rXs
-rXs
-rXs
-rXs
-rXs
-rXs
+lRN
+lRN
+lRN
+lRN
+lRN
+lRN
 bvD
 bIx
 cqz
@@ -91547,7 +91541,7 @@ ace
 abO
 abO
 abO
-oKb
+lvo
 abO
 abO
 adT
@@ -92176,7 +92170,7 @@ qzm
 bRr
 yhO
 qOx
-ldy
+wBF
 fBp
 bVd
 fBp
@@ -92433,7 +92427,7 @@ bRs
 mlD
 gur
 bSS
-tdr
+gVJ
 bUp
 bVe
 bVV
@@ -93194,17 +93188,17 @@ bGb
 laB
 xbB
 tqU
-ldy
-ldy
-ldy
+wBF
+wBF
+wBF
 bOj
 bKY
-ldy
-ldy
-ldy
-ldy
-ldy
-ldy
+wBF
+wBF
+wBF
+wBF
+wBF
+wBF
 bWP
 fuR
 bWO
@@ -94706,9 +94700,9 @@ prO
 ajQ
 pvZ
 gYW
-fJU
+gvM
 pTF
-fJU
+gvM
 beI
 lot
 lot
@@ -94760,13 +94754,13 @@ bJP
 bJP
 bJP
 bJP
-sbK
+hzr
 auI
 auI
 auI
 auI
 auI
-sbK
+hzr
 aaa
 aaa
 aaa
@@ -94963,9 +94957,9 @@ odh
 aZn
 bav
 cuL
-fJU
-icI
-fJU
+gvM
+pHf
+gvM
 bfv
 bgE
 lZc
@@ -94973,7 +94967,7 @@ bhR
 lZc
 bju
 bkt
-lpI
+qYI
 bmO
 bnQ
 boY
@@ -95220,9 +95214,9 @@ aYr
 aZn
 baw
 bbA
-fJU
-icI
-fJU
+gvM
+pHf
+gvM
 fkd
 sgZ
 bhl
@@ -95275,11 +95269,11 @@ cco
 lag
 bJP
 auI
-nHT
+iGR
 azm
 azN
 evU
-fWa
+ijt
 auI
 aaa
 aaa
@@ -95477,9 +95471,9 @@ nwK
 aZn
 bat
 syO
-fJU
-icI
-fJU
+gvM
+pHf
+gvM
 bfx
 bgG
 bhm
@@ -95532,11 +95526,11 @@ cby
 cby
 bJP
 auI
-nHT
+iGR
 rsy
 rjl
 syt
-fWa
+ijt
 auI
 aaa
 aaa
@@ -95734,9 +95728,9 @@ tQi
 hNd
 tYn
 nBt
-fJU
-icI
-fJU
+gvM
+pHf
+gvM
 bfy
 bgI
 bhn
@@ -95789,11 +95783,11 @@ bJP
 bJP
 bJP
 auI
-nHT
+iGR
 evU
 ssU
 azm
-fWa
+ijt
 auI
 aaa
 aaa
@@ -95993,13 +95987,13 @@ rJT
 sLD
 vQo
 dSK
-fJU
+gvM
 bfz
 bgI
 bhn
 bgI
 bfz
-fJU
+gvM
 iSi
 iSi
 bkt
@@ -96040,16 +96034,16 @@ bWO
 bYt
 bZf
 jOl
-sbK
-sbK
-sbK
-sbK
-sbK
-sbK
+hzr
+hzr
+hzr
+hzr
+hzr
+hzr
 ayG
-oWB
-oWB
-oWB
+pjM
+pjM
+pjM
 hCg
 auI
 aaa
@@ -96249,14 +96243,14 @@ aZn
 krI
 bbC
 lQr
-iMj
-fJU
+pBg
+gvM
 bfA
 bgJ
 bhn
 bhV
 vyn
-fJU
+gvM
 ltJ
 iSi
 vDT
@@ -96305,8 +96299,8 @@ cRm
 iVT
 mrH
 pGV
-oWB
-oWB
+pjM
+pjM
 wfp
 wQE
 xdQ
@@ -96506,15 +96500,15 @@ aZn
 aZn
 bbD
 jYA
-iMj
-fJU
-fJU
-fJU
+pBg
+gvM
+gvM
+gvM
 bhp
-fJU
-fJU
-fJU
-fJU
+gvM
+gvM
+gvM
+gvM
 iSi
 bmT
 bnU
@@ -96560,11 +96554,11 @@ yeD
 yeD
 yeD
 iiP
-frh
-oWB
-oWB
-oWB
-fWa
+opJ
+pjM
+pjM
+pjM
+ijt
 auI
 aaa
 aaa
@@ -96763,14 +96757,14 @@ aZn
 baz
 uwF
 jYA
-gUM
-sTF
-sTF
-sTF
+qhH
+khX
+khX
+khX
 fGd
 aam
 bix
-bqN
+yet
 fgl
 iSi
 bmU
@@ -96809,14 +96803,14 @@ pFG
 rGo
 eGT
 vLx
-sbK
+hzr
 ayJ
 dFK
-fiZ
-fiZ
-fiZ
-fiZ
-tva
+odp
+odp
+odp
+odp
+jWA
 mNv
 rfm
 sxs
@@ -97012,7 +97006,7 @@ wDZ
 aTo
 wDZ
 aUu
-avP
+wGr
 pvZ
 aXw
 aYv
@@ -97020,12 +97014,12 @@ aZo
 rWb
 bwD
 jYA
-fJU
-fJU
-fJU
-fJU
+gvM
+gvM
+gvM
+gvM
 aam
-bqN
+yet
 aam
 iSi
 iSi
@@ -97076,10 +97070,10 @@ bYw
 bYw
 bYw
 bYw
-sbK
-sbK
-sbK
-sbK
+hzr
+hzr
+hzr
+hzr
 aaa
 aaa
 aaa
@@ -97280,7 +97274,7 @@ nts
 lcH
 amb
 bfB
-fJU
+gvM
 jaJ
 xba
 dSK
@@ -97536,11 +97530,11 @@ bbI
 bcB
 hgV
 hgV
-csV
-fJU
+lkH
+gvM
 dRI
-bqN
-iMj
+gvM
+pBg
 iSi
 bkz
 fGH
@@ -97793,11 +97787,11 @@ bbI
 bcC
 qfZ
 xPf
-iXt
-fJU
+hgV
+hgV
 fQD
-fJU
-iMj
+gvM
+pBg
 iSi
 bkA
 blR
@@ -98053,8 +98047,8 @@ lGJ
 lGJ
 lGJ
 bhr
-fJU
-iMj
+gvM
+pBg
 iSi
 vYH
 xQM
@@ -98310,8 +98304,8 @@ xkk
 xkk
 xkk
 bhs
-fJU
-iMj
+gvM
+pBg
 iSi
 iSi
 wDf
@@ -98567,7 +98561,7 @@ hgV
 hgV
 pXH
 jYn
-fJU
+gvM
 biC
 dSK
 iSi
@@ -98824,9 +98818,9 @@ beO
 hgV
 pXH
 bhu
-fJU
-bqN
-iMj
+gvM
+yet
+pBg
 iSi
 aau
 aan
@@ -99081,9 +99075,9 @@ beP
 hgV
 pXH
 bhv
-fJU
-fJU
-iMj
+gvM
+gvM
+pBg
 iSi
 aaw
 pJU
@@ -99338,9 +99332,9 @@ bdI
 bfI
 bdI
 bbI
-fJU
-xxr
-iMj
+gvM
+dKH
+pBg
 aat
 aay
 hTq
@@ -99595,9 +99589,9 @@ bdI
 bfJ
 bdI
 aaa
-fJU
+gvM
 pKd
-iMj
+pBg
 iSi
 aaA
 aao
@@ -99852,9 +99846,9 @@ bdI
 oPy
 bdI
 aht
-fJU
-fJU
-iMj
+gvM
+gvM
+pBg
 iSi
 iSi
 aap
@@ -100110,7 +100104,7 @@ bfK
 aaa
 aaa
 aaa
-fJU
+gvM
 obj
 xba
 tim
@@ -100367,9 +100361,9 @@ aaa
 aaa
 aaa
 aaa
-fJU
-iMj
-bqN
+gvM
+pBg
+yet
 iSi
 nJI
 bky
@@ -100624,13 +100618,13 @@ aaa
 aaa
 aaa
 aaa
-fJU
-iMj
-fJU
+gvM
+pBg
+gvM
 iSi
 bky
-oPr
-oPr
+bpo
+bpo
 bqx
 bqs
 vfp
@@ -100881,9 +100875,9 @@ aaa
 aaa
 aaa
 aaa
-fJU
-iMj
-bqN
+gvM
+pBg
+yet
 bkD
 vxp
 boc
@@ -101138,9 +101132,9 @@ aaa
 aaa
 aaa
 aaa
-fJU
-iMj
-fJU
+gvM
+pBg
+gvM
 iSi
 iSi
 iSi
@@ -101383,26 +101377,26 @@ cDa
 mZS
 myc
 sAD
-fJU
+gvM
 uAh
 lQr
-fJU
-fJU
-fJU
-fJU
-fJU
-fJU
-fJU
-fJU
-fJU
-fJU
+gvM
+gvM
+gvM
+gvM
+gvM
+gvM
+gvM
+gvM
+gvM
+gvM
 oTl
 rpa
 rpa
 ipI
 rmP
 bpq
-fJU
+gvM
 brT
 eOJ
 wkZ
@@ -101624,7 +101618,7 @@ aur
 aur
 aEj
 noT
-ain
+ntb
 aFi
 aFi
 lru
@@ -101640,21 +101634,21 @@ rbx
 nNk
 myc
 uzX
-fJU
+gvM
 nTv
 kSG
 kXZ
-icI
-icI
-dOB
-sTF
+pHf
+pHf
+enf
+khX
 kjA
-sTF
+khX
 dSK
-dOB
-sTF
+enf
+khX
 fGd
-rjw
+isg
 cYn
 wAI
 rpa
@@ -101881,7 +101875,7 @@ aur
 aur
 aEj
 odG
-bpo
+rtA
 yiL
 yiL
 set
@@ -101890,23 +101884,23 @@ mdx
 mdx
 mdx
 mdx
-vHj
+nWl
 mXc
 saR
 tAm
 tvy
 eCB
 ahW
-kPA
-sTF
+vHj
+khX
 ajS
-sTF
-sTF
+khX
+khX
 vaa
 mri
-fJU
+gvM
 uSW
-fJU
+gvM
 gfi
 jHZ
 iSi
@@ -102154,16 +102148,16 @@ tko
 bbG
 xud
 bbG
-fJU
-xst
+gvM
+vgm
 jYA
-xst
-xst
-xst
-fJU
-fJU
+vgm
+vgm
+vgm
+gvM
+gvM
 tBP
-fJU
+gvM
 uSW
 lEn
 pnU
@@ -102417,10 +102411,10 @@ rax
 aaa
 aaa
 aaa
-fJU
+gvM
 iiy
 uSW
-fJU
+gvM
 uSW
 lEn
 uwb
@@ -102674,10 +102668,10 @@ rax
 aaa
 aaa
 aaa
-fJU
+gvM
 beS
 uSW
-fJU
+gvM
 uSW
 lEn
 biD
@@ -102931,10 +102925,10 @@ oCX
 sut
 aaa
 aaa
-fJU
-wYr
+gvM
+cJv
 dBQ
-fJU
+gvM
 uSW
 lEn
 vYN
@@ -103188,12 +103182,12 @@ igX
 rWE
 aht
 aht
-fJU
+gvM
 kIo
 bfN
-fJU
+gvM
 uSW
-fJU
+gvM
 iSi
 iSi
 iSi
@@ -103445,10 +103439,10 @@ baG
 sut
 aaa
 aaa
-fJU
-fJU
+gvM
+gvM
 lhf
-fJU
+gvM
 qHf
 dTR
 dTR
@@ -103702,13 +103696,13 @@ baG
 sut
 aaa
 aaa
-fJU
+gvM
 bfP
 fer
-fJU
-fJU
-fJU
-rjw
+gvM
+gvM
+gvM
+isg
 uSW
 iSi
 blX
@@ -103959,13 +103953,13 @@ baG
 sut
 aaa
 aaa
-fJU
+gvM
 pKd
 uSW
 hOz
-fJU
+gvM
 oRX
-bqN
+yet
 uSW
 iSi
 bnh
@@ -104216,7 +104210,7 @@ baG
 sut
 aaa
 aaa
-fJU
+gvM
 eZA
 tDn
 dTR
@@ -104473,11 +104467,11 @@ baG
 rWE
 aht
 aht
-fJU
+gvM
 vzT
 gUb
-bqN
-fJU
+yet
+gvM
 gSI
 uSW
 bfM
@@ -104730,12 +104724,12 @@ baG
 sut
 aaa
 aaa
-fJU
+gvM
 dsv
 dLY
 xyl
-fJU
-rjw
+gvM
+isg
 uSW
 ybX
 iSi
@@ -104987,12 +104981,12 @@ baG
 sut
 aaa
 aaa
-fJU
-fJU
-fJU
-fJU
-fJU
-fJU
+gvM
+gvM
+gvM
+gvM
+gvM
+gvM
 rAE
 bfM
 iSi
@@ -105249,7 +105243,7 @@ aht
 cdm
 aaa
 aaa
-xst
+vgm
 uSW
 ybX
 iSi
@@ -105506,7 +105500,7 @@ aaa
 cdm
 aaa
 aaa
-xst
+vgm
 uSW
 fNv
 iSi
@@ -105763,7 +105757,7 @@ aaa
 cdm
 aaa
 aaa
-xst
+vgm
 uSW
 bfM
 iSi
@@ -106020,7 +106014,7 @@ aaa
 cdm
 aaa
 aaa
-xst
+vgm
 uSW
 ybX
 iSi
@@ -106275,9 +106269,9 @@ aht
 aht
 aht
 cdm
-fJU
-fJU
-fJU
+gvM
+gvM
+gvM
 rAE
 fNv
 iSi
@@ -106532,9 +106526,9 @@ aht
 aaa
 aaa
 cdm
-xst
+vgm
 bnl
-bqN
+yet
 uSW
 kSG
 iSi
@@ -106789,7 +106783,7 @@ aht
 aaa
 aaa
 cdm
-xst
+vgm
 iCe
 rxa
 uSW
@@ -107046,16 +107040,16 @@ aht
 aaa
 aaa
 cdm
-xst
+vgm
 wOf
-bqN
+yet
 uSW
 qHf
 pvc
 wQU
 xvx
-rDV
-rDV
+qdt
+qdt
 bqO
 btB
 btF
@@ -107303,13 +107297,13 @@ aht
 aht
 aht
 bbP
-fJU
-fJU
-fJU
+gvM
+gvM
+gvM
 xyh
-fJU
+gvM
 jYA
-fJU
+gvM
 cJo
 qJB
 ops
@@ -107566,7 +107560,7 @@ hMc
 vZV
 fEo
 qIH
-fJU
+gvM
 iSi
 iSi
 iSi

--- a/StationMaps/PubbyStation/PubbyStation.dmm
+++ b/StationMaps/PubbyStation/PubbyStation.dmm
@@ -26804,7 +26804,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "bUo" = (
@@ -26817,8 +26816,6 @@
 	c_tag = "Engineering Access"
 	},
 /obj/machinery/light/directional/north,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "bUp" = (

--- a/StationMaps/PubbyStation/PubbyStation.dmm
+++ b/StationMaps/PubbyStation/PubbyStation.dmm
@@ -24,6 +24,7 @@
 	departmentType = 5;
 	name = "Brig Requests Console"
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "aaf" = (
@@ -183,14 +184,13 @@
 /area/station/science/explab)
 "aaC" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/machinery/button/door{
-	id = "evashutter";
-	name = "EVA Shutters Control";
-	pixel_x = -24;
-	req_access_txt = "18"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/button/door/directional/west{
+	id = "evashutter";
+	name = "EVA Shutters Control";
+	req_access = list("eva")
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
@@ -2099,7 +2099,7 @@
 	name = "Cell Lockdown Button";
 	pixel_x = 6;
 	pixel_y = 26;
-	req_access_txt = "2"
+	req_access = list("brig")
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
@@ -2535,7 +2535,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "ajg" = (
@@ -3097,8 +3097,7 @@
 /area/station/maintenance/department/security/brig)
 "akx" = (
 /obj/structure/bodycontainer/crematorium{
-	id = "seccrematorium";
-	id_tag = null
+	id = "seccrematorium"
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/processing/cremation)
@@ -3878,8 +3877,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/obj/effect/mapping_helpers/airlock/access/all/service/crematorium,
+/obj/effect/mapping_helpers/airlock/access/any/service/crematorium,
+/obj/effect/mapping_helpers/airlock/access/any/security/armory,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
 "amK" = (
@@ -4527,7 +4526,7 @@
 	name = "Permabrig Lockdown";
 	pixel_x = 5;
 	pixel_y = 8;
-	req_access_txt = "2"
+	req_access = list("armory")
 	},
 /obj/machinery/computer/security/telescreen/prison{
 	dir = 4;
@@ -4873,7 +4872,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/effect/mapping_helpers/airlock/access/all/security/detective,
 /turf/open/floor/iron,
 /area/station/security/office)
 "apQ" = (
@@ -6389,7 +6387,7 @@
 	normaldoorcontrol = 1;
 	pixel_x = -6;
 	pixel_y = 36;
-	req_access_txt = "63"
+	req_access = list("brig_entrance")
 	},
 /obj/machinery/button/door{
 	desc = "A remote control switch for the medbay foyer.";
@@ -6398,7 +6396,7 @@
 	normaldoorcontrol = 1;
 	pixel_x = -6;
 	pixel_y = 24;
-	req_access_txt = "63"
+	req_access = list("brig_entrance")
 	},
 /obj/machinery/button/flasher{
 	id = "brigentry";
@@ -10850,7 +10848,6 @@
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "aKk" = (
-/obj/effect/spawner/random/structure/crate,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -10989,7 +10986,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "aKY" = (
@@ -11250,7 +11247,7 @@
 	},
 /obj/machinery/door/window/brigdoor/right/directional/west{
 	name = "Command Storage";
-	req_access_txt = "19"
+	req_access = list("eva")
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
@@ -11381,18 +11378,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard)
 "aMt" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Cargo Bay Warehouse Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "aMw" = (
@@ -11632,7 +11618,7 @@
 	},
 /obj/machinery/door/window/brigdoor/left/directional/west{
 	name = "Command Storage";
-	req_access_txt = "19"
+	req_access = list("eva")
 	},
 /obj/structure/window/reinforced/spawner,
 /turf/open/floor/iron/dark,
@@ -16188,7 +16174,7 @@
 /area/station/hallway/primary/central)
 "bfu" = (
 /obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "bfv" = (
@@ -19226,8 +19212,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "sci-maint-passthrough"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "bqV" = (
@@ -20702,8 +20687,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "sci-maint-passthrough"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "bwq" = (
@@ -22780,6 +22764,9 @@
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "bDy" = (
@@ -23263,7 +23250,7 @@
 "bFq" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "bFr" = (
@@ -24284,7 +24271,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "bJO" = (
@@ -27618,9 +27605,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/science/general,
-/obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "bWb" = (
@@ -28507,7 +28492,7 @@
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bZt" = (
@@ -32630,7 +32615,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "cxq" = (
@@ -35978,7 +35963,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "feh" = (
@@ -36279,7 +36264,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "fqJ" = (
@@ -36732,7 +36717,7 @@
 	name = "Mineral Room"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "fLd" = (
@@ -37248,7 +37233,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "gld" = (
@@ -39326,13 +39311,23 @@
 /turf/open/floor/plating/airless,
 /area/station/engineering/supermatter/room)
 "inm" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/item/radio/intercom/directional/south,
+/obj/structure/table/reinforced,
+/obj/item/computer_hardware/hard_drive/portable/atmos{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/computer_hardware/hard_drive/portable/engineering,
 /turf/open/floor/iron,
-/area/station/security/brig)
+/area/station/command/heads_quarters/ce)
 "int" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall,
@@ -39426,6 +39421,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/service/crematorium,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
 "irZ" = (
@@ -40617,7 +40613,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
 "jHP" = (
@@ -41792,6 +41788,7 @@
 	name = "Firing Range Target"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
+/obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -41895,8 +41892,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "cargo-maint-passthrough"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/supply/general,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "kPM" = (
@@ -43852,7 +43848,7 @@
 	name = "Surgical Room"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "mEW" = (
@@ -44689,7 +44685,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
 "nts" = (
@@ -45159,9 +45155,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/medical/general,
-/obj/effect/mapping_helpers/airlock/access/any/science/general,
+/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "nTv" = (
@@ -45538,7 +45532,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "olj" = (
@@ -45710,7 +45704,7 @@
 	name = "Cell Lockdown Button";
 	pixel_x = 6;
 	pixel_y = 26;
-	req_access_txt = "2"
+	req_access = list("brig")
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
@@ -46647,7 +46641,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "peY" = (
@@ -48796,7 +48790,7 @@
 "qXq" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/abandoned,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "qXx" = (
@@ -54631,8 +54625,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "cargo-maint-passthrough"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/supply/general,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "vHR" = (
@@ -55655,6 +55648,21 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"wvg" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/table/glass,
+/obj/item/computer_hardware/hard_drive/portable/medical,
+/obj/item/computer_hardware/hard_drive/portable/chemistry{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/cmo)
 "wvk" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Chapel Access"
@@ -55781,7 +55789,7 @@
 	id = "armory";
 	name = "Armory Shutters";
 	pixel_y = 26;
-	req_access_txt = "3"
+	req_access = list("armory")
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
@@ -55807,7 +55815,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "wBO" = (
@@ -56236,7 +56244,7 @@
 /area/station/maintenance/department/engine)
 "wRz" = (
 /obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -56725,7 +56733,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "xhE" = (
@@ -56769,7 +56777,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "xjl" = (
@@ -58044,7 +58052,7 @@
 	name = "Cell Lockdown Button";
 	pixel_x = 6;
 	pixel_y = 26;
-	req_access_txt = "2"
+	req_access = list("brig")
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
@@ -82828,7 +82836,7 @@ apc
 apP
 aqy
 arr
-inm
+mJe
 ajM
 auE
 aoP
@@ -85712,7 +85720,7 @@ cSJ
 lsr
 hHJ
 bDw
-bEF
+wvg
 rXs
 bEz
 pca
@@ -86245,7 +86253,7 @@ bfQ
 cCP
 bTp
 bPB
-bUI
+inm
 bVD
 bWn
 bXf
@@ -98781,7 +98789,7 @@ aIl
 aEd
 aKj
 aEj
-aMt
+uXX
 aEj
 wDZ
 aTo
@@ -101859,7 +101867,7 @@ aur
 aur
 aEj
 noT
-aFi
+aMt
 aFi
 aFi
 lru

--- a/StationMaps/PubbyStation/PubbyStation.dmm
+++ b/StationMaps/PubbyStation/PubbyStation.dmm
@@ -17881,9 +17881,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "bmz" = (
@@ -33065,9 +33062,9 @@
 	},
 /area/station/maintenance/department/science)
 "cEJ" = (
-/obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer2,
 /obj/structure/cable,
+/obj/machinery/meter/layer2,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
 "cFB" = (
@@ -39959,9 +39956,6 @@
 	id_tag = "virology_airlock_exterior";
 	name = "Virology Exterior Airlock"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door_buttons/access_button{
 	idDoor = "virology_airlock_exterior";
@@ -39977,6 +39971,9 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/medical/virology,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "virology-entrance"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "jos" = (
@@ -40007,12 +40004,12 @@
 	pixel_x = -24;
 	req_access = list("virology")
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/medical/virology,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "virology-entrance"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "jry" = (

--- a/StationMaps/PubbyStation/PubbyStation.dmm
+++ b/StationMaps/PubbyStation/PubbyStation.dmm
@@ -1009,7 +1009,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "adX" = (
 /turf/closed/wall/r_wall,
@@ -1027,7 +1027,7 @@
 	c_tag = "MiniSat Bridge Starboard Fore";
 	network = list("minisat")
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "aec" = (
 /obj/machinery/suit_storage_unit/standard_unit,
@@ -1145,7 +1145,7 @@
 	c_tag = "MiniSat Bridge Port Aft";
 	network = list("minisat")
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "aeB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -4299,7 +4299,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/lobby)
 "aof" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -4321,7 +4321,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/lobby)
 "aok" = (
 /obj/machinery/computer/security/labor,
 /turf/open/floor/iron/dark,
@@ -5041,6 +5041,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "aqF" = (
@@ -11399,6 +11400,7 @@
 	},
 /obj/effect/landmark/start/assistant,
 /obj/machinery/newscaster/directional/south,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/auxiliary)
 "aNd" = (
@@ -20117,6 +20119,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/station/medical/cryo)
 "bvg" = (
@@ -22314,6 +22317,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "bCx" = (
@@ -22803,6 +22807,8 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "bEI" = (
@@ -26620,7 +26626,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/lobby)
 "bTI" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/atmos/glass{
@@ -26782,7 +26788,7 @@
 	},
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/lobby)
 "bUm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -26793,14 +26799,14 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/lobby)
 "bUn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/lobby)
 "bUo" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
@@ -26814,7 +26820,7 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/lobby)
 "bUp" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -27075,7 +27081,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/lobby)
 "bVa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -27086,7 +27092,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/goonplaque,
-/area/station/engineering/break_room)
+/area/station/engineering/lobby)
 "bVb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27095,7 +27101,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/lobby)
 "bVc" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
@@ -27106,7 +27112,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/lobby)
 "bVd" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics"
@@ -27342,7 +27348,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/lobby)
 "bVT" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line,
@@ -27352,7 +27358,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/lobby)
 "bVU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -27361,7 +27367,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/lobby)
 "bVV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -27612,7 +27618,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/lobby)
 "bWG" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
@@ -27620,7 +27626,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/lobby)
 "bWI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
@@ -27798,7 +27804,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/lobby)
 "bXr" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
@@ -29754,6 +29760,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden/monastery)
 "ciF" = (
@@ -30772,7 +30779,7 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/ai_sat_ext_as)
 "cnE" = (
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "cnJ" = (
 /obj/effect/turf_decal/delivery,
@@ -30787,6 +30794,7 @@
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/light/directional/north,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/lockers)
 "cnP" = (
@@ -30840,6 +30848,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/dorms/laundry)
 "coe" = (
@@ -33100,6 +33109,7 @@
 "cIe" = (
 /obj/machinery/computer/med_data/laptop,
 /obj/structure/table/glass,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/medical/abandoned)
 "cIt" = (
@@ -34400,7 +34410,7 @@
 "eaF" = (
 /obj/structure/table,
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/lobby)
 "ebp" = (
 /obj/structure/sign/plaques/kiddie{
 	desc = "It reads: PRIVATE EXHIBIT -  Please inquire with library staff for guided tours.";
@@ -35046,6 +35056,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
+"eFW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/fore)
 "eGF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -39020,6 +39041,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "iok" = (
@@ -41289,7 +41311,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/lobby)
 "kAD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41407,6 +41429,7 @@
 /area/station/maintenance/department/security/brig)
 "kGE" = (
 /obj/machinery/newscaster/directional/south,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "kHO" = (
@@ -43129,7 +43152,7 @@
 	network = list("minisat")
 	},
 /obj/machinery/light/small,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "mpd" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
@@ -44371,6 +44394,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel/monastery)
 "nwJ" = (
@@ -46561,7 +46585,7 @@
 /area/station/science/xenobiology)
 "pps" = (
 /turf/closed/wall,
-/area/station/engineering/break_room)
+/area/station/engineering/lobby)
 "ppQ" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
@@ -47775,9 +47799,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
-"qoK" = (
-/turf/closed/wall/r_wall,
-/area/station/engineering/break_room)
 "qph" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -84370,7 +84391,7 @@ amv
 alJ
 anS
 aoz
-api
+eFW
 aoz
 awj
 asK
@@ -91135,7 +91156,7 @@ bUl
 bUZ
 bVS
 bWG
-qoK
+qOx
 bYm
 bYZ
 bZG
@@ -91906,7 +91927,7 @@ bUo
 bVc
 kAo
 eaF
-qoK
+qOx
 aoq
 bZc
 bZJ

--- a/StationMaps/PubbyStation/PubbyStation.dmm
+++ b/StationMaps/PubbyStation/PubbyStation.dmm
@@ -87,7 +87,7 @@
 "aak" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/engine,
-/area/station/science/explab)
+/area/station/science/lab)
 "aal" = (
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -114,13 +114,13 @@
 	},
 /obj/effect/landmark/blobstart,
 /turf/open/floor/engine,
-/area/station/science/explab)
+/area/station/science/lab)
 "aao" = (
 /obj/structure/table/reinforced,
 /obj/item/pen,
 /obj/item/paper_bin,
 /turf/open/floor/engine,
-/area/station/science/explab)
+/area/station/science/lab)
 "aap" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -128,12 +128,12 @@
 	name = "Test Chamber Blast Door"
 	},
 /turf/open/floor/plating,
-/area/station/science/explab)
+/area/station/science/lab)
 "aaq" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
-/area/station/science/explab)
+/area/station/science/lab)
 "aas" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -147,7 +147,7 @@
 	},
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/engine,
-/area/station/science/explab)
+/area/station/science/lab)
 "aat" = (
 /obj/structure/sign/warning,
 /turf/closed/wall/r_wall,
@@ -156,7 +156,7 @@
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/rnd/experimentor,
 /turf/open/floor/engine,
-/area/station/science/explab)
+/area/station/science/lab)
 "aav" = (
 /obj/machinery/firealarm/directional/west,
 /obj/structure/cable,
@@ -169,7 +169,7 @@
 	},
 /obj/machinery/light/directional/north,
 /turf/open/floor/engine,
-/area/station/science/explab)
+/area/station/science/lab)
 "aax" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -177,14 +177,14 @@
 /obj/effect/landmark/start/scientist,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
-/area/station/science/explab)
+/area/station/science/lab)
 "aay" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Experimentation Lab Chamber";
 	network = list("ss13","rd")
 	},
 /turf/open/floor/engine,
-/area/station/science/explab)
+/area/station/science/lab)
 "aaz" = (
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/grimy,
@@ -193,7 +193,7 @@
 /obj/structure/table/reinforced,
 /obj/item/relic,
 /turf/open/floor/engine,
-/area/station/science/explab)
+/area/station/science/lab)
 "aaC" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/stripes/line{
@@ -322,7 +322,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "abb" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -16980,9 +16980,6 @@
 /obj/machinery/recharge_station,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
-"bjw" = (
-/turf/closed/wall/r_wall,
-/area/station/science/explab)
 "bjB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/circuit/telecomms,
@@ -17301,7 +17298,7 @@
 /area/station/science/server)
 "bky" = (
 /turf/open/floor/engine,
-/area/station/science/explab)
+/area/station/science/lab)
 "bkz" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -18240,16 +18237,16 @@
 	dir = 8
 	},
 /turf/open/floor/engine,
-/area/station/science/explab)
+/area/station/science/lab)
 "bod" = (
 /turf/closed/wall,
-/area/station/science/explab)
+/area/station/science/lab)
 "bof" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/engine{
 	name = "Holodeck Projector Floor"
 	},
-/area/station/science/explab)
+/area/station/science/lab)
 "bol" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -18494,7 +18491,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/station/science/explab)
+/area/station/science/lab)
 "bpq" = (
 /obj/effect/spawner/random/maintenance,
 /obj/structure/closet/crate,
@@ -18641,7 +18638,7 @@
 	name = "Research Shutters"
 	},
 /turf/open/floor/plating,
-/area/station/science/lab)
+/area/station/science/research)
 "bqc" = (
 /obj/structure/table/reinforced,
 /obj/item/pen{
@@ -18658,7 +18655,7 @@
 	},
 /obj/item/folder/white,
 /turf/open/floor/plating,
-/area/station/science/lab)
+/area/station/science/research)
 "bqd" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Research Division"
@@ -18786,7 +18783,7 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "bqp" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -18802,7 +18799,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "bqq" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -18812,7 +18809,7 @@
 	},
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "bqr" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -18821,10 +18818,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/science/explab)
-"bqs" = (
-/turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "bqt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18833,7 +18827,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "bqv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18848,7 +18842,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "bqw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -18863,7 +18857,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "bqx" = (
 /obj/item/stack/sheet/glass/fifty{
 	pixel_x = 3;
@@ -18887,7 +18881,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "bqy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -19135,7 +19129,7 @@
 	},
 /obj/machinery/computer/department_orders/science,
 /turf/open/floor/iron/white,
-/area/station/science/lab)
+/area/station/science/research)
 "brq" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -19149,7 +19143,7 @@
 	},
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white,
-/area/station/science/lab)
+/area/station/science/research)
 "brr" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/light/directional/north,
@@ -19165,7 +19159,7 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/science/lab)
+/area/station/science/research)
 "brs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -19177,7 +19171,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/science/lab)
+/area/station/science/research)
 "brt" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -19189,7 +19183,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/science/lab)
+/area/station/science/research)
 "bru" = (
 /obj/machinery/holopad,
 /obj/item/reagent_containers/glass/bucket,
@@ -19201,7 +19195,7 @@
 	},
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/white,
-/area/station/science/lab)
+/area/station/science/research)
 "brw" = (
 /obj/machinery/vending/wardrobe/robo_wardrobe,
 /turf/open/floor/iron/dark,
@@ -19287,7 +19281,7 @@
 	},
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "brI" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
@@ -19598,16 +19592,16 @@
 "bsR" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/white,
-/area/station/science/lab)
+/area/station/science/research)
 "bsS" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/white,
-/area/station/science/lab)
+/area/station/science/research)
 "bsT" = (
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/white,
-/area/station/science/lab)
+/area/station/science/research)
 "bsV" = (
 /obj/structure/chair{
 	dir = 8
@@ -19741,14 +19735,14 @@
 /obj/item/multitool,
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "bts" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "btt" = (
 /obj/machinery/door/airlock/research{
 	name = "Xenobiology Lab"
@@ -19976,18 +19970,18 @@
 /obj/machinery/rnd/destructive_analyzer,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/research)
 "buq" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/research)
 "bur" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/rnd/production/protolathe/department/science,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/research)
 "bus" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Research and Development Lab";
@@ -20002,7 +19996,7 @@
 	receive_ore_updates = 1
 	},
 /turf/open/floor/iron/white,
-/area/station/science/lab)
+/area/station/science/research)
 "but" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/purple{
@@ -20057,7 +20051,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "buy" = (
 /obj/item/kirbyplants/photosynthetic{
 	pixel_y = 10
@@ -20067,11 +20061,11 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "buz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/science/explab)
+/area/station/science/lab)
 "buD" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -20091,7 +20085,7 @@
 	},
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "buK" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -20267,7 +20261,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/research)
 "bvx" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/start/scientist,
@@ -20277,12 +20271,12 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/research)
 "bvy" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/rnd/production/circuit_imprinter/department/science,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/research)
 "bvB" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -20370,12 +20364,12 @@
 	network = list("ss13","rd")
 	},
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "bvJ" = (
 /obj/structure/closet/firecloset/full,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "bvL" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20390,13 +20384,13 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "bvO" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "bvP" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -20406,7 +20400,7 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "bvQ" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -20415,7 +20409,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "bvT" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -20430,16 +20424,16 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "bvU" = (
 /obj/machinery/recharger,
 /obj/structure/table,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "bvV" = (
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "bvW" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/green{
@@ -20457,12 +20451,12 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "bwa" = (
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "bwc" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/machinery/module_duplicator,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "bwm" = (
 /turf/closed/wall,
 /area/station/maintenance/department/science)
@@ -20629,13 +20623,13 @@
 /obj/item/disk/design_disk,
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
-/area/station/science/lab)
+/area/station/science/research)
 "bxc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /turf/open/floor/iron/white,
-/area/station/science/lab)
+/area/station/science/research)
 "bxd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -20652,7 +20646,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/science/lab)
+/area/station/science/research)
 "bxe" = (
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 8;
@@ -20669,7 +20663,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/science/lab)
+/area/station/science/research)
 "bxf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20685,7 +20679,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/science/lab)
+/area/station/science/research)
 "bxg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20698,7 +20692,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/science/lab)
+/area/station/science/research)
 "bxh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20717,7 +20711,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/science/general,
 /turf/open/floor/iron,
-/area/station/science/lab)
+/area/station/science/research)
 "bxi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -20826,7 +20820,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/science/research,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "bxt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20847,7 +20841,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/science/research,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "bxA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -20860,7 +20854,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "bxC" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -20872,11 +20866,11 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "bxD" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "bxH" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -20903,14 +20897,14 @@
 "bxK" = (
 /obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "bxL" = (
 /obj/structure/table,
 /obj/item/controller,
 /obj/item/compact_remote,
 /obj/item/compact_remote,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "bxM" = (
 /obj/machinery/disposal/bin,
 /obj/structure/window/reinforced{
@@ -21176,7 +21170,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/lab)
+/area/station/science/research)
 "byE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21194,14 +21188,14 @@
 	},
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white,
-/area/station/science/lab)
+/area/station/science/research)
 "byF" = (
 /obj/structure/chair/office/light{
 	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/science/lab)
+/area/station/science/research)
 "byG" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/purple,
@@ -21216,7 +21210,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/science/lab)
+/area/station/science/research)
 "byH" = (
 /obj/structure/table,
 /obj/item/multitool,
@@ -21227,7 +21221,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/station/science/lab)
+/area/station/science/research)
 "byJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -21304,7 +21298,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "byR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -21318,7 +21312,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "byU" = (
 /obj/structure/chair/comfy{
 	dir = 4
@@ -21328,7 +21322,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "byV" = (
 /obj/structure/table,
 /obj/item/folder,
@@ -21340,7 +21334,7 @@
 	},
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "byW" = (
 /obj/structure/chair/comfy{
 	dir = 8
@@ -21350,7 +21344,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "byX" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Research Division Secure Hallway"
@@ -21361,17 +21355,17 @@
 	},
 /obj/machinery/bluespace_vendor/directional/south,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "byY" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "bza" = (
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "bzb" = (
 /obj/structure/closet/radiation,
 /obj/structure/window/reinforced{
@@ -21386,17 +21380,17 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "bzc" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "bzd" = (
 /obj/structure/table,
 /obj/item/stock_parts/cell/high,
 /obj/machinery/cell_charger,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "bzg" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -21417,11 +21411,11 @@
 	network = list("ss13","rd")
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "bzi" = (
 /obj/machinery/component_printer,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "bzk" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio1";
@@ -22434,7 +22428,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "bCU" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -22445,7 +22439,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "bCV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -22679,7 +22673,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "bDT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22696,7 +22690,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "bDU" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/research/glass{
@@ -22979,7 +22973,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "bFh" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
@@ -23221,12 +23215,12 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "bGk" = (
 /obj/machinery/light,
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "bGl" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/tile/purple,
@@ -23234,7 +23228,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "bGm" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -31007,7 +31001,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "cpg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -33132,7 +33126,7 @@
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "cKQ" = (
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -33255,7 +33249,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "cQN" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -33327,7 +33321,7 @@
 	location = "Research Division"
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/lab)
+/area/station/science/research)
 "cTq" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/seed_extractor,
@@ -33485,7 +33479,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "dhy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -33531,7 +33525,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "dkU" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -33817,7 +33811,7 @@
 	pixel_x = -6
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/lab)
+/area/station/science/research)
 "duQ" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Departure Lounge Aft"
@@ -34007,7 +34001,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "dGO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -34459,7 +34453,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "edJ" = (
 /obj/structure/chair/office/light,
 /turf/open/floor/iron/white,
@@ -34491,7 +34485,7 @@
 "efu" = (
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "efC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -35204,7 +35198,7 @@
 	dir = 8
 	},
 /turf/open/floor/engine,
-/area/station/science/explab)
+/area/station/science/lab)
 "eNq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8;
@@ -35502,7 +35496,7 @@
 "eXo" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/engine,
-/area/station/science/explab)
+/area/station/science/lab)
 "eXv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -35855,7 +35849,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "fkd" = (
 /obj/machinery/mechpad,
 /obj/machinery/airalarm/directional/north,
@@ -35880,7 +35874,7 @@
 	},
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "flq" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -37430,7 +37424,7 @@
 	req_access = list("research")
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/lab)
+/area/station/science/research)
 "gFw" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -37695,7 +37689,7 @@
 	icon_state = "plant-11"
 	},
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "gSH" = (
 /turf/closed/wall,
 /area/station/service/lawoffice)
@@ -38674,7 +38668,7 @@
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
-/area/station/science/explab)
+/area/station/science/lab)
 "hTr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39939,7 +39933,7 @@
 "jnp" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
-/area/station/science/explab)
+/area/station/science/lab)
 "jnG" = (
 /obj/machinery/door/airlock/virology{
 	autoclose = 0;
@@ -40226,7 +40220,7 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/science/explab)
+/area/station/science/lab)
 "jCr" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -40365,7 +40359,7 @@
 	pixel_x = 6
 	},
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "jKs" = (
 /obj/machinery/atmospherics/components/binary/pump/layer2{
 	dir = 8
@@ -40617,7 +40611,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "jWA" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating/airless,
@@ -40921,7 +40915,7 @@
 	},
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "klV" = (
 /obj/item/clothing/under/rank/civilian/clown/sexy,
 /turf/open/floor/iron/dark,
@@ -41726,7 +41720,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "kXe" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -42341,7 +42335,7 @@
 	name = "Connector Port (Air Supply)"
 	},
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "lAf" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -42364,7 +42358,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "lBJ" = (
 /obj/item/wrench,
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
@@ -42835,7 +42829,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/science/lab)
+/area/station/science/research)
 "mbe" = (
 /obj/machinery/vending/wardrobe/engi_wardrobe,
 /obj/effect/turf_decal/tile/yellow{
@@ -42888,6 +42882,9 @@
 	},
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/ai_sat_ext_as)
+"mdr" = (
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "mdx" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -42921,7 +42918,7 @@
 	pixel_y = -6
 	},
 /turf/open/floor/iron/white,
-/area/station/science/lab)
+/area/station/science/research)
 "meu" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -43400,7 +43397,7 @@
 "mAo" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "mAQ" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/effect/turf_decal/tile/yellow{
@@ -44176,7 +44173,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "nls" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -44486,7 +44483,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "nBO" = (
 /obj/machinery/light/dim{
 	dir = 8
@@ -44621,7 +44618,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/science/lab)
+/area/station/science/research)
 "nJc" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -44658,7 +44655,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/engine,
-/area/station/science/explab)
+/area/station/science/lab)
 "nLM" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -45483,7 +45480,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "ovF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45698,7 +45695,7 @@
 	network = list("ss13","rd")
 	},
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "oEA" = (
 /turf/closed/wall,
 /area/station/construction/mining/aux_base)
@@ -47028,7 +47025,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "pJU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -47038,7 +47035,7 @@
 	},
 /obj/item/beacon,
 /turf/open/floor/engine,
-/area/station/science/explab)
+/area/station/science/lab)
 "pKd" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
@@ -47239,7 +47236,7 @@
 	dir = 8
 	},
 /turf/open/floor/engine,
-/area/station/science/explab)
+/area/station/science/lab)
 "pTJ" = (
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
@@ -47304,7 +47301,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "pWT" = (
 /obj/effect/landmark/start/botanist,
 /obj/effect/turf_decal/tile/green,
@@ -47361,7 +47358,7 @@
 	icon_state = "plant-03"
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/lab)
+/area/station/science/research)
 "pYC" = (
 /obj/structure/sign/warning{
 	pixel_y = -32
@@ -47655,7 +47652,7 @@
 	name = "Test Chamber Blast Door"
 	},
 /turf/open/floor/plating,
-/area/station/science/explab)
+/area/station/science/lab)
 "qkk" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -49258,6 +49255,9 @@
 	icon_state = "panelscorched"
 	},
 /area/station/maintenance/department/engine)
+"rzS" = (
+/turf/closed/wall/r_wall,
+/area/station/science/research)
 "rzT" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -50854,7 +50854,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "sTy" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/chapel,
@@ -51139,7 +51139,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "tdB" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/purple{
@@ -51296,7 +51296,7 @@
 "tiI" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/science/lab)
+/area/station/science/research)
 "tiR" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue{
@@ -51667,7 +51667,7 @@
 "twS" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "txu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -51784,7 +51784,7 @@
 /obj/item/integrated_circuit/loaded/speech_relay,
 /obj/item/integrated_circuit/loaded/hello_world,
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "tBb" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Monastery Art Storage";
@@ -52810,7 +52810,7 @@
 "urP" = (
 /obj/machinery/light,
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "usl" = (
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
@@ -53159,7 +53159,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "uEr" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance,
@@ -53577,7 +53577,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "uVO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -53851,7 +53851,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "vfw" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -54217,7 +54217,7 @@
 /obj/structure/window/reinforced,
 /obj/item/assembly/mousetrap,
 /turf/open/floor/engine,
-/area/station/science/explab)
+/area/station/science/lab)
 "vyn" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 1
@@ -54830,7 +54830,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/station/science/lab)
+/area/station/science/research)
 "vXu" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -54958,7 +54958,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/explab)
+/area/station/science/lab)
 "wbB" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron,
@@ -55257,7 +55257,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "wmE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -90847,7 +90847,7 @@ bKM
 tGj
 cqh
 bKM
-cCl
+rzS
 pYw
 gFo
 cSK
@@ -91361,11 +91361,11 @@ uXh
 xbB
 cqi
 boQ
-cCl
+rzS
 brq
 tiI
-cCt
-cCt
+mdr
+mdr
 bxc
 nIU
 bAo
@@ -91618,7 +91618,7 @@ blx
 xbB
 cqi
 boR
-cCl
+rzS
 brr
 mba
 bup
@@ -92393,7 +92393,7 @@ bqb
 bru
 bsT
 bus
-cCt
+mdr
 bxg
 mdL
 bAo
@@ -92646,10 +92646,10 @@ blA
 njH
 bnL
 boU
-cCl
-cCl
-cCl
-cCl
+rzS
+rzS
+rzS
+rzS
 bqb
 bxh
 bqb
@@ -94963,9 +94963,9 @@ fIH
 brz
 bta
 bkt
-bjw
+cCl
 bxq
-bjw
+cCl
 bAy
 bBo
 bCO
@@ -97015,9 +97015,9 @@ iSi
 eSL
 eSL
 eSL
-bjw
-bjw
-bjw
+cCl
+cCl
+cCl
 bod
 bvP
 sTi
@@ -97787,7 +97787,7 @@ moh
 bnX
 eSL
 bqq
-bqs
+cCt
 vfp
 wlK
 bvQ
@@ -98044,7 +98044,7 @@ vXd
 bnY
 eSL
 bqr
-bqs
+cCt
 vfp
 wlK
 bvT
@@ -98301,7 +98301,7 @@ ukz
 ukz
 eSL
 jJQ
-bqs
+cCt
 vfp
 wlK
 bvU
@@ -98561,8 +98561,8 @@ edl
 lzP
 vfp
 twS
-bqs
-bqs
+cCt
+cCt
 urP
 bAF
 bBL
@@ -98817,10 +98817,10 @@ jBx
 bqt
 mAo
 vfp
-bqs
-bqs
-bqs
-bqs
+cCt
+cCt
+cCt
+cCt
 wnJ
 bBM
 bCX
@@ -99329,7 +99329,7 @@ hTq
 aax
 aap
 uDS
-bqs
+cCt
 vfp
 cKA
 bwa
@@ -99586,7 +99586,7 @@ aao
 jnp
 aap
 nBL
-bqs
+cCt
 vfp
 kVP
 bwa
@@ -99843,7 +99843,7 @@ aap
 aap
 aap
 bqv
-bqs
+cCt
 vfp
 djD
 bwa
@@ -100100,7 +100100,7 @@ eXo
 bof
 eXo
 bqw
-bqs
+cCt
 vfp
 wlK
 bwa
@@ -100357,7 +100357,7 @@ nJI
 bky
 bky
 lAR
-bqs
+cCt
 vfp
 wlK
 bwa
@@ -100614,7 +100614,7 @@ bky
 bpo
 bpo
 bqx
-bqs
+cCt
 vfp
 gRU
 bwc
@@ -100874,9 +100874,9 @@ tdp
 oDP
 cQy
 buH
-bjw
-bjw
-bjw
+cCl
+cCl
+cCl
 bHy
 bHy
 bHy

--- a/StationMaps/PubbyStation/information.txt
+++ b/StationMaps/PubbyStation/information.txt
@@ -11,10 +11,10 @@
 	},
 	"job_changes": {
 		"cook": {
-			"additional_cqc_areas": ["/area/service/bar/atrium"]
+			"additional_cqc_areas": ["/area/station/service/bar/atrium"]
 		}
 	}
 }
 
 
-// Latest commit since update: https://github.com/tgstation/tgstation/commit/99269a3a032763f70e66bdd47cc9e448f899894f
+// Latest commit since update: https://github.com/tgstation/tgstation/commit/d4d4d3f1cba314a591678bd3e0ef11431bac18ba


### PR DESCRIPTION
Nearly everything listed here was found thanks to the new ci linter that checks all maps instead of just Metastation.

- Updates accesses for doors, departments now generally have access to the maintenance rooms around it, like on current maps
- Updates ALL accesses, on windoors, doors, ect, to use the new defines rather than the old numbers that don't work anymore.
- Makes all buttons/airlocks/ect use uppercase names instead of lowercase (ci require this)
- Fixes 2 instances of double firelocks on one tile, and one instance (theatre) of 2 wooden tables on top of eachother.
- Moves things around so they aren't on top of eachother in a few locations
- Replaces ALL door button and light switches to use directionals (there wasn't an updatepaths for this from what I saw)
- Updates paths for cartridges AGAIN because san fuckin REVERTED it
- Updates AI upload as well
- Removes a SINGLE button in the bar because there's like 3 others and they ALL did the same thing 
- Adds reinforced windows next to the captain's desk so the windoor isn't just floating on air.
- Fixes the json file's cook CQC pathing
- Fixes a meter in Turbine not being on the second layer
- Fixes atmos, there were 2 distro pipes in Medbay lobby
- Fixes Virology's cyclelink helpers