### PR TITLE
DiscStation 2022: Post-playtest update

### DIFF
--- a/StationMaps/DiscStation/DiscStation.dmm
+++ b/StationMaps/DiscStation/DiscStation.dmm
@@ -19,15 +19,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
 /area/station/solars/starboard/fore)
-"abx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/science/research)
 "abC" = (
 /obj/machinery/power/solar{
 	id = "forestarboard";
@@ -122,17 +113,15 @@
 "acp" = (
 /turf/open/floor/plating/airless,
 /area/station/solars/starboard/fore)
+"acq" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet,
+/area/station/service/library)
 "act" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/station/solars/port/fore)
-"acw" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/security/prison)
 "acA" = (
 /obj/docking_port/stationary/random{
 	id = "pod_1_lavaland";
@@ -470,9 +459,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "adD" = (
-/obj/effect/spawner/random/structure/crate,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "adE" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/iron/dark,
@@ -816,13 +807,14 @@
 /area/station/hallway/primary/starboard)
 "afc" = (
 /obj/machinery/camera/directional/south{
-	c_tag = "Gateway"
+	c_tag = "Gateway";
+	dir = 8
 	},
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "afd" = (
-/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/bot_white/right,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
@@ -977,6 +969,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"afR" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "afV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -1013,13 +1011,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/gateway)
-"agr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/cryo)
 "agu" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
@@ -1056,7 +1047,9 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "agK" = (
-/obj/effect/turf_decal/trimline/purple/corner,
+/obj/effect/turf_decal/trimline/dark_blue/corner{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "agN" = (
@@ -1070,9 +1063,10 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "agO" = (
-/obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "agP" = (
 /obj/structure/transit_tube/station/dispenser{
@@ -1214,7 +1208,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "aib" = (
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "aic" = (
@@ -1224,13 +1217,9 @@
 /turf/closed/wall,
 /area/station/maintenance/starboard/fore)
 "ail" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "aio" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -1542,15 +1531,6 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
-"ajQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/dark_red/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/research)
 "ajR" = (
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1616,10 +1596,6 @@
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
-"akl" = (
-/obj/structure/sign/poster/contraband/random/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
 "akn" = (
 /obj/item/stack/rods/ten,
 /turf/open/floor/plating,
@@ -1628,18 +1604,6 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"akp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
-"akq" = (
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
 "aks" = (
 /obj/structure/chair{
 	dir = 4
@@ -1775,9 +1739,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "alb" = (
-/obj/effect/spawner/random/structure/crate,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "alc" = (
 /obj/structure/mirror{
 	icon_state = "mirror_broke";
@@ -1930,9 +1895,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "amb" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/station/science/auxlab)
+/area/station/engineering/main)
 "amc" = (
 /obj/machinery/newscaster/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2113,10 +2083,7 @@
 "ane" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "anh" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -2145,9 +2112,6 @@
 /area/station/science/ordnance/storage)
 "ano" = (
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/trimline/purple/corner{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "ant" = (
@@ -2237,7 +2201,7 @@
 /area/station/hallway/primary/starboard)
 "anP" = (
 /obj/structure/transit_tube/curved/flipped,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -2362,10 +2326,11 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "aot" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos)
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "aow" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "MiniSat Teleporter";
@@ -2627,14 +2592,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron,
 /area/station/science/ordnance)
-"apK" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "apL" = (
 /obj/machinery/door/airlock/research{
 	name = "Ordnance Launch Room"
@@ -2667,12 +2627,9 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "apP" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/turf_decal/box/corners{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/engineering/break_room)
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "apR" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance,
@@ -2744,6 +2701,12 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"aqq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron,
+/area/station/ai_monitored/command/storage/eva)
 "aqr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -2946,12 +2909,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/science/lab)
-"arb" = (
-/obj/effect/turf_decal/trimline/blue/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "ard" = (
 /obj/machinery/firealarm/directional/west,
 /obj/structure/table,
@@ -3106,7 +3063,7 @@
 /area/station/hallway/primary/starboard)
 "arQ" = (
 /obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -3258,14 +3215,6 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
-"asr" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "ast" = (
 /obj/machinery/camera/autoname/directional/south{
 	network = list("ss13","medbay")
@@ -3945,6 +3894,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/bar,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "avt" = (
@@ -3982,7 +3932,7 @@
 /area/station/science/lab)
 "avw" = (
 /obj/item/kirbyplants/photosynthetic,
-/obj/effect/turf_decal/tile/purple/opposingcorners,
+/obj/effect/turf_decal/trimline/dark_red/corner,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "avy" = (
@@ -4081,16 +4031,6 @@
 /obj/item/reagent_containers/blood/random,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"avT" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
-"awd" = (
-/turf/open/floor/iron/checker,
-/area/station/service/theater)
 "awh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4247,8 +4187,7 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "awV" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/white,
 /area/station/science/lab)
 "awY" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -4386,8 +4325,8 @@
 /area/station/science/genetics)
 "axz" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
@@ -4527,6 +4466,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"ays" = (
+/obj/machinery/computer/department_orders/security{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/red/filled/warning{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/security/brig)
 "ayu" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4781,6 +4732,10 @@
 /obj/item/kirbyplants/photosynthetic,
 /turf/open/floor/grass,
 /area/station/hallway/primary/starboard)
+"azF" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/grass,
+/area/station/medical/virology)
 "azH" = (
 /obj/machinery/computer/mecha{
 	dir = 4
@@ -4906,9 +4861,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aAd" = (
-/obj/effect/turf_decal/tile/blue/diagonal_centre,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/obj/machinery/camera/autoname/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/engineering/gravity_generator)
 "aAh" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -5143,12 +5098,9 @@
 /area/station/command/heads_quarters/rd)
 "aBl" = (
 /obj/effect/turf_decal/siding/purple/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/siding/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "aBm" = (
@@ -5394,11 +5346,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"aBZ" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/central)
 "aCb" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aCc" = (
@@ -5447,13 +5401,6 @@
 "aCm" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/rd)
-"aCn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "aCr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -5602,6 +5549,12 @@
 "aDc" = (
 /turf/closed/wall,
 /area/station/science/lab)
+"aDd" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "aDe" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5621,11 +5574,17 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aDj" = (
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
@@ -5640,6 +5599,9 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aDl" = (
@@ -5652,6 +5614,9 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aDm" = (
@@ -5659,6 +5624,9 @@
 /obj/item/storage/box/monkeycubes,
 /obj/item/storage/box/monkeycubes,
 /obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
@@ -5679,12 +5647,18 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aDo" = (
 /obj/machinery/monkey_recycler,
 /obj/machinery/firealarm/directional/north,
 /obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
@@ -5694,12 +5668,18 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aDq" = (
 /obj/machinery/smartfridge/extract,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
@@ -5898,6 +5878,9 @@
 /area/station/science/xenobiology)
 "aEg" = (
 /obj/machinery/light_switch/directional/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aEh" = (
@@ -6008,13 +5991,6 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron/white/textured,
 /area/station/science/research)
-"aED" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/escape)
 "aEE" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/camera/autoname/directional/south{
@@ -6119,10 +6095,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "aFf" = (
@@ -6139,6 +6111,15 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
+"aFg" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/turf/open/floor/carpet,
+/area/station/command/meeting_room)
 "aFh" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
@@ -6197,21 +6178,21 @@
 	network = list("ss13","rd","xeno")
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aFy" = (
 /obj/structure/closet/l3closet/scientist,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aFz" = (
 /obj/structure/closet,
 /obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aFA" = (
@@ -6220,6 +6201,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aFB" = (
@@ -6228,6 +6210,7 @@
 /obj/item/pen,
 /obj/machinery/requests_console/auto_name/directional/south,
 /obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aFC" = (
@@ -6237,6 +6220,7 @@
 	pixel_y = 9
 	},
 /obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aFD" = (
@@ -6244,6 +6228,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aFE" = (
@@ -6407,9 +6392,11 @@
 "aFX" = (
 /obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/tile/blue{
-	dir = 4
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "aFZ" = (
@@ -6472,6 +6459,15 @@
 "aGo" = (
 /turf/open/floor/plating,
 /area/station/construction)
+"aGp" = (
+/obj/structure/chair{
+	name = "Judge"
+	},
+/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security/courtroom)
 "aGr" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
@@ -6531,11 +6527,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
-"aGy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/checker,
-/area/station/service/theater)
 "aGz" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/security/telescreen{
@@ -6554,6 +6545,9 @@
 /area/station/science/xenobiology)
 "aGD" = (
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aGE" = (
@@ -6562,6 +6556,9 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Xenobiology Pens";
 	network = list("ss13","rd","xeno")
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
@@ -6712,8 +6709,8 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "aHc" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "aHg" = (
 /obj/item/clothing/mask/gas,
@@ -6735,6 +6732,9 @@
 /area/station/ai_monitored/turret_protected/ai)
 "aHj" = (
 /obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aHk" = (
@@ -6770,12 +6770,18 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aHo" = (
 /obj/structure/window/reinforced,
 /obj/structure/table/reinforced,
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aHp" = (
@@ -7009,6 +7015,9 @@
 	name = "Containment Pen";
 	req_access = list("xenobiology")
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aIi" = (
@@ -7018,6 +7027,9 @@
 	icon_state = "right";
 	name = "Containment Pen";
 	req_access = list("xenobiology")
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
@@ -7331,6 +7343,9 @@
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
@@ -7661,14 +7676,20 @@
 "aKz" = (
 /obj/machinery/light/directional/west,
 /obj/structure/sign/warning/electric_shock/directional/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aKA" = (
 /obj/structure/sink{
-	dir = 4;
+	dir = 8;
 	pixel_x = 11
 	},
 /obj/structure/sign/warning/electric_shock/directional/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aKB" = (
@@ -7795,6 +7816,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aLb" = (
@@ -7844,6 +7868,19 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"aLi" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"aLj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/ai_monitored/command/storage/eva)
 "aLk" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -8151,11 +8188,10 @@
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "aMq" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/obj/effect/turf_decal/bot_white/left,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/engineering/gravity_generator)
 "aMs" = (
 /obj/machinery/door/airlock/external{
 	name = "Arrival Airlock";
@@ -8319,9 +8355,8 @@
 /area/station/medical/medbay/lobby)
 "aNh" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
+	dir = 4
 	},
-/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "aNi" = (
@@ -8355,7 +8390,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -8405,13 +8440,11 @@
 /turf/closed/wall/r_wall,
 /area/station/science/robotics/mechbay)
 "aNB" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/station/cargo/miningdock)
+/area/station/hallway/primary/central)
 "aNC" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -8434,7 +8467,7 @@
 /area/station/cargo/storage)
 "aNG" = (
 /obj/structure/sink{
-	dir = 8;
+	dir = 4;
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -8443,11 +8476,17 @@
 	network = list("ss13","rd","xeno")
 	},
 /obj/structure/sign/warning/electric_shock/directional/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aNH" = (
 /obj/machinery/light/directional/east,
 /obj/structure/sign/warning/electric_shock/directional/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aNI" = (
@@ -8468,6 +8507,9 @@
 /obj/structure/sign/poster/official/random/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/structure/chair/sofa/bench{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
@@ -8993,6 +9035,9 @@
 "aPT" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/directional/south,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aPU" = (
@@ -9000,6 +9045,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aPV" = (
@@ -9012,6 +9058,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aPW" = (
@@ -9019,6 +9066,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aPX" = (
@@ -9369,12 +9417,8 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "aRp" = (
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "aRr" = (
 /obj/machinery/light_switch/directional/south,
 /obj/effect/turf_decal/stripes/corner{
@@ -9438,7 +9482,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
@@ -9447,16 +9490,19 @@
 "aRH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/chair/stool/bar/directional/north,
+/obj/machinery/newscaster/directional/north,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "aRI" = (
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/engineering/gravity_generator)
+/area/station/hallway/primary/starboard)
 "aRJ" = (
 /obj/item/stack/sheet/cardboard,
 /obj/item/flashlight,
@@ -9872,14 +9918,6 @@
 /obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
-"aTu" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "aTv" = (
 /obj/effect/turf_decal/tile/dark_blue/fourcorners,
 /obj/structure/chair/comfy/brown{
@@ -9967,17 +10005,21 @@
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "aTL" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/primary/central/aft)
 "aTN" = (
-/obj/effect/turf_decal/trimline/purple/corner{
-	dir = 8
+/obj/machinery/airalarm/directional/north,
+/obj/effect/spawner/random/structure/closet_private,
+/obj/item/clothing/head/wig/natural{
+	hairstyle = "Mohawk (Unshaven)";
+	icon_state = "hair_unshaven_mohawk";
+	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/station/science/research)
+/turf/open/floor/wood,
+/area/station/commons/dorms)
 "aTO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -10082,6 +10124,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/gateway)
+"aUn" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "aUp" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -10250,6 +10296,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "aUZ" = (
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "aVa" = (
@@ -10821,6 +10870,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
+"aXm" = (
+/turf/open/floor/iron/dark,
+/area/station/security)
 "aXn" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -10891,10 +10943,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
-"aXD" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/service/theater)
 "aXF" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -11116,9 +11164,10 @@
 /area/station/maintenance/starboard/aft)
 "aYN" = (
 /obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/structure/sign/directions/vault/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "aYQ" = (
@@ -11183,6 +11232,12 @@
 /obj/effect/turf_decal/tile/dark_blue/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"aZh" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "aZj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11208,8 +11263,9 @@
 	},
 /area/station/medical/morgue)
 "aZs" = (
-/obj/effect/turf_decal/tile/blue/diagonal_centre,
-/obj/effect/turf_decal/tile/blue/diagonal_edge,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "aZt" = (
@@ -11226,16 +11282,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/station/engineering/storage/tcomms)
-"aZy" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "aZz" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/electrical,
@@ -11316,7 +11362,7 @@
 /area/station/cargo/qm)
 "aZZ" = (
 /obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/brown/half/contrasted{
+/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -11396,6 +11442,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "bav" = (
@@ -11650,9 +11697,6 @@
 "bbx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "bby" = (
@@ -11686,16 +11730,10 @@
 "bbI" = (
 /obj/machinery/iv_drip,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"bbK" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
 "bbL" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -11936,13 +11974,6 @@
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
-"bcI" = (
-/obj/item/radio/intercom/directional/west,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "bcL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12256,15 +12287,6 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
-"bdR" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/station/commons/lounge)
 "bdS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -12557,12 +12579,6 @@
 	},
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/turret_protected/ai_upload)
-"bfc" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/break_room)
 "bfd" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/turretid{
@@ -12788,6 +12804,10 @@
 /obj/effect/landmark/navigate_destination/aiupload,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"bga" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/electrical)
 "bgb" = (
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -12894,6 +12914,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bgQ" = (
@@ -13053,16 +13076,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/textured,
 /area/station/cargo/storage)
-"bhM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
 "bhN" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13226,6 +13239,13 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
+"biH" = (
+/obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "biM" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -13256,7 +13276,6 @@
 /area/station/ai_monitored/command/nuke_storage)
 "biY" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners,
-/obj/structure/sign/warning/secure_area/directional/west,
 /turf/open/floor/iron,
 /area/station/maintenance/central)
 "bjb" = (
@@ -13310,13 +13329,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/cargo/qm)
-"bjk" = (
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "bjn" = (
 /obj/structure/bodycontainer/morgue,
 /obj/effect/decal/cleanable/cobweb,
@@ -13839,13 +13851,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
-"blo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/eva)
 "blp" = (
 /obj/structure/table,
 /obj/item/clipboard,
@@ -14101,6 +14106,16 @@
 /obj/item/camera,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain)
+"bme" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "bmf" = (
 /obj/machinery/door/airlock/command{
 	name = "Command Maintence"
@@ -14220,6 +14235,9 @@
 "bmN" = (
 /obj/machinery/chem_master{
 	pixel_x = -2
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
@@ -14680,13 +14698,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
-"boX" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "boY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood,
@@ -14701,6 +14712,15 @@
 "bpa" = (
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
+"bpb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "bpc" = (
 /obj/structure/table,
 /obj/item/beacon,
@@ -14717,7 +14737,9 @@
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
 "bpg" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
 "bph" = (
@@ -14726,6 +14748,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
+"bpk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "bpl" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -15030,6 +15061,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/central)
+"bqu" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "bqw" = (
 /obj/machinery/conveyor/inverted{
 	dir = 6;
@@ -15505,7 +15543,7 @@
 	name = "Judge"
 	},
 /obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/security/courtroom)
@@ -15608,6 +15646,7 @@
 /area/station/cargo/sorting)
 "bsI" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "bsJ" = (
@@ -15658,14 +15697,11 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "bsV" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/chair/sofa/bench{
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/area/station/hallway/primary/starboard)
 "bsW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/computer/pod/old/mass_driver_controller/chapelgun{
@@ -15749,8 +15785,8 @@
 "bts" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
@@ -16049,6 +16085,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
+"buP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "buR" = (
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
@@ -16207,6 +16247,7 @@
 /obj/structure/closet/crate/coffin,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "bvB" = (
@@ -16253,10 +16294,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/carpet,
 /area/station/service/chapel)
-"bvJ" = (
-/obj/structure/sign/poster/contraband/random/directional/west,
-/turf/open/floor/plating,
-/area/station/maintenance/port/aft)
 "bvL" = (
 /obj/machinery/light/directional/north,
 /obj/structure/chair,
@@ -16360,9 +16397,7 @@
 	dir = 8;
 	name = "Defense"
 	},
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
-	dir = 4
-	},
+/obj/effect/turf_decal/tile/green/anticorner/contrasted,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "bwn" = (
@@ -16484,8 +16519,8 @@
 /area/station/hallway/primary/starboard)
 "bwP" = (
 /obj/effect/spawner/random/vending/snackvend,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
@@ -16553,15 +16588,9 @@
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "bxh" = (
-/obj/machinery/button/door{
-	id = "EscapeBarShutters";
-	name = "Escape Bar Shutter Control";
-	pixel_x = 24;
-	req_access = list("bar")
-	},
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "bxi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -16644,6 +16673,14 @@
 /obj/effect/landmark/navigate_destination/eva,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
+"bxu" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "bxw" = (
 /obj/structure/filingcabinet,
 /obj/machinery/light/small/directional/north,
@@ -17457,13 +17494,11 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	name = "Mech Bay"
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
 /turf/open/floor/iron,
-/area/station/science/robotics/mechbay)
+/area/station/hallway/primary/starboard)
 "bAD" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -17546,6 +17581,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
+"bAT" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/turf_decal/box/corners,
+/turf/open/floor/iron/dark/textured,
+/area/station/engineering/break_room)
 "bAZ" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/captain/private)
@@ -17948,7 +17988,7 @@
 /area/station/command/heads_quarters/hop)
 "bCw" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 6
+	dir = 10
 	},
 /turf/open/floor/carpet,
 /area/station/command/meeting_room)
@@ -18032,7 +18072,6 @@
 "bCL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bCN" = (
@@ -18131,9 +18170,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/security)
 "bDl" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "bDm" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -18157,28 +18198,21 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "bDr" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
-"bDt" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"bDt" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "bDu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "bDv" = (
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bDw" = (
@@ -18432,9 +18466,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bEA" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/line,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "bEB" = (
 /obj/structure/chair{
 	dir = 4
@@ -18453,11 +18493,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "bEH" = (
-/obj/effect/turf_decal/trimline/purple/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/science/research)
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "bEI" = (
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/iron/fifty,
@@ -18497,7 +18535,9 @@
 "bEL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "bEM" = (
@@ -18598,6 +18638,9 @@
 /area/station/security/detectives_office)
 "bES" = (
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/turf_decal/trimline/purple/corner{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "bEW" = (
@@ -19087,11 +19130,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "bGS" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/area/station/hallway/secondary/exit/departure_lounge)
 "bGT" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/tile/neutral{
@@ -19175,6 +19218,12 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"bHA" = (
+/obj/machinery/chem_heater{
+	pixel_x = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/pharmacy)
 "bHE" = (
 /obj/machinery/camera/autoname/directional/north,
 /obj/effect/turf_decal/tile/red{
@@ -19203,16 +19252,8 @@
 /area/station/hallway/primary/central)
 "bHL" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
-"bHM" = (
-/obj/effect/turf_decal/bot_white/right,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/gravity_generator)
+/area/station/commons/lounge)
 "bHN" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/tile/neutral{
@@ -19228,13 +19269,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"bHT" = (
+"bHX" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/area/station/security/brig)
 "bHY" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -19388,11 +19427,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"bIX" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "bIY" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 1
@@ -19774,15 +19808,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
-"bKP" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "bKQ" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -19830,7 +19855,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -19901,8 +19926,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "bLw" = (
-/turf/open/floor/iron/large,
-/area/station/engineering/engine_smes)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/chair/stool/bar/directional/south,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/commons/lounge)
 "bLA" = (
 /obj/structure/window{
 	dir = 4
@@ -19960,27 +19994,24 @@
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "bLY" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/area/station/hallway/primary/starboard)
 "bLZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "bMa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/turf/closed/wall/r_wall,
+/area/station/maintenance/department/electrical)
 "bMc" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/camera/directional/east{
@@ -20057,6 +20088,10 @@
 /obj/effect/landmark/navigate_destination/sec,
 /turf/open/floor/iron,
 /area/station/security/brig)
+"bMn" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/turf/open/floor/iron,
+/area/station/security/brig)
 "bMq" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -20092,8 +20127,6 @@
 	name = "Atmospherics"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
@@ -20254,12 +20287,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "bNd" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/station/cargo/storage)
+/area/station/ai_monitored/command/storage/eva)
 "bNe" = (
 /obj/structure/flora/bush/grassy/style_random,
 /obj/structure/flora/bush/lavendergrass/style_random,
@@ -20272,15 +20307,20 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/science/explab)
 "bNi" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/area/station/hallway/primary/starboard)
 "bNj" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/machinery/firealarm/directional/west,
@@ -20871,6 +20911,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"bPr" = (
+/obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "bPA" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -20943,16 +20990,6 @@
 	},
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
-"bQc" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/iron,
-/area/station/engineering/storage)
 "bQe" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
@@ -21004,6 +21041,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
+"bQo" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "bQp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -21305,11 +21348,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "bRA" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/service/theater)
 "bRB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -21400,6 +21441,15 @@
 "bRO" = (
 /turf/closed/wall,
 /area/station/security)
+"bRQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/security/brig)
 "bRR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -21412,7 +21462,7 @@
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -21439,6 +21489,14 @@
 /obj/structure/falsewall,
 /turf/open/floor/iron,
 /area/station/service/theater)
+"bSm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "bSn" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -21509,9 +21567,6 @@
 /obj/structure/sign/poster/official/random/directional/south,
 /obj/machinery/camera/autoname/directional/south,
 /obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -21550,7 +21605,7 @@
 "bST" = (
 /obj/vehicle/ridden/secway,
 /obj/item/key/security,
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -21602,10 +21657,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "bSZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/service/hydroponics)
 "bTa" = (
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Atmospherics Monitoring"
@@ -21653,7 +21710,7 @@
 "bTg" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
+	dir = 5
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -21665,11 +21722,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
 "bTj" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/binary/pump/off{
+	dir = 8;
+	name = "Mix to Waste"
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
 "bTk" = (
@@ -21677,9 +21734,7 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Atmos North East"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
 "bTm" = (
@@ -22259,11 +22314,11 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "bVt" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/hallway/primary/central)
 "bVu" = (
 /obj/machinery/door/airlock/glass{
 	name = "Chapel"
@@ -22353,6 +22408,17 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
+"bVJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "bVL" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron,
@@ -22489,12 +22555,6 @@
 /obj/effect/turf_decal/tile/yellow/diagonal_centre,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"bWp" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security/prison)
 "bWq" = (
 /obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/tile/green/opposingcorners,
@@ -22628,9 +22688,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "bWO" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/light/directional/west,
+/obj/machinery/status_display/evac/directional/west,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "bWP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -22744,10 +22809,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/iron/dark,
 /area/station/security)
-"bXk" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/engineering/storage/tcomms)
 "bXm" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -22958,9 +23019,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/chair/sofa/bench/right{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "bYh" = (
@@ -22974,14 +23032,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"bYj" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/camera/autoname/directional/north,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "bYl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -23019,18 +23069,27 @@
 "bYB" = (
 /turf/closed/wall,
 /area/station/security/brig)
-"bYF" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+"bYE" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
-"bYG" = (
+/area/station/hallway/primary/starboard)
+"bYF" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"bYG" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/light/directional/east,
+/obj/machinery/status_display/evac/directional/east,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "bYH" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/firealarm/directional/east,
@@ -23189,11 +23248,7 @@
 /area/station/engineering/supermatter)
 "bZt" = (
 /obj/structure/dresser,
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/checker,
 /area/station/service/theater)
 "bZx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -23256,9 +23311,18 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/newscaster/directional/north,
+/obj/machinery/button/flasher{
+	id = "secentranceflasher";
+	name = "Brig Entrance Flasher";
+	req_access = list("security");
+	pixel_x = 26;
+	pixel_y = 26
+	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/security/warden)
@@ -23480,12 +23544,8 @@
 /area/station/hallway/primary/starboard)
 "caz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/chair/stool/bar/directional/south,
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
-/area/station/commons/lounge)
+/turf/open/floor/iron/white,
+/area/station/science/auxlab)
 "caB" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
@@ -23510,6 +23570,17 @@
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron,
 /area/station/security/brig)
+"caH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "caI" = (
 /obj/machinery/computer/crew{
 	dir = 4
@@ -24017,6 +24088,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
+"ccu" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
 "ccx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -24124,6 +24202,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/bar,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
 "ccS" = (
@@ -24559,6 +24638,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
+"cez" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "ceA" = (
 /obj/machinery/newscaster/directional/north,
 /obj/structure/cable,
@@ -25109,13 +25192,7 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "cgv" = (
-/obj/effect/landmark/start/hangover,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "cgw" = (
@@ -25423,6 +25500,9 @@
 /area/station/engineering/atmos)
 "chN" = (
 /obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/yellow/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "chO" = (
@@ -25432,13 +25512,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"chQ" = (
-/obj/machinery/vending/cigarette,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "chR" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
@@ -25628,11 +25701,11 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "ciN" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/hallway/primary/central)
 "ciO" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
 	dir = 8
@@ -25653,6 +25726,9 @@
 /area/station/engineering/atmos)
 "ciS" = (
 /obj/structure/closet/firecloset,
+/obj/effect/turf_decal/tile/yellow/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "ciV" = (
@@ -25896,6 +25972,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
+"cjS" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security/prison)
 "cjU" = (
 /obj/machinery/button/door{
 	id = "permacell3";
@@ -26040,7 +26123,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
@@ -26117,7 +26200,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "ckW" = (
@@ -26266,6 +26352,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/toilet/locker)
+"clI" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "clM" = (
 /obj/structure/table,
 /obj/item/stack/sheet/cardboard,
@@ -26313,11 +26403,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"clV" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet,
-/area/station/service/library)
 "cmh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -27337,6 +27422,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"cqn" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/station/service/theater)
 "cqs" = (
 /obj/machinery/space_heater,
 /obj/effect/turf_decal/trimline/yellow/filled/shrink_ccw{
@@ -27415,6 +27505,7 @@
 /area/station/commons/dorms)
 "cqL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
 "cqM" = (
@@ -27425,7 +27516,7 @@
 /area/station/commons/fitness/recreation/entertainment)
 "cqP" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
@@ -27474,9 +27565,8 @@
 "cqY" = (
 /obj/machinery/flasher/portable,
 /obj/machinery/flasher/portable,
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
@@ -27648,6 +27738,7 @@
 /obj/machinery/camera/directional/south{
 	c_tag = "Dorms Central South"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "crC" = (
@@ -27929,13 +28020,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
-"csD" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "csE" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen";
@@ -28160,7 +28244,7 @@
 "ctr" = (
 /obj/machinery/light_switch/directional/west,
 /obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
@@ -28570,6 +28654,11 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
+"cvg" = (
+/obj/effect/landmark/start/hangover,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "cvi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -28872,7 +28961,7 @@
 /area/station/engineering/break_room)
 "cwB" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
@@ -28883,6 +28972,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "cwD" = (
@@ -29164,12 +29254,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
-"cxK" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "cxN" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -29358,6 +29442,9 @@
 /area/station/maintenance/aft)
 "cyC" = (
 /obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/break_room)
 "cyD" = (
@@ -29366,7 +29453,6 @@
 /area/station/engineering/break_room)
 "cyE" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/effect/turf_decal/box/corners,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/break_room)
 "cyF" = (
@@ -29399,15 +29485,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/engineering/main)
-"cyO" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/chair/sofa/bench/right{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "cyP" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil{
@@ -29544,13 +29621,6 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/station/engineering/main)
-"czJ" = (
-/obj/machinery/camera/autoname/directional/south,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "czM" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -29714,6 +29784,9 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"cAn" = (
+/turf/open/floor/iron/checker,
+/area/station/service/theater)
 "cAp" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
@@ -29766,13 +29839,6 @@
 /obj/structure/cable,
 /turf/open/space/basic,
 /area/station/solars/port/fore)
-"cAE" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "cAJ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
@@ -29892,10 +29958,10 @@
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/ce)
 "cBl" = (
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/shower{
+	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cBm" = (
@@ -30264,10 +30330,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"cCZ" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
 "cDa" = (
 /obj/machinery/modular_computer/console/preset/id{
 	dir = 4
@@ -30861,13 +30923,6 @@
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
-"cGp" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/security)
 "cGr" = (
 /obj/item/shard{
 	icon_state = "small"
@@ -30977,6 +31032,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
 /area/station/solars/starboard/aft)
+"cGX" = (
+/obj/structure/sign/poster/contraband/random/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "cGZ" = (
 /obj/structure/grille,
 /obj/item/shard,
@@ -31123,12 +31182,6 @@
 "cHP" = (
 /turf/open/floor/plating,
 /area/station/engineering/main)
-"cHU" = (
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "cHV" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/o2,
 /turf/open/floor/iron,
@@ -31141,13 +31194,26 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"cJn" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+"cJA" = (
+/obj/machinery/button/door{
+	id = "Skynet_launch";
+	name = "Mech Bay Shutters";
+	pixel_y = 26;
+	req_access = list("robotics")
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/engineering/storage)
+/area/station/hallway/primary/starboard)
+"cJL" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "cKb" = (
 /obj/machinery/button/door{
 	id = "rdordnance";
@@ -31175,6 +31241,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
+"cKT" = (
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/trimline/purple/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "cLi" = (
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	id = "engsm";
@@ -31210,34 +31283,11 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
-"cNe" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
-"cNu" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
 "cNW" = (
 /obj/structure/closet/secure_closet/psychology,
 /obj/item/toy/figure/psychologist,
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
-"cOi" = (
-/obj/machinery/status_display/evac/directional/west,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "cOu" = (
 /obj/machinery/door/airlock/wood{
 	name = "Backstage"
@@ -31260,10 +31310,12 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
-"cPx" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating/airless,
-/area/station/maintenance/port/aft)
+"cPg" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/surgery/theatre)
 "cPD" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/iron,
@@ -31278,13 +31330,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"cPR" = (
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "cQM" = (
 /obj/structure/sign/poster/official/random/directional/west,
 /obj/effect/turf_decal/tile/blue{
@@ -31296,36 +31341,36 @@
 /obj/machinery/rnd/bepis,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"cRr" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
+"cRn" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/surgery/theatre)
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"cRs" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
+"cSi" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "cSu" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Atmospherics Plasma Tank"
 	},
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
-"cSA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/freezer,
-/area/station/commons/toilet/locker)
-"cSW" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
 "cTs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
@@ -31333,48 +31378,74 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
+"cTC" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "cUk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
-"cUQ" = (
-/obj/effect/turf_decal/tile/blue,
+"cUs" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
+"cUG" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"cUN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
+"cVj" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"cWu" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"cUT" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/commons/dorms)
 "cXe" = (
 /obj/structure/cable,
 /obj/structure/sign/departments/engineering/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"cXV" = (
+/obj/structure/table,
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "cYi" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"cYn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/ai_monitored/security/armory)
-"cZk" = (
-/obj/structure/cable,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/central)
-"cZy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
 "cZZ" = (
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/carpet,
@@ -31396,17 +31467,30 @@
 /obj/machinery/power/energy_accumulator/grounding_rod/anchored,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
-"daK" = (
+"daN" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 9
+	dir = 4
 	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
-/area/station/engineering/main)
+/area/station/engineering/engine_smes)
 "dbe" = (
 /obj/machinery/status_display/ai/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
+"dcl" = (
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"dcm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/closet/gmcloset,
+/turf/open/floor/iron,
+/area/station/service/theater)
 "dcJ" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/turf_decal/tile/brown{
@@ -31414,6 +31498,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"ddW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "ddZ" = (
 /turf/closed/wall,
 /area/station/maintenance/department/science)
@@ -31486,28 +31578,19 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"dhU" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "die" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
-"dje" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
-"djz" = (
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/chair/sofa/bench{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "djH" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/green{
@@ -31540,18 +31623,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
-"dkG" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/light/directional/east,
-/obj/machinery/status_display/evac/directional/east,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "dkW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31561,24 +31632,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"dlc" = (
-/obj/effect/landmark/start/hangover,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/structure/sign/poster/official/random/directional/east,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "dlo" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"dlr" = (
-/obj/structure/grille/broken,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
 "dls" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "lawyer_blast";
@@ -31591,10 +31649,36 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"dlZ" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/commons/fitness/recreation)
 "dmv" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
+"dmF" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
+"dmL" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/iron/dark/textured,
+/area/station/engineering/break_room)
+"dmT" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "dnh" = (
 /obj/structure/table,
 /obj/effect/spawner/random/aimodule/harmless,
@@ -31609,11 +31693,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
-"dom" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red/half/contrasted,
+"doy" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar,
 /turf/open/floor/iron,
-/area/station/security/prison)
+/area/station/hallway/primary/port)
 "doE" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
@@ -31621,13 +31707,13 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"doW" = (
+"dpP" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "dpY" = (
 /obj/machinery/computer/crew{
 	dir = 1
@@ -31659,6 +31745,17 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/bar)
+"dqX" = (
+/obj/effect/spawner/random/vending/snackvend,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"dqY" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/engineering/storage/tcomms)
 "dre" = (
 /obj/structure/chair/office/light,
 /obj/effect/landmark/start/scientist,
@@ -31666,6 +31763,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"drI" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
 "drM" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31704,21 +31812,29 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
-"duK" = (
-/obj/machinery/computer/security/telescreen/research{
-	pixel_y = 30
+"duu" = (
+/obj/machinery/door/window{
+	dir = 4;
+	req_access = list("bar");
+	name = "Escape Bar"
 	},
-/obj/effect/turf_decal/tile/purple/opposingcorners,
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/rd)
-"dxd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
+"dwS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/corner{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/engineering/main)
+/area/station/commons/dorms)
+"dxj" = (
+/obj/structure/grille/broken,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "dxF" = (
 /obj/machinery/door/airlock/external{
 	name = "Port Docking Bay 1"
@@ -31729,13 +31845,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"dyV" = (
-/obj/effect/spawner/random/entertainment/arcade,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit)
 "dyY" = (
 /obj/machinery/atmospherics/components/binary/valve/digital/on{
 	dir = 4;
@@ -31769,21 +31878,44 @@
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
+"dBk" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/storage)
+"dBN" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
+"dBZ" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/fluff/broken_flooring{
+	dir = 4;
+	icon_state = "singular"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
 "dCs" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"dCI" = (
-/obj/machinery/vending/boozeomat,
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "dDo" = (
 /obj/structure/transit_tube/curved/flipped{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"dED" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/storage)
 "dEN" = (
 /obj/structure/table/reinforced,
 /obj/item/wrench,
@@ -31796,6 +31928,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"dGk" = (
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "dGB" = (
 /obj/machinery/door/airlock/glass{
 	name = "Chapel"
@@ -31807,11 +31945,9 @@
 /obj/effect/landmark/navigate_destination/chapel,
 /turf/open/floor/carpet,
 /area/station/service/chapel)
-"dGC" = (
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+"dGG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "dGU" = (
@@ -31823,14 +31959,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
-"dHh" = (
-/obj/machinery/status_display/evac/directional/west,
-/obj/structure/transit_tube/station/dispenser{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/dark_blue/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "dHk" = (
@@ -31854,15 +31982,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"dIV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/research)
 "dIW" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4
@@ -31887,12 +32006,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/emergency/port)
-"dKZ" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/engineering/break_room)
 "dLy" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
@@ -31906,17 +32019,20 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"dMW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "dNc" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
+"dNe" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
 "dPa" = (
 /obj/structure/transit_tube/station/dispenser,
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
@@ -31924,28 +32040,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"dPn" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+"dPi" = (
+/obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
-"dPo" = (
-/obj/structure/sign/poster/contraband/random/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
-"dPN" = (
-/obj/structure/table,
-/obj/machinery/power/apc/auto_name/directional/east,
-/turf/open/floor/wood,
-/area/station/commons/lounge)
-"dPO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/closet/gmcloset,
+/area/station/hallway/primary/port)
+"dPF" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/station/service/theater)
+/area/station/security/prison)
 "dQe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31959,6 +32065,19 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
+"dRg" = (
+/obj/machinery/modular_computer/console/preset/cargochat/security{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/red/filled/warning{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/station/security/brig)
 "dRm" = (
 /obj/machinery/light/directional/west,
 /obj/structure/chair{
@@ -31975,43 +32094,50 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"dSd" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+"dSy" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
-"dTF" = (
-/obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron,
+/area/station/engineering/break_room)
+"dTV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/station/engineering/main)
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "dUp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"dUr" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "dUt" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"dVF" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 8
+"dVV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "dWi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -32019,36 +32145,36 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"dWk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/station/command/gateway)
 "dWU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/landmark/navigate_destination/janitor,
 /turf/open/floor/iron,
 /area/station/service/janitor)
-"dXb" = (
-/obj/structure/closet/firecloset,
-/obj/structure/sign/poster/official/state_laws{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
+"dYi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/commons/storage/primary)
+"dYr" = (
+/obj/effect/turf_decal/trimline/purple/line{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
-"dXA" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/turf/open/floor/iron/white,
+/area/station/science/lab)
 "dYP" = (
 /obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"dZF" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "dZG" = (
 /obj/item/flashlight/lamp,
 /obj/structure/table,
@@ -32057,6 +32183,13 @@
 	},
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
+"dZH" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "dZL" = (
 /obj/effect/landmark/start/station_engineer,
 /obj/effect/turf_decal/stripes/line{
@@ -32077,35 +32210,23 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
+"ebD" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/chair/sofa/bench/left{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "ecr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"ect" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
+"ecw" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron,
-/area/station/engineering/gravity_generator)
-"ecD" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
-"ecX" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/area/station/security/execution/transfer)
 "edn" = (
 /obj/structure/railing{
 	dir = 1
@@ -32113,6 +32234,21 @@
 /obj/effect/turf_decal/trimline/brown/filled/arrow_cw,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"edT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
+"edV" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/random/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
 "eej" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32146,21 +32282,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"egY" = (
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
-"ehK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
 "eiQ" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/west,
@@ -32174,12 +32295,6 @@
 	dir = 5
 	},
 /area/station/service/chapel)
-"ejO" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
 "eks" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -32188,6 +32303,16 @@
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"ekt" = (
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "ekQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32207,21 +32332,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
-"elh" = (
-/obj/machinery/button/door{
-	id = "Skynet_launch";
-	name = "Mech Bay Shutters";
-	pixel_y = 26;
-	req_access = list("robotics")
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "eli" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
@@ -32245,30 +32355,23 @@
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
-"elW" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/central)
 "emb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter/room)
-"emo" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "emu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
 /area/station/engineering/main)
-"emD" = (
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+"emK" = (
+/obj/machinery/chem_master/condimaster{
+	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
+	name = "HoochMaster Deluxe"
 	},
+/obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
-/area/station/hallway/secondary/exit)
+/area/station/hallway/secondary/exit/departure_lounge)
 "enH" = (
 /obj/structure/transit_tube/diagonal/topleft,
 /turf/open/floor/plating/airless,
@@ -32290,19 +32393,6 @@
 /obj/item/cigbutt/roach,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
-"eob" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/spawner/random/structure/crate,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
-"eoj" = (
-/obj/effect/turf_decal/trimline/dark_blue/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/science/research)
 "eow" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
 	dir = 5
@@ -32319,12 +32409,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
-"epz" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+"eoY" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/turf/open/floor/iron,
+/area/station/security/prison)
 "epG" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
@@ -32363,6 +32452,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"etA" = (
+/obj/machinery/light/directional/north,
+/obj/machinery/camera/autoname/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "etX" = (
 /obj/structure/transit_tube/curved/flipped{
 	dir = 1
@@ -32373,25 +32470,32 @@
 /obj/machinery/restaurant_portal/bar,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
-"euC" = (
-/obj/structure/disposalpipe/segment,
+"euI" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/warning{
+	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/station/security/prison)
 "eva" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
-"evl" = (
-/obj/machinery/smartfridge,
-/turf/closed/wall,
-/area/station/service/hydroponics)
+"evH" = (
+/obj/machinery/bluespace_vendor/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
+"evY" = (
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "ewn" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
@@ -32420,13 +32524,6 @@
 /obj/item/razor,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"eyh" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "eyj" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32435,10 +32532,25 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"eym" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/carpet,
+/area/station/command/meeting_room)
 "eyC" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
+"eyL" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/chair/sofa/bench/left{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "ezK" = (
 /turf/closed/wall,
 /area/station/medical/psychology)
@@ -32489,18 +32601,21 @@
 	},
 /turf/open/floor/iron,
 /area/station/security)
-"eCL" = (
-/obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
-"eCQ" = (
+"eCp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
+"eCI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
@@ -32514,32 +32629,19 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"eDZ" = (
-/obj/effect/turf_decal/trimline/purple/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/research)
-"eEb" = (
-/obj/structure/marker_beacon/burgundy,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
-"eEA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+"eEr" = (
+/obj/machinery/flasher/portable,
+/obj/machinery/flasher/portable,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/engineering/engine_smes)
+/area/station/ai_monitored/security/armory)
 "eED" = (
 /obj/structure/marker_beacon/purple,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"eEG" = (
-/obj/item/reagent_containers/glass/bucket,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/security/prison)
 "eFp" = (
 /obj/machinery/door/airlock/external{
 	name = "External Docking Port"
@@ -32563,6 +32665,17 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"eGH" = (
+/obj/machinery/vending/boozeomat,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
+"eGL" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security/execution/transfer)
 "eHc" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark/telecomms,
@@ -32579,6 +32692,10 @@
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
+"eHC" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/station/maintenance/port/aft)
 "eHX" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
@@ -32604,6 +32721,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"eJF" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/commons/fitness/recreation)
+"eJV" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "eKd" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -32617,6 +32747,13 @@
 	dir = 10
 	},
 /area/station/service/chapel)
+"eLE" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "eLF" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Xenobiology - Cell 5";
@@ -32625,19 +32762,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
-"eMG" = (
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
-"eMJ" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "eMM" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron,
@@ -32649,26 +32773,32 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"eNA" = (
-/obj/machinery/camera/autoname/directional/east,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "eNO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"eOn" = (
+"eOu" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/hallway/primary/port)
+"eOQ" = (
+/obj/structure/table,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/station/commons/lounge)
+"eOT" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security)
 "eOW" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/grimy,
@@ -32718,6 +32848,12 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/open/floor/plating,
 /area/station/construction)
+"eSl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/station/science/auxlab)
 "eSH" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -32761,28 +32897,17 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
-"eUz" = (
-/obj/structure/table,
-/obj/item/storage/medkit/regular,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "eUD" = (
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
-"eUR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
+"eUQ" = (
+/obj/item/radio/intercom/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/bar,
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/area/station/hallway/primary/starboard)
 "eUT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32790,13 +32915,6 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
-"eVa" = (
-/obj/structure/transit_tube/curved/flipped,
-/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "eVd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32815,41 +32933,20 @@
 	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
-"eWH" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "eWN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
-"eXf" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/commons/fitness/recreation)
-"eXq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/sign/poster/contraband/random/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/port/aft)
-"eXD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/iron/dark,
-/area/station/tcommsat/computer)
+"eXz" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "eXQ" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "eXV" = (
@@ -32892,6 +32989,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"eZw" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "eZE" = (
 /obj/structure/chair{
 	dir = 8
@@ -32917,6 +33021,14 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/security/warden)
+"faS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "faU" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 1
@@ -32929,13 +33041,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/service/library)
-"fbp" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/station/engineering/break_room)
 "fbO" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
@@ -32956,18 +33061,23 @@
 /obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"fcu" = (
+/obj/machinery/computer/security/telescreen/research{
+	pixel_y = 30
+	},
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/rd)
 "fde" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/service/janitor)
-"fdn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+"fdj" = (
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/station/command/heads_quarters/hop)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "fdB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -32997,35 +33107,29 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "fem" = (
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/turf/closed/wall,
-/area/station/maintenance/port/fore)
-"fet" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/dark_blue{
+/obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
-"ffu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"ffw" = (
+/obj/structure/transit_tube/curved/flipped,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/ai_monitored/security/armory)
+/area/station/hallway/primary/starboard)
+"fgf" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "fgk" = (
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
-"fgT" = (
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "fhE" = (
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/chapel{
@@ -33037,11 +33141,9 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"fhV" = (
-/obj/structure/cable,
-/obj/effect/landmark/start/hangover,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+"fie" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
@@ -33056,12 +33158,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
-"fjq" = (
-/obj/structure/chair/stool/bar/directional/east,
-/obj/effect/landmark/start/hangover,
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+"fkH" = (
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "fkZ" = (
 /obj/machinery/door/airlock/mining{
 	name = "Mining Office"
@@ -33070,16 +33172,21 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
-"fld" = (
-/obj/machinery/door/window/brigdoor{
-	dir = 8;
-	name = "Test Range"
+"flF" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/iron,
+/area/station/security/prison)
+"flI" = (
+/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
+	dir = 5
 	},
 /turf/open/floor/iron,
-/area/station/science/auxlab)
+/area/station/engineering/storage)
 "fma" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -33184,41 +33291,51 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"foX" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
+"foP" = (
+/obj/effect/turf_decal/trimline/blue/corner{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
-"fpH" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
+"fpk" = (
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
-"frc" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security/brig)
-"frQ" = (
-/obj/effect/turf_decal/stripes/corner{
+/area/station/hallway/primary/starboard)
+"fpt" = (
+/obj/effect/turf_decal/siding/purple/corner{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/rd)
+"fpS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/area/station/hallway/primary/starboard)
+"fqD" = (
+/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted,
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/cmo)
+"frA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/command)
 "frV" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/ai_upload)
-"fsv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 8
-	},
-/area/station/medical/morgue)
 "fsF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33230,6 +33347,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"ftu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "ftD" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -33242,12 +33366,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
-"ftR" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/commons/fitness/recreation)
 "fux" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
@@ -33278,28 +33396,22 @@
 /obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
-"fws" = (
+"fxb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/service/theater)
-"fxt" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/iron,
-/area/station/engineering/engine_smes)
+/area/station/ai_monitored/security/armory)
 "fyk" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/brown/half/contrasted{
+/obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/cargo/storage)
+/area/station/hallway/primary/starboard)
 "fzd" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
@@ -33325,15 +33437,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
-"fAN" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "fCf" = (
 /obj/structure/transit_tube/curved{
 	dir = 8
@@ -33346,35 +33449,39 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"fDP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+"fDb" = (
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
+"fEr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/station/security/execution/transfer)
+/area/station/security/prison/safe)
 "fEG" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"fFF" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/turf/open/floor/iron,
-/area/station/security)
+"fEL" = (
+/obj/effect/turf_decal/tile/blue/diagonal_centre,
+/obj/effect/turf_decal/tile/blue/diagonal_edge,
+/turf/open/floor/iron/white,
+/area/station/medical/surgery/theatre)
 "fGe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"fHg" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "fHr" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -33388,16 +33495,34 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
+"fHS" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron,
+/area/station/ai_monitored/security/armory)
 "fIj" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
+"fIn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"fIs" = (
+/obj/effect/turf_decal/bot_white/right,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/engineering/gravity_generator)
 "fJy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -33422,23 +33547,29 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
-"fLg" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "fMD" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
+"fMT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "fMV" = (
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"fNo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/iron/dark,
+/area/station/tcommsat/computer)
 "fNZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/table/reinforced,
@@ -33460,20 +33591,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"fOq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
-"fOD" = (
-/obj/effect/landmark/start/hangover,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/commons/fitness/recreation)
 "fPz" = (
 /obj/machinery/door/airlock/science{
 	name = "Medical Research"
@@ -33511,14 +33628,10 @@
 /obj/item/pen,
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
-"fRp" = (
-/obj/effect/landmark/start/station_engineer,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/station/engineering/main)
-"fRH" = (
+"fRs" = (
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron/white,
-/area/station/command/heads_quarters/cmo)
+/area/station/science/explab)
 "fRM" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
@@ -33546,15 +33659,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"fVM" = (
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
+/turf/open/floor/iron,
+/area/station/engineering/break_room)
 "fWj" = (
 /obj/effect/mapping_helpers/iannewyear,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
-"fWp" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
 "fWt" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
@@ -33609,28 +33721,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"gbr" = (
-/obj/item/radio/intercom/directional/east,
+"gbt" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/bar,
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
-"gbx" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/structure/bed/roller,
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
-"gbz" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/area/station/hallway/primary/central)
 "gbQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33651,6 +33750,20 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"gcL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/plating,
+/area/station/medical/abandoned)
+"gcZ" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "gdr" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
@@ -33671,6 +33784,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"gea" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "gej" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -33685,45 +33805,41 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
-"gff" = (
-/turf/closed/wall/r_wall,
-/area/station/command/heads_quarters/hop)
-"gfH" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
+"geH" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_blue{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/area/station/hallway/primary/central)
+"gff" = (
+/turf/closed/wall/r_wall,
+/area/station/command/heads_quarters/hop)
+"gfN" = (
+/obj/item/stack/tile/iron,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/station/maintenance/port/aft)
 "gfV" = (
 /obj/structure/window,
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"ggA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "ggT" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos/office)
-"ghp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+"ghe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/main)
-"ghq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "ghA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/bridge_pipe/supply/hidden/layer4{
@@ -33750,16 +33866,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)
+"giV" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/random/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "gjr" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
-"gjy" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/security/brig)
 "gjC" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Library Maintenance"
@@ -33773,6 +33890,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/central)
+"gjJ" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/ai_monitored/security/armory)
 "gjY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33795,25 +33919,23 @@
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron,
 /area/station/security/brig)
-"gml" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
-"gmm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "gmW" = (
 /obj/machinery/announcement_system,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
+"gnj" = (
+/obj/structure/sign/directions/vault/directional/west,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"gnl" = (
+/obj/effect/spawner/random/maintenance,
+/obj/effect/spawner/random/structure/table_or_rack,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "gnB" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay"
@@ -33821,6 +33943,13 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /turf/open/floor/iron,
 /area/station/cargo/office)
+"gnG" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "gnI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33828,6 +33957,26 @@
 /obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"gnR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"gov" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
+"goE" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "gpu" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass,
@@ -33841,11 +33990,14 @@
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron,
 /area/station/security/warden)
-"gpM" = (
-/obj/machinery/washing_machine,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/commons/dorms)
+"gpA" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/bed/roller,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "gqk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -33855,15 +34007,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/command/bridge)
-"gql" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "gqP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33883,14 +34026,16 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
+"gsi" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "gsS" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
-"gtj" = (
-/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted,
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/cmo)
 "gtw" = (
 /obj/machinery/computer/security/telescreen/interrogation{
 	pixel_y = 32
@@ -33929,6 +34074,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/command/gateway)
+"gvs" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/security/prison/safe)
 "gvu" = (
 /obj/structure/chair{
 	dir = 1
@@ -33950,6 +34100,15 @@
 /obj/machinery/atmospherics/components/binary/pump/on,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
+"gvG" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "gwH" = (
 /obj/effect/spawner/random/vending/snackvend,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -33958,9 +34117,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "gwR" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/central)
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "gxO" = (
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/turret_protected/ai_upload)
@@ -33998,12 +34159,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"gzX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/service/theater)
 "gAq" = (
 /obj/structure/closet/secure_closet/medical2,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
@@ -34011,15 +34166,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
-"gAV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "gBg" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -34054,12 +34200,6 @@
 /obj/effect/spawner/random/entertainment/wallet_lighter,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"gDh" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "gEj" = (
 /obj/structure/cable,
 /obj/effect/landmark/event_spawn,
@@ -34091,26 +34231,32 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/pumproom)
-"gFI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+"gFQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
-"gFQ" = (
-/obj/effect/turf_decal/trimline/brown/filled/warning{
+/area/station/security/execution/transfer)
+"gGn" = (
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/cargo/storage)
+/area/station/hallway/secondary/entry)
 "gGH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/service/hydroponics/garden)
+"gGN" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "gHx" = (
 /obj/structure/cable,
 /obj/structure/sign/departments/restroom/directional/south,
@@ -34126,6 +34272,13 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"gIU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/tcommsat/computer)
 "gJI" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -34145,6 +34298,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
+"gMG" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/random/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"gMK" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "gNN" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
@@ -34157,13 +34321,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/ordnance/burnchamber)
-"gOq" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
 "gOs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34187,6 +34344,13 @@
 /obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"gPD" = (
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/office)
 "gPM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/firealarm/directional/east,
@@ -34194,6 +34358,14 @@
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
+"gQk" = (
+/obj/machinery/camera/autoname/directional/south,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "gQH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -34201,10 +34373,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
-"gQP" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "gRd" = (
 /obj/machinery/computer/secure_data{
 	dir = 8
@@ -34215,21 +34383,26 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
+"gRk" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "gRN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"gRO" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/engine_smes)
 "gRT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"gSd" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/engineering/gravity_generator)
 "gSi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34252,20 +34425,13 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"gSN" = (
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+"gSR" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/bar,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
-"gSY" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
+/obj/structure/window/spawner/north,
 /turf/open/floor/iron/white,
-/area/station/medical/pharmacy)
+/area/station/medical/treatment_center)
 "gTq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -34273,6 +34439,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"gTv" = (
+/obj/machinery/computer/department_orders/engineering{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "gTx" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/suit/radiation,
@@ -34285,13 +34458,15 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"gUM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+"gTX" = (
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "gUX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34299,13 +34474,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"gVt" = (
-/obj/structure/sign/poster/official/random/directional/west,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit)
 "gVA" = (
 /obj/machinery/door/airlock/hatch,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34322,18 +34490,9 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"gXc" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
-"gXi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple{
+"gWZ" = (
+/obj/machinery/door/firedoor/heavy,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -34350,31 +34509,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
-"gZg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/station/engineering/main)
-"gZk" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
-"hab" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "hat" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
@@ -34389,10 +34523,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/explab)
-"hcr" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
+"hcp" = (
+/obj/effect/turf_decal/trimline/red/end{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/lockers)
 "hcT" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/table/wood,
@@ -34402,11 +34538,20 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
-"hdN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+"hdt" = (
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"hdT" = (
+/obj/item/grenade/barrier,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/ai_monitored/security/armory)
 "hdY" = (
 /obj/structure/sign/painting/library{
 	pixel_y = 32
@@ -34423,11 +34568,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"hep" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/trash/garbage,
-/turf/open/floor/plating,
-/area/station/medical/abandoned)
 "heW" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 4
@@ -34435,29 +34575,31 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "hff" = (
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/turf/open/floor/iron/large,
+/area/station/engineering/engine_smes)
 "hfh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
-"hft" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/department/electrical)
 "hfK" = (
 /obj/machinery/gulag_teleporter,
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
+"hgf" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/station/commons/lounge)
 "hgI" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos/pumproom)
+"hgL" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "hgQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -34467,6 +34609,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
+"hhB" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "hhI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34474,20 +34627,6 @@
 /obj/machinery/holopad/secure,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
-"hih" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
-"his" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
 "hjc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -34495,14 +34634,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"hju" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/green/opposingcorners,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "hjB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34523,17 +34654,6 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
-"hkS" = (
-/obj/structure/sign/poster/contraband/random/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
-"hld" = (
-/obj/effect/spawner/random/vending/snackvend,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "hlq" = (
 /obj/machinery/bluespace_vendor/directional/west,
 /obj/effect/turf_decal/tile/brown{
@@ -34547,22 +34667,45 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"hmG" = (
-/obj/item/clothing/head/cone,
-/obj/item/clothing/head/cone,
-/obj/item/clothing/head/cone,
-/obj/item/clothing/head/cone,
-/obj/item/clothing/head/cone,
-/obj/effect/turf_decal/bot{
+"hmb" = (
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/iron/white,
+/area/station/science/research)
+"hmT" = (
+/obj/effect/turf_decal/siding/purple,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/rd)
+"hnk" = (
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/engineering/storage)
+/area/station/science/ordnance)
 "hnO" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"hoc" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"hod" = (
+/obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "hoh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -34584,9 +34727,34 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
+"hpq" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"hqt" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/station/ai_monitored/security/armory)
 "hqK" = (
 /turf/closed/wall,
 /area/station/science/research)
+"hrq" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"hrV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/explab)
 "hrZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -34595,6 +34763,25 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
+"hsp" = (
+/obj/effect/turf_decal/trimline/dark_blue/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/science/research)
+"hsP" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/execution/education)
+"htD" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "huJ" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
@@ -34611,15 +34798,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"hwg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/ai_monitored/security/armory)
 "hwh" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -34664,6 +34842,21 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"hzD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/computer/security/telescreen/entertainment,
+/turf/closed/wall,
+/area/station/commons/lounge)
+"hAc" = (
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/commons/fitness/recreation)
 "hAm" = (
 /turf/closed/wall,
 /area/station/maintenance/department/security)
@@ -34676,22 +34869,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"hCC" = (
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/security/prison)
 "hDb" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/security/checkpoint/medical)
-"hDE" = (
-/obj/structure/closet/radiation,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/station/engineering/main)
 "hDM" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34703,23 +34885,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/lounge)
-"hDO" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/service/theater)
-"hEo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+"hEg" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/turf/open/floor/iron,
+/area/station/engineering/gravity_generator)
 "hFm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34738,20 +34912,30 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"hHb" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -12;
-	pixel_y = 2
+"hHj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
 	},
-/obj/structure/mirror/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/freezer,
-/area/station/commons/toilet/locker)
+/turf/open/floor/iron,
+/area/station/security/execution/transfer)
 "hHE" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"hIl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
+"hIZ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/commons/storage/primary)
 "hJe" = (
 /obj/structure/chair,
 /obj/machinery/firealarm/directional/east,
@@ -34771,14 +34955,10 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
-"hMO" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/security/brig)
+"hLz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/science/lab)
 "hMP" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
@@ -34787,6 +34967,19 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"hMY" = (
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
+"hNu" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "hNR" = (
 /obj/structure/sign/departments/medbay/alt/directional/west,
 /obj/effect/turf_decal/tile/blue{
@@ -34799,9 +34992,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"hOC" = (
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
 "hOM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34813,19 +35003,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
-"hPa" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
-"hPB" = (
-/obj/structure/chair{
-	dir = 8;
-	name = "Defense"
-	},
-/obj/effect/turf_decal/tile/green/anticorner/contrasted,
-/turf/open/floor/iron,
-/area/station/security/courtroom)
 "hPP" = (
 /obj/structure/table,
 /obj/item/storage/medkit/fire{
@@ -34847,17 +35024,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"hQg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/brown/filled/warning,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
-"hSu" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+"hPU" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
+/area/station/security/brig)
 "hSD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34878,6 +35051,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"hTt" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "hTE" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
@@ -34923,34 +35103,16 @@
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
-"hWG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/commons/dorms)
-"hXd" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/iron,
-/area/station/engineering/break_room)
-"hXy" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/carpet,
-/area/station/service/theater)
 "hXB" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
+"hYw" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "hZn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron,
@@ -34985,15 +35147,17 @@
 /obj/structure/transit_tube/crossing/horizontal,
 /turf/open/space/basic,
 /area/space/nearstation)
-"ibN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+"iaE" = (
+/obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/engineering/atmos/office)
+/area/station/hallway/primary/central)
+"ibE" = (
+/obj/effect/spawner/random/trash/hobo_squat,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "ibO" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
@@ -35006,21 +35170,34 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/pumproom)
-"iev" = (
-/obj/structure/sign/warning/pods/directional/east,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+"idF" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/area/station/science/auxlab)
 "iew" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"ieS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/pharmacy)
 "ifK" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
+"igA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/security)
 "ihg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
@@ -35039,6 +35216,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
+"iii" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "iit" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -35113,19 +35300,10 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
-"imJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet,
-/area/station/service/library)
-"imP" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
-/area/station/commons/lounge)
+"imQ" = (
+/obj/effect/turf_decal/tile/blue/diagonal_centre,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "inn" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8
@@ -35138,6 +35316,21 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
+"inC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/commons/dorms)
+"inE" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "inU" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
 	dir = 8
@@ -35150,18 +35343,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
-"iot" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/machinery/light/directional/west,
-/obj/machinery/status_display/evac/directional/west,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "ioA" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -35178,6 +35359,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
+"iph" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/service/bar)
 "iqX" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -35194,12 +35381,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"irU" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/security)
 "isn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35212,19 +35393,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
-"isq" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/dark,
-/area/station/engineering/gravity_generator)
-"iuz" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
+"itZ" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/hallway/primary/port)
 "ivL" = (
 /obj/structure/transit_tube/curved{
 	dir = 1
@@ -35234,31 +35408,54 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"ivP" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/chair/sofa/bench/right{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"ivY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "iwg" = (
 /obj/structure/transit_tube/horizontal,
 /turf/open/space/basic,
 /area/space/nearstation)
-"ixi" = (
-/obj/structure/chair{
-	dir = 4;
-	name = "Prosecution"
-	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+"iwS" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/security/courtroom)
+/area/station/hallway/primary/central)
+"ixC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "iyu" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/emergency/port)
-"izD" = (
-/obj/structure/chair{
+"iyw" = (
+/obj/machinery/modular_computer/console/preset/cargochat/engineering{
 	dir = 1
 	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/carpet,
-/area/station/service/theater)
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "iAl" = (
 /obj/machinery/door/airlock/medical{
 	name = "Morgue"
@@ -35286,12 +35483,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
-"iCx" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
 "iCJ" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -35299,32 +35490,27 @@
 /obj/structure/window/reinforced,
 /turf/open/space/basic,
 /area/space/nearstation)
-"iCY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/plating,
-/area/station/science/auxlab)
-"iDw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "iDC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"iFe" = (
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "iFt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"iFO" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "iFR" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Telecommunications"
@@ -35362,6 +35548,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
+"iHx" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
 "iHC" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L4"
@@ -35383,11 +35576,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
-"iIo" = (
-/obj/structure/sign/poster/official/random/directional/north,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
 "iIH" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -35398,6 +35586,13 @@
 	},
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
+"iJn" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 8
+	},
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "iJD" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 4;
@@ -35413,29 +35608,23 @@
 /obj/structure/fluff/beach_umbrella,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
-"iKA" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/dark,
-/area/station/security/courtroom)
-"iMB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
+"iMm" = (
+/obj/machinery/status_display/evac/directional/west,
+/obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/commons/dorms)
-"iMU" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/station/commons/lounge)
-"iMV" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 1
+/area/station/hallway/primary/starboard)
+"iMu" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/wood,
+/area/station/service/library)
+"iNa" = (
+/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
+/area/station/cargo/storage)
 "iNb" = (
 /obj/machinery/door/airlock/glass{
 	name = "Service Hall"
@@ -35447,23 +35636,6 @@
 /obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
-"iNh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
-"iNl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/commons/dorms)
 "iOF" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -35490,31 +35662,24 @@
 /obj/structure/cable,
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/command/nuke_storage)
-"iQj" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/commons/fitness/recreation)
 "iQn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
-"iQq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+"iQK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/security/brig)
-"iSU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/area/station/ai_monitored/security/armory)
+"iRU" = (
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "iTm" = (
@@ -35535,15 +35700,30 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"iUX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/brown{
+"iUA" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/hallway/primary/central)
+"iUT" = (
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
+"iVX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "iWo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35593,32 +35773,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
-"iZC" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "iZG" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
-"iZV" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
-/area/station/security)
 "jad" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/commons/storage/emergency/port)
-"jaB" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "jaX" = (
 /obj/structure/cable,
 /turf/open/floor/carpet,
@@ -35629,11 +35792,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"jbs" = (
-/obj/structure/chair/stool/bar/directional/east,
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "jbU" = (
 /obj/effect/spawner/random/structure/crate_abandoned,
 /obj/effect/decal/cleanable/cobweb,
@@ -35648,7 +35806,7 @@
 /area/station/maintenance/department/science)
 "jcM" = (
 /turf/open/floor/iron/dark,
-/area/station/security/courtroom)
+/area/station/science/ordnance)
 "jcU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -35688,13 +35846,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"jgc" = (
-/obj/effect/turf_decal/tile/green/opposingcorners,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "jgf" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35734,29 +35885,47 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/pumproom)
-"jkp" = (
+"jjK" = (
+/obj/machinery/washing_machine,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
+"jlr" = (
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/cmo)
-"jks" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research{
+	name = "Mech Bay"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
+/turf/open/floor/iron,
+/area/station/science/robotics/mechbay)
+"jlL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/service/theater)
+"jlO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"jlR" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
-"jlY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/station/engineering/break_room)
+"jmt" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security/prison)
 "jmx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35803,19 +35972,26 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
-"jrE" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+"jrg" = (
+/turf/open/floor/iron,
+/area/station/commons/lounge)
+"jsh" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
+"jsz" = (
+/obj/structure/sign/poster/official/wtf_is_co2,
+/turf/closed/wall,
 /area/station/hallway/primary/central)
-"jsu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/brown/filled/warning,
+"jsF" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/station/cargo/sorting)
+/area/station/hallway/primary/port)
 "jtH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35837,20 +36013,15 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"jut" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/turf/open/floor/iron,
-/area/station/security/courtroom)
-"juB" = (
+"jvg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/station/security/prison/safe)
-"jvn" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/security/prison)
+/area/station/hallway/secondary/entry)
 "jvu" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/directions/engineering{
@@ -35868,6 +36039,14 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"jwI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "jxj" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
@@ -35881,13 +36060,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
-"jyt" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/commons/fitness/recreation)
+"jxT" = (
+/obj/effect/turf_decal/bot_white/left,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/command/gateway)
 "jyv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -35900,22 +36077,18 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
-"jAi" = (
-/obj/structure/sign/poster/official/random/directional/west,
-/obj/effect/turf_decal/tile/neutral{
+"jzy" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/command/teleporter)
+"jAr" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/station/solars/starboard/fore)
+"jAW" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/green{
 	dir = 8
-	},
-/obj/structure/chair/sofa/bench{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
-"jAD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
@@ -35924,10 +36097,24 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"jBC" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "jCg" = (
 /obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
+"jDR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "jEm" = (
 /obj/item/radio/intercom/directional/east,
 /obj/effect/turf_decal/tile/neutral{
@@ -35935,13 +36122,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
-"jEF" = (
-/obj/structure/sign/directions/vault/directional/west,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "jEN" = (
 /obj/machinery/door/airlock/external{
 	name = "Security Escape Airlock"
@@ -35958,31 +36138,27 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
-"jFJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
+"jFY" = (
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
-"jGw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
-"jGJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/area/station/hallway/secondary/exit/departure_lounge)
 "jGM" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"jHp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "jHW" = (
 /obj/structure/sign/warning/radiation/rad_area{
 	pixel_y = 32
@@ -35998,16 +36174,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/hallway/primary/starboard)
-"jIx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/structure/fluff/broken_flooring{
-	dir = 4;
-	icon_state = "singular"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
 "jIX" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/siding/wideplating_new/dark{
@@ -36018,6 +36184,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
+"jIZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "jJc" = (
 /obj/machinery/door/airlock/external{
 	name = "Arrival Airlock";
@@ -36028,6 +36206,17 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
+"jJr" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/cafeteria,
+/area/station/service/kitchen)
+"jJH" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "jKm" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
@@ -36039,10 +36228,26 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/station/service/theater)
+"jKr" = (
+/obj/machinery/chem_master{
+	pixel_x = -2
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/pharmacy)
 "jKB" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/construction)
+"jLg" = (
+/obj/structure/chair{
+	dir = 4;
+	name = "Prosecution"
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/security/courtroom)
 "jLv" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/neutral{
@@ -36050,13 +36255,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"jMU" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "jNl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36066,12 +36264,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"jNT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/station/engineering/main)
 "jOa" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -36107,19 +36299,48 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"jQf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron/white,
-/area/station/medical/cryo)
+"jRm" = (
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron,
+/area/station/engineering/gravity_generator)
+"jRn" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple/full,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/science/xenobiology)
 "jRv" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"jRQ" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/engine_smes)
+"jTw" = (
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "jUq" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
+"jVx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/security/execution/transfer)
 "jVQ" = (
 /obj/machinery/light_switch/directional/south,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
@@ -36153,6 +36374,15 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"jWH" = (
+/obj/structure/window{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "jXd" = (
 /turf/open/floor/wood,
 /area/station/service/library/lounge)
@@ -36183,10 +36413,12 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"jXT" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner,
+"jXR" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/open/floor/iron,
-/area/station/cargo/storage)
+/area/station/engineering/main)
 "jYl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -36196,19 +36428,6 @@
 /obj/structure/cable/layer3,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"jYo" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
-"jYG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "jZk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36219,11 +36438,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
-"jZz" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/commons/lounge)
 "kaG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -36249,35 +36463,12 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
-"kcF" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
-"kcL" = (
-/obj/structure/sign/poster/contraband/random/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
-"kdb" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
-"kdE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
-	},
+"kcG" = (
+/obj/structure/table,
+/obj/item/storage/dice,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
+/area/station/hallway/secondary/exit/departure_lounge)
 "kdW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -36286,28 +36477,12 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
-"keE" = (
-/obj/effect/landmark/start/hangover,
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/station/commons/lounge)
 "keV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
-"kfq" = (
-/turf/open/floor/iron/white,
-/area/station/science/lab)
-"kfz" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "kfT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -36318,22 +36493,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"kfX" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
-"kgo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
 "kgY" = (
 /obj/structure/table,
 /obj/machinery/light/small/directional/west,
@@ -36356,10 +36515,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"khs" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted,
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
 "khu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -36392,12 +36547,11 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"kiX" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 4
-	},
+"kjc" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
-/area/station/security/brig)
+/area/station/engineering/engine_smes)
 "kjL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36411,15 +36565,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
-"kkk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "kkp" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/plaque{
@@ -36427,44 +36572,34 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"kle" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
-"klj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
 "klw" = (
 /obj/machinery/suit_storage_unit/industrial/loader,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
-"klY" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+"klB" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
+"klL" = (
+/obj/machinery/button/door{
+	id = "EscapeBarShutters";
+	name = "Escape Bar Shutter Control";
+	pixel_x = 24;
+	req_access = list("bar")
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/cryo)
-"kmn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
+"kmj" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/hallway/primary/central)
 "kmo" = (
 /obj/machinery/computer/warrant{
 	dir = 4
@@ -36486,15 +36621,24 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"knW" = (
+"koa" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"kom" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "koo" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -36508,12 +36652,13 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
-"kpB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+"kpH" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
-/area/station/science/auxlab)
+/area/station/engineering/break_room)
 "kpJ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/status_display/evac/directional/east,
@@ -36522,12 +36667,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"kpK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/gravity_generator)
 "kpM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
@@ -36551,6 +36690,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"kql" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/security/execution/transfer)
 "kqD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/airalarm/mixingchamber{
@@ -36574,21 +36719,22 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
-"krx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/station/engineering/storage)
 "krU" = (
 /turf/open/floor/iron/recharge_floor,
 /area/station/science/robotics/mechbay)
 "krX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
+"kst" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/end,
+/turf/open/floor/iron,
+/area/station/engineering/storage)
 "ksH" = (
 /obj/structure/chair,
 /obj/structure/sign/poster/official/random/directional/north,
@@ -36605,23 +36751,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"ksZ" = (
-/obj/structure/sign/poster/contraband/random/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/central)
-"ktp" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
-"ktI" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "ktU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -36644,16 +36773,6 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
-"kvW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron,
-/area/station/commons/fitness/recreation)
 "kvZ" = (
 /obj/machinery/shower{
 	dir = 4
@@ -36672,21 +36791,33 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
-"kza" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+"kxc" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/security/execution/transfer)
+/area/station/hallway/primary/starboard)
+"kyb" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/security)
+"kyF" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "kzf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 4
+/obj/effect/turf_decal/trimline/dark_blue/line{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
@@ -36696,16 +36827,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"kzs" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
-"kzw" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "kzH" = (
 /obj/structure/chair{
 	dir = 1
@@ -36713,15 +36834,17 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet,
 /area/station/service/theater)
+"kzM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white/textured,
+/area/station/science/research)
 "kzT" = (
 /obj/machinery/firealarm/directional/north,
 /obj/effect/landmark/start/depsec/engineering,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)
-"kAe" = (
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
-/turf/open/floor/iron,
-/area/station/engineering/break_room)
 "kAu" = (
 /obj/structure/chair{
 	dir = 1
@@ -36729,24 +36852,10 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
-"kAJ" = (
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "kAQ" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/engine,
 /area/station/science/explab)
-"kBa" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
-"kBy" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/engine_smes)
 "kBH" = (
 /obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/stripes/corner{
@@ -36757,29 +36866,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
-"kBO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
-"kCa" = (
-/obj/item/kirbyplants/photosynthetic,
-/turf/open/floor/iron/white,
-/area/station/science/research)
-"kCn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
+"kBV" = (
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/security/medical)
 "kCt" = (
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -36787,16 +36880,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
-"kCA" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
-"kCF" = (
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "kDj" = (
 /obj/machinery/light/built/directional/east,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -36817,37 +36900,23 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
-"kEj" = (
-/obj/effect/turf_decal/siding/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/rd)
 "kEo" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/carpet,
 /area/station/service/theater)
-"kEy" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "kET" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
-"kFz" = (
-/obj/machinery/chem_master/condimaster{
-	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
-	name = "HoochMaster Deluxe"
+"kFy" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/area/station/hallway/primary/starboard)
 "kFB" = (
 /obj/structure/window/reinforced/plasma{
 	dir = 4
@@ -36857,18 +36926,26 @@
 /obj/machinery/power/energy_accumulator/tesla_coil/anchored,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
+"kGt" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "kGP" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
-"kHf" = (
-/turf/open/floor/iron/white,
-/area/station/security/medical)
-"kHr" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/station/commons/lounge)
+"kGX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron,
+/area/station/ai_monitored/security/armory)
 "kHJ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -36888,20 +36965,21 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"kJg" = (
+"kIN" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
-"kJh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+"kIS" = (
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/station/cargo/storage)
+/area/station/hallway/primary/port)
 "kJy" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -36913,46 +36991,33 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron,
 /area/station/maintenance/central)
-"kJX" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/turf/open/floor/carpet,
-/area/station/command/meeting_room)
-"kKb" = (
-/obj/structure/dresser,
-/turf/open/floor/iron/checker,
-/area/station/service/theater)
+"kJM" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "kKi" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/vending/wallmed/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
-"kKS" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/commons/lounge)
-"kLt" = (
-/obj/effect/turf_decal/bot_white/left,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/command/gateway)
-"kLW" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/security)
 "kMe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/bar,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"kMr" = (
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
+"kMK" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/green/half/contrasted,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "kMM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 6
@@ -36965,37 +37030,51 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"kOc" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"kOl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/iron,
+/area/station/commons/storage/primary)
 "kOL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison)
-"kOO" = (
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+"kPj" = (
+/obj/machinery/camera/autoname/directional/south,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"kPq" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "kPC" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"kPT" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
+"kPI" = (
+/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/iron,
-/area/station/security/brig)
+/area/station/hallway/primary/starboard)
 "kRv" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
-"kRP" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron/airless,
-/area/station/maintenance/port/aft)
-"kTR" = (
-/obj/machinery/door/firedoor,
+"kSj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -37017,17 +37096,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
-"kVb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/iron,
-/area/station/engineering/main)
 "kVe" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -37035,18 +37103,17 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"kVE" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/engine_smes)
 "kVL" = (
 /obj/structure/transit_tube/curved/flipped{
 	dir = 8
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"kXa" = (
+/obj/effect/spawner/random/trash/garbage,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
 "kXe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -37068,18 +37135,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"kXW" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/ai_monitored/security/armory)
 "kYr" = (
 /obj/machinery/newscaster/directional/west,
 /obj/item/kirbyplants/random,
@@ -37091,18 +37148,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
-"kYx" = (
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/carpet,
-/area/station/commons/dorms)
-"kYQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+"kYv" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/commons/dorms)
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
 "kZo" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -37115,17 +37169,19 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
-"kZN" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+"kZz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
+"lbB" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 8
 	},
-/obj/structure/sign/poster/official/random/directional/east,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
-"laH" = (
-/obj/effect/landmark/navigate_destination/hydro,
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
+/area/station/hallway/primary/starboard)
 "lbF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37133,26 +37189,26 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security)
-"ldu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+"lcA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/security)
+"leb" = (
+/obj/effect/turf_decal/tile/brown/opposingcorners,
+/obj/structure/sign/warning/secure_area/directional/west,
+/turf/open/floor/iron,
+/area/station/maintenance/central)
 "lfD" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Atmospherics N2 Tank"
 	},
 /turf/open/floor/engine/n2,
 /area/station/engineering/atmos)
-"lfK" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/main)
 "lga" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
@@ -37170,13 +37226,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/library/lounge)
-"lhp" = (
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/turf_decal/tile/brown/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/cargo/office)
 "liM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37197,23 +37246,22 @@
 /obj/effect/spawner/random/entertainment/lighter,
 /turf/open/floor/carpet,
 /area/station/hallway/secondary/entry)
-"ljE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
-"lkp" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
+"liW" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/purple/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/research)
+"lki" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/area/station/engineering/atmos)
 "lkE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37231,13 +37279,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"lkW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "lkY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
@@ -37304,12 +37345,20 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plating,
 /area/station/construction)
-"lpg" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
+"lqc" = (
+/obj/machinery/door/window/brigdoor{
+	dir = 8;
+	name = "Test Range"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/security/brig)
+/area/station/science/auxlab)
+"lqW" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "lrC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -37333,6 +37382,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
+"lug" = (
+/obj/machinery/vending/wallmed/directional/south,
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "lvR" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
@@ -37347,32 +37401,35 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"lwD" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
-"lwF" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/clothing/mask/gas{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas{
-	pixel_x = -3;
-	pixel_y = -3
-	},
+"lxl" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
+"lxr" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
-/area/station/engineering/main)
-"lxj" = (
-/obj/effect/turf_decal/caution/stand_clear,
+/area/station/engineering/storage)
+"lyd" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/carpet,
+/area/station/command/meeting_room)
+"lyn" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
-/area/station/commons/dorms)
+/area/station/hallway/primary/central/aft)
+"lyI" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "lzC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37389,16 +37446,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
-"lAf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/main)
 "lAC" = (
 /obj/structure/chair/stool/directional/east,
 /turf/open/floor/plating,
@@ -37408,12 +37455,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"lAV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
+"lBf" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/command/gateway)
+"lBq" = (
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
-/area/station/medical/pharmacy)
+/area/station/medical/chemistry)
 "lBw" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
@@ -37438,6 +37489,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "lDn" = (
@@ -37450,13 +37504,18 @@
 	},
 /turf/open/floor/wood,
 /area/station/commons/dorms)
-"lDt" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
+"lDp" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/station/security/courtroom)
+"lDt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair/stool/bar/directional/south,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/floor/iron,
+/area/station/commons/lounge)
 "lDI" = (
 /obj/structure/table,
 /obj/item/surgical_drapes,
@@ -37474,6 +37533,30 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/grass,
 /area/station/science/genetics)
+"lFS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"lGf" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
+"lGG" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/sign/poster/official/high_class_martini{
+	pixel_y = -32
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "lHb" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/engineering/tracking_beacon,
@@ -37488,12 +37571,17 @@
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "lHM" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners{
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/science/lab)
+"lIA" = (
+/obj/effect/turf_decal/trimline/neutral/end{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_edge{
 	dir = 8
 	},
-/obj/structure/closet/emcloset,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
+/area/station/medical/morgue)
 "lIC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37527,13 +37615,32 @@
 	},
 /turf/open/floor/iron,
 /area/station/security)
-"lLh" = (
-/obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+"lLB" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
+/area/station/hallway/primary/starboard)
+"lLL" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/station/command/heads_quarters/captain)
+"lMh" = (
+/obj/structure/sink/kitchen{
+	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
+	name = "old sink"
+	},
+/turf/open/floor/iron,
+/area/station/security/prison)
+"lMC" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "lNe" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/trimline/purple/corner{
@@ -37541,6 +37648,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"lOx" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "lPi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37585,11 +37698,17 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
-"lRP" = (
-/obj/effect/turf_decal/stripes/corner{
+"lRr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet,
+/area/station/service/library)
+"lRN" = (
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "lSc" = (
@@ -37597,12 +37716,47 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"lSH" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+"lSd" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"lSL" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet,
+/area/station/service/theater)
+"lSQ" = (
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/rd)
+"lTM" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/obj/structure/sign/directions/science/directional/east{
+	dir = 2
+	},
+/obj/structure/sign/directions/supply/directional/east{
+	dir = 2;
+	pixel_y = 8
+	},
+/obj/structure/sign/directions/vault/directional/east{
+	pixel_y = -8;
+	dir = 2
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "lTU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -37610,6 +37764,12 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
+"lTY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "lUl" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/wood{
@@ -37624,6 +37784,13 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"lUC" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security/brig)
 "lUN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -37634,12 +37801,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
-"lVR" = (
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "lWs" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
@@ -37649,19 +37810,13 @@
 /obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/iron,
 /area/station/engineering/main)
-"lWw" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/station/command/gateway)
+"lWu" = (
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "lWL" = (
 /turf/open/space/basic,
 /area/space)
-"lXd" = (
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/carpet,
-/area/station/command/meeting_room)
 "lXv" = (
 /obj/machinery/requests_console{
 	department = "Medbay";
@@ -37671,6 +37826,23 @@
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
+"lYb" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"lYm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "lYn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37682,12 +37854,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
-"lYK" = (
-/obj/effect/turf_decal/tile/purple/opposingcorners{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "lYT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37706,6 +37872,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
+"maa" = (
+/obj/structure/sign/poster/official/random/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/commons/storage/primary)
 "mcQ" = (
 /obj/structure/chair{
 	dir = 4
@@ -37716,31 +37887,13 @@
 /obj/effect/turf_decal/tile/blue/diagonal_edge,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
-"mcV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
-"mdG" = (
-/obj/structure/table,
-/obj/item/storage/dice,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
-"meE" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
+"mdy" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "meR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/delivery,
@@ -37749,10 +37902,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"meU" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "mfp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -37766,10 +37915,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"mfG" = (
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "mgf" = (
 /obj/machinery/gulag_item_reclaimer{
 	pixel_y = 24
@@ -37786,14 +37931,19 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
+"mgo" = (
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 4
+	},
+/obj/machinery/smartfridge/organ,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "mgP" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine/atmos)
@@ -37843,14 +37993,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
-"miD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "mjZ" = (
 /obj/machinery/atmospherics/components/binary/pump/off{
 	name = "Port to Air";
@@ -37869,6 +38011,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"mlK" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "mmB" = (
 /obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37907,24 +38056,26 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
-"mnz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
+"mno" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/ai_monitored/security/armory)
+/area/station/hallway/primary/central)
 "mnO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter)
-"moH" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
+"mol" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "moZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -37932,13 +38083,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
-"mpf" = (
-/obj/machinery/bluespace_vendor/directional/west,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit)
 "mpA" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -37949,24 +38093,16 @@
 /obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
-"mqT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+"mrk" = (
+/turf/open/floor/iron/dark,
+/area/station/security/courtroom)
+"mry" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/dark_blue/line{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/station/science/research)
-"mrb" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/hallway/secondary/exit)
 "mrA" = (
 /obj/machinery/computer/prisoner/gulag_teleporter_computer{
 	dir = 4
@@ -37980,6 +38116,21 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"msd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/break_room)
+"msO" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "msY" = (
 /obj/machinery/light_switch/directional/east,
 /obj/effect/turf_decal/stripes/line{
@@ -37987,17 +38138,23 @@
 	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
-"mtO" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
+"mtd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/security/brig)
-"mtV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/virology)
+/area/station/medical/medbay/central)
+"muS" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "muT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38026,25 +38183,31 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter)
-"mww" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
 "mwG" = (
 /obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
-"mwP" = (
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+"mwR" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/sign/directions/supply/directional/west{
+	pixel_y = 12;
 	dir = 1
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/obj/structure/sign/directions/science/directional/west{
+	pixel_y = 5;
+	dir = 1
+	},
+/obj/structure/sign/directions/security/directional/west{
+	pixel_y = -2
+	},
+/obj/structure/sign/directions/vault/directional/west{
+	dir = 1;
+	pixel_y = -9
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "mxi" = (
 /obj/machinery/light/directional/west,
 /obj/structure/sign/departments/medbay/alt/directional/west,
@@ -38080,37 +38243,6 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
-"myb" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security/checkpoint/escape)
-"myt" = (
-/obj/structure/sign/poster/contraband/random/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/port/aft)
-"myF" = (
-/obj/effect/landmark/start/hangover,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
-"myL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
 "myP" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -38123,50 +38255,39 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
-"mBd" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
+"mAo" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/sign/poster/official/high_class_martini{
-	pixel_y = -32
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
-"mCv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
-"mCw" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
-"mDr" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
-"mDO" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
-"mDX" = (
+/area/station/medical/medbay/central)
+"mBR" = (
+/obj/structure/dresser,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/service/theater)
+"mCr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/security/prison/safe)
+"mDF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/engineering/main)
 "mEi" = (
 /obj/effect/landmark/start/roboticist,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -38174,6 +38295,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
+"mEv" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "mEJ" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
@@ -38182,13 +38310,17 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter)
-"mGN" = (
-/obj/structure/sink/kitchen{
-	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
-	name = "old sink"
+"mGK" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/security/prison)
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
+"mGV" = (
+/obj/structure/closet/crate,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet,
+/area/station/commons/dorms)
 "mHj" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -38203,10 +38335,12 @@
 	dir = 1
 	},
 /area/station/service/chapel)
-"mHV" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/station/commons/lounge)
+"mHW" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "mIl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38223,20 +38357,20 @@
 "mIV" = (
 /turf/closed/wall,
 /area/station/medical/medbay/central)
-"mJz" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/purple/filled/corner,
+"mJx" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet,
+/area/station/service/theater)
+"mKl" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron/white,
-/area/station/science/xenobiology)
-"mMb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/science/genetics)
 "mMC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -38276,21 +38410,33 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"mOC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+"mPs" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"mPC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/structure/sign/poster/contraband/random/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "mQw" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"mRl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "mRP" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
@@ -38298,18 +38444,15 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"mTy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+"mSl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
-/area/station/engineering/main)
-"mTI" = (
+/area/station/engineering/gravity_generator)
+"mUn" = (
 /obj/machinery/button/door{
 	id = "Skynet_launch";
 	name = "Mech Bay Shutters";
@@ -38319,44 +38462,24 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
-"mUp" = (
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/structure/sign/directions/science/directional/east{
-	dir = 2
-	},
-/obj/structure/sign/directions/supply/directional/east{
-	dir = 2;
-	pixel_y = 8
-	},
-/obj/structure/sign/directions/vault/directional/east{
-	pixel_y = -8;
-	dir = 2
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "mUJ" = (
 /obj/structure/window/fulltile,
 /turf/open/floor/plating,
 /area/station/service/library/lounge)
+"mVn" = (
+/obj/structure/sign/poster/official/safety_eye_protection{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "mVS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"mWc" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/commons/fitness/recreation)
-"mWo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "mWC" = (
 /obj/structure/table,
 /obj/item/pipe_dispenser{
@@ -38391,14 +38514,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"mXU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/structure/chair/stool/bar/directional/south,
+"mXT" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/station/commons/lounge)
+/area/station/engineering/break_room)
+"mYr" = (
+/obj/effect/turf_decal/tile/neutral/diagonal_centre,
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "mYJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -38406,6 +38534,11 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
+"mYP" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "mYR" = (
 /obj/structure/safe,
 /obj/item/clothing/neck/stethoscope,
@@ -38441,28 +38574,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
-"nab" = (
-/obj/structure/closet/crate,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet,
-/area/station/commons/dorms)
-"naE" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
-"naS" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "naU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38480,6 +38591,25 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
+"nbw" = (
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/chair/sofa/bench{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"ncd" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "ncu" = (
 /obj/machinery/door/airlock/medical{
 	name = "Patient Room"
@@ -38498,15 +38628,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"ncE" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "ncQ" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/cargo_gauntlet{
@@ -38532,6 +38653,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
+"ndG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/engine_smes)
 "nee" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/suit/radiation,
@@ -38569,6 +38696,14 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"nfr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "nfs" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
@@ -38596,10 +38731,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
-"ngT" = (
-/obj/machinery/camera/autoname/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/engineering/gravity_generator)
 "ngV" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -38609,12 +38740,12 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/bar)
-"nhS" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
+"nhF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/station/cargo/storage)
+/area/station/cargo/miningdock)
 "nig" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -38640,19 +38771,6 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
-"njz" = (
-/obj/structure/cable,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/chair/stool{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/red/filled/end{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/security/warden)
 "nko" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -38664,13 +38782,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"nlW" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/structure/chair/sofa/bench/right,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "nmh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -38678,12 +38789,6 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"nnB" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "nnI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38715,13 +38820,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
-"nol" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
+"nov" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "noN" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
@@ -38740,15 +38847,25 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/gateway,
 /turf/open/floor/iron,
 /area/station/command/gateway)
+"npV" = (
+/obj/structure/sign/warning/pods/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "nqr" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
-"nqM" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
+"nqN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "nrc" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -38769,6 +38886,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/central)
+"nrS" = (
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/rd)
 "nsh" = (
 /obj/structure/chair/office,
 /turf/open/floor/iron/dark,
@@ -38792,18 +38913,26 @@
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
-"nsW" = (
-/obj/effect/turf_decal/tile/purple/opposingcorners,
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/rd)
-"ntR" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
+"nsT" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/cryo)
+/area/station/science/xenobiology)
+"ntk" = (
+/obj/machinery/camera/autoname/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"ntu" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "ntU" = (
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Antechamber"
@@ -38814,29 +38943,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
-"nui" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
+"ntV" = (
+/obj/structure/sign/poster/contraband/random/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "num" = (
 /obj/effect/landmark/start/station_engineer,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/engineering/main)
-"nuJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/turf/open/floor/iron,
-/area/station/security/brig)
 "nuY" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -38851,32 +38966,30 @@
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"nwq" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/turf/open/floor/iron,
+/area/station/security/execution/transfer)
+"nwC" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "nwT" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
-"nxj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"nxu" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/button/flasher{
-	id = "secentranceflasher";
-	name = "Brig Entrance Flasher";
-	req_access = list("security");
-	pixel_x = 26;
-	pixel_y = 26
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/security/warden)
+/area/station/hallway/primary/port)
 "nxx" = (
 /obj/machinery/computer/bank_machine,
 /obj/item/radio/intercom/directional/north,
@@ -38899,13 +39012,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"nym" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "nyw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -38914,20 +39020,28 @@
 /obj/structure/dresser,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
+"nyY" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
+"nzt" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/science/auxlab)
 "nAW" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
 /obj/structure/statue/sandstone/assistant,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
-"nBj" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+"nBt" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/station/maintenance/port/aft)
 "nCg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38949,6 +39063,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"nDa" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "nDk" = (
 /obj/structure/table,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -38957,15 +39080,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"nDx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/command)
 "nDQ" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/transit_tube/diagonal,
@@ -38975,20 +39089,25 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
-"nFV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+"nFo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
+"nFO" = (
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4
+	dir = 8
+	},
+/obj/structure/sign/poster/official/cleanliness{
+	pixel_y = -32
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
-"nGK" = (
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron,
-/area/station/engineering/gravity_generator)
+/area/station/hallway/primary/central)
+"nGA" = (
+/turf/closed/wall,
+/area/station/commons/lounge)
 "nHa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/machinery/meter,
@@ -39001,11 +39120,21 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"nHF" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/green/half/contrasted,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+"nHH" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/chair/sofa/bench{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"nIa" = (
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "nIy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -39017,16 +39146,23 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
-"nJf" = (
-/obj/effect/turf_decal/tile/neutral{
+"nJF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
+"nKp" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/secondary/exit)
-"nJE" = (
-/obj/machinery/holopad,
-/turf/open/floor/iron,
-/area/station/service/theater)
+/area/station/hallway/primary/port)
 "nKs" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39034,10 +39170,15 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
-"nKS" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/station/service/library)
+"nKJ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/chair/sofa/bench/right{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "nLx" = (
 /obj/structure/chair{
 	dir = 8
@@ -39045,11 +39186,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
-"nLG" = (
-/obj/effect/landmark/start/hangover,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/station/commons/lounge)
 "nLR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39057,12 +39193,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
-"nMj" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security)
 "nMm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39072,16 +39202,8 @@
 /obj/structure/cable,
 /obj/structure/chair/stool/bar/directional/south,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/commons/lounge)
-"nMp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted,
-/turf/open/floor/iron,
-/area/station/security/brig)
 "nMq" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
@@ -39117,33 +39239,10 @@
 /obj/machinery/holopad/secure,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain)
-"nMR" = (
-/obj/effect/landmark/start/hangover,
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "nNJ" = (
 /obj/effect/landmark/start/depsec/engineering,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)
-"nNK" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
-"nOm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "nOZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -39188,31 +39287,24 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"nTl" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner,
-/obj/effect/decal/cleanable/dirt,
+"nSX" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/obey{
+	pixel_y = -32
+	},
 /turf/open/floor/iron,
-/area/station/cargo/storage)
+/area/station/hallway/primary/port)
+"nTd" = (
+/obj/structure/cable,
+/obj/effect/landmark/navigate_destination,
+/obj/effect/turf_decal/tile/green/half/contrasted,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "nTF" = (
 /turf/open/floor/plating,
 /area/station/security/execution/transfer)
-"nTG" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/station/ai_monitored/security/armory)
-"nUg" = (
-/obj/machinery/modular_computer/console/preset/cargochat/security{
-	dir = 1
-	},
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/station/security/brig)
 "nUx" = (
 /obj/structure/bed,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -39237,16 +39329,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
-"nVv" = (
-/obj/machinery/airalarm/directional/north,
-/obj/effect/spawner/random/structure/closet_private,
-/obj/item/clothing/head/wig/natural{
-	hairstyle = "Mohawk (Unshaven)";
-	icon_state = "hair_unshaven_mohawk";
-	dir = 4
+"nVU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/wood,
-/area/station/commons/dorms)
+/turf/open/floor/iron,
+/area/station/ai_monitored/command/storage/eva)
 "nWr" = (
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -39257,13 +39345,21 @@
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "nXo" = (
-/obj/effect/landmark/start/hangover,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
+"nXF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
+"nXS" = (
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "nYi" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 10
@@ -39273,16 +39369,40 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"oas" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
+"nYr" = (
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
-"oaR" = (
+/area/station/engineering/main)
+"nZw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"oaw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/purple/full,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/science/xenobiology)
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "oaU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39290,8 +39410,20 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"oaV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/engine_smes)
 "oaZ" = (
 /obj/machinery/door/airlock/external{
 	name = "Security Escape Airlock"
@@ -39310,19 +39442,6 @@
 /obj/machinery/pdapainter/engineering,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
-"obq" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/carpet,
-/area/station/commons/dorms)
-"ocD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
 "ocE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39330,13 +39449,6 @@
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
-"ocF" = (
-/obj/effect/turf_decal/siding/purple/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/rd)
 "ocI" = (
 /obj/machinery/power/emitter/welded{
 	dir = 8
@@ -39344,11 +39456,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
-"odJ" = (
-/obj/machinery/vending/wallmed/directional/south,
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+"odb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/freezer,
+/area/station/commons/toilet/locker)
 "odN" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/camera/emp_proof/directional/south{
@@ -39377,21 +39488,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
-"oey" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/engineering/gravity_generator)
 "oeA" = (
 /obj/structure/flora/bush/flowers_yw/style_3,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
-"oeQ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
 "ofb" = (
 /obj/machinery/camera/emp_proof{
 	c_tag = "Engineering - Emitter Room East";
@@ -39401,9 +39501,6 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
-"ofl" = (
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "ohc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39420,13 +39517,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/theater)
-"oir" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/tcommsat/computer)
+"ohq" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "oiG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall,
@@ -39437,16 +39534,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
-"ojV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/security)
-"okT" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
 "olh" = (
 /obj/item/kirbyplants/random,
 /obj/structure/sign/departments/medbay/alt/directional/north,
@@ -39486,18 +39573,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"oni" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/security/warden)
 "onE" = (
 /obj/structure/cable,
 /obj/item/radio/intercom/directional/north,
@@ -39512,41 +39587,44 @@
 	},
 /turf/open/floor/carpet,
 /area/station/service/chapel)
-"ooJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/computer/security/telescreen/entertainment,
-/turf/closed/wall,
-/area/station/commons/lounge)
-"opp" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/structure/chair/sofa/bench/left,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
-"opr" = (
-/obj/structure/window{
+"onO" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
+"ooE" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
+"opq" = (
+/obj/machinery/light/directional/east,
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/drinks{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
-/area/station/hallway/secondary/exit)
+/area/station/hallway/secondary/exit/departure_lounge)
 "oqG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
-"org" = (
-/obj/effect/turf_decal/bot_white/left,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/gravity_generator)
+"oqY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
+"orO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/station/command/gateway)
 "oty" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 1
@@ -39584,12 +39662,15 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
-"ouX" = (
-/obj/effect/turf_decal/tile/red{
+"oxp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/station/security/courtroom)
 "oxs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39601,13 +39682,11 @@
 	},
 /turf/open/floor/iron/checker,
 /area/station/service/theater)
-"ozo" = (
-/obj/effect/turf_decal/tile/brown/half/contrasted{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
+"oyM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/iron/white,
+/area/station/medical/abandoned)
 "ozp" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
@@ -39620,13 +39699,20 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"oAq" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 4
+"oAG" = (
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/station/cargo/storage)
+"oAM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "oBj" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -39634,28 +39720,31 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"oBm" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "oBt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/holopad,
 /turf/open/floor/carpet/red,
 /area/station/cargo/qm)
-"oBv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/station/science/robotics/lab)
-"oBD" = (
-/obj/effect/spawner/random/maintenance,
-/obj/effect/spawner/random/structure/table_or_rack,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
 "oCl" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/security/prison)
+"oCq" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/left/directional/west{
+	name = "Genetics Desk";
+	req_access = list("genetics");
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
 "oCu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39670,6 +39759,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
+"oDC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "oDO" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -39678,6 +39776,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"oDV" = (
+/obj/effect/turf_decal/trimline/purple/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "oEP" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
@@ -39719,44 +39826,38 @@
 /obj/machinery/vending/games,
 /turf/open/floor/wood,
 /area/station/service/library/lounge)
+"oGi" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security)
 "oGx" = (
 /obj/structure/transit_tube/curved/flipped{
 	dir = 4
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"oHd" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
-"oIx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/brown/filled/warning,
-/turf/open/floor/iron,
-/area/station/cargo/sorting)
-"oIJ" = (
+"oIq" = (
 /obj/effect/turf_decal/tile/blue{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/lobby)
 "oIK" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/station/construction)
+"oIP" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security/brig)
 "oIX" = (
 /obj/structure/table,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
-"oJj" = (
-/obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "oJW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -39764,10 +39865,23 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"oKr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "oKO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"oKY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "oLa" = (
 /obj/structure/cable,
 /turf/open/floor/carpet,
@@ -39796,15 +39910,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
-"oMO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit)
+"oMG" = (
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "oMQ" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge"
@@ -39826,43 +39935,24 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"oNK" = (
+"oOh" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/engineering/gravity_generator)
-"oOf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/spawner/random/structure/crate,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
-"oOx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/station/science/auxlab)
-"oPs" = (
-/obj/machinery/flasher/portable,
-/obj/machinery/flasher/portable,
-/obj/effect/turf_decal/stripes/line{
+/area/station/ai_monitored/command/storage/eva)
+"oOu" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/ai_monitored/security/armory)
+/area/station/cargo/storage)
 "oPF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "oPW" = (
@@ -39879,10 +39969,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/explab)
-"oRI" = (
-/obj/structure/sign/poster/official/wtf_is_co2,
-/turf/closed/wall,
-/area/station/hallway/primary/central)
+"oQB" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "oRU" = (
 /obj/structure/cable,
 /obj/machinery/holopad,
@@ -39940,6 +40032,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"oUD" = (
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/carpet,
+/area/station/commons/dorms)
 "oUZ" = (
 /obj/item/radio/intercom/directional/south{
 	broadcasting = 1;
@@ -39949,23 +40045,29 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
+"oVy" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/commons/lounge)
 "oVB" = (
 /obj/structure/transit_tube/horizontal,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"oVG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "oVI" = (
 /obj/structure/reflector/double/anchored{
 	dir = 6
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
-"oWh" = (
-/obj/effect/turf_decal/tile/neutral/diagonal_centre,
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "oXJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39973,13 +40075,16 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
-"oXV" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red/half/contrasted{
+"oYe" = (
+/obj/machinery/portable_atmospherics/pump,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/security/brig)
+/area/station/hallway/primary/central)
 "oYp" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/carpet/red,
@@ -39993,6 +40098,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"oZK" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/ai_monitored/security/armory)
 "oZR" = (
 /obj/structure/grille/broken,
 /obj/structure/cable,
@@ -40003,6 +40114,12 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
+"pax" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "paS" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -40093,17 +40210,23 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"peu" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+"pff" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"pfy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "pfz" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -40115,53 +40238,25 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
-"pgm" = (
-/obj/machinery/computer/mechpad{
-	dir = 1
-	},
-/turf/open/floor/circuit/green,
-/area/station/science/robotics/mechbay)
 "pgx" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
-"pgM" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
 "pgS" = (
 /obj/machinery/holopad,
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
-"phj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+"piM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
-"pig" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
-"piN" = (
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/engineering/break_room)
 "piS" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/tile/blue/opposingcorners,
@@ -40174,50 +40269,35 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"pkp" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+"pkd" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 1
 	},
-/turf/open/floor/iron,
-/area/station/engineering/main)
-"pkC" = (
+/turf/open/floor/iron/dark/textured,
+/area/station/engineering/break_room)
+"pkl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/structure/chair/stool/bar/directional/south,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron,
-/area/station/commons/lounge)
+/area/station/security/brig)
 "pkW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/construction)
-"plS" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security/brig)
-"pmc" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "pmF" = (
 /obj/structure/transit_tube/curved{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"pmQ" = (
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "pnf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40231,17 +40311,19 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
+"pnx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos/office)
 "ppM" = (
 /obj/structure/cable/multilayer/connected,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
-"ppY" = (
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
-	dir = 4
-	},
-/obj/machinery/smartfridge/organ,
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
 "pqm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -40258,6 +40340,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"pqG" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "pqR" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/engineering_hacking{
@@ -40274,15 +40363,6 @@
 	},
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
-"prz" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "prW" = (
 /obj/structure/transit_tube/crossing,
 /obj/structure/cable,
@@ -40294,6 +40374,13 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
+"pui" = (
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
 "puW" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office"
@@ -40310,6 +40397,10 @@
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"pvf" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/iron,
+/area/station/commons/storage/primary)
 "pwd" = (
 /obj/structure/bed/roller,
 /obj/item/radio/intercom/directional/west,
@@ -40318,16 +40409,31 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"pyl" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "pyB" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"pzi" = (
+/obj/effect/turf_decal/siding/purple/corner,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/rd)
 "pzm" = (
 /obj/machinery/camera/autoname/directional/east,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/bar,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "pAo" = (
@@ -40338,28 +40444,34 @@
 "pAU" = (
 /turf/closed/wall,
 /area/station/service/library/lounge)
+"pBj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
+"pBI" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "pBK" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"pCp" = (
+/turf/open/floor/iron/dark/textured,
+/area/station/engineering/break_room)
 "pCv" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"pCP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "pDY" = (
 /obj/machinery/rnd/production/techfab/department/security,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -40371,6 +40483,12 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
+"pFb" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
 "pFe" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
@@ -40378,11 +40496,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"pFs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron/white,
-/area/station/science/auxlab)
 "pFL" = (
 /obj/machinery/holopad/secure,
 /turf/open/floor/iron/dark,
@@ -40391,6 +40504,21 @@
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
+"pFY" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/security/brig)
+"pGz" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "pGT" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -40416,6 +40544,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
+"pIr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/courtroom)
 "pIx" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
@@ -40424,20 +40558,25 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"pKx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
+"pKC" = (
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
-/area/station/commons/storage/primary)
-"pLN" = (
+/area/station/cargo/storage)
+"pLm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/station/security/brig)
+"pLJ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/freezer,
+/area/station/commons/toilet/locker)
 "pLR" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -40450,37 +40589,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
-"pMl" = (
-/obj/effect/turf_decal/siding/purple/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
-"pMu" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
-"pNh" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/turf/open/floor/iron,
-/area/station/security/brig)
-"pNn" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
-"pNI" = (
-/obj/effect/turf_decal/siding/purple/corner,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/siding/purple{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/rd)
 "pON" = (
 /obj/structure/grille,
 /obj/structure/window/fulltile,
@@ -40488,22 +40596,25 @@
 /turf/open/floor/plating,
 /area/station/engineering/storage)
 "pOS" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"pPt" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/commons/dorms)
-"pPs" = (
+/area/station/engineering/engine_smes)
+"pPA" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"pPt" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
 "pPD" = (
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/east,
@@ -40520,6 +40631,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"pQt" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/filled/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "pQE" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer2{
 	dir = 8
@@ -40530,6 +40649,13 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
 /turf/open/floor/engine/airless,
 /area/station/science/ordnance/freezerchamber)
+"pQQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "pRj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40537,6 +40663,17 @@
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain/private)
+"pRp" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/engineering/gravity_generator)
+"pRv" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "pRz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -40559,20 +40696,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"pSa" = (
-/obj/structure/chair{
-	name = "Judge"
-	},
-/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security/courtroom)
 "pSe" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"pSy" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "pSA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40582,15 +40715,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
-"pSF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "pTN" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/chemistry{
@@ -40607,15 +40731,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
-"pUe" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/sign/poster/official/obey{
-	pixel_y = -32
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "pUk" = (
 /obj/effect/landmark/start/lawyer,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40623,51 +40738,19 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
-"pUG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
-"pUU" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/sign/directions/supply/directional/west{
-	pixel_y = 12;
+"pVH" = (
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 1
 	},
-/obj/structure/sign/directions/science/directional/west{
-	pixel_y = 5;
-	dir = 1
-	},
-/obj/structure/sign/directions/security/directional/west{
-	pixel_y = -2
-	},
-/obj/structure/sign/directions/vault/directional/west{
-	dir = 1;
-	pixel_y = -9
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "pVW" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/meter,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"pXx" = (
-/obj/structure/sign/poster/official/safety_eye_protection{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "pXJ" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/box/white{
@@ -40697,6 +40780,11 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"pYz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "pYG" = (
 /obj/structure/girder,
 /turf/open/floor/iron/dark,
@@ -40705,12 +40793,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
 /area/station/engineering/storage/tcomms)
-"pZe" = (
-/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "pZj" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40721,50 +40803,36 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"pZJ" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+"qag" = (
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
-"qaw" = (
-/obj/machinery/chem_heater{
-	pixel_x = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/pharmacy)
+/area/station/science/auxlab)
 "qaU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
-"qbz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
+"qbm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
-"qbN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"qbp" = (
+/obj/structure/sign/poster/contraband/random/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
+"qbz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white/textured,
-/area/station/science/research)
-"qbO" = (
-/obj/effect/turf_decal/siding/purple{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
+/obj/machinery/camera/autoname/directional/west,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "qce" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40788,6 +40856,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
+"qey" = (
+/obj/effect/turf_decal/trimline/purple/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "qeB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
@@ -40808,37 +40882,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/gateway)
-"qfE" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
-"qfK" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+"qft" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/science/auxlab)
-"qgj" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/main)
-"qgE" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/left/directional/west{
-	name = "Genetics Desk";
-	req_access = list("genetics");
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
+/area/station/hallway/secondary/exit)
 "qhw" = (
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 4
@@ -40851,23 +40900,13 @@
 /obj/structure/cable/layer3,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"qiU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "qjk" = (
 /obj/machinery/atmospherics/components/binary/valve/digital,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "qjl" = (
 /obj/machinery/restaurant_portal/restaurant,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/wood,
+/turf/open/floor/iron,
 /area/station/commons/lounge)
 "qkc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -40889,30 +40928,48 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"qli" = (
-/obj/structure/cable,
+"qlf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/newscaster/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/chair/stool/bar/directional/south,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/area/station/commons/lounge)
 "qlC" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"qnG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+"qnl" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/engineering/main)
+/area/station/hallway/primary/port)
+"qod" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/mirror/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/freezer,
+/area/station/commons/toilet/locker)
 "qoh" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
+"qon" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/escape)
 "qoo" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -40928,16 +40985,10 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"qpc" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/service/bar)
-"qpp" = (
-/obj/effect/turf_decal/stripes/corner,
+"qoV" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "qpq" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -40947,13 +40998,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"qpv" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "qqK" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
@@ -40961,6 +41005,24 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"qrO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"qsb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/commons/fitness/recreation)
 "qst" = (
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Atmospherics Monitoring"
@@ -40973,37 +41035,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
-"qts" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/power/apc/auto_name/directional/west,
-/turf/open/floor/wood,
-/area/station/service/bar)
-"qtK" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
 "qtV" = (
 /obj/structure/transit_tube/diagonal,
 /turf/open/space/basic,
 /area/space/nearstation)
-"qvN" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "qvO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/spawner/random/engineering/tracking_beacon,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
-"qwi" = (
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "qwj" = (
@@ -41023,6 +41063,9 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
+"qwk" = (
+/turf/open/floor/iron/white,
+/area/station/science/auxlab)
 "qwq" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/plaque{
@@ -41030,13 +41073,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"qxa" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/security/brig)
 "qxg" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
@@ -41063,6 +41099,15 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/hallway/primary/port)
+"qyb" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "qyi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -41078,13 +41123,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/security)
-"qyM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+"qzj" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
+/area/station/hallway/secondary/entry)
 "qzm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41118,6 +41163,11 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"qAo" = (
+/obj/structure/marker_beacon/burgundy,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "qBy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41129,15 +41179,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
+"qBz" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "qBT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
-"qCa" = (
-/turf/open/floor/iron/dark,
-/area/station/security)
 "qCf" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
@@ -41154,6 +41206,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/bar,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "qCT" = (
@@ -41170,22 +41223,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"qDj" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
-"qDO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/red/filled/line,
+"qDl" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner,
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/area/station/cargo/storage)
+"qDQ" = (
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "qEo" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -41196,12 +41243,34 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"qEs" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security/warden)
 "qEW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security)
+"qEY" = (
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/rd)
 "qFe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41215,24 +41284,15 @@
 /obj/effect/landmark/navigate_destination/dockescpod1,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"qHe" = (
-/obj/effect/landmark/start/hangover,
-/obj/effect/decal/cleanable/dirt,
+"qHw" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/iron,
-/area/station/commons/dorms)
+/area/station/hallway/primary/central)
 "qHy" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
-"qHB" = (
-/obj/effect/turf_decal/siding/purple,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/siding/purple{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/rd)
 "qHQ" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -41243,19 +41303,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
-"qIO" = (
+"qJi" = (
+/obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/dark_blue{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
-"qJa" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/area/station/hallway/primary/central)
 "qJk" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron,
@@ -41283,6 +41337,10 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"qKB" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "qKI" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Xenobiology - Cell 4";
@@ -41295,25 +41353,24 @@
 /obj/machinery/skill_station,
 /turf/open/floor/wood,
 /area/station/service/library/lounge)
-"qKP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+"qLg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/security)
+/area/station/hallway/primary/starboard)
+"qLt" = (
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/security/prison)
 "qLF" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
-"qLL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/eva)
 "qMe" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -41334,6 +41391,19 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"qPk" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security/execution/transfer)
+"qPM" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair/stool/bar/directional/north,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "qPO" = (
 /obj/structure/chair/stool/directional/east,
 /turf/open/floor/plating,
@@ -41352,8 +41422,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
-"qRE" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+"qQQ" = (
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/engineering/gravity_generator)
+"qQZ" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
@@ -41373,10 +41448,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
-"qWP" = (
-/obj/effect/spawner/random/structure/crate,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
+"qVY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/command/gateway)
 "qWR" = (
 /obj/structure/disposalpipe/segment,
 /obj/item/radio/intercom/directional/east,
@@ -41385,15 +41465,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"qXh" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/chair/sofa/bench/left{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "qXt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -41414,20 +41485,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/cargo/storage)
-"qYg" = (
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
-/area/station/commons/lounge)
-"qYs" = (
-/obj/machinery/dna_scannernew,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
 "qYD" = (
 /obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/tile/yellow{
@@ -41442,11 +41499,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
-"raE" = (
-/obj/effect/decal/cleanable/oil,
-/obj/structure/sign/poster/contraband/random/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
 "raH" = (
 /obj/machinery/atmospherics/components/binary/pump/off{
 	name = "Air to Port";
@@ -41471,25 +41523,17 @@
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
-"rbo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+"rce" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "rcw" = (
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
-"rcB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "rcW" = (
 /obj/machinery/holopad,
 /turf/open/floor/wood,
@@ -41500,20 +41544,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
-"rdw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
-"rdC" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
 "rdQ" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/structure/sign/poster/official/wtf_is_co2{
@@ -41521,12 +41551,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
-"rfG" = (
-/obj/effect/turf_decal/tile/green{
+"rey" = (
+/obj/structure/closet/firecloset,
+/obj/structure/sign/poster/official/state_laws{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
+/area/station/hallway/primary/starboard)
 "rfL" = (
 /obj/machinery/door/airlock/external{
 	name = "Auxiliary Dock"
@@ -41535,21 +41569,11 @@
 /obj/effect/landmark/navigate_destination/dockaux,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
-"rga" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/ce)
 "rgL" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"rgN" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "rgR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41560,45 +41584,32 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"rhJ" = (
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/dark_blue{
+"riw" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "rjj" = (
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
-"rjm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
+/area/station/hallway/secondary/entry)
 "rjn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"rjN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+"rjz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/green/opposingcorners,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/service/hydroponics)
+/area/station/hallway/primary/starboard)
 "rkD" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/maintenance,
@@ -41613,10 +41624,24 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
-"rkP" = (
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/purple{
+"rlg" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"rlI" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
@@ -41633,12 +41658,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security)
-"rmQ" = (
-/obj/effect/turf_decal/trimline/dark_blue/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/science/research)
 "rnx" = (
 /obj/machinery/rnd/production/techfab/department/cargo,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
@@ -41646,6 +41665,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
+"rny" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "rnQ" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -41653,6 +41679,37 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"roC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"roJ" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
+"roK" = (
+/obj/machinery/status_display/evac/directional/west,
+/obj/structure/transit_tube/station/dispenser{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/dark_blue/fourcorners,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"rpj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "rpI" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -41669,14 +41726,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"rqu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "rra" = (
 /obj/effect/landmark/start/scientist,
 /obj/structure/cable,
@@ -41685,10 +41734,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/explab)
-"rrh" = (
-/obj/structure/sign/poster/contraband/random/directional/west,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+"rri" = (
+/obj/effect/turf_decal/siding/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/rd)
 "rro" = (
 /obj/effect/mapping_helpers/ianbirthday,
 /turf/open/floor/wood,
@@ -41706,17 +41758,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
-"rsF" = (
-/obj/machinery/door/firedoor,
+"rsC" = (
+/obj/effect/decal/cleanable/oil,
+/obj/structure/sign/poster/contraband/random/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
+"rtH" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"rtl" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/wood,
-/area/station/commons/lounge)
 "rum" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
 	dir = 8
@@ -41732,24 +41787,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"ruZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/storage)
-"rvb" = (
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/surgery/theatre)
 "rvo" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L12"
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"rwd" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "rwG" = (
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
@@ -41759,13 +41809,13 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/cargo/qm)
-"rxw" = (
-/obj/effect/landmark/start/hangover,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/commons/fitness/recreation)
+"rxu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "rxM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -41785,10 +41835,36 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"ryG" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
+"rzP" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "rzW" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"rAk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "rAv" = (
 /obj/structure/table,
 /obj/item/stock_parts/scanning_module{
@@ -41832,6 +41908,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"rBb" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/gravity_generator)
+"rBi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "rBl" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
@@ -41840,15 +41931,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"rBK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
+"rBs" = (
+/obj/structure/sign/poster/official/random/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/security/brig)
+/area/station/hallway/secondary/exit)
 "rBM" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
@@ -41863,34 +41952,47 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_white,
 /area/station/engineering/engine_smes)
+"rCv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/cmo)
+"rCX" = (
+/obj/machinery/computer/mechpad{
+	dir = 1
+	},
+/turf/open/floor/circuit/green,
+/area/station/science/robotics/mechbay)
 "rDR" = (
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/wood,
 /area/station/service/library)
-"rEp" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/station/engineering/main)
 "rEL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"rEQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/science/auxlab)
 "rFm" = (
 /obj/structure/easel,
 /obj/item/canvas/twentythree_twentythree,
 /turf/open/floor/wood,
 /area/station/service/library/lounge)
-"rFq" = (
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/iron/white,
-/area/station/science/explab)
-"rFO" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted,
+"rFw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/warning,
 /turf/open/floor/iron,
-/area/station/security/brig)
+/area/station/security/execution/transfer)
 "rFV" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -41898,27 +42000,41 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
-"rGq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
+"rGk" = (
+/obj/machinery/holopad,
+/turf/open/floor/iron,
+/area/station/service/theater)
+"rGt" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
+"rGx" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
-"rGz" = (
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/area/station/hallway/primary/port)
 "rGN" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
+"rHk" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/station/ai_monitored/command/storage/eva)
+"rHD" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "rHE" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -41926,6 +42042,14 @@
 /obj/structure/window/reinforced,
 /turf/open/space/basic,
 /area/space/nearstation)
+"rIg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/chair/stool/bar/directional/south,
+/turf/open/floor/iron,
+/area/station/commons/lounge)
 "rIp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/stripes/corner{
@@ -41948,13 +42072,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"rJj" = (
-/obj/machinery/chem_dispenser,
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/pharmacy)
 "rJk" = (
 /obj/machinery/vending/wardrobe/hydro_wardrobe,
 /obj/effect/turf_decal/tile/green/opposingcorners,
@@ -41979,21 +42096,13 @@
 	},
 /turf/open/floor/wood,
 /area/station/cargo/qm)
-"rLo" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
-"rML" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners{
+"rLE" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/commons/fitness/recreation)
+/area/station/hallway/primary/starboard)
 "rNb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -42005,10 +42114,10 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"rNh" = (
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/grass,
-/area/station/medical/virology)
+"rNi" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/service/theater)
 "rOb" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
 	dir = 8
@@ -42018,12 +42127,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"rOf" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "rOi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42033,15 +42136,12 @@
 /obj/effect/spawner/random/bureaucracy/pen,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
-"rON" = (
-/obj/machinery/light/directional/east,
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/drinks{
+"rOs" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/area/station/hallway/primary/starboard)
 "rPf" = (
 /obj/structure/chair/stool/directional/north,
 /obj/effect/turf_decal/tile/red/opposingcorners{
@@ -42049,28 +42149,37 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
-"rPh" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+"rQe" = (
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/station/security)
+"rRA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "rSm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"rST" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security/checkpoint/escape)
 "rTc" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/circuit/green,
 /area/station/science/robotics/mechbay)
-"rUc" = (
-/obj/effect/turf_decal/tile/brown/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "rUA" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron,
@@ -42080,39 +42189,35 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/bar)
-"rVw" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 4
-	},
+"rVz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/newscaster/directional/south,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
-"rVK" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/area/station/hallway/secondary/exit/departure_lounge)
 "rVS" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"rWk" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security)
+"rWC" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "rWY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
-"rXp" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/iron/white,
-/area/station/science/research)
-"rXt" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
 "rXU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42130,6 +42235,12 @@
 /obj/machinery/holopad/secure,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
+"rYs" = (
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "rZi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -42150,6 +42261,12 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/wood,
 /area/station/cargo/qm)
+"saC" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "saT" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42160,23 +42277,32 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
 /area/station/security/medical)
-"sby" = (
-/obj/structure/cable,
-/obj/effect/landmark/navigate_destination,
-/obj/effect/turf_decal/tile/green/half/contrasted,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
-"sbC" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+"saV" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security/brig)
+"saW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security/prison)
+"scA" = (
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
-"sdj" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/iron/dark,
-/area/station/tcommsat/computer)
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"seH" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "seT" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Atmospherics CO2 Tank"
@@ -42197,21 +42323,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
-"sfB" = (
-/obj/machinery/chem_master{
-	pixel_x = -2
+"sgd" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white/side{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/pharmacy)
-"sfL" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/medical/medbay/lobby)
 "sgf" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -42220,10 +42337,27 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation)
+"sgL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security/execution/transfer)
 "sgQ" = (
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron,
 /area/station/construction)
+"sha" = (
+/obj/vehicle/ridden/secway,
+/obj/item/key/security,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security)
 "shq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -42255,6 +42389,7 @@
 /area/station/commons/dorms)
 "sjk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/white,
 /area/station/science/auxlab)
 "sjn" = (
@@ -42265,16 +42400,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"sjM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/command/gateway)
 "sjP" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
+"sjW" = (
+/obj/machinery/iv_drip,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "ske" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics"
@@ -42284,6 +42420,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"skl" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "skt" = (
 /obj/structure/table,
 /obj/item/training_toolbox,
@@ -42292,6 +42435,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
+"skC" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/checker,
+/area/station/service/theater)
 "skL" = (
 /obj/structure/window,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -42308,22 +42455,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
-"slu" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/iron,
-/area/station/ai_monitored/security/armory)
-"slJ" = (
-/obj/machinery/iv_drip,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
-"slM" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos)
 "slQ" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
@@ -42333,12 +42464,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
-"smz" = (
-/obj/effect/turf_decal/siding/wood{
+"smf" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
 	dir = 8
 	},
-/turf/open/floor/carpet,
-/area/station/command/heads_quarters/captain)
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "smC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /turf/open/floor/iron,
@@ -42361,6 +42493,13 @@
 /obj/item/flashlight,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"sqv" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "sqE" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
@@ -42370,18 +42509,15 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/security/brig)
-"srK" = (
+"ssg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
-"srV" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/area/station/hallway/primary/starboard)
 "ssi" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -42398,12 +42534,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
-"ste" = (
-/obj/effect/turf_decal/trimline/purple/line{
+"sti" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/station/science/lab)
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "stp" = (
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain/private)
@@ -42412,12 +42549,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"suc" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/red/filled/line,
+"suC" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/area/station/hallway/primary/central/aft)
 "svt" = (
 /obj/structure/chair{
 	dir = 1
@@ -42474,6 +42611,13 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
+"swT" = (
+/obj/machinery/camera/autoname/directional/east,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "sxw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42485,23 +42629,32 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
+"sxG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "sxX" = (
 /obj/effect/landmark/navigate_destination/dockesc,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"syA" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
+"syj" = (
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/station/commons/lounge)
+/obj/structure/sign/poster/official/love_ian{
+	pixel_y = 32
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "syC" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -42522,14 +42675,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"szo" = (
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/structure/sign/directions/vault/directional/south,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "sAj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -42555,26 +42700,22 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
-"sBQ" = (
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+"sCA" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
-"sCP" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/area/station/hallway/primary/starboard)
 "sCV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/service/chapel/funeral)
-"sDv" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
+"sDf" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -42611,25 +42752,25 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"sGn" = (
-/obj/item/grenade/barrier,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
+"sGl" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/ai_monitored/security/armory)
+/area/station/security)
 "sGt" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"sGV" = (
-/obj/effect/turf_decal/trimline/neutral/end{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/smooth_edge{
+"sGx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 8
 	},
-/area/station/medical/morgue)
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "sGW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -42637,11 +42778,22 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
-"sHy" = (
-/obj/structure/lattice,
-/obj/structure/sign/warning/docking/directional/east,
-/turf/open/space/basic,
-/area/space/nearstation)
+"sGZ" = (
+/obj/structure/sign/poster/contraband/random/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
+"sHb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "sHI" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office"
@@ -42652,28 +42804,14 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
-"sHX" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/fluff/broken_flooring{
-	dir = 4;
-	icon_state = "singular"
-	},
+"sIh" = (
+/obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/port/aft)
 "sIA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"sJb" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/main)
 "sJL" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall,
@@ -42718,7 +42856,9 @@
 /area/station/ai_monitored/turret_protected/ai_upload)
 "sMp" = (
 /obj/effect/landmark/start/hangover,
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "sMu" = (
@@ -42729,13 +42869,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
-"sNi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/red/filled/line,
+"sMM" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/station/ai_monitored/security/armory)
+/area/station/commons/lounge)
+"sPb" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "sPr" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -42749,17 +42890,23 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
-"sPO" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/service/theater)
-"sRx" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+"sRr" = (
+/obj/item/kirbyplants/photosynthetic,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/turf/open/floor/iron/white,
+/area/station/science/research)
+"sRN" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/engineering/break_room)
+"sSa" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/structure/window/spawner/north,
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/turf/open/floor/iron,
+/area/station/security/brig)
 "sSE" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical,
@@ -42771,19 +42918,22 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"sSI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/commons/storage/primary)
+"sTD" = (
+/obj/structure/sign/poster/contraband/random/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "sUf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
-"sUp" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/station/engineering/main)
 "sUF" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -42810,23 +42960,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
-"sVA" = (
-/obj/structure/cable,
+"sVO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/spawner/random/trash/garbage,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
-"sWm" = (
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/effect/turf_decal/trimline/purple/corner{
-	dir = 4
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"sVX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
 	},
-/turf/open/floor/iron/white,
-/area/station/science/research)
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "sXM" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -42835,15 +42982,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
-"sYb" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
+"sYf" = (
+/obj/structure/sign/poster/contraband/random/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
+"sYz" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/turf/open/floor/iron,
+/area/station/security)
 "sYH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -42854,12 +43002,6 @@
 /obj/structure/window/reinforced,
 /turf/open/space/basic,
 /area/space/nearstation)
-"sZl" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "tam" = (
 /obj/machinery/light/directional/west,
 /obj/item/radio/intercom/directional/west,
@@ -42877,12 +43019,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"tbv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/station/engineering/main)
 "tcb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /turf/open/floor/plating,
@@ -42907,20 +43043,27 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"tdf" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/station/commons/lounge)
-"tdv" = (
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "tdF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
+"tdH" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
+"tdL" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security/brig)
+"tdZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/cafeteria,
+/area/station/service/kitchen)
 "teu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -42928,22 +43071,24 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
+"teK" = (
+/obj/structure/disposalpipe/junction/flip,
+/obj/structure/fluff/broken_flooring,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
+"tfa" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/iron/dark,
+/area/station/tcommsat/computer)
 "tgt" = (
 /obj/effect/turf_decal/tile/red{
-	dir = 4
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
-"tgJ" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
-"thy" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/engineering/gravity_generator)
 "thO" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/west{
@@ -42953,17 +43098,14 @@
 /obj/structure/desk_bell,
 /turf/open/floor/iron,
 /area/station/science/genetics)
+"tib" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "tiP" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/station/service/hydroponics/garden)
-"tiW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/red/filled/warning,
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
 "tiY" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/machinery/door/window/right/directional/south{
@@ -42973,28 +43115,12 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/science/ordnance/freezerchamber)
-"tjz" = (
-/obj/machinery/modular_computer/console/preset/cargochat/engineering{
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/station/engineering/main)
 "tjB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
-"tjO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/break_room)
 "tjY" = (
 /obj/structure/chair/stool/directional/east,
 /turf/open/floor/plating,
@@ -43003,6 +43129,16 @@
 /obj/structure/chair/sofa/left,
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
+"tkt" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "tky" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron,
@@ -43016,6 +43152,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"tlc" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/ce)
 "tli" = (
 /obj/structure/transit_tube/curved{
 	dir = 4
@@ -43026,10 +43166,6 @@
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
-"tlO" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/station/science/robotics/lab)
 "tlV" = (
 /obj/structure/cable,
 /obj/machinery/door_timer{
@@ -43045,23 +43181,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
-"tmK" = (
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 4
-	},
-/obj/structure/sign/poster/official/love_ian{
-	pixel_y = 32
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
-"tmM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+"tmL" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "tmS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -43083,13 +43206,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
-"tof" = (
-/obj/effect/turf_decal/stripes/line{
+"toX" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
-/area/station/engineering/engine_smes)
+/area/station/security/brig)
 "tpv" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43104,19 +43226,12 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
-"tpX" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/chair/sofa/bench{
-	dir = 4
+"tqq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
-"tqv" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
+/area/station/science/auxlab)
 "tqz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43129,16 +43244,21 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/library/lounge)
-"trO" = (
-/obj/structure/disposalpipe/junction/flip,
-/obj/structure/fluff/broken_flooring,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
 "trV" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
+"tsz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron,
+/area/station/commons/fitness/recreation)
 "tsL" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -43151,12 +43271,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
-"tux" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/command/teleporter)
+"tuj" = (
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "tva" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
@@ -43171,13 +43289,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"tvs" = (
-/obj/machinery/camera/autoname/directional/south,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "tvx" = (
 /obj/effect/spawner/random/vending/snackvend,
 /obj/structure/sign/poster/official/random/directional/north,
@@ -43186,6 +43297,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"twj" = (
+/obj/effect/spawner/random/entertainment/arcade,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
 "txN" = (
 /obj/machinery/smartfridge/drinks{
 	icon_state = "boozeomat"
@@ -43200,22 +43318,37 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "tyB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos)
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "tyO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
+"tzb" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/security/brig)
 "tzn" = (
 /turf/open/floor/iron/chapel{
 	dir = 8
 	},
 /area/station/service/chapel)
+"tzJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "tzQ" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
@@ -43224,12 +43357,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/central)
-"tAs" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "tAZ" = (
 /obj/structure/chair{
 	dir = 1
@@ -43239,47 +43366,45 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
-"tCr" = (
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/station/commons/dorms)
-"tDu" = (
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
-"tDT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
-"tEG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
+"tBl" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/command/gateway)
-"tEZ" = (
-/obj/machinery/door/firedoor,
+/area/station/hallway/primary/port)
+"tBm" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/chair/sofa/bench/left,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"tCv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/dark_blue{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/station/hallway/secondary/command)
+"tFP" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
+"tFV" = (
+/obj/effect/turf_decal/tile/purple/opposingcorners{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "tGp" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
-"tHc" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "tHi" = (
@@ -43289,6 +43414,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
+"tHt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
+/area/station/medical/morgue)
 "tHD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43301,28 +43432,42 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
+"tIx" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
+"tII" = (
+/obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"tIJ" = (
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"tJc" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "tJR" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
+"tKX" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/dark_blue{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
-"tKg" = (
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/research)
-"tKJ" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/primary/central)
 "tLg" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -43340,73 +43485,33 @@
 	},
 /turf/open/floor/plating,
 /area/station/medical/treatment_center)
-"tMo" = (
+"tLM" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/spawner/random/structure/crate,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
-"tNf" = (
-/obj/effect/landmark/start/station_engineer,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/main)
-"tNk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/purple/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/purple/line,
-/turf/open/floor/iron/white,
-/area/station/science/research)
-"tNo" = (
-/obj/effect/spawner/random/trash/hobo_squat,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos)
-"tNA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
-"tND" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/brown/half/contrasted{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/cargo/storage)
+/area/station/security/brig)
+"tMI" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/carpet,
+/area/station/commons/dorms)
 "tOg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
-"tOx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+"tPe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/chair/stool/bar/directional/south,
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
-/area/station/commons/lounge)
-"tOA" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/primary/port)
 "tPz" = (
 /obj/structure/reflector/single/anchored{
 	dir = 9
@@ -43440,15 +43545,33 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
-"tRr" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 10
+"tRi" = (
+/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
+"tRo" = (
+/obj/structure/chair{
+	dir = 8;
+	name = "Defense"
+	},
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
+/area/station/security/courtroom)
 "tRI" = (
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
+"tRP" = (
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/cargo/office)
 "tSp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43472,29 +43595,21 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
-"tVj" = (
-/obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+"tTD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
-"tVB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/fluff/broken_flooring{
+	dir = 4;
+	icon_state = "singular"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
+"tVJ" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
-/area/station/commons/dorms)
-"tWk" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/science/lab)
+/area/station/security)
 "tWm" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
@@ -43508,6 +43623,30 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"tWC" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
+"tYw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/newscaster/directional/north,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security/warden)
 "tYz" = (
 /obj/structure/filingcabinet/filingcabinet,
 /turf/open/floor/wood/parquet,
@@ -43516,6 +43655,19 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
 /area/station/commons/storage/emergency/port)
+"tYP" = (
+/obj/structure/cable,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/chair/stool{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/end{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security/warden)
 "tZf" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -43528,15 +43680,27 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
+"uaa" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "uac" = (
 /obj/structure/cable,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"ubi" = (
-/obj/effect/spawner/random/structure/grille,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+"uad" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/command)
 "ubu" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -43565,9 +43729,19 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/end,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
+"ubG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "ubL" = (
 /turf/closed/wall,
 /area/station/security/prison/toilet)
@@ -43582,21 +43756,22 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"uci" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
+"ucq" = (
 /turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
-"udZ" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/area/station/command/heads_quarters/cmo)
+"udA" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
+"ueo" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/area/station/medical/virology)
 "ues" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
@@ -43614,20 +43789,21 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
-"ugC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
+"ufS" = (
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron/cafeteria,
+/area/station/security/prison)
+"uhB" = (
+/obj/structure/chair/stool/bar/directional/east,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
-/area/station/commons/storage/primary)
+/area/station/hallway/secondary/exit/departure_lounge)
 "uik" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
 /area/station/science/explab)
-"uiF" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating/airless,
-/area/station/solars/starboard/fore)
 "ujh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43640,18 +43816,14 @@
 /obj/machinery/holopad/secure,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
-"ujA" = (
-/turf/open/floor/iron/white,
-/area/station/science/research)
-"ujQ" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+"ujp" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/cargo/miningdock)
+/area/station/hallway/secondary/exit/departure_lounge)
 "ukw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -43662,10 +43834,21 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"uml" = (
-/obj/structure/sign/poster/contraband/random/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+"umz" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"uns" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "unt" = (
 /obj/machinery/button/door{
 	id = "permacell2";
@@ -43679,11 +43862,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
-"unY" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "uou" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/stripes/line{
@@ -43691,6 +43869,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"uoM" = (
+/obj/structure/lattice,
+/obj/structure/sign/warning/docking/directional/east,
+/turf/open/space/basic,
+/area/space/nearstation)
 "upm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43716,15 +43899,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"upO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/camera/autoname/directional/west,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
 "uqn" = (
 /obj/machinery/door/airlock/external{
 	name = "External Docking Port"
@@ -43744,19 +43918,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
-"usT" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
+"urd" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
+/obj/structure/chair/sofa/bench/right,
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
-"usY" = (
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/hallway/primary/central)
+"usQ" = (
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "usZ" = (
 /obj/structure/bed,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -43774,25 +43945,11 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/grass,
 /area/station/science/genetics)
-"utS" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/chair/sofa/bench/right{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "uuH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security)
-"uuM" = (
-/obj/structure/bodycontainer/morgue,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/medical/morgue)
 "uuU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43812,6 +43969,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
+"uwA" = (
+/obj/structure/sign/poster/contraband/random/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/central)
+"uxb" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/ai_monitored/security/armory)
 "uxh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/meter/monitored/waste_loop,
@@ -43820,44 +43987,39 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"uxR" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "uxX" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
-"uyj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
 "uyN" = (
 /obj/structure/cable,
 /obj/structure/chair/stool/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"uyO" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white/side{
-	dir = 8
+"uzq" = (
+/obj/machinery/dna_scannernew,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/area/station/medical/medbay/lobby)
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
 "uzS" = (
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/station/maintenance/port/aft)
+"uAa" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "uAm" = (
-/turf/closed/wall/r_wall,
-/area/station/maintenance/department/electrical)
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "uAO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43872,25 +44034,10 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"uBw" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/structure/sign/poster/official/random/directional/east,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit)
-"uCm" = (
-/obj/machinery/door/window{
-	dir = 4;
-	req_access = list("bar");
-	name = "Escape Bar"
-	},
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+"uBy" = (
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/service/bar)
 "uCw" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
 	dir = 8
@@ -43909,23 +44056,22 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"uDx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/checker,
+/area/station/service/theater)
+"uDK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/warning,
+/turf/open/floor/iron,
+/area/station/security/execution/transfer)
 "uDS" = (
 /obj/effect/turf_decal/trimline/white/filled/shrink_cw,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"uEf" = (
-/obj/effect/turf_decal/trimline/purple/filled/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/purple{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
-"uEk" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/freezer,
-/area/station/commons/toilet/locker)
 "uEw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43958,12 +44104,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"uFU" = (
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "uGp" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Interrogation room";
@@ -43971,19 +44111,20 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
-"uGL" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security)
 "uGZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
+"uHe" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/hallway/primary/starboard)
 "uHh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43999,21 +44140,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
-"uIi" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
+"uIf" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/station/commons/lounge)
-"uID" = (
-/obj/machinery/camera/autoname/directional/east,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"uIh" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/security/courtroom)
 "uJy" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44030,31 +44166,19 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"uKm" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/checker,
-/area/station/service/theater)
+"uKv" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "uKM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/station/engineering/storage/tcomms)
-"uKR" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/wood,
-/area/station/service/library)
-"uLN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/security/courtroom)
-"uMw" = (
-/obj/item/stack/tile/iron,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating/airless,
-/area/station/maintenance/port/aft)
 "uME" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -44084,24 +44208,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
-"uNa" = (
-/obj/effect/turf_decal/tile/red{
+"uNx" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
-/area/station/security/medical)
-"uNE" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/trash/garbage,
-/turf/open/floor/iron/white,
-/area/station/medical/abandoned)
-"uNZ" = (
-/obj/effect/turf_decal/trimline/brown/filled/warning,
-/turf/open/floor/iron,
-/area/station/cargo/sorting)
+/area/station/science/xenobiology)
 "uOc" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Monkey Pen"
@@ -44109,14 +44221,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/genetics,
 /turf/open/floor/iron,
 /area/station/science/genetics)
-"uOl" = (
-/obj/vehicle/ridden/secway,
-/obj/item/key/security,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security)
 "uOM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -44126,10 +44230,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"uQs" = (
-/obj/effect/turf_decal/tile/brown/opposingcorners,
-/turf/open/floor/iron,
-/area/station/maintenance/central)
 "uQA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -44139,43 +44239,39 @@
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/service/theater)
-"uRq" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/engineering/break_room)
 "uRM" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
-"uRR" = (
-/obj/effect/turf_decal/siding/wood{
+"uSP" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"uTS" = (
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 10
 	},
-/turf/open/floor/carpet,
-/area/station/command/meeting_room)
-"uSo" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
+"uUU" = (
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/obj/structure/sign/poster/official/random/directional/west,
+/obj/structure/sign/poster/official/random/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"uSL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/main)
-"uSR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+"uVS" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "uWn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -44191,36 +44287,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"uWO" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+"uWM" = (
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/command/gateway)
 "uXo" = (
 /obj/effect/landmark/navigate_destination/library,
 /turf/open/floor/carpet,
 /area/station/service/library)
-"uXy" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/station/engineering/break_room)
-"uXV" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/chair/sofa/bench/left{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "uXX" = (
 /obj/machinery/door/airlock/external{
 	name = "Engineering External Access"
@@ -44260,37 +44335,33 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"uZz" = (
+/obj/machinery/mechpad,
+/turf/open/floor/circuit/green,
+/area/station/science/robotics/mechbay)
 "uZA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/service/library)
-"uZT" = (
-/obj/structure/window{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
-"vaw" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "vaF" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
-"vaN" = (
-/obj/effect/turf_decal/bot_white/right,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/command/gateway)
+"vaR" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
+"vbC" = (
+/obj/machinery/vending/cigarette,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "vbW" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge"
@@ -44305,6 +44376,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
+"vcA" = (
+/obj/structure/sign/poster/contraband/random/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "vdi" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -44319,6 +44394,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
+"vfg" = (
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/chair/sofa/bench/right{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "vfK" = (
 /obj/machinery/flasher/directional/west{
 	id = "Cell 3"
@@ -44327,61 +44412,42 @@
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron,
 /area/station/security/brig)
-"vfY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
-"vfZ" = (
-/obj/effect/turf_decal/siding/purple/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/rd)
-"vii" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/eva)
+"vge" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "vjd" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
+"vkP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/station/command/gateway)
 "vkV" = (
 /obj/effect/spawner/random/trash/mess,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/station/medical/abandoned)
-"vlo" = (
+"vlk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/science/lab)
-"vlx" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
-"vly" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
-"vma" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/engineering/atmos/office)
+"vlF" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "vmc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44396,10 +44462,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
-"vnw" = (
-/obj/effect/turf_decal/caution/stand_clear,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "vnK" = (
 /obj/structure/transit_tube/diagonal/topleft,
 /turf/open/space/basic,
@@ -44428,17 +44490,12 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
-"voI" = (
-/obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+"vpk" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
-"voV" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
+/area/station/hallway/primary/starboard)
 "vpY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -44446,9 +44503,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
-"vqE" = (
-/turf/open/floor/iron,
-/area/station/commons/lounge)
 "vqG" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance"
@@ -44457,13 +44511,22 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
-"vsl" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners{
-	dir = 8
+"vrn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
-/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
+"vrJ" = (
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/hallway/primary/central)
 "vsu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -44472,27 +44535,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security)
-"vsM" = (
-/obj/machinery/camera/autoname/directional/south,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
-"vtY" = (
-/obj/effect/turf_decal/tile/brown/half/contrasted{
-	dir = 8
+"vuf" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/cargo/office)
-"vul" = (
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/station/commons/fitness/recreation)
 "vvc" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
@@ -44507,31 +44556,23 @@
 /obj/structure/girder,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"vya" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/ai_monitored/security/armory)
-"vyr" = (
-/obj/structure/cable,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
-"vyA" = (
-/turf/open/floor/iron/white,
-/area/station/science/auxlab)
-"vyT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+"vxX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/station/hallway/primary/central/aft)
+"vza" = (
+/obj/structure/bodycontainer/morgue,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "vzb" = (
-/turf/closed/wall,
-/area/station/commons/lounge)
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "vzz" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 8
@@ -44541,13 +44582,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
-"vzU" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/iron,
-/area/station/science/ordnance)
 "vzY" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -44576,29 +44610,23 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/pumproom)
-"vAu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/science/auxlab)
-"vBg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security/prison)
-"vDp" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/break_room)
 "vDt" = (
 /obj/structure/cable,
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
+"vDB" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
+"vDV" = (
+/obj/structure/sign/poster/official/random/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "vEa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -44619,13 +44647,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
-"vEG" = (
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
 "vEU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44633,17 +44654,19 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"vFh" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "vFo" = (
 /obj/effect/spawner/random/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
-"vFr" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "vFD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44654,28 +44677,22 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
-"vGd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/line{
+"vFP" = (
+/obj/item/clothing/head/cone,
+/obj/item/clothing/head/cone,
+/obj/item/clothing/head/cone,
+/obj/item/clothing/head/cone,
+/obj/item/clothing/head/cone,
+/obj/effect/turf_decal/bot{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/area/station/engineering/storage)
 "vGx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
-"vGA" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
 "vHd" = (
 /obj/structure/chair/stool/directional/east,
 /obj/effect/decal/cleanable/dirt,
@@ -44715,6 +44732,20 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"vKq" = (
+/obj/effect/turf_decal/trimline/purple/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/science/research)
+"vKw" = (
+/obj/effect/landmark/start/hangover,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "vKA" = (
 /obj/effect/landmark/start/prisoner,
 /obj/structure/toilet/greyscale{
@@ -44722,6 +44753,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
+"vKH" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "vKS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44732,13 +44772,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
-"vKU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
 "vLc" = (
 /obj/effect/landmark/start/lawyer,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44754,29 +44787,17 @@
 /obj/item/stack/cable_coil,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
-"vLs" = (
-/obj/structure/chair/stool/directional/west,
-/obj/machinery/light/small/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
+"vLz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted,
 /turf/open/floor/iron,
-/area/station/security/prison/safe)
-"vMh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
-"vMn" = (
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/neutral/opposingcorners{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/security/brig)
+"vLN" = (
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "vMJ" = (
 /obj/structure/closet/l3closet/virology,
 /obj/effect/turf_decal/tile/green/anticorner/contrasted{
@@ -44784,26 +44805,44 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"vPs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
+"vNo" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/bar{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
-/area/station/commons/fitness/recreation)
-"vPW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/area/station/hallway/primary/central)
+"vNv" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/floor/iron,
+/area/station/service/bar)
+"vOn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
-"vQx" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos)
+/area/station/hallway/primary/central/aft)
+"vOF" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"vQy" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"vQJ" = (
+/obj/effect/turf_decal/trimline/purple/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "vQX" = (
 /obj/structure/transit_tube/curved{
 	dir = 8
@@ -44819,38 +44858,26 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"vRH" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
-"vRN" = (
-/obj/machinery/airalarm/directional/south,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "vSh" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
+"vSi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "vSn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
-"vSq" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "vSw" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44861,26 +44888,29 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"vSB" = (
-/obj/machinery/mechpad,
-/turf/open/floor/circuit/green,
-/area/station/science/robotics/mechbay)
 "vSS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
+"vTd" = (
+/obj/machinery/chem_dispenser,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/pharmacy)
 "vUz" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/station/service/hydroponics/garden)
-"vVu" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+"vVh" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "vVP" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -44895,6 +44925,12 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"vWC" = (
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/gravity_generator)
 "vWD" = (
 /obj/machinery/door/airlock/glass{
 	name = "Garden"
@@ -44904,11 +44940,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
-"vXQ" = (
-/obj/effect/spawner/random/trash/garbage,
-/obj/effect/decal/cleanable/dirt,
+"vWK" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/station/cargo/sorting)
+/area/station/hallway/primary/starboard)
+"vYv" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron,
+/area/station/security/brig)
 "vYD" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube/junction/flipped{
@@ -44916,26 +44960,17 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"vZC" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
+"vYK" = (
+/obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/engineering/main)
+/area/station/cargo/storage)
 "vZE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/hallway/primary/starboard)
-"vZH" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Escape Bar";
-	pixel_y = -22
-	},
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "vZV" = (
 /obj/machinery/camera/autoname/directional/east,
 /obj/effect/turf_decal/tile/neutral{
@@ -44945,9 +44980,19 @@
 /area/station/hallway/primary/starboard)
 "vZW" = (
 /obj/machinery/camera/autoname/directional/south,
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"wao" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "waD" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
 	dir = 6
@@ -44957,13 +45002,16 @@
 	},
 /turf/open/floor/engine/airless,
 /area/station/science/ordnance/freezerchamber)
-"wba" = (
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+"waG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/station/service/theater)
 "wbU" = (
 /obj/structure/sign/departments/chemistry/pharmacy/directional/west,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -44971,36 +45019,43 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
+"wbY" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/commons/lounge)
 "wcm" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
-"wdk" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
+"wcN" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/cargo/sorting)
 "wfu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"wgq" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
-/area/station/service/bar)
-"wgZ" = (
+"whN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/station/command/heads_quarters/hop)
+"whT" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
+/area/station/engineering/atmos)
 "whV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
@@ -45025,6 +45080,10 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"wiv" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "wjH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45054,10 +45113,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"wld" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/iron/dark/textured,
-/area/station/engineering/break_room)
 "wlf" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
@@ -45070,31 +45125,34 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"wmR" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/science/lab)
+"wpd" = (
+/obj/structure/table,
+/obj/item/storage/medkit/regular,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "wpf" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/auxlab)
-"wqw" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/explab)
-"wqy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
+"wpS" = (
+/obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/turf/open/floor/iron,
+/area/station/cargo/storage)
+"wqU" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/central)
 "wqY" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -45103,22 +45161,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
-"wrb" = (
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/science/research)
-"wrB" = (
-/turf/open/floor/iron/dark/textured,
-/area/station/engineering/break_room)
-"wrI" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit)
+"wrn" = (
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "wrO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -45138,36 +45185,10 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"wsf" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+"wsK" = (
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
-/area/station/engineering/storage)
-"wsm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/command)
-"wsN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
-"wsU" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/security)
+/area/station/hallway/secondary/exit/departure_lounge)
 "wtj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45183,13 +45204,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
-"wtO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/security/prison/safe)
 "wuA" = (
 /obj/machinery/atmospherics/components/binary/pump/off{
 	dir = 8;
@@ -45197,31 +45211,29 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"wuL" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"wuN" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "wvh" = (
 /obj/machinery/atmospherics/components/binary/valve/digital{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
-"wvo" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "wvs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
-"wvB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/aft)
 "wwm" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance"
@@ -45249,6 +45261,23 @@
 /obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"wxd" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
+"wxk" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/service/bar)
+"wxB" = (
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/commons/fitness/recreation)
 "wxE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45257,6 +45286,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
+"wyc" = (
+/obj/machinery/smartfridge,
+/turf/closed/wall,
+/area/station/service/hydroponics)
 "wzk" = (
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/east,
@@ -45265,6 +45298,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
+"wzE" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "wzV" = (
 /obj/machinery/door/poddoor/shutters/window{
 	id = "gateshutter";
@@ -45280,18 +45319,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"wAC" = (
-/obj/effect/spawner/random/structure/grille,
-/turf/open/floor/plating,
-/area/station/maintenance/port/aft)
-"wBw" = (
+"wBn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
+/obj/structure/cable,
+/obj/structure/sign/poster/contraband/random/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "wBU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45302,24 +45336,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security)
-"wBZ" = (
-/obj/machinery/light/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
-"wCu" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/sign/poster/official/cleanliness{
-	pixel_y = -32
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "wCN" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -45333,6 +45349,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
+"wDj" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/commons/storage/primary)
 "wDE" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -45340,44 +45361,37 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"wEN" = (
-/obj/item/kirbyplants/photosynthetic,
-/obj/effect/turf_decal/trimline/dark_red/corner,
-/turf/open/floor/iron/white,
-/area/station/science/research)
+"wEr" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/commons/fitness/recreation)
 "wGd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
+"wGf" = (
+/obj/machinery/camera/autoname/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "wHk" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/construction)
-"wHL" = (
-/obj/effect/turf_decal/siding/purple{
+"wIu" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/station/service/library)
+"wJj" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/rd)
-"wIs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit)
-"wIF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/command)
+/turf/open/floor/iron/white,
+/area/station/medical/pharmacy)
 "wJI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45391,15 +45405,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/primary/starboard)
-"wKp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
+"wKh" = (
+/obj/effect/landmark/navigate_destination/hydro,
 /turf/open/floor/iron,
-/area/station/engineering/atmos/office)
+/area/station/service/hydroponics)
 "wKv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
@@ -45408,18 +45417,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"wKZ" = (
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
-"wLe" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/red/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/security/prison)
 "wLl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -45427,47 +45424,23 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
-"wLn" = (
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
-"wLp" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
-"wLC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+"wLs" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/commons/dorms)
+"wLv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "wPv" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
-"wQT" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
-"wRj" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit)
 "wRV" = (
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai_upload)
@@ -45485,29 +45458,38 @@
 "wSW" = (
 /turf/closed/wall,
 /area/station/security/prison/safe)
+"wTh" = (
+/obj/machinery/camera/directional/east{
+	c_tag = "Escape Bar";
+	pixel_y = -22
+	},
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "wTz" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
-"wTC" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
+"wTO" = (
+/obj/structure/sign/poster/contraband/random/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
+"wTP" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
 	},
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "wTS" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/medical/cryo)
-"wUB" = (
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
-"wUP" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/aft)
+"wUu" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/commons/fitness/recreation)
 "wVr" = (
 /obj/structure/window/reinforced/plasma{
 	dir = 8
@@ -45517,21 +45499,27 @@
 /obj/machinery/power/energy_accumulator/tesla_coil/anchored,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
-"wWF" = (
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/bar{
+"wWE" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
-"wWQ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 9
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
+"wWK" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 1
 	},
-/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
+/area/station/hallway/primary/starboard)
+"wWY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "wXd" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -45549,12 +45537,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
-"wZo" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+"wYC" = (
+/obj/effect/turf_decal/trimline/purple/corner,
+/turf/open/floor/iron/white,
+/area/station/science/research)
+"wZp" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/science/ordnance)
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "wZD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45567,25 +45559,6 @@
 /obj/structure/cable/layer3,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"xae" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
-"xcp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
 "xcq" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
@@ -45599,6 +45572,16 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
+"xcH" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "xda" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -45610,13 +45593,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
-"xdF" = (
-/obj/effect/landmark/start/hangover,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "xdK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -45634,15 +45610,15 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
-"xfD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
+"xft" = (
+/obj/structure/chair/stool/directional/west,
+/obj/machinery/light/small/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/security/prison/safe)
 "xfS" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45654,25 +45630,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/closed/wall/r_wall,
 /area/station/maintenance/port/fore)
-"xhb" = (
-/obj/machinery/computer/department_orders/engineering{
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/station/engineering/main)
-"xhe" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/eva)
-"xhq" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/security)
 "xhD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45682,6 +45639,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
+"xhW" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "xiO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -45710,21 +45674,23 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/escape)
-"xkf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/security/courtroom)
 "xld" = (
 /obj/structure/table,
 /obj/item/paper,
 /obj/item/pen,
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
+"xlO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "xmc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45734,6 +45700,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
+"xmk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "xmC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45754,22 +45729,26 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/central)
-"xoI" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+"xof" = (
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
 "xpm" = (
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
-"xpY" = (
-/obj/effect/turf_decal/siding/thinplating_new/light{
+"xpw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/ai_monitored/security/armory)
+"xqF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/turf/open/floor/iron,
+/area/station/ai_monitored/command/storage/eva)
 "xqJ" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
@@ -45789,6 +45768,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"xqV" = (
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "xqX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -45802,6 +45788,27 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"xrK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/ai_monitored/security/armory)
+"xrX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/iron,
+/area/station/commons/storage/primary)
+"xsN" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/chair/sofa/bench{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "xth" = (
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	id = "engsm";
@@ -45812,10 +45819,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/supermatter)
-"xtR" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
 "xuT" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
@@ -45823,6 +45826,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"xvo" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "xvx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -45840,6 +45852,13 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
+"xwT" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "xxh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45876,18 +45895,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
-"xAv" = (
-/obj/effect/turf_decal/tile/brown/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
-"xAH" = (
-/obj/effect/turf_decal/trimline/red/end{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/lockers)
 "xBJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -45898,15 +45905,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/prison)
-"xCJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/research)
 "xDp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -45922,6 +45920,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"xDE" = (
+/obj/structure/window{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
 "xDK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45948,11 +45955,6 @@
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"xGB" = (
-/obj/effect/decal/cleanable/blood/drip,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
 "xHu" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/camera/directional/west{
@@ -45960,19 +45962,39 @@
 	},
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
-"xJl" = (
-/obj/structure/disposalpipe/segment,
+"xHA" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"xHD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
-"xJT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/structure/sign/poster/contraband/random/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/area/station/commons/dorms)
+"xId" = (
+/obj/machinery/light/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
+"xIm" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/commons/fitness/recreation)
+"xJC" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/turf/open/floor/iron,
+/area/station/security)
 "xKi" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -45982,6 +46004,15 @@
 /obj/effect/spawner/random/techstorage/tcomms_all,
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
+"xKR" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "xKT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -45995,10 +46026,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"xNL" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
 "xPa" = (
 /obj/machinery/ticket_machine/directional/north,
 /obj/effect/turf_decal/tile/dark_blue{
@@ -46014,12 +46041,34 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
-"xPT" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+"xPE" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/station/ai_monitored/security/armory)
+/area/station/engineering/break_room)
+"xQq" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"xQW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "xRg" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46052,16 +46101,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
-"xSF" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "xTf" = (
 /obj/structure/transit_tube/curved{
 	dir = 1
@@ -46088,29 +46127,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
-"xUA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/security/prison/safe)
-"xUH" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/green/half/contrasted{
+"xWs" = (
+/obj/effect/turf_decal/trimline/blue/line{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/virology)
-"xVr" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/medical/medbay/lobby)
 "xWC" = (
 /obj/machinery/holopad,
 /turf/open/floor/carpet,
@@ -46119,6 +46141,29 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
+"xXd" = (
+/obj/structure/chair/stool/bar/directional/east,
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
+"xXn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
+"xXN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "xXQ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46171,18 +46216,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
-"yab" = (
-/obj/machinery/computer/department_orders/security{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/station/security/brig)
 "yaz" = (
 /obj/machinery/rnd/server/master,
 /turf/open/floor/circuit/telecomms/server,
@@ -46212,23 +46245,45 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
+"ycF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/station/science/robotics/lab)
 "ycT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
-"yeI" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/red/line{
+"ydl" = (
+/obj/effect/landmark/start/station_engineer,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
+"ydt" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"ydO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/security/brig)
-"yeR" = (
-/obj/structure/disposalpipe/segment,
+/area/station/hallway/primary/central/aft)
+"yeE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
-/area/station/commons/lounge)
+/area/station/ai_monitored/command/storage/eva)
 "yfr" = (
 /turf/closed/wall,
 /area/station/hallway/secondary/service)
@@ -46238,19 +46293,22 @@
 	},
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
-"yiO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/newscaster/directional/south,
-/obj/effect/turf_decal/tile/bar/opposingcorners,
+"yfJ" = (
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/area/station/engineering/main)
 "yjd" = (
 /obj/structure/cable,
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"ykt" = (
-/obj/machinery/light/directional/west,
+"yjJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -46260,15 +46318,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
-"ylh" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "ylm" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "MiniSat Exterior - Aft Port";
@@ -46277,6 +46326,9 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"ylB" = (
+/turf/open/floor/iron/white,
+/area/station/security/medical)
 "ylN" = (
 /obj/structure/lattice,
 /obj/machinery/camera/directional/south{
@@ -46286,6 +46338,13 @@
 	},
 /turf/open/space/basic,
 /area/station/ai_monitored/turret_protected/ai)
+"yme" = (
+/obj/effect/landmark/start/station_engineer,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 
 (1,1,1) = {"
 lWL
@@ -55970,14 +56029,14 @@ cAS
 cha
 cil
 cAa
-wUP
+ooE
 cYi
 cAa
 cAa
 cAa
 cAa
 cxw
-wUP
+ooE
 cAa
 cwc
 cAa
@@ -56461,16 +56520,16 @@ acc
 bEB
 bEB
 dRm
-kCF
-kCF
-kCF
-kCF
-kCF
+aUn
+aUn
+aUn
+aUn
+aUn
 aNJ
 bEB
 bEB
 auz
-kCF
+aUn
 bWP
 uvG
 bDm
@@ -56493,7 +56552,7 @@ lWL
 cAS
 cAS
 cAa
-wUP
+ooE
 cAa
 cAS
 cAS
@@ -56716,17 +56775,17 @@ byu
 bAg
 acc
 kXR
-pUG
-pUG
-pUG
-pUG
-pUG
-cgv
-pUG
+bGS
+bGS
+bGS
+bGS
+bGS
+jFY
+bGS
 sxX
-pUG
-pUG
-pUG
+bGS
+bGS
+bGS
 bSG
 bUf
 bUe
@@ -56973,8 +57032,8 @@ byv
 bBD
 acc
 anw
-kAJ
-cxK
+wsK
+lGf
 anw
 bKT
 bKT
@@ -56984,7 +57043,7 @@ bKT
 bKT
 bKT
 bKT
-dPn
+bEE
 bWP
 bSH
 jFy
@@ -56993,7 +57052,7 @@ bHe
 aKM
 cAS
 cAa
-wUP
+ooE
 cAa
 chb
 cim
@@ -57234,18 +57293,18 @@ fzd
 cjH
 tvx
 tvb
-qpp
-dkG
-aZy
-mdG
-aZy
-dkG
-frQ
+cgv
+bYG
+mEv
+kcG
+mEv
+bYG
+cgv
 aRG
 bUf
-myb
+rST
 aQD
-aED
+qon
 pPD
 xjO
 cAS
@@ -57487,17 +57546,17 @@ acc
 acc
 acc
 anw
-odJ
+lug
 cjH
 aKJ
 gRN
-bLY
+cgv
 cjH
 dQm
 bNe
 dQm
 cjH
-nXo
+vzb
 bLZ
 bUf
 eri
@@ -57746,18 +57805,18 @@ bkB
 anw
 fzd
 cjH
-chQ
+vbC
 gRN
-xoI
-iot
-gZk
-eUz
-gZk
-iot
-lRP
-aCn
+cgv
+bWO
+dmF
+wpd
+dmF
+bWO
+cgv
+bLZ
 clc
-asr
+ujp
 bEE
 bEE
 qQJ
@@ -57766,7 +57825,7 @@ cAS
 aZj
 aZj
 aZj
-eXq
+wBn
 raS
 aZj
 aZj
@@ -58001,9 +58060,9 @@ bDh
 bpF
 bVu
 anw
-srK
-bcI
-pMu
+gGN
+eZw
+lRN
 gRN
 bKT
 bKT
@@ -58018,9 +58077,9 @@ iTL
 bKT
 bKT
 bKT
-srK
+gGN
 cAS
-wvB
+rxu
 cAS
 cAS
 cAS
@@ -58204,7 +58263,7 @@ auU
 auU
 ary
 azY
-alb
+apP
 auU
 auU
 pYa
@@ -58262,20 +58321,20 @@ bKT
 bHg
 bKT
 aiS
-wKZ
-jbs
-fjq
-jbs
-jbs
-jbs
-jbs
-jbs
-wKZ
+cJL
+uhB
+xXd
+uhB
+uhB
+uhB
+uhB
+uhB
+cJL
 aoK
 bKT
 bHg
 bKT
-srK
+gGN
 cAS
 aZj
 cdp
@@ -58294,7 +58353,7 @@ cAa
 cus
 cAS
 aZj
-wUP
+ooE
 cdk
 cAS
 cAS
@@ -58488,7 +58547,7 @@ bDP
 iIH
 aqN
 aqN
-cCZ
+gMK
 aqN
 aqN
 aqN
@@ -58514,11 +58573,11 @@ onH
 bDh
 bgy
 bVu
-myF
+xqV
 aKy
 oeA
 bUd
-yiO
+rVz
 cjH
 bKK
 bKK
@@ -58528,7 +58587,7 @@ bKK
 gCT
 bKK
 cjH
-qli
+aRH
 aKy
 bHh
 bUd
@@ -58553,7 +58612,7 @@ cbT
 aZj
 aZj
 cAa
-bvJ
+sTD
 cAa
 cAS
 cAS
@@ -58715,7 +58774,7 @@ aCI
 lWL
 lWL
 auU
-kcL
+sGZ
 azo
 aAa
 aAK
@@ -58777,15 +58836,15 @@ bKe
 bUd
 aMu
 bKK
-bNi
-bNi
-bNi
-bNi
-bNi
-bNi
-bNi
+bDt
+bDt
+bDt
+bDt
+bDt
+bDt
+bDt
 bKK
-aRH
+qPM
 aKy
 bJp
 bUd
@@ -59008,7 +59067,7 @@ bDP
 bDP
 bDP
 aqN
-cCZ
+gMK
 aqN
 bDP
 bDP
@@ -59034,15 +59093,15 @@ bGe
 bUd
 aMu
 bKK
-bNi
-bxh
-bNi
-bNi
-bNi
-bNi
-bNi
+bDt
+klL
+bDt
+bDt
+bDt
+bDt
+bDt
 bKK
-aRH
+qPM
 aKy
 nAW
 bUd
@@ -59254,7 +59313,7 @@ rZi
 tYz
 cNW
 bDP
-cCZ
+gMK
 aqN
 bnV
 oZR
@@ -59267,7 +59326,7 @@ aqN
 aqN
 fJW
 aqN
-cZy
+ivY
 vff
 vff
 vff
@@ -59279,10 +59338,10 @@ vff
 vff
 vff
 awM
-oMO
-oMO
-oMO
-oMO
+yjJ
+yjJ
+yjJ
+yjJ
 aJt
 cbS
 bHm
@@ -59291,13 +59350,13 @@ bJp
 bUd
 gRN
 cjH
-bNi
+bDt
 cjH
-dCI
-vZH
-rON
-hff
-kFz
+eGH
+wTh
+opq
+jTw
+emK
 cjH
 iTL
 aKy
@@ -59504,7 +59563,7 @@ auU
 auU
 auU
 auU
-fem
+auU
 aUF
 eVd
 tPL
@@ -59523,7 +59582,7 @@ ycT
 bdP
 ycT
 ycT
-cZy
+ivY
 ycT
 aqN
 bDP
@@ -59537,7 +59596,7 @@ bDP
 bDP
 bDP
 cbS
-nJf
+qft
 bVy
 fQi
 bIB
@@ -59548,7 +59607,7 @@ bHh
 bUd
 gRN
 cjH
-uCm
+duu
 cjH
 cjH
 cjH
@@ -59752,7 +59811,7 @@ atu
 atu
 aDv
 atu
-dXA
+sPb
 atu
 atu
 atu
@@ -59784,7 +59843,7 @@ bgz
 nMq
 ahO
 bDP
-uuM
+vza
 blB
 bnN
 blB
@@ -59794,30 +59853,30 @@ blB
 blB
 aQU
 bkF
-nJf
+qft
 bVy
 fQi
 bIB
 rGN
 rGN
 rGN
-opr
+xDE
 rGN
 bIx
-ykt
+pui
 rGN
-emD
+ccu
 rGN
 rGN
-mpf
-gVt
+evH
+rBs
 rGN
 rGN
 aZW
 rGN
-opr
+xDE
 rGN
-wrI
+mry
 cAS
 aZj
 cdp
@@ -60043,15 +60102,15 @@ bDP
 bDP
 blC
 xSs
-fsv
+tHt
 xSs
 bpJ
 jXj
 aZr
-sGV
-tDu
+lIA
+aib
 bkH
-wRj
+pFb
 cvn
 fQi
 bBL
@@ -60065,7 +60124,7 @@ fQi
 fQi
 fQi
 fQi
-wIs
+hIl
 fQi
 fQi
 fQi
@@ -60074,7 +60133,7 @@ fQi
 fQi
 fQi
 fQi
-oMO
+yjJ
 iOT
 aZj
 cdp
@@ -60291,29 +60350,29 @@ bDP
 bax
 bhT
 iIa
-agr
-klY
+pQQ
+xcH
 bfy
 wTS
-vEG
-kgo
+pVH
+cUN
 iAl
 nxU
 bmI
 bnO
-tDu
+aib
 kKi
 iac
-aib
-kBa
-ppY
+lWu
+dBN
+mgo
 bkF
 bxk
 bVy
 bVy
 bVy
 bBM
-nJf
+qft
 bVy
 bVy
 cis
@@ -60342,7 +60401,7 @@ cjJ
 ckZ
 mgf
 loa
-rdC
+kql
 cpV
 cpV
 crZ
@@ -60354,11 +60413,11 @@ cpV
 aCI
 cbR
 cAU
-wUP
+ooE
 cAa
 cbT
 aZj
-wAC
+sIh
 cAS
 cAS
 aCI
@@ -60545,14 +60604,14 @@ aQJ
 aRL
 bbN
 bbC
-ntR
-jQf
+tRi
+buP
 uWn
 lHD
-jQf
+buP
 bdQ
 bbk
-mDO
+oQB
 bjw
 bkI
 bkI
@@ -60567,12 +60626,12 @@ buy
 bkF
 bxl
 bxl
-uBw
+edV
 bxl
 bBN
 jEm
-nJf
-nJf
+qft
+qft
 cis
 bVy
 bjv
@@ -60589,7 +60648,7 @@ bVy
 bVy
 qEo
 rGN
-dyV
+twj
 bBN
 cev
 cfX
@@ -60597,13 +60656,13 @@ chh
 gPM
 rbk
 ckZ
-bbK
+qPk
 cmh
 cmh
 cpU
 xmc
 cHB
-vGA
+cqP
 ihA
 cwf
 cxD
@@ -60758,14 +60817,14 @@ lWL
 auU
 auU
 amM
-vyr
+kPq
 amM
-alb
-alb
+apP
+apP
 akb
 atu
 crI
-dXA
+sPb
 auX
 avK
 beQ
@@ -60791,11 +60850,11 @@ aLN
 aOH
 aMY
 aNT
-rbo
+bgJ
 qTH
 mIV
 aQK
-bts
+fMT
 aOP
 bgI
 aQK
@@ -60809,7 +60868,7 @@ bdS
 vzz
 bfA
 wTS
-mDO
+oQB
 bjw
 bkJ
 blE
@@ -60829,7 +60888,7 @@ bGg
 bGg
 bGg
 bGg
-nJf
+qft
 cis
 bVy
 bjv
@@ -60856,14 +60915,14 @@ cjL
 ckZ
 xqX
 chf
-khs
+nwq
 cpV
 cqQ
 csb
-cqP
-cqP
-cqP
-cqP
+hsP
+hsP
+hsP
+hsP
 cpV
 aCI
 cAS
@@ -61025,31 +61084,31 @@ ijO
 auY
 auY
 auY
-uAm
+bMa
 axk
-mtV
+bbx
 aya
 awD
 axk
-mtV
+bbx
 aya
 awD
 axk
-mtV
+bbx
 aya
 aFa
 aFR
 aGM
 cpM
 aIs
-fRH
+ucq
 aJA
 aLN
-kOO
+dUr
 aNj
 aNj
-bgJ
-gml
+nXF
+cWu
 mIV
 bgI
 ncu
@@ -61070,9 +61129,9 @@ wDE
 bjx
 bkJ
 cHr
-gSY
-gSY
-gSY
+wJj
+wJj
+wJj
 bpL
 bqO
 kvZ
@@ -61082,15 +61141,15 @@ bGg
 tWm
 byB
 bRD
-kCA
-kCA
-bDv
+onO
+onO
+iUT
 bGg
 bIt
 bJr
 axE
 cjE
-bYF
+pax
 hAm
 hAm
 hAm
@@ -61109,9 +61168,9 @@ auS
 auS
 auS
 auS
-kza
-ehK
-rjm
+hHj
+jVx
+sgL
 hpk
 coQ
 coQ
@@ -61130,7 +61189,7 @@ aCI
 cAS
 cAS
 aZj
-myt
+ntV
 cAS
 cbR
 cbR
@@ -61282,7 +61341,7 @@ aso
 dmv
 auZ
 avM
-uAm
+bMa
 ayF
 axX
 ayF
@@ -61296,34 +61355,34 @@ aDy
 ayF
 aFa
 aFS
-fRH
+ucq
 aCr
 kdW
+rCv
 bau
-jkp
 aLM
 awQ
 aNj
 aNU
-bgJ
+nXF
 aOI
 agu
-mwP
-uyj
+gsi
+bts
 aSW
 aJH
-epz
-wqy
-epz
+gwR
+dTV
+gwR
 pwd
-uci
-aNh
+jDR
+hgL
 bhS
 bdT
 pQd
 dgu
-epz
-oIJ
+gwR
+lMC
 aYe
 bkK
 ckW
@@ -61331,23 +61390,23 @@ blG
 blG
 blG
 bpM
-lAV
-lAV
+ieS
+ieS
 btl
 axR
 bvP
 gev
-bWO
-bYG
-bYG
-jaB
-bWO
+bDv
+bYF
+bYF
+vDB
+bDv
 bGg
 fXy
 bJr
 qJM
 fGe
-kkk
+jHp
 bMd
 bZB
 bZB
@@ -61363,13 +61422,13 @@ cbW
 cbW
 sKi
 cex
-uNa
+tgt
 chk
 auS
-bbK
+qPk
 chf
 loa
-qtK
+ecw
 coQ
 cpW
 cqR
@@ -61389,7 +61448,7 @@ cAS
 aZj
 crV
 cAS
-kRP
+nBt
 smQ
 cGy
 cAS
@@ -61533,23 +61592,23 @@ aCI
 aCI
 auY
 auc
-hft
+bga
 aso
-hft
+bga
 auc
 auc
 auc
-uAm
+bMa
 axm
-bbx
-bbx
-upO
-bbx
-bbx
-bbx
+sGx
+sGx
+qbz
+sGx
+sGx
+sGx
 aBY
-bbx
-bbx
+sGx
+sGx
 vMJ
 aFa
 aFT
@@ -61557,15 +61616,15 @@ aKT
 aHy
 aIt
 aKT
-gtj
+fqD
 aLN
-kCn
-bgJ
-bgJ
-bgJ
+sHb
+nXF
+nXF
+nXF
 aIq
 lvR
-jks
+oqY
 cFT
 cFT
 cFT
@@ -61573,15 +61632,15 @@ cFT
 cFT
 cFT
 cFT
-uSR
-ocD
-knW
+oaw
+vrn
+pfy
 cFT
 cFT
-uSR
-ocD
-knW
-myL
+oaw
+vrn
+pfy
+ckT
 bkL
 blH
 bmM
@@ -61594,11 +61653,11 @@ bmM
 axR
 bvP
 bxm
-gQP
-bDl
-bDl
-csD
-bWO
+oMG
+lBq
+lBq
+mdy
+bDv
 bGg
 bIt
 bJr
@@ -61620,18 +61679,18 @@ hAm
 hAm
 sKi
 cey
-kHf
+ylB
 oPW
 auS
 cjO
 chf
 chf
-fDP
+uDK
 coP
-wtO
-juB
+mCr
+gvs
 csc
-wLe
+euI
 clj
 cwh
 clj
@@ -61794,9 +61853,9 @@ fgk
 aso
 auc
 ues
-hft
+bga
 avO
-uAm
+bMa
 axn
 sIA
 aEn
@@ -61816,52 +61875,52 @@ aFa
 aJD
 cHp
 aFa
-qbz
-cUQ
-kfz
-kfz
-ljE
+oaU
+uGZ
+wZp
+wZp
+ghe
 agu
-rGz
-rVK
+wzE
+aNh
 khu
-rVK
-rVK
-rVK
-rVK
-cNu
+aNh
+aNh
+aNh
+aNh
+dVV
 baD
 bgI
 cPL
-xpY
-xpY
+nXo
+nXo
 wim
 bgI
 baC
-myL
+ckT
 bkM
 blI
 bmM
 bmM
 bmM
 bpN
-qaw
+bHA
 bmM
-bmN
+jKr
 axR
 bvQ
 nIy
-bWO
-kCA
-kCA
-vVu
-bWO
+bDv
+onO
+onO
+oBm
+bDv
 bGg
 bWN
 bJr
 axE
 siP
-bHT
+eOu
 bKW
 bNj
 bOQ
@@ -61883,15 +61942,15 @@ auS
 cjP
 chf
 loa
-qtK
+ecw
 coQ
 cqe
 cqS
 wSW
-acw
+cjS
 cyr
 vHd
-mGN
+lMh
 cyr
 cyr
 czo
@@ -61906,7 +61965,7 @@ cAS
 cFW
 cFY
 cGA
-cPx
+eHC
 cGR
 cAS
 cAS
@@ -62053,7 +62112,7 @@ atr
 aue
 dmv
 avP
-uAm
+bMa
 axo
 ayE
 aEn
@@ -62066,7 +62125,7 @@ aEn
 azs
 aEp
 awC
-kcF
+tWC
 aGO
 aFU
 awC
@@ -62089,16 +62148,16 @@ aRU
 aNl
 baD
 bbG
-oeQ
+qQZ
 bfC
 wKv
 bfB
 pXR
 baC
-myL
+ckT
 bkN
-rJj
-sfB
+vTd
+bmN
 pTN
 boH
 brY
@@ -62107,18 +62166,18 @@ brZ
 blJ
 buB
 bvP
-pXx
+mVn
 byC
 hwh
-bYG
-bYG
+bYF
+bYF
 amu
 bKj
-meE
+fie
 bJr
 xda
 siP
-bHT
+eOu
 dsS
 iyu
 bOR
@@ -62137,10 +62196,10 @@ ceA
 cgb
 bLX
 cix
-mww
+gFQ
 mgh
 swH
-qtK
+ecw
 coQ
 wSW
 wSW
@@ -62150,7 +62209,7 @@ cuA
 cwj
 vsu
 pRz
-eEG
+qLt
 cAe
 cAW
 lWL
@@ -62161,10 +62220,10 @@ aZj
 chb
 cbR
 cFX
-cPx
+eHC
 cGB
 cFY
-cPx
+eHC
 smQ
 cGZ
 lWL
@@ -62298,7 +62357,7 @@ ajj
 akc
 akY
 ahR
-vyr
+kPq
 ahR
 aCI
 ahR
@@ -62310,27 +62369,27 @@ ats
 auf
 avd
 auY
-uAm
+bMa
 axp
-akq
-akq
-akq
-akq
-uyN
-akq
-akq
-aAU
-akq
-nHF
-aFb
 aCb
-akq
-sby
+aCb
+aCb
+aCb
+uyN
+aCb
+aCb
+aAU
+aCb
+kMK
+aFb
+ueo
+aCb
+nTd
 aIu
-qpv
-prz
+dpP
+mAo
 aLO
-hEo
+jIZ
 aNi
 aNZ
 aOM
@@ -62343,14 +62402,14 @@ mcQ
 aVk
 aWD
 aYa
-qDj
+dUt
 baD
-bbI
-qRE
+sjW
+hYw
 rAy
 lBw
-wQT
-bbI
+inE
+sjW
 baC
 cHq
 bkJ
@@ -62371,11 +62430,11 @@ bGg
 bGg
 bGg
 bGg
-srV
+pyl
 bJr
 axE
 siP
-bHT
+eOu
 dKw
 iyu
 bOS
@@ -62394,15 +62453,15 @@ ceB
 cgc
 jpY
 auS
-vRH
+eGL
 chf
 loa
-qtK
+ecw
 coQ
 cpZ
 vKA
 wSW
-acw
+flF
 cuB
 cwk
 vsu
@@ -62419,10 +62478,10 @@ csG
 cFJ
 uzS
 cFY
-uMw
+gfN
 cFY
 cGS
-cPx
+eHC
 cHa
 lWL
 lWL
@@ -62560,16 +62619,16 @@ ahR
 aCI
 ahR
 atu
-dXA
+sPb
 auY
 atn
 auY
 auY
 auY
 auY
-uAm
+bMa
 axq
-xUH
+gnG
 ayK
 aOQ
 aAh
@@ -62585,9 +62644,9 @@ ayK
 aHB
 awC
 dAF
-bgJ
-bgJ
-oaU
+nXF
+nXF
+xmk
 ast
 aOL
 aON
@@ -62596,9 +62655,9 @@ aQh
 ezR
 aRU
 siK
-aZs
-aZs
-aZs
+fEL
+fEL
+fEL
 aRU
 hem
 baD
@@ -62609,15 +62668,15 @@ bfC
 cgp
 bfC
 baC
-ckT
+mol
 aNg
 olh
 wbU
-apK
-apK
-apK
-apK
-apK
+wWE
+wWE
+wWE
+wWE
+wWE
 bid
 aet
 bvR
@@ -62632,7 +62691,7 @@ bIt
 bJr
 axE
 siP
-sZl
+uIf
 bKW
 bNm
 bNn
@@ -62648,24 +62707,24 @@ caB
 bDk
 sKi
 ceC
-tgt
+kBV
 chp
 auS
 cfW
 chf
 chf
-fDP
+uDK
 coR
 tTx
-xUA
+fEr
 csd
 xSz
 coe
 coe
 kOL
 cny
-jvn
-dom
+dPF
+eoY
 cAW
 lWL
 lWL
@@ -62679,7 +62738,7 @@ cFY
 cFY
 cFY
 cGT
-cPx
+eHC
 cbR
 lWL
 lWL
@@ -62842,7 +62901,7 @@ aAi
 aAi
 aAi
 xYV
-bgJ
+nXF
 aLQ
 bIM
 dpY
@@ -62859,14 +62918,14 @@ aTb
 aRU
 aVm
 baD
-slJ
-wLp
+bbI
+kyF
 bfC
 pKr
 mVS
 sjn
 bhZ
-ckT
+mol
 afs
 lPi
 lPi
@@ -62877,15 +62936,15 @@ pqm
 aOR
 pgx
 aet
-xfD
+bNd
 rIp
-blo
+xqF
 bAr
-xhe
-xhe
+aLj
+aLj
 bEJ
 aet
-ylh
+qyb
 bJr
 axE
 siP
@@ -62911,7 +62970,7 @@ bYA
 cjU
 chf
 nWx
-qtK
+ecw
 coQ
 cqb
 cqS
@@ -62932,9 +62991,9 @@ eQi
 cAS
 cAS
 cGa
-cPx
+eHC
 cFY
-cPx
+eHC
 cFY
 cAS
 cAS
@@ -63086,7 +63145,7 @@ aye
 ayf
 ayf
 aye
-rNh
+azF
 aAi
 nnR
 aCd
@@ -63094,12 +63153,12 @@ aCz
 aDB
 kYr
 aFc
-qYs
+aFX
 aGQ
 aYf
 aAi
 nHr
-bgJ
+nXF
 ees
 nxY
 pYn
@@ -63114,39 +63173,39 @@ gAq
 aVn
 aWE
 fWt
-rdw
+nJF
 baD
 aLb
-oeQ
+qQZ
 upw
 beP
-hPa
+vaR
 aNf
 baC
 bKl
 bkQ
-qwi
-qwi
-arb
+xWs
+xWs
+foP
 fai
 ajJ
 faU
-ofl
+usQ
 cHs
 aet
 biD
-qLL
+nVU
 tmS
 bAr
 xpm
 xpm
-bSZ
+yeE
 tQl
-fOq
+nxu
 bJr
 axE
 siP
-pUe
+nSX
 bKW
 bKW
 bKW
@@ -63324,7 +63383,7 @@ lWL
 cAC
 auU
 auU
-alb
+apP
 atu
 amM
 auU
@@ -63345,7 +63404,7 @@ ayf
 ayf
 aye
 aAi
-dSd
+kYv
 aCA
 aGT
 aDC
@@ -63353,10 +63412,10 @@ aGT
 bgC
 aGT
 aCA
-hih
-qgE
-sYb
-bgJ
+mKl
+oCq
+gTX
+nXF
 aNj
 bIM
 aRV
@@ -63367,7 +63426,7 @@ aQi
 hPP
 aRU
 aTd
-cRr
+cPg
 aVo
 aQn
 bbO
@@ -63379,7 +63438,7 @@ bcP
 bbO
 bgI
 bgI
-sRx
+gSR
 bjE
 aNg
 blM
@@ -63388,7 +63447,7 @@ aYg
 qvO
 bpP
 bqS
-ofl
+usQ
 btn
 aet
 biD
@@ -63396,14 +63455,14 @@ ePD
 byX
 bAs
 iBy
+aqq
 bEL
-kmn
 bGi
-vGd
+iVX
 qkd
 siP
 siP
-sZl
+uIf
 bMi
 bNn
 tYN
@@ -63411,21 +63470,21 @@ bNn
 bRI
 bYA
 bUl
-nuJ
+pkl
 caC
 bYB
 bZG
-nuJ
+pkl
 caC
 bYB
 ceD
-nuJ
+pkl
 caC
 bYB
 cjV
 chf
 loa
-qtK
+ecw
 coQ
 cqc
 mhW
@@ -63443,10 +63502,10 @@ aCI
 aCI
 cCh
 bcL
-ubi
+nXS
 cCh
-kRP
-kRP
+nBt
+nBt
 cGD
 cAS
 cAS
@@ -63582,7 +63641,7 @@ cAC
 lWL
 auU
 auU
-alb
+apP
 amM
 auU
 auU
@@ -63602,15 +63661,15 @@ axt
 axt
 axt
 aAi
-dSd
+kYv
 aGT
 aGT
 aDD
 aEs
 jgf
-his
-his
 aFe
+aFe
+drI
 aIv
 aJI
 oNl
@@ -63624,7 +63683,7 @@ aQk
 fof
 aRU
 aTe
-cRr
+cPg
 aVp
 xPb
 bbO
@@ -63639,17 +63698,17 @@ dGU
 dGU
 aua
 aNn
-aAd
+imQ
 bmQ
 aYg
 aQN
 bpP
 sxD
-ofl
-kzw
+usQ
+clI
 aet
 bvT
-vSh
+oOh
 xpm
 bAr
 xpm
@@ -63682,17 +63741,17 @@ bYB
 cjW
 chf
 cmh
-tiW
+rFw
 coS
 iny
 nsP
 cse
-wLe
+euI
 cny
 cwo
-vBg
+saW
 cys
-bWp
+jmt
 cAj
 cAW
 aCI
@@ -63859,7 +63918,7 @@ azv
 azv
 azv
 uOc
-dSd
+kYv
 aCB
 aGT
 aGT
@@ -63867,21 +63926,21 @@ nwT
 pnt
 aGT
 aGT
-hih
+mKl
 aWO
-sYb
-aLa
+gTX
+mtd
 aNj
 aNj
-gml
+cWu
 aNZ
-wLn
-iCx
-iCx
+aDd
+jsh
+jsh
 lXv
 aRU
 aTf
-rvb
+aZs
 aVq
 vGx
 bbO
@@ -63891,8 +63950,8 @@ bdZ
 bez
 beR
 sHI
-dUt
-rLo
+vKH
+tzJ
 olA
 bKl
 aNg
@@ -63902,15 +63961,15 @@ aYg
 aQN
 bpP
 bqS
-ofl
+usQ
 eli
 aet
 bvU
-vSh
+oOh
 xpm
 bAr
 bBS
-vii
+rHk
 bEN
 aet
 bIt
@@ -63924,24 +63983,24 @@ bYA
 bYA
 bYA
 bSJ
-yeI
+pFY
 cip
-yeI
+pFY
 tlV
-yeI
+pFY
 cip
-yeI
+pFY
 cdt
-yeI
+pFY
 cip
-yeI
+pFY
 bYA
 cjK
 clh
 cjK
 cjK
 coQ
-vLs
+xft
 xld
 wSW
 ubL
@@ -63949,8 +64008,8 @@ cuG
 ubL
 cxN
 rPf
-hCC
-hCC
+ufS
+ufS
 cAW
 aCI
 aCI
@@ -64102,7 +64161,7 @@ qkc
 auU
 aCI
 auU
-dXA
+sPb
 atu
 crI
 atu
@@ -64118,16 +64177,16 @@ lFz
 aWO
 aBB
 aCg
-aFX
+uzq
 aDF
 gyK
-gOq
+iHx
 aFf
 aSw
 aHG
 aAi
 ayL
-xae
+aLa
 tLg
 gwH
 aNk
@@ -64148,7 +64207,7 @@ bea
 bcS
 bVI
 bcP
-gbx
+gpA
 bfF
 rnQ
 bjs
@@ -64156,14 +64215,14 @@ aNg
 blO
 bmS
 aYg
-ldu
+ftu
 cKB
 hJe
-vaw
-kzw
+oIq
+clI
 aet
 msY
-eOn
+vSh
 byG
 bAr
 bBT
@@ -64174,10 +64233,10 @@ bqy
 bJr
 bJv
 eBz
-rOf
+adD
 bMk
 bNq
-hMO
+tLM
 bQn
 bRJ
 bdu
@@ -64193,9 +64252,9 @@ bWW
 bWW
 pIf
 ciz
-iQq
+bRQ
 pIf
-mtO
+tzb
 bYA
 coQ
 wSW
@@ -64355,7 +64414,7 @@ aCI
 lWL
 lWL
 auU
-xJT
+mPC
 auU
 aCI
 auU
@@ -64416,8 +64475,8 @@ bnR
 aZq
 aNg
 aNg
-uyO
-uyO
+sgd
+sgd
 aet
 aet
 bxs
@@ -64427,32 +64486,32 @@ aet
 aet
 aet
 bGj
-qJa
+axz
 wCN
 anB
 bIE
-suc
+itZ
 bRK
-gjy
+sSa
 bNr
-kPT
+vYv
 bRK
-lpg
+oIP
 bUr
 naU
 gtN
-oXV
+lUC
 bZK
-plS
-plS
-plS
-plS
-frc
+toX
+toX
+toX
+toX
+tdL
 bUr
 ciA
 bUr
 xzG
-pNh
+bHX
 coT
 coT
 coT
@@ -64468,7 +64527,7 @@ ciy
 ciy
 aCI
 cCh
-oOf
+wLv
 bcL
 cEV
 cCh
@@ -64622,76 +64681,76 @@ crI
 aEm
 atu
 auU
-gfH
-bGS
-bGS
-bGS
-bGS
-bGS
-uSo
-bGS
-bGS
+kGt
+aot
+aot
+aot
+aot
+aot
+gMG
+aot
+aot
 ape
 aCD
 aDG
 aEu
 aDG
 aGa
-bGS
-gbz
+aot
+kOc
 ape
-bGS
-pCP
-bGS
-bGS
-bGS
-qXh
-djz
-utS
-bGS
-bGS
-bGS
+aot
+rlg
+aot
+aot
+aot
+eyL
+nbw
+ivP
+aot
+aot
+aot
 cQM
-bGS
+aot
 aVs
 aWH
-bGS
-bGS
-bGS
-bGS
-bGS
-qXh
-bsV
-utS
-bGS
-bGS
-pSF
-bGS
-bGS
+aot
+aot
+aot
+aot
+aot
+eyL
+nHH
+ivP
+aot
+aot
+nDa
+aot
+aot
 hNR
-bGS
-gql
-bGS
-bGS
-bGS
-bGS
+aot
+tPe
+aot
+aot
+aot
+aot
 mxi
-bGS
-bHT
-bYF
-bYF
+aot
+eOu
+pax
+pax
 aGU
-bYF
-bYF
-bYF
+pax
+pax
+pax
 axE
 bJr
 avm
 rrv
-qDO
+jlO
 bMm
 bNs
-rBK
+pLm
 bQp
 bRL
 pIf
@@ -64704,15 +64763,15 @@ bXc
 bXc
 bXc
 bXc
-kiX
-plS
+saV
+toX
 ciB
 cka
 clk
-nMp
+vLz
 coT
 coT
-kXW
+gjJ
 cqW
 csf
 ctd
@@ -64951,12 +65010,12 @@ bYA
 bYA
 bYA
 bYA
-qxa
+hPU
 bUr
 bUr
-pNh
-njz
-nxj
+bHX
+tYP
+bZM
 caI
 ccc
 cdv
@@ -64970,10 +65029,10 @@ cmj
 coT
 coT
 kBH
-cYn
+xrK
 csg
-tqv
-tqv
+qoV
+qoV
 coT
 lWL
 cCh
@@ -64983,7 +65042,7 @@ cCh
 csj
 cCh
 bcL
-ubi
+nXS
 cCh
 cCh
 aCI
@@ -65136,7 +65195,7 @@ crI
 aWB
 atu
 jtP
-wsN
+wWY
 cjE
 axE
 ayg
@@ -65202,7 +65261,7 @@ axE
 ubu
 bkm
 rrv
-sZl
+uIf
 bvX
 bMj
 tRI
@@ -65211,9 +65270,9 @@ bYB
 dHA
 bUr
 gtN
-rFO
+bMn
 bXd
-oni
+qEs
 caJ
 ccd
 cdw
@@ -65223,12 +65282,12 @@ cht
 bXc
 ckc
 cll
-hwg
+iQK
 cnG
 coT
 cqh
 cqT
-nTG
+hqt
 cte
 cuJ
 coT
@@ -65237,7 +65296,7 @@ cCh
 czr
 cAl
 cCh
-pPt
+bEH
 bcL
 bcL
 cAl
@@ -65383,11 +65442,11 @@ aCI
 lWL
 auU
 auU
-vyr
+kPq
 auU
 aCI
 ahR
-cSW
+fgf
 crI
 crI
 aWB
@@ -65465,12 +65524,12 @@ bNu
 bNu
 hXB
 bRM
-qxa
+hPU
 bUr
 bVL
-nUg
+dRg
 bXd
-bZM
+tYw
 caK
 cdy
 faD
@@ -65478,12 +65537,12 @@ cdy
 cdy
 chu
 bXc
-sGn
+hdT
 ckd
 wYn
-sNi
+kGX
 coU
-mnz
+fxb
 wYn
 csh
 lYC
@@ -65496,7 +65555,7 @@ cAm
 cwt
 bcL
 bcL
-dPo
+wTO
 cCh
 cCh
 lWL
@@ -65655,7 +65714,7 @@ cjE
 cpR
 bIt
 bIt
-avo
+tBl
 bIt
 aBa
 afn
@@ -65665,58 +65724,58 @@ aDG
 aEu
 aDG
 foL
-qCy
-eyh
-eNA
+dPi
+uaa
+ntk
 bIt
 aLh
 aLX
 aMD
-lkp
-sCP
-sCP
-sCP
-sCP
-pzm
-avo
-voI
-tAs
-akp
-tAs
-tAs
+aNm
+saC
+saC
+saC
+saC
+swT
+tBl
+biH
+pBI
+nfr
+pBI
+pBI
 bIt
 bIt
-avo
+tBl
 afn
 bIt
-uID
-cNe
-miD
-uxR
-cNe
-gSN
+pzm
+doy
+kMe
+lYb
+doy
+avo
 neN
-gbr
-uID
-cNe
-eUR
+qCy
+pzm
+doy
+fIn
 bqU
-fpH
+bDl
 jNl
-eWH
-fpH
-ecX
+uKv
+bDl
+nKp
 byI
-aNm
-sBQ
-kZN
-fpH
-fpH
+rGx
+pqG
+giV
+bDl
+bDl
 axE
 cpR
 bJz
 rrv
-vsM
+gQk
 bvX
 bNv
 bPa
@@ -65725,7 +65784,7 @@ bYB
 vdi
 clT
 bVM
-yab
+ays
 bYH
 bZO
 fNZ
@@ -65735,14 +65794,14 @@ ceF
 cgk
 chv
 ciD
-xPT
+uxb
 cnH
 cnH
-slu
+fHS
 coT
 cqj
 cnH
-nTG
+hqt
 ctg
 cuL
 coT
@@ -65752,7 +65811,7 @@ cCh
 cCh
 cCh
 bcL
-pPt
+bEH
 cCh
 cCh
 lWL
@@ -65907,9 +65966,9 @@ asx
 aty
 auo
 atx
-qJa
+axz
 xRg
-pmc
+lSd
 ayi
 ayi
 ayi
@@ -65930,7 +65989,7 @@ ayi
 ayi
 ayi
 ayi
-oWh
+mYr
 aOS
 aPy
 aQm
@@ -65969,11 +66028,11 @@ hVo
 hVo
 hVo
 bGk
-tHc
+bqu
 hOm
 anB
 huX
-axz
+jsF
 bvX
 bNw
 bNw
@@ -65993,19 +66052,19 @@ bXd
 bXd
 ciC
 ckf
-vya
+oZK
 cmn
 cnJ
 coT
+eEr
 cqY
-oPs
-ffu
-tqv
-tqv
+xpw
+qoV
+qoV
 coT
 lWL
 cCh
-oOf
+wLv
 bcL
 bcL
 bcL
@@ -66166,7 +66225,7 @@ aup
 avj
 bIt
 cjE
-bHT
+eOu
 ayi
 ayP
 bcU
@@ -66226,11 +66285,11 @@ jde
 bAv
 bEP
 hVo
-rsF
+hNu
 hGr
 bJB
 egK
-bHL
+nwC
 bvX
 tRI
 uGp
@@ -66239,14 +66298,14 @@ bRO
 gtw
 cns
 bVN
-xhq
-xhq
+kyb
+kyb
 bZQ
 cch
 cch
 cch
 bWU
-xhq
+kyb
 eCe
 cjF
 ckg
@@ -66263,7 +66322,7 @@ coT
 lWL
 cCh
 bcL
-pPt
+bEH
 cBa
 cCh
 cCh
@@ -66421,7 +66480,7 @@ mvU
 atA
 ouR
 bMg
-wsN
+wWY
 cjE
 hyR
 ayi
@@ -66452,12 +66511,12 @@ aFZ
 aUx
 aTj
 aYh
-eXD
-sdj
+fNo
+tfa
 xTS
 bcU
 bcU
-elW
+tmL
 bcU
 ayi
 beU
@@ -66483,19 +66542,19 @@ bBV
 bDC
 mMC
 bGm
-bDt
+aNB
 xMx
 bJC
 lCe
-ouX
+mHW
 bvX
 brC
 lHi
 brC
 bRO
-kLW
+oGi
 cns
-iZV
+tVJ
 bXe
 bXe
 qyx
@@ -66678,7 +66737,7 @@ asA
 fob
 aur
 avj
-foX
+qnl
 rXU
 abX
 nfs
@@ -66709,7 +66768,7 @@ bcU
 bcU
 ayi
 aUv
-eXD
+fNo
 aUv
 ayi
 aFh
@@ -66740,7 +66799,7 @@ bBW
 cir
 bEQ
 bGn
-pLN
+qrO
 bTw
 aiP
 lCe
@@ -66752,15 +66811,15 @@ bQs
 bRO
 pDY
 bUu
-fFF
+xJC
 bXf
 bYI
 fJy
-qCa
+aXm
 ccj
 cdA
 ceI
-kLW
+oGi
 wBU
 kXe
 cki
@@ -66777,7 +66836,7 @@ aCI
 lWL
 cCh
 bcL
-ubi
+nXS
 cCh
 lWL
 lWL
@@ -66923,7 +66982,7 @@ atu
 dxF
 gEj
 alf
-vyr
+kPq
 amM
 amM
 amM
@@ -66935,9 +66994,9 @@ jgL
 bOT
 aus
 atx
-foX
+qnl
 cjE
-tvs
+wGf
 ayi
 ayS
 bcU
@@ -66997,28 +67056,28 @@ bBX
 bDD
 bER
 bGm
-bDt
+aNB
 xMx
 bJD
 lCe
 bLf
 bNF
 bNz
-wsU
-xhq
-xhq
-irU
+sYz
+kyb
+kyb
+rQe
 uuH
-fFF
+xJC
 bXg
 bYJ
 mEJ
-qCa
+aXm
 cck
 cdB
 ceJ
-kLW
-qKP
+oGi
+lcA
 ciG
 cnD
 coJ
@@ -67181,7 +67240,7 @@ auU
 adP
 aWB
 adP
-alb
+apP
 auU
 auU
 auU
@@ -67192,9 +67251,9 @@ atx
 atx
 atx
 atx
-fhV
+kIS
 cjE
-bYF
+pax
 ayi
 ayT
 bcU
@@ -67254,11 +67313,11 @@ hVo
 hVo
 hVo
 hVo
-bDt
+aNB
 xMx
 bJD
 dIW
-bLg
+xQq
 bNF
 bNA
 bPd
@@ -67269,13 +67328,13 @@ uYm
 lKn
 eZE
 bXh
-xhq
-xhq
+kyb
+kyb
 ccl
 bXh
 ceK
-irU
-cGp
+rQe
+sGl
 kXe
 ckk
 xhD
@@ -67291,7 +67350,7 @@ cwp
 cCh
 bcL
 bcL
-oBD
+gnl
 cCh
 aCI
 aCI
@@ -67441,12 +67500,12 @@ auU
 auU
 auU
 aol
-aRp
-kkk
+scA
+jHp
 aqG
 arC
-iDw
-bHT
+lFS
+eOu
 bal
 aBd
 cpR
@@ -67511,7 +67570,7 @@ bCb
 bEc
 bFD
 bGo
-xdF
+vrJ
 xMx
 bJD
 lCe
@@ -67520,8 +67579,8 @@ bNF
 bNB
 bPe
 xiO
-nMj
-uGL
+eOT
+rWk
 chz
 chz
 vsw
@@ -67543,7 +67602,7 @@ ckm
 aCI
 csj
 ctj
-pPt
+bEH
 cAl
 cCh
 bcL
@@ -67735,16 +67794,16 @@ aPC
 aQo
 aQV
 aSa
-oir
+gIU
 aUy
-oir
+gIU
 aNo
 bKw
 aZz
 pYH
 iWo
 uKM
-bXk
+dqY
 aba
 bfL
 bKw
@@ -67778,14 +67837,14 @@ bNC
 bPf
 bNC
 cqU
-uOl
 bST
+sha
 rmn
 vsw
 bYL
 bZT
-nMj
-nMj
+eOT
+eOT
 cdC
 ceM
 iGo
@@ -67959,13 +68018,13 @@ iew
 rzW
 axE
 aKU
-kMe
-dlc
+sVO
+uUU
 auv
-avo
+tBl
 bIt
-iev
-dje
+npV
+smf
 ayi
 bcU
 bcU
@@ -68020,7 +68079,7 @@ afE
 afB
 kzm
 pYa
-bEA
+qKB
 bBY
 bDG
 erz
@@ -68060,7 +68119,7 @@ cuN
 bcL
 bcL
 bcL
-jGJ
+nFo
 czx
 cAq
 cBb
@@ -68213,7 +68272,7 @@ lWL
 anB
 aoo
 pdu
-uFU
+dcl
 aqH
 anB
 anB
@@ -68295,14 +68354,14 @@ cqU
 bSU
 bUw
 bVP
-ojV
+igA
 bYM
 bRO
 caQ
 bYN
 ceR
 ceO
-tgJ
+wxd
 cCh
 lWL
 lWL
@@ -68313,7 +68372,7 @@ cCh
 cCh
 cCh
 cCh
-ubi
+nXS
 bcL
 cCh
 cCh
@@ -68539,20 +68598,20 @@ siq
 bEd
 bEW
 gfV
-bDt
+aNB
 xMx
 bJD
 lCe
 bLk
 bGl
 qIs
-xAH
+hcp
 gas
 cqU
 bSV
-ojV
-ojV
-ojV
+igA
+igA
+igA
 bYN
 bRO
 caR
@@ -68565,7 +68624,7 @@ cCh
 cCh
 cCh
 cmt
-pPt
+bEH
 cuN
 cuN
 cuN
@@ -68796,11 +68855,11 @@ bGt
 bGt
 bGt
 bGt
-bDt
+aNB
 xMx
 bJD
 lCe
-kzs
+ciN
 bGl
 bNE
 bPg
@@ -68826,11 +68885,11 @@ ctn
 coZ
 cql
 cra
-tMo
+pGz
 ctn
 cuS
 cwt
-xGB
+mYP
 cyB
 cxP
 ceR
@@ -68975,7 +69034,7 @@ lWL
 aCI
 aCI
 ahR
-hdN
+edT
 akh
 auU
 aCI
@@ -69053,11 +69112,11 @@ bLv
 bLv
 bLv
 pcv
-fAN
+rtH
 vKb
 bNI
 lCe
-dGC
+mlK
 bGl
 bGl
 bGl
@@ -69310,12 +69369,12 @@ bGt
 bGt
 bGt
 bGt
-bDt
+aNB
 xMx
 bJD
 jXm
-kzs
-ecD
+ciN
+eLE
 bNG
 bNG
 bQx
@@ -69576,7 +69635,7 @@ hGr
 xMx
 bJD
 bJD
-jYG
+dGG
 bSY
 eFv
 bVS
@@ -69598,7 +69657,7 @@ bUO
 bUO
 aCI
 ceR
-ubi
+nXS
 ceO
 hHE
 hHE
@@ -69816,7 +69875,7 @@ bGt
 bwb
 btB
 btB
-jcM
+mrk
 bxD
 byR
 bAE
@@ -69824,13 +69883,13 @@ bCe
 bDJ
 bEY
 bGv
-bDt
+aNB
 fhR
 bJF
 bKs
-emo
-jrE
-oAq
+qHw
+iUA
+kmj
 bJD
 bJD
 bRR
@@ -69857,9 +69916,9 @@ aCI
 ceR
 cHo
 ceO
-pPt
+bEH
 cuN
-pPt
+bEH
 cuN
 cuN
 cBd
@@ -70081,18 +70140,18 @@ bAF
 mqF
 bDJ
 bGw
-bDt
+aNB
 fhR
 bJG
 bKs
-meU
-oRI
-rPh
+tib
+jsz
+hTt
 bXo
 xMx
-mWo
+pOS
 bTa
-ibN
+pnx
 teu
 bRy
 ggT
@@ -70265,14 +70324,14 @@ aCI
 auU
 auU
 auU
-dXA
+sPb
 khd
 pYa
 eDG
 pYa
 aHp
 arG
-dXA
+sPb
 atD
 aiD
 aCI
@@ -70327,7 +70386,7 @@ boP
 btA
 bLv
 bGt
-jcM
+mrk
 buI
 buI
 kET
@@ -70338,13 +70397,13 @@ bCg
 bDJ
 bDJ
 dls
-bDt
+aNB
 fhR
 bJH
 bKs
-gDh
-boX
-ktp
+afR
+eJV
+aZh
 bJD
 bJD
 dEN
@@ -70376,7 +70435,7 @@ cCh
 cAp
 cuN
 cuN
-pPt
+bEH
 cuN
 cCh
 lWL
@@ -70585,9 +70644,9 @@ boP
 bqd
 bGt
 oqG
-uLN
+pIr
 oFA
-uLN
+pIr
 bxE
 bJd
 bAH
@@ -70604,7 +70663,7 @@ bMq
 bNI
 bNI
 bNI
-jlY
+rBi
 ggT
 bUE
 bVW
@@ -70856,15 +70915,15 @@ dKs
 xMx
 bJD
 lCe
-mfG
-lDt
+tuj
+iaE
 bNJ
 bNJ
-xSF
+oYe
 fRM
 ggT
 bUF
-wKp
+vlk
 jVQ
 ggT
 aEk
@@ -70887,11 +70946,11 @@ ceR
 cuX
 ceR
 ceR
-pPt
+bEH
 czA
 cAt
 cBe
-dPo
+wTO
 cCh
 cCh
 lWL
@@ -71104,12 +71163,12 @@ buG
 bsf
 bsf
 byV
-jcM
+mrk
 tpP
-iKA
+uIh
 kmo
 bGx
-bDt
+aNB
 xMx
 bJD
 lCe
@@ -71359,25 +71418,25 @@ bsl
 bAL
 bAL
 bwe
-ixi
+jLg
 bGx
 bCi
 bCi
 bCi
-jcM
+mrk
 bGx
-bDt
+aNB
 xMx
 bJD
 lCe
-wCu
+nFO
 bMy
 bNK
 bPi
 bQz
 bMz
 bTb
-vMh
+lki
 oFn
 uxh
 bYP
@@ -71397,9 +71456,9 @@ bXw
 cpg
 crb
 csk
-cwB
+mXT
 svB
-hXd
+dSy
 ceR
 ceR
 ceR
@@ -71614,20 +71673,20 @@ bqf
 bGt
 bsm
 btI
-xkf
+oxp
 bwf
 bxG
 bGx
 bCi
 bCi
 bCi
-jcM
+mrk
 bGx
-xdF
+vrJ
 xMx
 bJD
 lCe
-nnB
+bDr
 bMy
 bNL
 bPj
@@ -71654,16 +71713,16 @@ cHV
 bXw
 crc
 csk
-cwB
+mXT
 svB
-fbp
-dKZ
+kIN
+pkd
+dmL
 cyC
-apP
 ceR
 cAp
 wlf
-pPt
+bEH
 cCh
 lWL
 lWL
@@ -71869,22 +71928,22 @@ bnY
 boP
 bLv
 bGt
-bsn
+aGp
 btJ
 pUk
 bsf
-jut
+lDp
 bGx
 bCi
 bCi
 bCi
-jcM
+mrk
 bGx
-bDt
+aNB
 xMx
 xMx
 bzh
-cTs
+lYm
 bMv
 bMu
 bPk
@@ -71909,17 +71968,17 @@ cdH
 cpg
 cpg
 bXw
-mCw
+wiv
 ske
 gYL
 svB
-uXy
-wrB
-cyC
-cyC
+cwC
+pCp
+dmL
+dmL
 ceR
 cBg
-pPt
+bEH
 cuN
 cCh
 cCh
@@ -72132,16 +72191,16 @@ buN
 bwg
 bxI
 byY
-uLN
+pIr
 llF
 fiS
-jcM
+mrk
 bGy
-bDt
+aNB
 xMx
 bJD
 lCe
-nnB
+bDr
 bMy
 bNN
 dWU
@@ -72171,7 +72230,7 @@ csk
 ctv
 svB
 cwD
-wrB
+pCp
 cyD
 cyD
 ceR
@@ -72383,18 +72442,18 @@ blS
 btA
 bLv
 bGt
-pSa
+bsn
 btL
 vLc
 bsf
-jut
+lDp
 bGx
 tAZ
 log
 kAu
 bFd
 bGx
-bDt
+aNB
 xMx
 bJD
 lCe
@@ -72404,7 +72463,7 @@ bNO
 bPm
 bQD
 bMz
-bTg
+nyY
 bXu
 paY
 cpg
@@ -72427,14 +72486,14 @@ crf
 csk
 ctw
 svB
-fbp
-uRq
-wld
+kIN
+sRN
 cyE
+bAT
 ceR
 cBi
 cCl
-pPt
+bEH
 cHo
 cCh
 lWL
@@ -72649,9 +72708,9 @@ bGx
 tAZ
 bCi
 bCi
-jcM
+mrk
 bGx
-bDt
+aNB
 xMx
 bJD
 lCe
@@ -72661,13 +72720,13 @@ bNP
 fde
 bQE
 bMz
-cAE
-gUM
-jFJ
-fHg
-qiU
-qiU
-vPW
+bTg
+oKY
+bSm
+whT
+vSi
+vSi
+gea
 caU
 cpg
 bcM
@@ -72900,19 +72959,19 @@ bGt
 bsq
 btN
 eyC
+tRo
 bwi
-hPB
 bGx
 tAZ
 bCi
 bCi
-jcM
+mrk
 bGx
-bDt
+aNB
 xMx
 sGt
 lCe
-vul
+dZH
 bMy
 bNQ
 fWD
@@ -72941,7 +73000,7 @@ crh
 csm
 cty
 cve
-kJg
+kpH
 csp
 cyF
 czE
@@ -73154,22 +73213,22 @@ lWL
 bGt
 bLv
 bGt
-jcM
+mrk
 btO
 nuY
 bsf
 bxL
 bGx
-uLN
+pIr
 bCl
 bAO
 bwb
 bGx
-bDt
+aNB
 xMx
 bJD
 lCe
-qvN
+vQy
 bMz
 bMz
 bMz
@@ -73181,7 +73240,7 @@ aOC
 buR
 bjr
 gFj
-rcB
+ubG
 chE
 chE
 mXu
@@ -73198,7 +73257,7 @@ cri
 csk
 ctz
 svB
-vDp
+cwB
 csp
 cyF
 cHP
@@ -73426,7 +73485,7 @@ mMH
 xMx
 bJD
 lCe
-nnB
+bDr
 ayX
 bQH
 bQH
@@ -73455,7 +73514,7 @@ jXO
 csk
 ctA
 cwK
-vDp
+cwB
 csp
 cyG
 cHP
@@ -73679,15 +73738,15 @@ bCm
 bCm
 bCm
 bGz
-euC
+tKX
 nig
 czM
 bKt
-nnB
+bDr
 ayX
-vQx
-tyB
-tyB
+lqW
+rpI
+rpI
 bMB
 bTj
 gLd
@@ -73695,7 +73754,7 @@ xWK
 iYa
 iYa
 jiT
-uGZ
+sVX
 cdH
 cdH
 cdH
@@ -73712,7 +73771,7 @@ cId
 cmx
 vKS
 ltG
-vDp
+cwB
 csp
 cyG
 cHP
@@ -73936,14 +73995,14 @@ btQ
 btQ
 btQ
 btQ
-egY
+bVt
 xMx
 bJD
 lCe
-vyT
+bDr
 mgP
-aot
-tyB
+bQH
+rpI
 crn
 ayX
 bTk
@@ -73952,7 +74011,7 @@ cvZ
 iYa
 cUk
 kpM
-naS
+ekt
 bXw
 cdL
 bXw
@@ -73969,7 +74028,7 @@ bXq
 csk
 ctL
 ltG
-vDp
+cwB
 csp
 cyG
 cHP
@@ -74197,10 +74256,10 @@ xPa
 xMx
 bJD
 lCe
-nnB
+bDr
 ayX
 bQH
-slM
+tIx
 crn
 ayX
 kVa
@@ -74222,11 +74281,11 @@ cmD
 bXw
 cph
 cqs
-kEy
+wTP
 csk
-cwB
+mXT
 ltG
-vDp
+cwB
 csp
 cyH
 czG
@@ -74234,7 +74293,7 @@ cyH
 cBj
 cCq
 wGd
-rga
+tlc
 cEy
 cBj
 lWL
@@ -74450,7 +74509,7 @@ bCo
 bDQ
 pCv
 dfK
-gXc
+geH
 xMx
 bJD
 lCe
@@ -74483,7 +74542,7 @@ csk
 csk
 ctE
 ltG
-vDp
+cwB
 csp
 pAo
 cHP
@@ -74702,7 +74761,7 @@ btA
 btQ
 bxO
 bzg
-fdn
+whN
 bCp
 gff
 bFh
@@ -74740,7 +74799,7 @@ aCI
 csp
 ctF
 ltG
-vDp
+cwB
 csp
 cyI
 cyI
@@ -74910,7 +74969,7 @@ pYa
 pYa
 pYa
 pYa
-bEA
+qKB
 lWL
 aCI
 lWL
@@ -74964,7 +75023,7 @@ bCq
 gff
 bFi
 bGC
-egY
+bVt
 xMx
 bJK
 adr
@@ -74997,14 +75056,14 @@ aCI
 csp
 ctG
 ltG
-vDp
+cwB
 cvy
-daK
-uSL
-uSL
-cBl
+lTY
+seH
+seH
+yfJ
 cCt
-qnG
+pff
 cDK
 cvy
 cvy
@@ -75163,7 +75222,7 @@ lWL
 lWL
 lWL
 pYa
-bEA
+qKB
 vxE
 aAn
 pYa
@@ -75221,11 +75280,11 @@ bCr
 gff
 bFj
 bGC
-egY
+bVt
 uac
 tky
 dIW
-nNK
+bLg
 ayX
 bQH
 bQH
@@ -75256,7 +75315,7 @@ ctH
 cvi
 qzx
 cxR
-peu
+hhB
 fux
 cBm
 cBm
@@ -75478,14 +75537,14 @@ bCs
 bDQ
 bFk
 bGC
-nMR
+hdt
 xMx
 bJD
 lCe
 bLo
 ayX
 bQH
-vQx
+lqW
 bQK
 ayX
 aCI
@@ -75513,8 +75572,8 @@ ctH
 vmF
 cwI
 cvy
-jNT
-mOC
+jXR
+eCI
 emu
 bZU
 bZU
@@ -75680,7 +75739,7 @@ pYa
 pYa
 pYa
 pYa
-bEA
+qKB
 pYa
 lWL
 aCI
@@ -75711,9 +75770,9 @@ lWL
 lWL
 lWL
 baK
-rhJ
+fDb
 bfd
-klj
+tyB
 bxS
 bir
 bjP
@@ -75735,7 +75794,7 @@ bCt
 bDQ
 pCv
 bGC
-gXc
+geH
 xMx
 xMx
 bzh
@@ -75768,10 +75827,10 @@ aCI
 csp
 ctJ
 vmF
-vDp
+cwB
 csp
 cFj
-lAf
+ixC
 myP
 pqR
 wjQ
@@ -75968,14 +76027,14 @@ aRb
 baK
 baK
 baK
-qIO
+rYs
 aVJ
-klj
+tyB
 bxS
 bis
 xcq
 iHF
-smz
+lLL
 bnd
 bpa
 wvs
@@ -75992,11 +76051,11 @@ bCu
 bDT
 bFl
 bGD
-egY
+bVt
 xMx
 bJD
 lCe
-vRN
+hod
 ayX
 bQH
 cdO
@@ -76025,11 +76084,11 @@ aCI
 csp
 ctK
 lAb
-cwC
+xPE
 csp
 cyN
-kVb
-num
+caH
+yme
 cFi
 cFi
 cFi
@@ -76227,7 +76286,7 @@ fAw
 mkl
 bwn
 bwn
-klj
+tyB
 bxS
 blY
 blb
@@ -76249,11 +76308,11 @@ bCB
 gff
 gff
 gff
-tmK
+syj
 xMx
 bJD
 lCe
-vul
+dZH
 ayX
 bQH
 bQH
@@ -76285,7 +76344,7 @@ cvl
 cwL
 csp
 cBp
-mTy
+kom
 xZs
 cFi
 bQU
@@ -76484,7 +76543,7 @@ bwn
 bde
 bel
 bwn
-klj
+tyB
 bxS
 biu
 bjS
@@ -76506,13 +76565,13 @@ eVe
 nqr
 bFm
 gff
-egY
+bVt
 xMx
 bJD
 lCe
-nnB
+bDr
 ayX
-vQx
+lqW
 bQH
 bQH
 ayX
@@ -76542,7 +76601,7 @@ cvl
 cwM
 csp
 cBq
-mTy
+kom
 cCx
 cFi
 rya
@@ -76741,7 +76800,7 @@ bwn
 bdf
 bem
 bwn
-klj
+tyB
 bxS
 biv
 iOF
@@ -76763,16 +76822,16 @@ bDX
 oLa
 bFn
 gff
-tEZ
+qJi
 hGr
 bJB
 liM
-pZJ
+xwT
 ayX
 bQH
 bQH
 bQH
-vQx
+lqW
 bQH
 bUP
 bQH
@@ -76783,23 +76842,23 @@ bQH
 bQH
 cdO
 bQH
-vQx
+lqW
 bQH
 bQH
 bQH
-vQx
+lqW
 bQH
 cnZ
-wWQ
+lyn
 qJU
-tRr
+uTS
 csq
-bfc
+jlR
 cvl
 cwN
 csp
 cyP
-mTy
+kom
 cCy
 cFi
 adW
@@ -77020,11 +77079,11 @@ bCy
 bDV
 bFo
 gff
-egY
+bVt
 ueW
 jPX
 lCe
-nnB
+bDr
 ayX
 bNX
 cdO
@@ -77036,10 +77095,10 @@ ayX
 ayX
 ayX
 ayX
-vQx
+lqW
 bQH
 bUP
-tNo
+ibE
 ayX
 ayX
 ayX
@@ -77047,17 +77106,17 @@ ayX
 bQH
 bQH
 coa
-iMV
+hMY
 bNZ
-qyM
+vxX
 csr
-tjO
-rGq
-kAe
+piM
+msd
+fVM
 csp
 cyQ
-mTy
-hDE
+kom
+iRU
 cFi
 sSE
 wZL
@@ -77255,7 +77314,7 @@ bwn
 bwn
 dlY
 bwn
-klj
+tyB
 bxS
 bxS
 bRm
@@ -77281,7 +77340,7 @@ bHH
 cdP
 iHC
 lCe
-nnB
+bDr
 bMC
 ayX
 ayX
@@ -77304,7 +77363,7 @@ ayX
 ayX
 ayX
 cnZ
-rgN
+suC
 bNZ
 gIQ
 csp
@@ -77313,7 +77372,7 @@ csp
 csp
 csp
 uou
-ghp
+xlO
 bXB
 cFi
 qzy
@@ -77515,7 +77574,7 @@ bwn
 bff
 jIX
 bix
-nDx
+frA
 bri
 bri
 bri
@@ -77528,50 +77587,50 @@ bri
 bri
 bri
 bgY
-wIF
+uad
 bBe
 bCz
 bBe
-dVF
-cHU
+umz
+tIJ
 bJD
 gbe
 bJN
 lCe
-vyT
+uns
 bME
-ail
-ail
-ail
-bRZ
-ail
-ail
-ail
-ail
-ail
-ail
-tNA
-bRZ
+xXn
+xXn
+xXn
+xId
+xXn
+xXn
+xXn
+xXn
+xXn
+xXn
+pBj
+xId
 mOA
 cfa
-ail
-ail
-ail
-ail
-wBw
-wBZ
+xXn
+xXn
+xXn
+xXn
+ydO
+bRZ
 svz
-kdE
+wao
 rjn
 bWh
 cxe
 ctP
-sUp
+cBl
 cwP
 cxT
-iSU
+oKr
 jZk
-tbv
+vlF
 cHb
 oJW
 wZL
@@ -77820,15 +77879,15 @@ hPR
 aJv
 gvh
 gvh
-bIX
+wuN
 coH
 xKi
-rEp
+jBC
 lWs
 cst
-lfK
+cUs
 oua
-dTF
+rHD
 qwj
 cCB
 qil
@@ -78031,7 +78090,7 @@ doa
 fST
 fST
 fST
-wsm
+tCv
 bxV
 fST
 fST
@@ -78046,9 +78105,9 @@ bzt
 vbW
 wqY
 vbW
-rVw
-gXc
-gXc
+bxu
+geH
+geH
 qwq
 bJP
 bKz
@@ -78057,33 +78116,33 @@ bMF
 qWR
 bOa
 oSL
-rfG
+aTL
 bTm
-lLh
-rfG
+bPr
+aTL
 hAJ
-rfG
-rfG
-rfG
-rfG
+aTL
+aTL
+aTL
+aTL
 sUS
-hSu
-hSu
-hSu
+msO
+msO
+msO
 aAw
-hSu
+msO
 ubO
 cmH
-iNh
-wgZ
+vOn
+riw
 cqx
 cxE
 cxe
 ctR
-rEp
+jBC
 cwQ
 cvy
-iSU
+oKr
 cBv
 sLt
 cBt
@@ -78281,7 +78340,7 @@ bwn
 baO
 bwn
 bwn
-fet
+roJ
 baK
 gqk
 bhb
@@ -78309,7 +78368,7 @@ bHK
 knH
 rvo
 lCe
-oHd
+mno
 bMG
 bMH
 bMI
@@ -78562,21 +78621,21 @@ bCC
 bDW
 bFr
 bwt
-egY
+bVt
 kkp
 hKi
 lCe
-vFr
+hpq
 bMH
 bOb
-jgc
+bSZ
 bQR
-jgc
+bSZ
 bTn
 bUR
 bWq
-rjN
-jgc
+rAk
+bSZ
 aEH
 cbd
 bMH
@@ -78585,7 +78644,7 @@ cgJ
 cgJ
 cgM
 lAL
-nab
+mGV
 clD
 cmJ
 uEw
@@ -78597,7 +78656,7 @@ ctS
 bKQ
 cwS
 cxV
-iSU
+oKr
 chH
 csu
 cFi
@@ -78805,7 +78864,7 @@ aZQ
 bmh
 vSn
 bmi
-bpg
+jzy
 tjB
 tjB
 bwt
@@ -78819,13 +78878,13 @@ bzi
 bzi
 bFs
 bwt
-tEZ
+qJi
 hGr
 bJB
 bjc
-nym
+jAW
 bMH
-jgc
+bSZ
 bZe
 bZe
 bZe
@@ -78842,7 +78901,7 @@ cfc
 cgJ
 cgM
 lAL
-kYx
+oUD
 clD
 cmK
 uEw
@@ -78854,7 +78913,7 @@ kzT
 apu
 cwT
 puW
-tNf
+ydl
 chH
 cpe
 cFi
@@ -79052,7 +79111,7 @@ cid
 cid
 cid
 cid
-fet
+roJ
 baK
 ncU
 bhd
@@ -79070,19 +79129,19 @@ bzi
 bvd
 bww
 bxX
-lXd
+lyd
 bzi
 bDU
-uRR
+bCw
 bFt
 bwt
-egY
+bVt
 xMx
 bJD
 lCe
-oHd
+mno
 bMI
-jgc
+bSZ
 bZe
 bXL
 bZe
@@ -79111,9 +79170,9 @@ gix
 apu
 cwU
 cxV
-iSU
+oKr
 chH
-rEp
+jBC
 cFi
 ybE
 gvk
@@ -79329,17 +79388,17 @@ bwx
 bxY
 bzx
 bzi
-kJX
-bCw
+aFg
+eym
 bFu
 bwt
 ksH
 uac
 bJD
 lCe
-oHd
+mno
 bMI
-jgc
+bSZ
 bZe
 bXL
 bSd
@@ -79368,9 +79427,9 @@ nNJ
 cvs
 cwV
 cxV
-jNT
-dxd
-rEp
+jXR
+ddW
+jBC
 cFi
 cCF
 gbT
@@ -79576,15 +79635,15 @@ lWL
 aZQ
 vSn
 bmi
-tux
-tux
-tux
+bpg
+bpg
+bpg
 bwt
 bzi
 ihv
 bwy
 bwy
-bCw
+eym
 bzi
 bzi
 bzi
@@ -79594,7 +79653,7 @@ bHZ
 xMx
 bJS
 lCe
-oHd
+mno
 bMI
 bOd
 bZe
@@ -79626,8 +79685,8 @@ cvt
 cwW
 csv
 cyU
-eCQ
-rEp
+eCp
+jBC
 cFi
 cFi
 wrZ
@@ -79863,7 +79922,7 @@ vIh
 rdb
 bZb
 bZe
-jgc
+bSZ
 ccC
 cgJ
 cgJ
@@ -79883,11 +79942,11 @@ csv
 csv
 csv
 cyV
-eCQ
-sJb
-uSL
+eCp
+sqv
+seH
 cxY
-vZC
+mPs
 cDX
 cxe
 cxe
@@ -79898,7 +79957,7 @@ lWL
 lWL
 lWL
 lWL
-lVR
+qDQ
 lWL
 lWL
 lWL
@@ -80104,13 +80163,13 @@ bwt
 bwt
 bwt
 bwt
-egY
+bVt
 xMx
 sGt
 lCe
-oHd
+mno
 bMI
-jgc
+bSZ
 bZe
 bXL
 bZe
@@ -80140,7 +80199,7 @@ aCI
 aCI
 cxW
 cyM
-eCQ
+eCp
 xKi
 chH
 chH
@@ -80356,16 +80415,16 @@ aZQ
 bhm
 aZQ
 bzA
-qfE
+hIZ
 boi
 bBk
 bFv
 bGI
-rjj
+xHA
 xMx
 bJD
 lCe
-oHd
+mno
 bMI
 bOf
 bZe
@@ -80380,7 +80439,7 @@ bZe
 cbi
 bMH
 cdX
-cUT
+wLs
 exY
 chS
 ciW
@@ -80397,12 +80456,12 @@ lWL
 lWL
 cxW
 cEM
-gZg
-cku
-pkp
+faS
+mDF
+amb
 cAB
 xKi
-lwF
+nYr
 cxe
 cFk
 cvy
@@ -80612,17 +80671,17 @@ aZQ
 aZQ
 aIL
 aZQ
-iIo
-moH
+maa
+wDj
 bCG
-moH
-qfE
+wDj
+hIZ
 bGK
-rjj
+xHA
 xMx
 bJD
 lCe
-oHd
+mno
 bMI
 bOg
 bZe
@@ -80637,7 +80696,7 @@ bZe
 cbj
 bMH
 cdY
-qHe
+cvg
 cgE
 cgM
 lAL
@@ -80656,7 +80715,7 @@ bbD
 bby
 bby
 bby
-qgj
+cku
 cAB
 xKi
 cEa
@@ -80870,30 +80929,30 @@ vSn
 aIL
 aZQ
 bzC
-moH
+wDj
 bCH
-voV
+pvf
 bFw
 bGI
-rjj
+xHA
 xMx
 bJD
 lCe
-oHd
+mno
 bMI
 bOh
 bZe
 bXL
 bZe
-jgc
+bSZ
 bUT
 bWs
-hju
-hju
-hju
+goE
+goE
+goE
 cbk
 bMH
-gpM
+jjK
 cgM
 cgD
 cgM
@@ -81127,18 +81186,18 @@ vSn
 bhm
 aZQ
 bzD
-moH
+wDj
 bCI
-voV
+pvf
 bFx
 byb
-bYj
+etA
 xMx
 bJD
 lCe
 djH
 bMH
-jgc
+bSZ
 bZe
 bZe
 bZe
@@ -81166,7 +81225,7 @@ czk
 clQ
 cvz
 cwY
-krx
+eXQ
 dZL
 czP
 bby
@@ -81367,7 +81426,7 @@ lWL
 lWL
 aZQ
 aZQ
-ksZ
+uwA
 aIL
 tZz
 aZQ
@@ -81393,11 +81452,11 @@ aJj
 dlo
 bJD
 lCe
-oHd
+mno
 eks
-jgc
+bSZ
 bZe
-laH
+wKh
 bZe
 bTu
 bMI
@@ -81423,14 +81482,14 @@ czk
 cFE
 cvz
 cyT
-ruZ
-eXQ
+dED
+lxr
 czQ
 pON
-qgj
+cku
 cAB
 xKi
-fRp
+num
 cEJ
 cvy
 lWL
@@ -81641,28 +81700,28 @@ vSn
 aIL
 aZQ
 bzF
-pKx
+bCL
 bCK
-jGw
+xrX
 bFz
 byb
-rjj
+xHA
 xMx
 bJD
 jXm
-oHd
+mno
 eks
-jgc
-jgc
-jgc
-jgc
+bSZ
+bSZ
+bSZ
+bSZ
 bTv
 bMH
 bWu
 eQI
 bZl
 cac
-nqM
+jJr
 ccE
 bUV
 cfh
@@ -81671,7 +81730,7 @@ cgM
 lAL
 cgJ
 csw
-nVv
+aTN
 wLl
 csw
 cmQ
@@ -81682,9 +81741,9 @@ cvv
 bWi
 qBy
 cyY
-hmG
+vFP
 pON
-qgj
+cku
 cAB
 lHb
 myP
@@ -81898,18 +81957,18 @@ vSn
 pac
 aZQ
 bzG
-bCL
+sSI
 bCH
 eJc
 bBk
 bGI
-rjj
+xHA
 xMx
 bJD
 lCe
-wba
+iwS
 bMH
-evl
+wyc
 bPA
 oSj
 bPA
@@ -81938,10 +81997,10 @@ bZW
 cvz
 cxb
 csy
-bQc
 ubB
+kst
 cAJ
-qgj
+cku
 cAB
 xKi
 myP
@@ -82155,16 +82214,16 @@ vSn
 wtj
 lZG
 bwC
-vKU
+kOl
 cbF
-ugC
 krX
+dYi
 qMe
-rqu
+kSj
 fdQ
 fdQ
 bKy
-aTu
+wuL
 hZP
 bqm
 bqm
@@ -82198,7 +82257,7 @@ fdB
 fIj
 ilB
 pON
-qgj
+cku
 cAB
 xKi
 myP
@@ -82414,23 +82473,23 @@ aZQ
 bzI
 tHI
 bCN
-qfE
+hIZ
 bFC
 bGL
-kle
+ohq
 aeW
 bHG
 bKx
 bJD
-tdf
-vqE
-vqE
-vqE
-vqE
-pkC
+bHL
+jrg
+jrg
+jrg
+jrg
+qlf
 paS
 bWx
-kBO
+tdZ
 bZi
 sAV
 cac
@@ -82448,14 +82507,14 @@ oLC
 oLC
 oLC
 czk
-sVA
+iii
 cvz
 cxd
-cJn
-eXQ
+dBk
+lxr
 czS
 pON
-qgj
+cku
 cAB
 xKi
 myP
@@ -82674,17 +82733,17 @@ byb
 byb
 byb
 byb
-rjj
+xHA
 xMx
 bJD
 lCe
 bJD
-tdf
-vqE
-kKS
-iMU
-vqE
-mXU
+bHL
+jrg
+sMM
+hgf
+jrg
+rIg
 bUW
 cac
 gdv
@@ -82709,7 +82768,7 @@ dkW
 cvz
 bby
 cya
-eXQ
+lxr
 czT
 bby
 cBC
@@ -82931,20 +82990,20 @@ bCb
 bEc
 bFD
 bGo
-lkW
+nqN
 kqh
 bJE
 bKz
-oas
+hrq
 bML
-yeR
-yeR
-yeR
-jZz
+oVy
+oVy
+oVy
+wbY
 boO
 bUX
 cac
-nqM
+jJr
 bZl
 cag
 nPb
@@ -82966,14 +83025,14 @@ ctZ
 cvz
 cxf
 cyb
-eXQ
+lxr
 czU
 pON
-eCQ
+eCp
 cAB
 xKi
 myP
-tjz
+iyw
 cvy
 lWL
 aCI
@@ -83188,16 +83247,16 @@ bBY
 bDF
 bJD
 bGp
-lkW
+nqN
 fhR
 bJF
 bKs
-nol
+cSi
 bMM
 qjl
-syA
-syA
-uIi
+sMM
+sMM
+sMM
 bTy
 kZo
 cac
@@ -83217,20 +83276,20 @@ cmW
 cky
 cgJ
 cqF
-obq
+tMI
 czk
 bZW
 cvz
 cxg
-wsf
+flI
 pfz
 czT
 pON
-gZg
-cku
+faS
+mDF
 cDq
 ccx
-xhb
+gTv
 cvy
 aCI
 aCI
@@ -83377,13 +83436,13 @@ lWL
 qoT
 lWL
 lWL
-eEb
+qAo
 lWL
 lWL
 lWL
 lWL
 lWL
-eEb
+qAo
 lWL
 vnK
 lWL
@@ -83445,17 +83504,17 @@ bBY
 bDG
 erz
 gdS
-rjj
+xHA
 fhR
 bJG
 bKs
-nol
-vzb
-bOj
-bOk
-nLG
-qYg
-ooJ
+cSi
+nGA
+cXV
+eOQ
+vKw
+iFO
+hzD
 bUV
 bWz
 bUV
@@ -83702,19 +83761,19 @@ bBY
 vRv
 bJD
 bGr
-dMW
+sti
 fhR
 bJH
 bKs
-jYo
-vzb
+dhU
+nGA
 bOk
 bOi
 bQW
-sMp
-tOx
+wrn
+nMm
 bUY
-wgq
+vNv
 bXR
 cep
 cai
@@ -83722,8 +83781,8 @@ cbr
 oCu
 cdZ
 cfo
-tCr
-lxj
+cRs
+ntu
 lAL
 cGl
 clF
@@ -83737,9 +83796,9 @@ cuc
 cvA
 cFE
 cvz
-fxt
+kjc
 czW
-tof
+daN
 cBG
 mIl
 cDr
@@ -83890,7 +83949,7 @@ lWL
 lWL
 api
 lWL
-bEA
+qKB
 pYa
 lWL
 lWL
@@ -83959,19 +84018,19 @@ siq
 bEd
 bEW
 gfV
-dMW
+sti
 wJI
 kpO
 lCe
-nol
+cSi
 bMO
 bOk
 bPC
 bOk
 bSf
-nMm
+bLw
 eqN
-qpc
+wxk
 bXS
 cep
 caj
@@ -84216,19 +84275,19 @@ pAU
 pAU
 pAU
 pAU
-rjj
+xHA
 xMx
 bJD
 lCe
-wWF
-vzb
+vNo
+nGA
 bOl
 bOi
 bQX
-qYg
+tdH
 bTA
 dqV
-wgq
+vNv
 bXT
 cep
 cak
@@ -84236,8 +84295,8 @@ cbt
 aeH
 ceb
 cfp
-tCr
-lxj
+cRs
+ntu
 lAL
 jaX
 clF
@@ -84252,7 +84311,7 @@ cvC
 cFE
 cvz
 dgf
-bLw
+hff
 rCr
 cBI
 tdF
@@ -84387,7 +84446,7 @@ lWL
 aCI
 aCI
 lWL
-bEA
+qKB
 pYa
 abT
 oVB
@@ -84411,7 +84470,7 @@ lWL
 lWL
 lWL
 lWL
-sHy
+uoM
 lWL
 lWL
 lWL
@@ -84473,19 +84532,19 @@ bCO
 bCO
 bFF
 pAU
-rjj
+xHA
 xMx
 bJD
 lCe
-mBd
-vzb
+lGG
+nGA
 bOj
 bOk
-rtl
+eXz
 oeb
 bTA
 bVa
-wgq
+vNv
 bXU
 cep
 cal
@@ -84511,7 +84570,7 @@ cvz
 tch
 czX
 cAN
-kVE
+ndG
 tdF
 cDu
 cyd
@@ -84709,7 +84768,7 @@ lWL
 aCI
 lWL
 lWL
-bEA
+qKB
 pYa
 pYa
 lWL
@@ -84720,7 +84779,7 @@ lWL
 bqr
 bru
 bsz
-uKR
+iMu
 bvj
 bwE
 bvj
@@ -84730,12 +84789,12 @@ bCP
 bEe
 bFG
 pAU
-nlW
+urd
 xMx
 bJD
 lCe
-nol
-vzb
+cSi
+nGA
 bOk
 bOi
 bQW
@@ -84751,14 +84810,14 @@ aeH
 ced
 cfr
 cgK
-hWG
-tVB
-pPs
+rRA
+dwS
+pPA
 clF
 cna
 cos
 cos
-hHb
+qod
 crE
 czk
 sDI
@@ -84766,7 +84825,7 @@ seW
 cxi
 cvz
 tch
-bLw
+hff
 rCr
 ngx
 cCO
@@ -84991,15 +85050,15 @@ jpU
 xMx
 bJD
 lCe
-nol
+cSi
 bMO
 bOk
 bPC
 bOk
-kHr
+uVS
 pbE
 cAL
-wgq
+vNv
 bXW
 cep
 cep
@@ -85010,12 +85069,12 @@ csw
 csw
 csw
 cjf
-pPs
+pPA
 clF
 cnb
 cot
 crE
-uEk
+pLJ
 crF
 czk
 sDI
@@ -85025,7 +85084,7 @@ cvz
 tch
 czX
 cAN
-kVE
+ndG
 czi
 cyd
 aCI
@@ -85244,45 +85303,45 @@ try
 lgJ
 qeX
 pAU
-opp
+tBm
 xMx
 bJD
 lCe
-nol
-vzb
+cSi
+nGA
 bOk
 bOi
 bQX
-sMp
-caz
+wrn
+lDt
 bUZ
 nhn
 eqo
 bZn
 dAE
-qts
-can
+iph
+uBy
 csw
 cfs
 cgL
 csw
-iNl
-iMB
+jwI
+inC
 clH
 cnc
 cou
+odb
+odb
 cqL
-cqL
-cSA
 czk
 sDI
 uHh
 cFE
 cvz
 tch
-bLw
+hff
 rCr
-kVE
+ndG
 cCP
 cyd
 lWL
@@ -85416,9 +85475,9 @@ pYa
 pYa
 pYa
 vZE
-tdv
+bQo
 apx
-usY
+vOF
 adQ
 pYa
 pYa
@@ -85506,12 +85565,12 @@ xMx
 bJD
 lCe
 bGN
-vzb
+nGA
 bOj
 bOk
 bOi
 bSi
-caz
+lDt
 bUZ
 txN
 bXY
@@ -85523,7 +85582,7 @@ csw
 cft
 con
 chZ
-iNl
+jwI
 gHx
 clF
 cnd
@@ -85539,7 +85598,7 @@ cvz
 tch
 czX
 cAN
-kVE
+ndG
 cyd
 cyd
 lWL
@@ -85667,15 +85726,15 @@ lWL
 aCI
 aCI
 lWL
-bEA
+qKB
 pYa
 pYa
 pYa
 pYa
 vZE
-doW
+wWK
 yjd
-vZW
+kPj
 adQ
 pYa
 pYa
@@ -85758,19 +85817,19 @@ bCR
 enV
 mUJ
 pAU
-rjj
+xHA
 xMx
 bJD
 lCe
-nol
-vzb
+cSi
+nGA
 bOl
-rtl
+eXz
 bQW
-keE
+sMp
+xKR
+vFh
 oPF
-bdR
-imP
 bXZ
 bMN
 cap
@@ -85780,8 +85839,8 @@ csw
 lny
 cgN
 csw
-iNl
-pPs
+jwI
+pPA
 clF
 cne
 clF
@@ -85793,10 +85852,10 @@ cug
 bZW
 cug
 cvz
-kBy
+pPt
 czZ
-eEA
-gRO
+oaV
+jRQ
 cyd
 lWL
 lWL
@@ -85930,9 +85989,9 @@ pYa
 pYa
 pYa
 adQ
-dXb
+rey
 aeZ
-unY
+pSy
 adQ
 ajB
 ajB
@@ -85976,7 +86035,7 @@ fEG
 aRj
 aRj
 ayn
-isq
+pRp
 ayn
 ayn
 aRj
@@ -86004,7 +86063,7 @@ adj
 adj
 aZQ
 brx
-uKR
+iMu
 bud
 bsA
 bwI
@@ -86015,18 +86074,18 @@ bsA
 gBg
 fbm
 bBn
-rjj
+xHA
 xMx
 bJD
 lCe
-nol
+cSi
 bMO
 bOk
 bPC
 bOk
-mHV
+bxh
 bOi
-mHV
+bxh
 bTC
 bbs
 bMN
@@ -86037,8 +86096,8 @@ csw
 lDn
 mhI
 csw
-iNl
-pPs
+jwI
+pPA
 clF
 clF
 clF
@@ -86232,9 +86291,9 @@ aKm
 fEG
 aRj
 aRj
-bHM
-agO
-org
+fIs
+qQQ
+aMq
 aPI
 aQu
 aRe
@@ -86270,15 +86329,15 @@ aVK
 aVK
 aVK
 qFe
-imJ
+lRr
 bGO
-jAD
+cTs
 vKb
 bNI
 adr
-wWF
-vzb
-dPN
+vNo
+nGA
+bOk
 bPD
 bQX
 bSj
@@ -86445,8 +86504,8 @@ lWL
 lWL
 lWL
 adQ
-vsl
-naE
+lbB
+koa
 agl
 jOh
 apx
@@ -86468,7 +86527,7 @@ lWL
 lWL
 lWL
 ajB
-bDr
+rlI
 awL
 ayo
 lWL
@@ -86492,9 +86551,9 @@ aRj
 jHW
 ayn
 aPb
-oey
-aQt
 ane
+aQt
+mSl
 axF
 aTD
 aVS
@@ -86514,11 +86573,11 @@ biS
 dRs
 aCI
 buf
-gwR
+wqU
 adj
 aZQ
 brz
-nKS
+wIu
 bsA
 bsA
 bwH
@@ -86527,9 +86586,9 @@ bzK
 bBo
 bBo
 bBo
-clV
+acq
 bGP
-kle
+ohq
 nCD
 bHG
 bKx
@@ -86551,7 +86610,7 @@ csw
 cmP
 cgO
 csw
-iNl
+jwI
 jWC
 cgJ
 oLC
@@ -86702,12 +86761,12 @@ lWL
 lWL
 adT
 aew
-ciN
+bNi
 yjd
 olW
 cfu
 cfu
-bVt
+vVh
 jId
 pYa
 pYa
@@ -86725,8 +86784,8 @@ atG
 lWL
 lWL
 ajB
-ciN
-aYN
+bNi
+cRn
 ayo
 ayo
 ayo
@@ -86746,9 +86805,9 @@ rVS
 lWL
 aRj
 aRj
-org
-agO
-bHM
+aMq
+qQQ
+fIs
 tyO
 aQu
 aRf
@@ -86757,7 +86816,7 @@ aTE
 aVS
 jbU
 bdr
-uNE
+oyM
 bdr
 aYC
 bhN
@@ -86786,11 +86845,11 @@ bCS
 bEg
 bFI
 bBn
-rjj
+xHA
 xMx
 bJD
 lCe
-nnB
+bDr
 bMP
 bOm
 bPE
@@ -86800,7 +86859,7 @@ bTG
 bVf
 bWD
 bYa
-kKb
+bZt
 bMP
 cbB
 kEo
@@ -86960,11 +87019,11 @@ lWL
 lWL
 adQ
 afb
-oJj
-iuz
-ciN
+eUQ
+cVj
+bNi
 cfu
-bVt
+vVh
 fCf
 ajB
 ajB
@@ -86982,8 +87041,8 @@ atH
 ajB
 lWL
 ajB
-ciN
-bVt
+bNi
+vVh
 ayo
 ayY
 ayY
@@ -87004,11 +87063,11 @@ lWL
 aRj
 aRj
 ayn
-thy
-ngT
+gSd
+aAd
 ayn
 aQu
-kpK
+agO
 bVq
 aTF
 aVS
@@ -87053,11 +87112,11 @@ bOn
 bRc
 bLB
 cee
-aGy
+uDx
 oxs
 bWE
-uKm
-awd
+skC
+cAn
 bTI
 cbC
 cdb
@@ -87065,7 +87124,7 @@ csw
 cfv
 gQH
 csw
-pOS
+lOx
 iXM
 lAL
 cnh
@@ -87219,19 +87278,19 @@ acD
 acD
 acD
 acD
-wdk
+hoc
 cfu
-bVt
-vlx
-anP
+vVh
+jJH
+ffw
 puZ
 ivL
-vlx
-uWO
-eVa
-dHh
+jJH
+rLE
+anP
+roK
 xTf
-uWO
+rLE
 abT
 abT
 ajB
@@ -87239,8 +87298,8 @@ atI
 ajB
 abT
 abT
-ciN
-bVt
+bNi
+vVh
 ayo
 ayo
 wHk
@@ -87265,7 +87324,7 @@ aRj
 aRj
 aRj
 aRj
-kpK
+agO
 aSv
 aTG
 aVS
@@ -87294,7 +87353,7 @@ byh
 bvm
 bwI
 aVK
-nKS
+wIu
 bBr
 bsA
 bsA
@@ -87307,7 +87366,7 @@ tlb
 bLD
 bMP
 bOo
-sPO
+bRA
 bRa
 bMP
 bTI
@@ -87469,14 +87528,14 @@ lWL
 aCI
 acp
 acD
-vaN
 afd
-kLt
+uWM
+jxT
 aex
 afc
 afL
 wzV
-mrb
+kxc
 cfu
 apx
 apx
@@ -87496,8 +87555,8 @@ atJ
 ajB
 aeY
 abT
-ciN
-bVt
+bNi
+vVh
 abT
 ayo
 ayY
@@ -87523,7 +87582,7 @@ aRj
 aRj
 aRj
 aRi
-fHu
+hEg
 aTH
 aVS
 aVV
@@ -87543,7 +87602,7 @@ dRs
 aCI
 buf
 aIL
-cZk
+aBZ
 aZQ
 hdY
 bsA
@@ -87576,8 +87635,8 @@ cas
 cbD
 aLd
 cOu
-aXD
-aXD
+rNi
+rNi
 bMP
 cji
 iXM
@@ -87587,7 +87646,7 @@ coy
 con
 mhI
 czk
-buS
+bme
 sDI
 fRa
 sDI
@@ -87724,16 +87783,16 @@ lWL
 lWL
 lWL
 aCI
-uiF
+jAr
 acD
 acU
 ads
-afd
+uWM
 uHX
 aez
 mfp
 agn
-mrb
+kxc
 gjY
 gjY
 oFB
@@ -87745,16 +87804,16 @@ shq
 gjY
 gjY
 gjY
-bMa
+aRI
 aqO
-bMa
-bMa
-bMa
-bMa
-bMa
-bMa
+aRI
+aRI
+aRI
+aRI
+aRI
+aRI
 gjY
-bMa
+aRI
 abT
 ayo
 ayo
@@ -87784,7 +87843,7 @@ aSx
 aRj
 aVS
 aVW
-hep
+gcL
 ayu
 aYC
 aYC
@@ -87821,7 +87880,7 @@ skL
 bLD
 bMP
 bOq
-sPO
+bRA
 bLB
 bSl
 bTJ
@@ -87829,12 +87888,12 @@ bVi
 oLS
 bYc
 bFE
-izD
+mJx
 cbE
 svt
 cef
 cfw
-hDO
+cqn
 bMP
 cjj
 ckL
@@ -87983,14 +88042,14 @@ lWL
 aCI
 acp
 acD
-kLt
+jxT
+uWM
 afd
-vaN
 kGP
 acT
-dWk
+vkP
 fKB
-wLC
+bVJ
 gjY
 apx
 bDn
@@ -88037,8 +88096,8 @@ lWL
 lWL
 aRj
 aRk
-oNK
-aRI
+fHu
+vWC
 aVS
 aVX
 uOM
@@ -88071,15 +88130,15 @@ bCU
 rFV
 aoW
 yfr
-rjj
+xHA
 xMx
 bJK
 adr
-uZT
+jWH
 bMP
 bOr
 bRc
-gzX
+jlL
 bMP
 bTJ
 bTJ
@@ -88088,14 +88147,14 @@ bYc
 bFE
 cat
 cbE
-hXy
+lSL
 cef
 cfx
-aXD
+rNi
 bMP
 cjk
 iXM
-kYQ
+xHD
 csw
 csw
 csw
@@ -88256,19 +88315,19 @@ apx
 alD
 amv
 cpf
-iuz
-ciN
+cVj
+bNi
 wkS
-ciN
-avT
-tVj
-oJj
-vfY
-ktI
-mUp
-vSq
+bNi
+gWZ
+tII
+eUQ
+rjz
+gRk
+lTM
+bsV
 lAa
-bMa
+aRI
 ayp
 cHn
 azC
@@ -88294,8 +88353,8 @@ aCI
 aCI
 aRj
 aRl
-ect
-nGK
+rBb
+jRm
 aVS
 aYC
 aZL
@@ -88328,14 +88387,14 @@ iXa
 lzC
 bEi
 iNb
-nui
+gbt
 vKb
 bNI
 vmc
-nnB
+bDr
 bMP
 bOs
-nJE
+rGk
 bRe
 bMP
 bTK
@@ -88503,14 +88562,14 @@ adZ
 aey
 afe
 acD
-eMJ
+rOs
 apx
 gjY
 apx
 aiV
 apx
 apx
-kfX
+lLB
 amx
 amx
 amx
@@ -88523,9 +88582,9 @@ adQ
 atL
 adQ
 adQ
-vSq
+bsV
 apx
-bMa
+aRI
 abT
 abT
 abT
@@ -88585,7 +88644,7 @@ eTk
 bEj
 aPq
 yfr
-rjj
+xHA
 xMx
 bJD
 lCe
@@ -88593,7 +88652,7 @@ ncA
 bMP
 bOt
 bPI
-dPO
+dcm
 bMP
 bTJ
 bTJ
@@ -88602,14 +88661,14 @@ bYc
 bFE
 kzH
 cbE
-hXy
+lSL
 cef
 cfz
-hDO
+cqn
 bMP
 cgJ
 iXM
-kYQ
+xHD
 cnk
 cgM
 cgM
@@ -88755,12 +88814,12 @@ lWL
 acp
 acD
 acY
-lWw
-sjM
+orO
+lBf
 uME
 aUk
 acD
-ciN
+bNi
 apx
 gjY
 apx
@@ -88780,50 +88839,50 @@ uZn
 tbk
 hVl
 adQ
-vSq
+bsV
 apx
-bMa
+aRI
 ayq
 azb
 azD
 aAq
 cli
-bVt
-mDr
-fLg
-mDr
-aNL
+vVh
+uAa
+cUG
+uAa
+vDV
 bwM
-cPR
-bVt
-dHf
-bVt
-hld
-aLr
-gFI
-bVt
-uXV
-tpX
 bYf
-bVt
-aNL
-mDr
-xVr
-mDr
+vVh
 dHf
-bVt
-bVt
-gAV
+vVh
+bwP
+aLr
+nZw
+vVh
+ebD
+xsN
+vfg
+vVh
+vDV
+uAa
+ncd
+uAa
+dHf
+vVh
+vVh
+xQW
 aZQ
 baV
 aIL
 aIL
 aIL
-gwR
+wqU
 aIL
-biY
+leb
 exz
-uQs
+biY
 aIL
 aIL
 aIL
@@ -88842,11 +88901,11 @@ aZQ
 aZQ
 aZQ
 aZQ
-rjj
+xHA
 xMx
 bJD
 lCe
-nnB
+bDr
 bMP
 bOu
 bRc
@@ -88862,11 +88921,11 @@ cbE
 svt
 cef
 cfA
-aXD
+rNi
 bMP
 aVg
 iXM
-kYQ
+xHD
 cnk
 cgM
 cgM
@@ -89014,15 +89073,15 @@ acD
 acZ
 adw
 cjG
-tEG
+qVY
 bYl
 afN
-nFV
+bpb
 gjY
 oFB
 apx
-oJj
-iuz
+eUQ
+cVj
 akH
 alG
 amx
@@ -89037,7 +89096,7 @@ apx
 atM
 atM
 adQ
-vSq
+bsV
 apx
 gjY
 akG
@@ -89070,7 +89129,7 @@ gjY
 gjY
 gjY
 gjY
-gAV
+xQW
 bya
 bdl
 bdl
@@ -89099,14 +89158,14 @@ aIL
 aIL
 aIL
 lga
-rjj
+xHA
 xMx
 bJU
 lCe
-nnB
+bDr
 bMP
 bOv
-sPO
+bRA
 bRf
 bMP
 bTJ
@@ -89119,11 +89178,11 @@ ekQ
 aLd
 cOu
 cfB
-aXD
+rNi
 bMP
 nUz
 iXM
-kYQ
+xHD
 cnk
 cgM
 cgM
@@ -89274,10 +89333,10 @@ aec
 aeB
 qfq
 acD
-ciN
+bNi
 vZV
-bKP
-vMn
+bAC
+lyI
 aiY
 aiY
 aiY
@@ -89327,7 +89386,7 @@ bug
 bug
 brJ
 gjY
-szo
+aYN
 aZQ
 baX
 aIL
@@ -89338,7 +89397,7 @@ aIL
 bkl
 exz
 bkl
-gwR
+wqU
 aIL
 aIL
 bpl
@@ -89356,14 +89415,14 @@ baV
 bmh
 bok
 aZQ
-kTR
+cTC
 hGr
 bJB
 egK
-pZJ
+xwT
 bMP
 bOw
-sPO
+bRA
 bRg
 bMP
 drS
@@ -89551,7 +89610,7 @@ abT
 abT
 abT
 adQ
-vly
+qbm
 cfu
 gjY
 cfu
@@ -89584,7 +89643,7 @@ apx
 apx
 kit
 gjY
-czJ
+vZW
 abT
 abT
 abT
@@ -89613,21 +89672,21 @@ aZQ
 aZQ
 aZQ
 aZQ
-sDv
+xhW
 lSc
 abT
 ahZ
-jMU
+kFy
 bMP
 bOx
 gJI
 bTM
 eXV
-fws
+waG
 ohc
 bWF
-fws
-fws
+waG
+waG
 bTL
 uQA
 iAx
@@ -89783,7 +89842,7 @@ lWL
 aFr
 aeG
 adb
-rrh
+cGX
 agv
 aik
 afh
@@ -89806,75 +89865,75 @@ bUA
 arU
 asS
 atN
-awV
+lHM
 asO
-vly
+qbm
 cfu
 akG
-vSq
+bsV
 mxO
-vSq
+bsV
 uWA
-vSq
-gmm
-rkP
-vSq
-vSq
-vSq
-vSq
-vSq
-vSq
-arQ
-vSq
-vSq
-vly
-rkP
-vSq
-vSq
-vSq
-vSq
-vSq
-vSq
-vSq
-rkP
-vSq
-vSq
+bsV
+sxG
+rwd
+bsV
+bsV
+bsV
+bsV
+bsV
+bsV
+fyk
+bsV
+bsV
+qbm
+rwd
+bsV
+bsV
+bsV
+bsV
+bsV
+bsV
+bsV
+rwd
+bsV
+bsV
 aWh
 gjY
-aMq
-cOi
-aMq
+fem
+iMm
+fem
 crA
 bdv
 bey
-aMq
-aMq
-jEF
-usT
-piN
-aMq
+fem
+fem
+gnj
+uSP
+fpk
+fem
 hlq
-bVt
-uXV
-jAi
-cyO
+vVh
+ebD
+aNL
+nKJ
 dam
-cPR
-bVt
+bYf
+vVh
 bvp
 bwM
 byj
-bVt
-aNL
-bVt
-bVt
+vVh
+vDV
+vVh
+vVh
 tam
-pUU
+mwR
 apx
 cfu
 bnt
 jmx
-xJl
+sCA
 jKq
 bOy
 bPK
@@ -89884,19 +89943,19 @@ bTN
 bVl
 bWG
 bYe
-bZt
+mBR
 bMP
 cbI
 cdc
 ceh
-jyt
+vuf
 isn
 coC
 qJk
 eKd
 wxE
 cnn
-ftR
+eJF
 cpD
 czk
 crJ
@@ -90040,7 +90099,7 @@ lWL
 aFr
 aeG
 agv
-xNL
+vge
 agv
 aik
 agv
@@ -90060,10 +90119,10 @@ aoL
 bUA
 bUA
 bUA
-awV
-awV
-awV
-awV
+lHM
+lHM
+lHM
+lHM
 asO
 awk
 eRh
@@ -90075,9 +90134,9 @@ aCm
 aCm
 aBG
 aCm
-lYK
-lYK
-lYK
+tFV
+tFV
+tFV
 adQ
 azu
 azu
@@ -90095,7 +90154,7 @@ aNy
 aNy
 aNy
 aNy
-vSq
+bsV
 gSF
 gjY
 gjY
@@ -90131,7 +90190,7 @@ gjY
 gjY
 xDK
 bKC
-tmM
+gnR
 bMR
 bMP
 bPL
@@ -90313,11 +90372,11 @@ amq
 amy
 bJw
 anX
-abx
+oVG
 cKb
 aDc
-tWk
-awV
+wmR
+lHM
 asU
 atO
 auC
@@ -90327,9 +90386,9 @@ cfu
 axM
 aCm
 azd
-pNI
+pzi
 aAr
-vfZ
+fpt
 aBH
 aCm
 atd
@@ -90352,7 +90411,7 @@ aOs
 aOs
 aRo
 aNy
-vSq
+bsV
 jcU
 bug
 bug
@@ -90388,22 +90447,22 @@ bug
 hnO
 hnO
 bYi
-mCv
-mCv
+ssg
+ssg
 bOz
-mCv
-mCv
-mCv
-mcV
-mCv
-mCv
+ssg
+ssg
+ssg
+uHe
+ssg
+ssg
 vSw
-mCv
+ssg
 caw
-kvW
-vPs
-vPs
-vPs
+tsz
+qsb
+qsb
+qsb
 hgQ
 rOi
 cjp
@@ -90557,7 +90616,7 @@ asm
 asm
 asm
 asm
-adD
+ail
 afO
 aEG
 nSv
@@ -90571,7 +90630,7 @@ ajO
 nYi
 xGr
 bDg
-ujA
+aRp
 aDc
 aqS
 arV
@@ -90579,14 +90638,14 @@ pHv
 arV
 auD
 asO
-vSq
+bsV
 cfu
 axH
 aCm
 aze
-qHB
+hmT
 aAs
-kEj
+lSQ
 aBI
 bqa
 aCY
@@ -90595,12 +90654,12 @@ aEz
 hqK
 aGs
 aHb
-tlO
 aHc
-aHc
-aHc
-aHc
-aHc
+tJc
+tJc
+tJc
+tJc
+tJc
 aNC
 aOq
 aPf
@@ -90608,8 +90667,8 @@ aPN
 aPf
 iog
 iog
-bAC
-gXi
+jlr
+roC
 cfd
 apx
 apx
@@ -90664,8 +90723,8 @@ nUO
 cgS
 skt
 cjq
-fOD
-mWc
+hAc
+wEr
 cnq
 wjH
 cpG
@@ -90819,7 +90878,7 @@ aEG
 agv
 agU
 ahz
-adD
+ail
 aiY
 ajN
 akN
@@ -90828,22 +90887,22 @@ ajO
 hWd
 aQF
 xxh
-ujA
+aRp
 aDc
 aqT
-kfq
-kfq
-kfq
+awV
+awV
+awV
 auE
 avu
-vSq
+bsV
 cfu
 bnq
 aCm
 azf
+qEY
+rri
 aBl
-wHL
-ocF
 blF
 bqa
 asP
@@ -90856,73 +90915,73 @@ moZ
 xeL
 mvk
 lTU
-xcp
-xcp
+rpj
+rpj
 ewn
 iog
 mEi
 sAv
 iog
 iog
-mTI
+mUn
 aNy
-elh
+cJA
 cfd
 apx
-sfL
-fgT
-sfL
-sfL
-sfL
+ydt
+aLi
+ydt
+ydt
+ydt
 auw
-sfL
-sfL
-eCL
-sfL
-pig
-sfL
-ncE
-sfL
-sfL
-sfL
+ydt
+ydt
+arQ
+ydt
+fpS
+ydt
+sDf
+ydt
+ydt
+ydt
 auw
-pig
+fpS
 bBx
 dcJ
 ani
-bwP
+dqX
 bym
-fgT
-sfL
-sfL
-iUX
+aLi
+ydt
+ydt
+qLg
 apx
 bGT
-ciN
-ciN
-ciN
+bNi
+bNi
+bNi
 bKE
-ciN
+bNi
 cfu
 kpJ
-ciN
-ciN
-oJj
-tVj
+bNi
+bNi
+eUQ
+tII
 vZV
-ciN
-ciN
-ciN
+bNi
+bNi
+bNi
 kHJ
-eXf
+wUu
 iaj
 coC
 cfH
 qJk
 sEf
 cjq
-mWc
-fOD
+wEr
+hAc
 cnq
 wjH
 cpH
@@ -91085,7 +91144,7 @@ ajO
 hqK
 oLs
 xxh
-ujA
+aRp
 aDc
 aqU
 arX
@@ -91094,7 +91153,7 @@ apE
 auF
 avv
 bTT
-gXi
+roC
 aer
 aCm
 azg
@@ -91109,11 +91168,11 @@ aEB
 hqK
 aGu
 lYn
-oBv
+ycF
 voD
 voD
 voD
-xcp
+rpj
 agN
 aNC
 aHT
@@ -91123,7 +91182,7 @@ aPO
 aPg
 aos
 aSE
-phj
+bLY
 cfd
 aXx
 abT
@@ -91159,7 +91218,7 @@ bIe
 bIe
 bIe
 bGU
-tKJ
+htD
 lPC
 bGU
 bOD
@@ -91171,7 +91230,7 @@ bOD
 bOD
 bOD
 bOD
-eXf
+wUu
 iaj
 coC
 coC
@@ -91336,16 +91395,16 @@ aLI
 aoU
 aoU
 ajP
-aUZ
+jcM
 akS
 amz
 aMe
-xCJ
+liW
 xxh
 aEF
 aDc
 aqV
-vlo
+hLz
 eUD
 fKX
 auG
@@ -91354,33 +91413,33 @@ atd
 atw
 atd
 bqa
-duK
-nsW
+fcu
+nrS
 azI
 aBj
 aBL
 bqa
 aDb
-qbN
+kzM
 aEC
 hqK
 aGv
 lYn
-tlO
-aIZ
 aHc
+aIZ
+tJc
 keV
 aMk
 aMO
 aNC
 aOt
-vSB
+uZz
 krU
 rTc
 krU
 aos
 aSE
-phj
+bLY
 cfd
 aXx
 aYQ
@@ -91397,8 +91456,8 @@ brL
 apx
 anO
 bnt
-vnw
-pNn
+kPI
+vpk
 bqz
 brE
 bsE
@@ -91409,14 +91468,14 @@ bvt
 bvt
 bBt
 bqz
-tJR
-tOA
+jvg
+rjj
 bGU
 bIf
 bJg
 bIf
 bGU
-aTL
+gGn
 akA
 bGU
 bPN
@@ -91584,26 +91643,26 @@ aik
 agv
 agv
 agv
-xNL
+vge
 agv
 aEG
 agv
 acE
 alP
-aUZ
-aUZ
-aUZ
+jcM
+jcM
+jcM
 rZl
 nEK
 vEU
 nbc
 bvr
 xxh
-bES
+vLN
 aDc
 aqW
-vlo
-kfq
+hLz
+awV
 fKX
 auH
 asO
@@ -91625,19 +91684,19 @@ aGw
 lYn
 aMl
 aIZ
-aHc
+tJc
 uqO
 aiK
 aMP
 aNC
 aOs
-pgm
+rCX
 aPi
 bho
 aPi
 aos
 aSE
-phj
+bLY
 cfd
 aXx
 aYQ
@@ -91647,33 +91706,33 @@ bcs
 bdz
 aYQ
 bdt
-bRA
-nBj
-nBj
-mMb
+bYE
+gvG
+gvG
+oDC
 bll
-mDX
-mDX
-bRA
+vWK
+vWK
+bYE
 bpo
 bqz
 brF
-uNZ
-bsI
-bsI
-bsI
-bsI
-vXQ
+kMr
+wcN
+wcN
+wcN
+wcN
+kXa
 bBu
 bqz
-tJR
-tOA
+jvg
+rjj
 bGU
 bGU
 bGU
 bGU
 bGU
-aTL
+gGn
 akA
 bGU
 bPT
@@ -91687,16 +91746,16 @@ bPT
 bOD
 qZf
 coC
-eXf
+wUu
 cfI
 cgU
 cgU
-eXf
+wUu
 cgU
 cgU
-eXf
+wUu
 cgU
-rML
+dlZ
 czk
 crQ
 efJ
@@ -91847,26 +91906,26 @@ aEG
 agv
 acE
 alP
-aUZ
-aUZ
-aUZ
+jcM
+jcM
+jcM
 akQ
 aBA
 lFy
 ajc
-bEH
+vKq
 xxh
-ujA
+aRp
 aDc
 aqX
 atV
-ste
+dYr
 eHq
 auI
 asO
-avw
+sRr
 xxh
-rXp
+ano
 aCm
 azj
 azK
@@ -91874,9 +91933,9 @@ aAx
 nLR
 aBN
 bqa
-ano
-abx
-tNk
+cKT
+oVG
+bEA
 aFu
 aGx
 lYn
@@ -91915,22 +91974,22 @@ bjd
 bpp
 bqz
 brG
-oIx
 bsI
-bsI
-bsI
-bsI
-bsI
+wcN
+wcN
+wcN
+wcN
+wcN
 bBt
 bqz
-tJR
-tOA
+jvg
+rjj
 bKF
 bIg
 gyL
 bKa
 bKF
-aTL
+gGn
 qCT
 bGU
 bPT
@@ -91942,8 +92001,8 @@ bPT
 bPT
 bPT
 bOD
-eXf
-ftR
+wUu
+eJF
 bWL
 bWL
 cgV
@@ -92096,12 +92155,12 @@ lWL
 lWL
 lWL
 aik
-adD
+ail
 agv
 aeF
 aeE
 aEG
-uml
+vcA
 acE
 ahB
 aXp
@@ -92111,9 +92170,9 @@ xuT
 bRB
 amC
 aMe
-ujA
+aRp
 xxh
-ujA
+aRp
 aDc
 aqY
 ssi
@@ -92131,9 +92190,9 @@ azk
 aBm
 bqa
 bqa
-ujA
+aRp
 xxh
-aTN
+qey
 hqK
 cGM
 cGM
@@ -92161,7 +92220,7 @@ bcu
 bjj
 aZY
 gdr
-vtY
+tRP
 bhG
 bIu
 bks
@@ -92181,13 +92240,13 @@ bvu
 bBv
 bqz
 kfT
-tOA
+rjj
 bGW
 bIh
 nyw
 bJZ
 bKG
-aTL
+gGn
 llK
 bGU
 bPQ
@@ -92199,8 +92258,8 @@ bOD
 bOD
 bOD
 bOD
-eXf
-ftR
+wUu
+eJF
 bWL
 cfJ
 cfJ
@@ -92361,34 +92420,34 @@ aEG
 agv
 acE
 bZE
-aUZ
+jcM
 kMM
 qjk
 hUu
 lFy
 amD
 aMe
-ujA
+aRp
 xxh
 ulF
 aqm
-aTN
+qey
 cgR
-wrb
+dGk
 rKT
-bEH
-kCa
-aTN
-abx
-bEH
+vKq
+hmb
+qey
+oVG
+vKq
 amG
 iXP
 aNO
-eoj
-mqT
-rmQ
+agK
+kzf
+hsp
 sYH
-ujA
+aRp
 bDg
 aEE
 hqK
@@ -92407,7 +92466,7 @@ aRt
 aRt
 aRt
 aEQ
-jIx
+tTD
 blZ
 jcF
 jRv
@@ -92429,22 +92488,22 @@ pRR
 bpr
 bqz
 brI
-oIx
 bsI
+wcN
 eoI
-bsI
-bsI
+wcN
+wcN
 bzT
 bBt
 bqz
-tJR
-tOA
+jvg
+rjj
 bKF
 gRT
 bJi
 bEu
 bKF
-aTL
+gGn
 akA
 bGU
 bPR
@@ -92453,11 +92512,11 @@ bPT
 bTP
 tiP
 bOD
-iQj
-ftR
-ftR
+xIm
+eJF
+eJF
 coC
-ftR
+eJF
 bWL
 cfJ
 cfJ
@@ -92650,7 +92709,7 @@ xxh
 aEF
 hqK
 aEI
-xtR
+gov
 aIc
 aJf
 aFE
@@ -92686,7 +92745,7 @@ bny
 pSA
 bqB
 nnT
-jsu
+kZz
 iFt
 iFt
 aLs
@@ -92695,13 +92754,13 @@ bzU
 bSp
 bqz
 bEo
-tOA
+rjj
 bGU
 bIj
 bJj
 bKb
 bGU
-aTL
+gGn
 akA
 bOF
 gGH
@@ -92710,10 +92769,10 @@ bTP
 bTP
 taD
 bOD
-eXf
-eXf
-rxw
-eXf
+wUu
+wUu
+wxB
+wUu
 cdg
 bWL
 cfJ
@@ -92882,29 +92941,29 @@ akR
 bOK
 amF
 aMe
-kCa
-agK
-dIV
-eDZ
-ujA
-ujA
-ujA
-ujA
+hmb
+wYC
+xXN
+vQJ
+aRp
+aRp
+aRp
+aRp
 auJ
-wEN
-ajQ
-tKg
-agK
+avw
+nov
+fkH
+wYC
 aAX
 lNe
-agK
-kzf
-eDZ
-ujA
+wYC
+bpk
+vQJ
+aRp
 ahh
-agK
-dIV
-sWm
+wYC
+xXN
+bES
 hqK
 aGA
 die
@@ -92932,7 +92991,7 @@ aYQ
 aZY
 aYQ
 bny
-lhp
+gPD
 rnx
 bje
 bkv
@@ -92951,14 +93010,14 @@ bwQ
 bzV
 bBw
 bqz
-tJR
-tOA
+jvg
+rjj
 bGU
 bIk
 bGU
 bGU
 bGU
-aTL
+gGn
 akA
 bGU
 tcb
@@ -93137,7 +93196,7 @@ aSS
 ajT
 akR
 bOK
-aUZ
+jcM
 ajd
 ajd
 ajc
@@ -93164,7 +93223,7 @@ aEb
 aDg
 aFv
 aEI
-xtR
+gov
 aIb
 sER
 aKx
@@ -93174,7 +93233,7 @@ aIk
 jqM
 aWk
 aPl
-trO
+teK
 aRt
 aRt
 aRt
@@ -93183,7 +93242,7 @@ aUV
 gnI
 aXC
 ddZ
-bjk
+aZZ
 bbr
 bcx
 bdF
@@ -93208,10 +93267,10 @@ bqz
 bqz
 bqz
 bqz
-tJR
-ghq
-ghq
-ghq
+jvg
+rce
+rce
+rce
 elu
 bKc
 fdF
@@ -93394,10 +93453,10 @@ rXX
 aXN
 kDF
 bOK
-aUZ
+jcM
 ant
 aog
-aUZ
+jcM
 lFy
 xdA
 ard
@@ -93416,12 +93475,12 @@ hcg
 rra
 aBP
 aBO
-ejO
-lCD
-wUB
+gcZ
+mRl
+ryG
 aFw
 aQG
-okT
+kJM
 xjM
 aJf
 aFE
@@ -93443,19 +93502,19 @@ aYS
 bIZ
 aTO
 bbg
-nhS
+wpS
 beF
-xAv
-ozo
+vYK
+oAG
 oTZ
 bjf
 bkx
 ncQ
 aHw
-tND
+skl
 bav
 aNF
-hQg
+ggA
 oDn
 eYe
 gEp
@@ -93651,13 +93710,13 @@ aje
 ajT
 akT
 wvh
-aUZ
-aUZ
-aUZ
-aUZ
+jcM
+jcM
+jcM
+jcM
 lFy
 bUc
-lwD
+tFP
 ase
 asZ
 atW
@@ -93666,17 +93725,17 @@ avz
 aww
 axa
 axc
-iCY
+eSl
 aBO
 azO
 aoV
 aBs
 aBQ
 aBO
-ejO
+nsT
 liO
-hOC
-fWp
+iFe
+cez
 aEI
 ioA
 boN
@@ -93693,16 +93752,16 @@ aQy
 gOs
 def
 def
-sHX
+dBZ
 def
 afV
 ddZ
-pZe
+iNa
 aLU
-fyk
-fyk
-fyk
-bNd
+oOu
+oOu
+oOu
+rny
 aqP
 aqP
 aqP
@@ -93712,7 +93771,7 @@ ciY
 aqM
 awK
 byN
-kJh
+oAM
 brN
 jiK
 bum
@@ -93911,7 +93970,7 @@ alR
 bIs
 anv
 aoh
-pMl
+nIa
 lFy
 qBT
 bgw
@@ -93932,7 +93991,7 @@ aBR
 aBO
 aDi
 liO
-hOC
+iFe
 aFy
 aFv
 aFv
@@ -94168,10 +94227,10 @@ alS
 alW
 alS
 alW
-qbO
-apJ
-aqr
 aUZ
+fdj
+aqr
+jcM
 atc
 atb
 atW
@@ -94211,19 +94270,19 @@ ddZ
 aWp
 aXF
 aYT
-ujQ
+xvo
 vEk
 bcz
 bdG
 aUX
-rUc
+pKC
 bbg
-hcr
+tJR
 bbg
 pSe
 eMM
 pSe
-hcr
+tJR
 bJf
 bbg
 mRP
@@ -94425,17 +94484,17 @@ waD
 amJ
 eow
 alW
-qbO
-apJ
 aUZ
+fdj
+jcM
 arf
-aUZ
-aUZ
+jcM
+jcM
 atX
 auP
-sjk
+caz
 awy
-pFs
+sjk
 axS
 ayx
 azU
@@ -94461,19 +94520,19 @@ aHl
 aIk
 aIk
 jqM
-bhM
+dNe
 ddZ
 ddZ
 ddZ
 aWq
 jOp
-nOm
+nhF
 eva
 bbj
 aXR
-wvo
+muS
 beG
-rUc
+pKC
 bbg
 bbg
 bbg
@@ -94683,27 +94742,27 @@ amK
 anx
 alW
 lBR
-apJ
+fdj
 aqs
 arg
 iOI
 aQE
 atX
-vyA
+qwk
 avB
 awz
 axe
-vyA
+qwk
 ayy
 aBO
 azS
 aAB
 aAB
-rFq
+fRs
 azU
 aDl
 cHC
-hOC
+iFe
 aFB
 aFv
 aHl
@@ -94732,21 +94791,21 @@ bdI
 aUX
 bfs
 bbg
-hcr
+tJR
 bbg
-jXT
-gFQ
-iZC
-tDT
-nTl
-gFQ
+qDl
+uAm
+udA
+pYz
+qBz
+uAm
 bqH
 csx
 ckS
 bsP
 csx
-lHM
-tOA
+iJn
+rjj
 bAb
 bEu
 bDb
@@ -94758,7 +94817,7 @@ bEu
 bEu
 bEu
 bEu
-tOA
+rjj
 aul
 bPY
 neu
@@ -94940,27 +94999,27 @@ pQE
 alW
 alW
 aNQ
-apJ
+fdj
 aZb
 bwV
 aZb
 bwV
 atX
-vyA
+qwk
 avC
 atX
 axf
-fld
-qfK
+lqc
+idF
 azU
-wqw
 bNg
-bNg
+hrV
+hrV
 aBV
 azU
 aDm
 cHC
-hOC
+iFe
 aFC
 aFv
 aHm
@@ -94987,7 +95046,7 @@ wTz
 bag
 bdJ
 aUX
-rUc
+pKC
 bHx
 dYP
 iYV
@@ -95005,17 +95064,17 @@ csx
 ksV
 bEu
 bEu
-aTL
-aTL
-aTL
-aTL
+gGn
+gGn
+gGn
+gGn
 cjv
-aTL
-aTL
-aTL
-aTL
-aTL
-tOA
+gGn
+gGn
+gGn
+gGn
+gGn
+rjj
 bGU
 bUx
 bPY
@@ -95186,7 +95245,7 @@ aik
 aik
 aik
 ahz
-xNL
+vge
 agv
 aiv
 agv
@@ -95196,19 +95255,19 @@ alU
 amL
 any
 bFY
-uEf
-apJ
+oDV
+fdj
 wwK
 aVf
 bBC
 mWC
 atX
-vyA
-vyA
+qwk
+qwk
 atX
-kpB
+nzt
 auQ
-amb
+qag
 azU
 azT
 aAE
@@ -95244,7 +95303,7 @@ aXR
 bag
 bdK
 aUX
-aZZ
+evY
 bgv
 bhK
 bjg
@@ -95261,7 +95320,7 @@ csx
 csx
 bGU
 bju
-tOA
+rjj
 bwU
 bwU
 bwU
@@ -95271,7 +95330,7 @@ bwU
 bwU
 bwU
 bwU
-aTL
+gGn
 uDS
 bwU
 bPZ
@@ -95440,12 +95499,12 @@ lWL
 lWL
 aik
 aik
-adD
-adD
+ail
+ail
 afp
 agv
 agv
-dlr
+dxj
 agv
 ajY
 acE
@@ -95454,7 +95513,7 @@ akO
 any
 tiY
 eZf
-apJ
+fdj
 bwV
 foq
 ask
@@ -95463,9 +95522,9 @@ atX
 avE
 avD
 atX
-kpB
+nzt
 axT
-amb
+qag
 azU
 kAQ
 aAF
@@ -95475,18 +95534,18 @@ azU
 aDo
 aEf
 liO
-hOC
+dmT
 aGD
-mJz
-lSH
-pgM
+pQt
+mGK
+rzP
 aKz
-mJz
-lSH
-pgM
+pQt
+mGK
+rzP
 aNG
-mJz
-lSH
+pQt
+mGK
 aPU
 jqM
 gFc
@@ -95496,8 +95555,8 @@ ddZ
 aWu
 aXI
 aYV
-hab
-aNB
+klB
+dZF
 bcA
 bdL
 aUX
@@ -95528,7 +95587,7 @@ lWL
 lWL
 lWL
 bwU
-eMG
+qzj
 bDe
 bwU
 bPZ
@@ -95718,11 +95777,11 @@ jqM
 jqM
 jqM
 auR
-vyA
+qwk
 atX
 axg
-vAu
-oOx
+rEQ
+tqq
 azU
 azT
 azT
@@ -95730,20 +95789,20 @@ azT
 nQf
 azU
 aDp
-hOC
+iFe
 eTp
-wUB
+pmQ
 mrV
-rXt
-oaR
-wTC
-wUB
-rXt
-oaR
-wTC
-wUB
-rXt
-oaR
+alb
+jRn
+pRv
+pmQ
+alb
+jRn
+pRv
+pmQ
+alb
+jRn
 aPV
 aQz
 aRw
@@ -95967,15 +96026,15 @@ lWL
 lWL
 lWL
 aik
-wZo
-vzU
+hnk
+apJ
 ddZ
-qWP
-vma
+xof
+rGt
 qLF
 atY
 wpf
-vyA
+qwk
 jqM
 jqM
 jqM
@@ -95991,16 +96050,16 @@ aEg
 lCD
 wcm
 aGE
-sbC
-kdb
-udZ
+tkt
+uNx
+rWC
 aKA
-sbC
-kdb
-udZ
+tkt
+uNx
+rWC
 aNH
-sbC
-kdb
+tkt
+uNx
 aPW
 jqM
 bgx
@@ -96224,8 +96283,8 @@ aeG
 aeG
 aeG
 aik
-wZo
-vzU
+hnk
+apJ
 aoi
 aqb
 aqb
@@ -96238,7 +96297,7 @@ gaP
 ayW
 blZ
 blZ
-qWP
+xof
 aoH
 aBv
 aBW
@@ -96482,7 +96541,7 @@ aEG
 aEG
 ozp
 aoZ
-vzU
+apJ
 ddZ
 ark
 blZ
@@ -96500,7 +96559,7 @@ aAH
 aqb
 aqb
 tpv
-eob
+lxl
 aqb
 aqb
 eWN
@@ -97011,7 +97070,7 @@ ayC
 ddZ
 btv
 ddZ
-qWP
+xof
 blZ
 aoH
 ayW
@@ -97264,14 +97323,14 @@ blZ
 awA
 blZ
 lAC
-vma
+rGt
 ddZ
 nWr
 ddZ
 ddZ
 blZ
 aoH
-vma
+rGt
 aEh
 aoH
 eWN
@@ -97515,7 +97574,7 @@ aqv
 apM
 ddZ
 ati
-vma
+rGt
 auT
 byL
 ddZ
@@ -97546,7 +97605,7 @@ jqM
 jqM
 jqM
 bgx
-raE
+rsC
 ddZ
 aVb
 ddZ
@@ -98031,7 +98090,7 @@ ddZ
 atk
 byL
 blZ
-akl
+sYf
 ddZ
 aCI
 ddZ
@@ -98039,9 +98098,9 @@ ddZ
 blZ
 blZ
 blZ
-vma
+rGt
 blZ
-hkS
+qbp
 blZ
 ddZ
 ddZ
@@ -98049,14 +98108,14 @@ ddZ
 ddZ
 ddZ
 ddZ
-vma
+rGt
 aKC
 anu
 ddZ
 ddZ
 ddZ
 ddZ
-qWP
+xof
 blZ
 blZ
 bao
@@ -98306,14 +98365,14 @@ lWL
 lWL
 lWL
 ddZ
-qWP
+xof
 aKD
 blZ
-qWP
+xof
 aOB
 aNI
 blZ
-vma
+rGt
 blZ
 blZ
 bao
@@ -98327,7 +98386,7 @@ pYa
 pYa
 pYa
 pYa
-bEA
+qKB
 lWL
 lWL
 lWL
@@ -98826,7 +98885,7 @@ aEV
 aEV
 lWL
 ddZ
-qWP
+xof
 ddZ
 lWL
 ddZ
@@ -99861,7 +99920,7 @@ ddZ
 aRA
 ddZ
 ddZ
-bEA
+qKB
 aCI
 lWL
 lWL
@@ -101397,7 +101456,7 @@ lWL
 lWL
 lWL
 lWL
-bEA
+qKB
 ddZ
 bWj
 aRE

--- a/StationMaps/DiscStation/DiscStation.dmm
+++ b/StationMaps/DiscStation/DiscStation.dmm
@@ -116,7 +116,7 @@
 "acq" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/royalblack,
 /area/station/service/library)
 "act" = (
 /obj/structure/lattice/catwalk,
@@ -667,10 +667,8 @@
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "aez" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "aeB" = (
@@ -811,6 +809,9 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "afd" = (
@@ -853,7 +854,7 @@
 	dir = 10
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "afp" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
@@ -980,7 +981,7 @@
 	dir = 9
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "afZ" = (
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat_interior)
@@ -2060,7 +2061,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "ana" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -2123,7 +2124,7 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "anv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
 	dir = 8
@@ -3416,7 +3417,10 @@
 /area/station/maintenance/department/science)
 "atj" = (
 /obj/structure/table/wood,
-/obj/effect/spawner/random/maintenance,
+/obj/item/toy/plush/abductor/agent{
+	name = "Agent Incognito";
+	desc = "He's always watching."
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "atk" = (
@@ -3886,9 +3890,8 @@
 /turf/open/floor/plating,
 /area/station/commons/storage/tools)
 "avm" = (
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/turf/closed/wall,
+/area/station/maintenance/department/bridge)
 "avo" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral{
@@ -4479,11 +4482,12 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "ayu" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/medical/abandoned)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "ayv" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Firing Range"
@@ -4837,7 +4841,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "azY" = (
 /obj/structure/table,
 /obj/effect/spawner/random/entertainment/deck,
@@ -6039,7 +6043,7 @@
 "aEQ" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aEV" = (
 /turf/closed/wall,
 /area/station/maintenance/disposal)
@@ -6240,7 +6244,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aFG" = (
 /obj/structure/grille/broken,
 /obj/structure/cable,
@@ -6925,7 +6929,7 @@
 /obj/structure/rack,
 /obj/item/stack/sheet/iron/fifty,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "aHP" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -6933,7 +6937,7 @@
 /obj/structure/rack,
 /obj/item/storage/medkit/o2,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "aHQ" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -6943,7 +6947,7 @@
 	},
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "aHT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -7259,7 +7263,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "aIL" = (
 /turf/open/floor/plating,
 /area/station/maintenance/central)
@@ -7559,14 +7563,14 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "aKf" = (
 /obj/item/wrench,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "aKg" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -7576,7 +7580,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "aKj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -7701,7 +7705,7 @@
 	dir = 6
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aKC" = (
 /obj/item/shard{
 	icon_state = "medium"
@@ -7712,7 +7716,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aKD" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/disposalpipe/segment{
@@ -7720,7 +7724,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aKE" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Disposal Access"
@@ -7732,7 +7736,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
 /obj/effect/landmark/navigate_destination/disposals,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aKF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7900,20 +7904,20 @@
 	c_tag = "Starboard Maintence Bubble"
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "aLn" = (
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "aLo" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "aLp" = (
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
@@ -7966,7 +7970,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aLB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -8004,7 +8008,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/station/science/ordnance/storage)
 "aLI" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -8098,7 +8102,7 @@
 	},
 /obj/machinery/pipedispenser/disposal/transit_tube,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "aMb" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -8109,7 +8113,7 @@
 	opened = 1
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "aMc" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -8153,6 +8157,7 @@
 /obj/item/retractor,
 /obj/item/hemostat,
 /obj/item/cautery,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "aMn" = (
@@ -8300,9 +8305,9 @@
 /area/station/science/robotics/lab)
 "aMQ" = (
 /obj/machinery/computer/operating{
-	name = "Robotics Operating Computer"
+	name = "Robotics Operating Computer";
+	dir = 8
 	},
-/obj/machinery/light/directional/south,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "aMR" = (
@@ -8321,7 +8326,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aMW" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
@@ -8420,7 +8425,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "aNv" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -8494,7 +8499,7 @@
 /obj/item/weldingtool,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aNJ" = (
 /obj/machinery/status_display/evac/directional/west,
 /obj/structure/chair{
@@ -8588,7 +8593,6 @@
 /area/station/tcommsat/computer)
 "aOk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -8643,14 +8647,14 @@
 "aOv" = (
 /obj/item/clothing/head/welding,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aOw" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1;
 	sortType = 17
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aOz" = (
 /obj/structure/disposalpipe/sorting/mail{
 	sortType = 4
@@ -8659,7 +8663,7 @@
 	icon_state = "singular"
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aOA" = (
 /obj/structure/table,
 /obj/machinery/light/small/directional/east,
@@ -8667,11 +8671,11 @@
 	info = "What the hell Gary? What is this shit? SIXTEEN sort junctions? NT is going to kill us if this isn't fixed before the shift start. Get your ass on this once you're done futzing about on the port transit station maint."
 	},
 /turf/open/floor/iron,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aOB" = (
 /obj/structure/girder/displaced,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aOC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /obj/machinery/meter/monitored/distro_loop,
@@ -8853,7 +8857,7 @@
 	sortType = 23
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aPl" = (
 /obj/structure/disposalpipe/junction/flip,
 /obj/structure/fluff/broken_flooring{
@@ -8861,17 +8865,17 @@
 	icon_state = "pile"
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aPm" = (
 /obj/structure/disposalpipe/sorting/mail{
 	sortType = 6
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aPn" = (
 /obj/item/weldingtool/largetank,
 /turf/open/floor/iron,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aPo" = (
 /obj/machinery/door/window/left/directional/north{
 	base_state = "right";
@@ -9025,13 +9029,13 @@
 	icon_state = "singular"
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aPS" = (
 /obj/structure/disposalpipe/sorting/mail{
 	sortType = 5
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aPT" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/directional/south,
@@ -9073,16 +9077,16 @@
 /obj/machinery/computer/station_alert,
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aPY" = (
 /obj/machinery/computer/atmos_alert,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aPZ" = (
 /obj/machinery/computer/crew,
 /turf/open/floor/iron,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aQa" = (
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
@@ -9192,7 +9196,7 @@
 	sortType = 10
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aQx" = (
 /obj/structure/disposalpipe/sorting/mail{
 	sortType = 7
@@ -9202,26 +9206,26 @@
 	icon_state = "singular"
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aQy" = (
 /obj/structure/girder/reinforced,
 /turf/open/floor/iron,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aQz" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aQB" = (
 /obj/structure/chair/office{
 	dir = 1
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aQC" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aQD" = (
 /obj/structure/cable,
 /obj/machinery/door/window/brigdoor/right/directional/south{
@@ -9314,8 +9318,9 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aQT" = (
 /obj/structure/table,
 /obj/item/multitool,
@@ -9358,7 +9363,7 @@
 	},
 /obj/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "aRd" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -9367,7 +9372,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "aRe" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
@@ -9432,17 +9437,17 @@
 	sortType = 9
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aRt" = (
 /obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aRu" = (
 /obj/structure/disposalpipe/sorting/mail{
 	sortType = 8
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aRw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9452,7 +9457,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aRA" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Observation Pod"
@@ -9462,22 +9467,22 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /turf/open/floor/iron,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aRB" = (
 /turf/open/floor/iron,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aRC" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aRE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aRG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -9642,7 +9647,7 @@
 	},
 /obj/item/canvas,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "aSm" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -9650,7 +9655,7 @@
 /obj/effect/decal/cleanable/generic,
 /obj/item/toy/crayon/spraycan,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "aSn" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -9660,7 +9665,7 @@
 	},
 /obj/item/storage/crayons,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "aSp" = (
 /obj/structure/girder/reinforced,
 /turf/open/floor/plating/airless,
@@ -9733,19 +9738,19 @@
 	sortType = 22
 	},
 /turf/open/floor/iron,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aSH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /turf/open/floor/iron,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aSI" = (
 /obj/structure/disposalpipe/sorting/mail{
 	sortType = 15
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aSK" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Storage Room"
@@ -9754,7 +9759,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aSL" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Storage Room"
@@ -9762,24 +9767,24 @@
 /obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aSM" = (
 /obj/structure/closet,
 /obj/item/flashlight,
 /obj/item/extinguisher,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aSP" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aSQ" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aSR" = (
 /obj/structure/sign/poster/official/report_crimes{
 	pixel_y = -32
@@ -9944,11 +9949,11 @@
 /obj/item/canvas/nineteen_nineteen,
 /obj/item/canvas,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "aTA" = (
 /obj/item/canvas/twentythree_twentythree,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "aTB" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -10035,26 +10040,26 @@
 	sortType = 21
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aTQ" = (
 /obj/structure/disposalpipe/junction,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aTR" = (
 /obj/structure/disposalpipe/sorting/mail{
 	sortType = 16
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aTU" = (
 /obj/item/multitool,
 /obj/item/radio,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aTV" = (
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aTW" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/bottle/morphine{
@@ -10064,51 +10069,51 @@
 /obj/item/reagent_containers/glass/bottle/multiver,
 /obj/item/reagent_containers/glass/bottle/salglu_solution,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aTX" = (
 /obj/item/reagent_containers/glass/beaker,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aUa" = (
 /obj/item/reagent_containers/syringe,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aUb" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /obj/item/reagent_containers/syringe,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aUc" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aUd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aUe" = (
 /obj/machinery/vending/snack,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aUf" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aUg" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Auxiliary Dock"
 	},
 /turf/open/floor/iron,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aUi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -10238,13 +10243,13 @@
 /obj/structure/easel,
 /obj/item/canvas,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "aUN" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "aUO" = (
 /obj/machinery/door/airlock/hatch,
 /obj/effect/mapping_helpers/airlock/access/any/command/maintenance,
@@ -10258,7 +10263,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "aUP" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -10267,24 +10272,24 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "aUU" = (
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 1;
 	sortType = 22
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aUV" = (
 /obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/iron,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aUW" = (
 /obj/structure/disposalpipe/sorting/mail{
 	sortType = 18
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aUX" = (
 /turf/closed/wall,
 /area/station/cargo/miningdock)
@@ -10294,7 +10299,7 @@
 /obj/item/reagent_containers/blood/o_minus,
 /obj/item/reagent_containers/blood/o_minus,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aUZ" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 1
@@ -10308,14 +10313,14 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aVb" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aVd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10339,7 +10344,7 @@
 /area/station/science/ordnance/office)
 "aVg" = (
 /obj/machinery/bluespace_vendor/directional/north,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "aVk" = (
 /obj/structure/chair{
@@ -10448,7 +10453,7 @@
 "aVK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/royalblack,
 /area/station/service/library)
 "aVM" = (
 /obj/structure/window/reinforced{
@@ -10459,7 +10464,7 @@
 	c_tag = "Art Bubble"
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "aVN" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -10569,7 +10574,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aWn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -10578,7 +10583,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aWo" = (
 /obj/structure/disposalpipe/sorting/mail{
 	sortType = 19
@@ -10587,7 +10592,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aWp" = (
 /obj/structure/closet/crate,
 /obj/item/flashlight{
@@ -10821,7 +10826,7 @@
 	pixel_x = 12
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "aXf" = (
 /obj/structure/window/reinforced,
 /obj/structure/table/glass,
@@ -10833,7 +10838,7 @@
 	pixel_x = -12
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "aXg" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -10845,7 +10850,7 @@
 	pixel_x = -12
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "aXh" = (
 /obj/structure/table/glass,
 /obj/machinery/light/directional/west,
@@ -10902,8 +10907,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "aXy" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -10926,7 +10929,7 @@
 /obj/item/stack/ore/iron,
 /obj/item/pickaxe,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aXB" = (
 /obj/structure/rack,
 /obj/item/stack/ore/silver,
@@ -10934,7 +10937,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aXC" = (
 /obj/structure/table,
 /obj/item/storage/bag/ore,
@@ -10942,7 +10945,7 @@
 	dir = 9
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aXF" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -11140,7 +11143,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/floor,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "aYB" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/pillbottles,
@@ -11186,7 +11189,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/supply/general,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aYT" = (
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/light/directional/west,
@@ -11218,7 +11221,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "aYZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11328,25 +11331,25 @@
 /obj/item/dest_tagger,
 /obj/item/paper_bin/carbon,
 /obj/item/toy/figure/qm,
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/blue,
 /area/station/cargo/qm)
 "aZT" = (
 /obj/structure/closet/secure_closet/quartermaster,
 /obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/blue,
 /area/station/cargo/qm)
 "aZU" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/light/directional/north,
 /obj/machinery/modular_computer/console/preset/id,
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/blue,
 /area/station/cargo/qm)
 "aZV" = (
 /obj/machinery/camera/autoname/directional/north,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /obj/structure/filingcabinet/chestdrawer,
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/blue,
 /area/station/cargo/qm)
 "aZW" = (
 /obj/structure/cable,
@@ -11371,7 +11374,7 @@
 /obj/effect/decal/cleanable/oil/streak,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "bab" = (
 /obj/machinery/door/airlock/mining{
@@ -11427,7 +11430,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "bap" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/structure/sign/warning/secure_area/directional/west,
@@ -11602,7 +11605,7 @@
 	department = "Quartermaster's Desk";
 	name = "Quartermaster's Requests Console"
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/blue,
 /area/station/cargo/qm)
 "bbb" = (
 /obj/structure/chair/office{
@@ -11612,10 +11615,10 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/quartermaster,
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/blue,
 /area/station/cargo/qm)
 "bbe" = (
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/blue,
 /area/station/cargo/qm)
 "bbf" = (
 /obj/machinery/door/firedoor,
@@ -11819,7 +11822,7 @@
 	},
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "bcd" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -11829,7 +11832,7 @@
 	},
 /obj/machinery/atmospherics/components/tank/air,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "bce" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -12416,7 +12419,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "bet" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -12426,7 +12429,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "beu" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
@@ -12882,7 +12885,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "bgy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
@@ -12900,7 +12903,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/floor,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "bgC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -12984,11 +12987,11 @@
 /obj/structure/table,
 /obj/item/toy/cards/deck,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "bhg" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "bhh" = (
 /obj/structure/sign/warning/vacuum/external/directional/south,
 /obj/effect/turf_decal/stripes/line,
@@ -12997,7 +13000,7 @@
 "bhj" = (
 /obj/structure/closet,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "bhm" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
@@ -13249,7 +13252,7 @@
 "biM" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "biS" = (
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/command/nuke_storage)
@@ -13832,7 +13835,7 @@
 /obj/structure/rack,
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "bll" = (
 /obj/machinery/computer/cargo/request{
 	dir = 1
@@ -13946,6 +13949,7 @@
 /obj/structure/cable,
 /obj/item/storage/box/beakers,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "blF" = (
@@ -14072,7 +14076,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "blV" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood,
@@ -14125,7 +14129,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "bmh" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -14137,7 +14141,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "bmm" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -14225,7 +14229,6 @@
 	c_tag = "Chemistry";
 	network = list("ss13","medbay")
 	},
-/obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
@@ -14321,7 +14324,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "bnq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -15024,12 +15027,12 @@
 "bqo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "bqp" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "bqr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -15291,22 +15294,22 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "brq" = (
 /obj/item/plate,
 /obj/item/trash/popcorn,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "brr" = (
 /obj/item/trash/chips,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "brs" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance,
 /obj/item/trash/candle,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "brt" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -15593,7 +15596,7 @@
 "bsx" = (
 /obj/item/food/deadmouse,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "bsy" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster/directional/west,
@@ -15681,6 +15684,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
+"bsO" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "bsP" = (
 /obj/effect/spawner/random/structure/crate_empty,
 /obj/effect/spawner/random/maintenance/two,
@@ -15931,7 +15941,7 @@
 	c_tag = "Library North"
 	},
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/royalblack,
 /area/station/service/library)
 "bud" = (
 /obj/structure/bookcase/random/fiction,
@@ -16494,14 +16504,14 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/royalblack,
 /area/station/service/library)
 "bwH" = (
 /obj/machinery/holopad,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/royalblack,
 /area/station/service/library)
 "bwI" = (
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/royalblack,
 /area/station/service/library)
 "bwM" = (
 /obj/machinery/status_display/evac/directional/west,
@@ -16549,7 +16559,7 @@
 	name = "Auxiliary Dock"
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "bxa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -16868,7 +16878,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/royalblack,
 /area/station/service/library)
 "byh" = (
 /turf/closed/wall,
@@ -17285,7 +17295,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/royalblack,
 /area/station/service/library)
 "bzL" = (
 /obj/structure/disposalpipe/trunk{
@@ -17445,6 +17455,11 @@
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/service/chapel)
+"bAo" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/department/bridge)
 "bAr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -17585,7 +17600,7 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/turf_decal/box/corners,
 /turf/open/floor/iron/dark/textured,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "bAZ" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/captain/private)
@@ -17633,7 +17648,7 @@
 /area/station/service/library)
 "bBo" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/royalblack,
 /area/station/service/library)
 "bBp" = (
 /obj/structure/table/wood,
@@ -19113,13 +19128,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/glass_large,
 /obj/structure/cable,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/royalblack,
 /area/station/service/library)
 "bGP" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/royalblack,
 /area/station/service/library)
 "bGR" = (
 /obj/machinery/door/airlock/maintenance,
@@ -19128,7 +19143,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "bGS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -22085,8 +22100,8 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "bUA" = (
-/turf/closed/wall,
-/area/station/science/ordnance/storage)
+/turf/open/floor/plating,
+/area/station/maintenance/department/bridge)
 "bUD" = (
 /obj/machinery/computer/atmos_alert,
 /obj/machinery/camera/directional/north{
@@ -22531,7 +22546,7 @@
 "bWj" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "bWl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/mix_output{
 	dir = 8
@@ -22675,7 +22690,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "bWL" = (
 /turf/closed/wall,
 /area/station/commons/fitness/recreation)
@@ -24436,19 +24451,19 @@
 "cdR" = (
 /obj/structure/table/wood,
 /obj/item/instrument/guitar,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "cdS" = (
 /obj/structure/table/wood,
 /obj/item/storage/medkit/regular,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "cdT" = (
 /obj/structure/table/wood,
 /obj/item/coin/silver,
 /obj/machinery/light/directional/north,
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "cdU" = (
 /obj/structure/table/wood,
@@ -24456,12 +24471,12 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Dorms West"
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "cdV" = (
 /obj/structure/table/wood,
 /obj/item/paicard,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "cdX" = (
 /obj/machinery/washing_machine,
@@ -24877,7 +24892,7 @@
 /area/station/commons/dorms)
 "cfc" = (
 /obj/structure/chair/stool/directional/north,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "cfd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -24888,18 +24903,18 @@
 "cfg" = (
 /obj/structure/table/wood/poker,
 /obj/effect/spawner/random/entertainment/dice,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "cfh" = (
 /obj/structure/table/wood/poker,
 /obj/machinery/light/directional/north,
 /obj/item/storage/crayons,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "cfi" = (
 /obj/item/toy/cards/deck,
 /obj/structure/table/wood/poker,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "cfj" = (
 /obj/machinery/door/airlock/maintenance,
@@ -24914,20 +24929,20 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Dorms Central"
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "cfl" = (
 /obj/machinery/vending/coffee,
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "cfm" = (
 /obj/effect/spawner/random/vending/snackvend,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "cfn" = (
 /obj/machinery/vending/assist,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "cfo" = (
 /obj/machinery/navbeacon{
@@ -25233,17 +25248,17 @@
 /area/station/commons/dorms)
 "cgH" = (
 /obj/effect/spawner/random/entertainment/arcade,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "cgJ" = (
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "cgK" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "cgL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -25292,7 +25307,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "cgR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/purple/line{
@@ -25788,23 +25803,23 @@
 "cji" = (
 /obj/structure/table,
 /obj/effect/spawner/random/entertainment/dice,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "cjj" = (
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "cjk" = (
 /obj/structure/table,
 /obj/item/storage/crayons,
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "cjl" = (
 /obj/structure/chair/stool,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "cjp" = (
 /obj/structure/window/reinforced{
@@ -26135,12 +26150,12 @@
 /area/station/engineering/atmos)
 "cky" = (
 /obj/structure/closet/crate,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "ckA" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/chair/stool/directional/east,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "ckB" = (
 /obj/structure/table/wood,
@@ -26151,13 +26166,13 @@
 	pixel_x = -8;
 	pixel_y = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "ckF" = (
 /obj/structure/table,
 /obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "ckG" = (
 /obj/machinery/light/directional/south,
@@ -26595,14 +26610,14 @@
 /area/station/commons/dorms)
 "cmT" = (
 /obj/effect/decal/cleanable/oil/streak,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "cmW" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen";
 	opened = 1
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "cmX" = (
 /obj/machinery/shower{
@@ -26662,7 +26677,7 @@
 /area/station/commons/toilet/locker)
 "cnf" = (
 /obj/structure/bedsheetbin,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "cng" = (
 /obj/machinery/camera/directional/south{
@@ -26670,16 +26685,16 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "cnh" = (
 /obj/machinery/light/directional/south,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "cnj" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "cnk" = (
 /obj/structure/table,
@@ -27472,7 +27487,7 @@
 /area/station/engineering/storage/tech)
 "cqF" = (
 /obj/effect/decal/cleanable/generic,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "cqG" = (
 /obj/effect/spawner/random/structure/closet_private,
@@ -27960,7 +27975,7 @@
 /area/station/engineering/atmos)
 "csp" = (
 /turf/closed/wall/r_wall,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "csq" = (
 /obj/machinery/door/airlock/glass{
 	name = "Engineering Corridor"
@@ -27968,7 +27983,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "csr" = (
 /obj/machinery/door/airlock/glass{
 	name = "Engineering Corridor"
@@ -27979,7 +27994,7 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "cst" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engine Room"
@@ -28247,7 +28262,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "ctv" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/light/directional/north,
@@ -28255,7 +28270,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "ctw" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -28263,14 +28278,14 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "ctx" = (
 /obj/effect/spawner/random/vending/snackvend,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "cty" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera/directional/north{
@@ -28281,7 +28296,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "ctz" = (
 /obj/structure/chair,
 /obj/machinery/airalarm/directional/north,
@@ -28289,7 +28304,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "ctA" = (
 /obj/structure/table,
 /obj/item/clothing/glasses/meson,
@@ -28297,7 +28312,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "ctE" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -28305,28 +28320,28 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "ctF" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "ctG" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "ctH" = (
 /obj/effect/spawner/random/entertainment/arcade,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "ctJ" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Engineering Cutthrough"
@@ -28336,7 +28351,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "ctK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/firealarm/directional/north,
@@ -28344,14 +28359,14 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "ctL" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "ctN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -28477,7 +28492,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "cuz" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/bottle/morphine{
@@ -28653,7 +28668,7 @@
 	},
 /obj/machinery/holopad,
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "cvg" = (
 /obj/effect/landmark/start/hangover,
 /obj/effect/decal/cleanable/dirt,
@@ -28668,7 +28683,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "cvj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28680,13 +28695,13 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "cvl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "cvn" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -28958,13 +28973,13 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "cwB" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "cwC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -28974,7 +28989,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "cwD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -28984,14 +28999,14 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "cwI" = (
 /obj/machinery/light_switch/directional/south,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "cwK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29000,7 +29015,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "cwL" = (
 /obj/structure/chair{
 	dir = 4
@@ -29009,7 +29024,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "cwM" = (
 /obj/structure/table,
 /obj/item/toy/cards/deck,
@@ -29018,14 +29033,14 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "cwN" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "cwP" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
@@ -29446,15 +29461,15 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "cyD" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/iron/dark/textured,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "cyE" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/iron/dark/textured,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "cyF" = (
 /obj/machinery/shieldgen,
 /turf/open/floor/plating,
@@ -30921,7 +30936,7 @@
 "cGl" = (
 /obj/structure/chair/stool/directional/east,
 /obj/structure/cable,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "cGr" = (
 /obj/item/shard{
@@ -30963,6 +30978,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
 /area/station/solars/port/aft)
+"cGF" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/central)
 "cGG" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
@@ -31127,7 +31147,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "cHy" = (
 /obj/machinery/door/airlock/hatch,
 /obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
@@ -31283,6 +31303,12 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
+"cND" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/tcommsat/computer)
 "cNW" = (
 /obj/structure/closet/secure_closet/psychology,
 /obj/item/toy/figure/psychologist,
@@ -31365,6 +31391,12 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
+"cTq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "cTs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31515,7 +31547,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "deq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31591,6 +31623,13 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"diT" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "djH" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/green{
@@ -31672,7 +31711,7 @@
 "dmL" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/iron/dark/textured,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "dmT" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -31899,7 +31938,7 @@
 	icon_state = "singular"
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "dCs" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
@@ -31924,6 +31963,13 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"dFe" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "dFl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -32032,7 +32078,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "dPa" = (
 /obj/structure/transit_tube/station/dispenser,
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
@@ -32100,7 +32146,7 @@
 	},
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "dTV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32272,7 +32318,7 @@
 	},
 /obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "egK" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -32452,6 +32498,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"etv" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "etA" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/camera/autoname/directional/north,
@@ -32658,6 +32711,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
+"eFN" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/space/basic,
+/area/station/maintenance/starboard/fore)
 "eGu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33057,10 +33114,9 @@
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
 "fcs" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/area/station/maintenance/department/science/xenobiology)
 "fcu" = (
 /obj/machinery/computer/security/telescreen/research{
 	pixel_y = 30
@@ -33110,6 +33166,14 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"fen" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "ffw" = (
@@ -33223,7 +33287,7 @@
 	dir = 6
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "fmW" = (
 /obj/machinery/holopad,
 /obj/effect/decal/cleanable/dirt,
@@ -33365,7 +33429,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "fux" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
@@ -33652,6 +33716,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
+"fTf" = (
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "fUB" = (
 /obj/machinery/atmospherics/components/binary/pump/off{
 	dir = 4;
@@ -33662,7 +33730,7 @@
 "fVM" = (
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "fWj" = (
 /obj/effect/mapping_helpers/iannewyear,
 /turf/open/floor/wood,
@@ -33956,7 +34024,7 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "gnR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33965,6 +34033,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"gou" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/station/maintenance/department/bridge)
 "gov" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -33998,6 +34070,10 @@
 /obj/structure/bed/roller,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"gpC" = (
+/obj/structure/chair/stool/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/department/bridge)
 "gqk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -34099,7 +34175,7 @@
 "gvD" = (
 /obj/machinery/atmospherics/components/binary/pump/on,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "gvG" = (
 /obj/structure/chair{
 	dir = 8
@@ -34226,7 +34302,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "gFj" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -34309,6 +34385,14 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
+"gNn" = (
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "gNN" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
@@ -34329,7 +34413,7 @@
 	dir = 6
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "gOy" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark,
@@ -34508,12 +34592,16 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "hat" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/pumproom)
+"hbK" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "hcg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34653,7 +34741,14 @@
 "hkC" = (
 /obj/machinery/light/floor,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
+"hla" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "hlq" = (
 /obj/machinery/bluespace_vendor/directional/west,
 /obj/effect/turf_decal/tile/brown{
@@ -34719,6 +34814,13 @@
 /obj/machinery/holopad/secure,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain/private)
+"hon" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "hpk" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34819,7 +34921,7 @@
 /area/station/engineering/supermatter)
 "hwL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/royalblack,
 /area/station/service/library)
 "hxf" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
@@ -34906,7 +35008,7 @@
 "hFD" = (
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "hGr" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -35236,6 +35338,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
+"iiB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "ije" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35309,7 +35421,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "iny" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35456,6 +35568,10 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"izr" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "iAl" = (
 /obj/machinery/door/airlock/medical{
 	name = "Morgue"
@@ -35613,6 +35729,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "iMu" = (
@@ -35772,7 +35889,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "iZG" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -35784,7 +35901,7 @@
 /area/station/commons/storage/emergency/port)
 "jaX" = (
 /obj/structure/cable,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "jbb" = (
 /obj/structure/disposalpipe/segment,
@@ -35803,7 +35920,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "jcM" = (
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
@@ -35863,7 +35980,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/royalblack,
 /area/station/service/library)
 "jgL" = (
 /obj/structure/closet/toolcloset,
@@ -35919,7 +36036,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "jmt" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
@@ -36031,6 +36148,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit/departure_lounge)
+"jwv" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "jwA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -36248,6 +36373,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/courtroom)
+"jLs" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "jLv" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/neutral{
@@ -36312,7 +36444,7 @@
 "jRv" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "jRQ" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -36658,7 +36790,7 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "kpJ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/status_display/evac/directional/east,
@@ -36751,6 +36883,12 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"ktk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/bridge)
 "ktU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -36759,7 +36897,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "kuT" = (
 /obj/structure/rack,
 /obj/item/fuel_pellet,
@@ -36971,7 +37109,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "kIS" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
@@ -37381,7 +37519,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "lug" = (
 /obj/machinery/vending/wallmed/directional/south,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
@@ -37445,7 +37583,7 @@
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "lAC" = (
 /obj/structure/chair/stool/directional/east,
 /turf/open/floor/plating,
@@ -37574,6 +37712,25 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
+"lIk" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"lIy" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/hatch,
+/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "lIA" = (
 /obj/effect/turf_decal/trimline/neutral/end{
 	dir = 4
@@ -37648,6 +37805,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"lNw" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/department/bridge)
 "lOx" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -37703,7 +37865,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/royalblack,
 /area/station/service/library)
 "lRN" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -37871,12 +38033,15 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "maa" = (
 /obj/structure/sign/poster/official/random/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
+"mcq" = (
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "mcQ" = (
 /obj/structure/chair{
 	dir = 4
@@ -38124,7 +38289,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "msO" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -38214,6 +38379,12 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"mxq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "mxz" = (
@@ -38319,7 +38490,7 @@
 "mGV" = (
 /obj/structure/closet/crate,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "mHj" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -38410,6 +38581,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"mPo" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "mPs" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -38494,7 +38672,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/royalblack,
 /area/station/service/library)
 "mWU" = (
 /obj/machinery/door/airlock/maintenance,
@@ -38519,7 +38697,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "mYr" = (
 /obj/effect/turf_decal/tile/neutral/diagonal_centre,
 /obj/structure/chair{
@@ -38573,7 +38751,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "naU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38885,7 +39063,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "nrS" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron/dark,
@@ -39322,7 +39500,7 @@
 /area/station/commons/dorms)
 "nUz" = (
 /obj/machinery/light/directional/north,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "nUO" = (
 /obj/structure/disposalpipe/segment,
@@ -39369,6 +39547,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"nYo" = (
+/obj/effect/decal/cleanable/crayon{
+	name = "THIS ROOM FUCKING SUCKS.";
+	desc = "I HATE IT. I HATE IT SO MUCH. PLEASE JUST MAKE IT NOT SUCK SO MUCH."
+	},
+/turf/open/floor/iron,
+/area/station/construction)
 "nYr" = (
 /obj/structure/rack{
 	dir = 8;
@@ -39593,6 +39778,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"ood" = (
+/obj/structure/disposalpipe/junction/flip,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "ooE" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
@@ -39730,7 +39920,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/holopad,
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/blue,
 /area/station/cargo/qm)
 "oCl" = (
 /obj/machinery/holopad,
@@ -39786,7 +39976,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "oEP" = (
-/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/dark_blue{
@@ -39806,6 +39995,7 @@
 "oFp" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "oFA" = (
@@ -39897,7 +40087,7 @@
 "oLC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "oLS" = (
 /obj/effect/turf_decal/siding/wood,
@@ -39935,6 +40125,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"oNq" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "oOh" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -40034,7 +40230,7 @@
 /area/station/cargo/storage)
 "oUD" = (
 /obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "oUZ" = (
 /obj/item/radio/intercom/directional/south{
@@ -40113,7 +40309,7 @@
 "pac" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "pax" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -40256,7 +40452,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "piS" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/tile/blue/opposingcorners,
@@ -40274,7 +40470,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "pkl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40465,7 +40661,7 @@
 /area/station/science/xenobiology)
 "pCp" = (
 /turf/open/floor/iron/dark/textured,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "pCv" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/bot,
@@ -40656,6 +40852,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
+"pRb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "pRj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40663,6 +40865,11 @@
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain/private)
+"pRl" = (
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "pRp" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
@@ -40941,6 +41148,11 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"qmL" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/bridge)
 "qnl" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -41073,6 +41285,9 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"qwF" = (
+/turf/closed/wall/r_wall,
+/area/station/maintenance/department/bridge)
 "qxg" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
@@ -41149,7 +41364,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "qzy" = (
 /obj/structure/table/reinforced,
 /obj/item/tank/internals/emergency_oxygen/engi{
@@ -41231,6 +41446,7 @@
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 8
 	},
+/obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
 "qEo" = (
@@ -41275,7 +41491,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/royalblack,
 /area/station/service/library)
 "qFf" = (
 /obj/machinery/door/airlock/external{
@@ -41371,6 +41587,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"qLI" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "qMe" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -41491,7 +41715,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "qZf" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/neutral{
@@ -41568,7 +41792,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/navigate_destination/dockaux,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "rgL" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/event_spawn,
@@ -41618,7 +41842,7 @@
 "rkH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "rkI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41679,6 +41903,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"roc" = (
+/mob/living/simple_animal/pet/cat{
+	name = "Katie";
+	desc = "Yoss, queen, slay."
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/electrical)
 "roC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41762,7 +41993,7 @@
 /obj/effect/decal/cleanable/oil,
 /obj/structure/sign/poster/contraband/random/directional/south,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "rtH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -41793,6 +42024,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"rvQ" = (
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "rwd" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/purple{
@@ -41820,6 +42058,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/medical/psychology)
+"rxQ" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "rxT" = (
 /obj/machinery/computer/security/telescreen/ce,
 /turf/closed/wall/r_wall,
@@ -42290,6 +42532,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
+"sca" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/bluespace_vendor/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "scA" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/neutral{
@@ -42385,13 +42634,11 @@
 /area/station/hallway/primary/port)
 "sjg" = (
 /obj/effect/spawner/random/trash/bin,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "sjk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron/white,
-/area/station/science/auxlab)
+/turf/closed/wall,
+/area/station/maintenance/department/science/xenobiology)
 "sjn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/iv_drip,
@@ -42400,6 +42647,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"sjq" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "sjP" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark/telecomms,
@@ -42579,7 +42833,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "svT" = (
 /obj/effect/turf_decal/trimline/white/filled/arrow_ccw{
 	dir = 4
@@ -42606,7 +42860,7 @@
 "swx" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "swH" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron,
@@ -42636,7 +42890,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "sxX" = (
@@ -42699,7 +42953,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "sCA" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
@@ -42889,7 +43143,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/floor,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
+"sRp" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/tcommsat/computer)
 "sRr" = (
 /obj/item/kirbyplants/photosynthetic,
 /obj/effect/turf_decal/tile/purple/opposingcorners,
@@ -42900,7 +43159,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "sSa" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -42959,12 +43218,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "sVO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "sVX" = (
@@ -43075,7 +43335,7 @@
 /obj/structure/disposalpipe/junction/flip,
 /obj/structure/fluff/broken_flooring,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "tfa" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/dark,
@@ -43124,7 +43384,7 @@
 "tjY" = (
 /obj/structure/chair/stool/directional/east,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "tkk" = (
 /obj/structure/chair/sofa/left,
 /turf/open/floor/carpet,
@@ -43205,7 +43465,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "toX" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
@@ -43389,6 +43649,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
+"tEv" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/station/maintenance/department/bridge)
 "tFP" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -43496,7 +43760,7 @@
 "tMI" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "tOg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
@@ -43589,6 +43853,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
+"tTa" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "tTx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43604,7 +43875,7 @@
 	icon_state = "singular"
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/department/science/xenobiology)
 "tVJ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
@@ -43679,7 +43950,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "uaa" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -43899,6 +44170,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"upX" = (
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "uqn" = (
 /obj/machinery/door/airlock/external{
 	name = "External Docking Port"
@@ -43972,7 +44248,7 @@
 "uwA" = (
 /obj/structure/sign/poster/contraband/random/directional/east,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "uxb" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -44096,7 +44372,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "uFd" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
@@ -44294,7 +44570,7 @@
 /area/station/command/gateway)
 "uXo" = (
 /obj/effect/landmark/navigate_destination/library,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/royalblack,
 /area/station/service/library)
 "uXX" = (
 /obj/machinery/door/airlock/external{
@@ -44343,7 +44619,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/royalblack,
 /area/station/service/library)
 "vaF" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -44461,7 +44737,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "vnK" = (
 /obj/structure/transit_tube/diagonal/topleft,
 /turf/open/space/basic,
@@ -44591,7 +44867,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "vAj" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -44771,7 +45047,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
 "vLc" = (
 /obj/effect/landmark/start/lawyer,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44877,7 +45153,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/bridge)
 "vSw" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45036,6 +45312,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"wdw" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron,
+/area/station/construction)
 "wfu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45125,6 +45408,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"wmE" = (
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/white,
+/area/station/science/auxlab)
 "wmR" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/purple{
@@ -45290,6 +45577,13 @@
 /obj/machinery/smartfridge,
 /turf/closed/wall,
 /area/station/service/hydroponics)
+"wyt" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "wzk" = (
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/east,
@@ -45354,6 +45648,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
+"wDz" = (
+/turf/closed/wall/r_wall,
+/area/station/maintenance/department/science/xenobiology)
 "wDE" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -45392,6 +45689,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
+"wJu" = (
+/obj/effect/spawner/random/engineering/atmospherics_portable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "wJI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45619,6 +45920,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
+"xfI" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "xfS" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45873,7 +46181,7 @@
 	active_power_usage = 0
 	},
 /turf/open/space/basic,
-/area/space)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "xzf" = (
 /obj/structure/table,
 /obj/item/food/mint,
@@ -45999,6 +46307,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"xKm" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "xKM" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/tcomms_all,
@@ -46049,7 +46362,17 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/engineering/break_room)
+/area/station/engineering/hallway)
+"xPM" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	tag = "icon-camera (NORTHWEST)";
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "xQq" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -46135,7 +46458,7 @@
 /area/station/medical/medbay/lobby)
 "xWC" = (
 /obj/machinery/holopad,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "xWK" = (
 /obj/structure/cable,
@@ -46325,7 +46648,7 @@
 	active_power_usage = 0
 	},
 /turf/open/space/basic,
-/area/space)
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "ylB" = (
 /turf/open/floor/iron/white,
 /area/station/security/medical)
@@ -60628,7 +60951,7 @@ bxl
 bxl
 edV
 bxl
-bBN
+cbS
 jEm
 qft
 qft
@@ -61851,7 +62174,7 @@ auY
 aqA
 fgk
 aso
-auc
+roc
 ues
 bga
 avO
@@ -64686,10 +65009,10 @@ aot
 aot
 aot
 aot
-aot
+etv
 gMG
 aot
-aot
+mPo
 ape
 aCD
 aDG
@@ -64699,7 +65022,7 @@ aGa
 aot
 kOc
 ape
-aot
+sca
 rlg
 aot
 aot
@@ -64709,12 +65032,12 @@ nbw
 ivP
 aot
 aot
-aot
+etv
 cQM
 aot
 aVs
 aWH
-aot
+mPo
 aot
 aot
 aot
@@ -64741,11 +65064,11 @@ pax
 pax
 aGU
 pax
-pax
+jLs
 pax
 axE
 bJr
-avm
+axE
 rrv
 jlO
 bMm
@@ -64946,7 +65269,7 @@ ayM
 ayM
 ayM
 cjE
-cjE
+mxq
 cjE
 cjE
 aDH
@@ -64971,7 +65294,7 @@ cjE
 cjE
 siP
 siP
-siP
+pRb
 gSi
 siP
 siP
@@ -65203,9 +65526,9 @@ ayN
 aOo
 aPd
 aAZ
+hbK
 axE
-axE
-axE
+aWI
 axE
 bkm
 axE
@@ -65225,10 +65548,10 @@ iew
 axE
 axE
 axE
-axE
-eYV
 aWI
+eYV
 axE
+hbK
 axE
 axE
 axE
@@ -65460,7 +65783,7 @@ bKA
 bKA
 cKc
 cpR
-cpR
+pRl
 cpR
 cpR
 aDI
@@ -65717,8 +66040,8 @@ bIt
 tBl
 bIt
 aBa
-afn
-bIt
+ayu
+xPM
 aCG
 aDG
 aEu
@@ -65742,8 +66065,8 @@ biH
 pBI
 nfr
 pBI
-pBI
-bIt
+tTa
+diT
 bIt
 tBl
 afn
@@ -67786,8 +68109,8 @@ lWL
 ayi
 bcU
 aLY
-aNo
-aNo
+cND
+sRp
 aOk
 kjL
 aPC
@@ -77079,7 +77402,7 @@ bCy
 bDV
 bFo
 gff
-bVt
+rvQ
 ueW
 jPX
 lCe
@@ -78346,10 +78669,10 @@ gqk
 bhb
 gqk
 baK
-bmi
+qwF
 bmf
-bmi
-bmi
+qwF
+qwF
 boh
 boh
 brj
@@ -78604,9 +78927,9 @@ lIC
 biB
 baK
 bli
-wtj
+ktk
 vSn
-bmi
+qwF
 bpc
 bqk
 brk
@@ -78860,10 +79183,10 @@ bgh
 uxX
 uxX
 baK
-aZQ
-bmh
+avm
+tEv
 vSn
-bmi
+qwF
 jzy
 tjB
 tjB
@@ -79111,16 +79434,16 @@ cid
 cid
 cid
 cid
-roJ
+jwv
 baK
 ncU
 bhd
 ncU
 baK
-aZQ
-aZQ
+avm
+avm
 vSn
-bmi
+qwF
 qHy
 nMF
 brm
@@ -79375,9 +79698,9 @@ baK
 baK
 baK
 lWL
-aZQ
+avm
 vSn
-bmi
+qwF
 bpf
 tjB
 brn
@@ -79632,9 +79955,9 @@ lWL
 lWL
 lWL
 lWL
-aZQ
+avm
 vSn
-bmi
+qwF
 bpg
 bpg
 bpg
@@ -79889,9 +80212,9 @@ lWL
 lWL
 lWL
 lWL
-aZQ
+avm
 vSn
-bmi
+qwF
 bph
 bqn
 bro
@@ -80140,23 +80463,23 @@ aCI
 aCI
 aCI
 aCI
-aZQ
+avm
 bqo
 bqo
 bqo
-aZQ
+avm
 lWL
-aZQ
+avm
 bnk
-bmi
+qwF
 boh
 boh
 boh
 bwt
 bwt
-bmi
-bmi
-bmi
+qwF
+qwF
+qwF
 bwt
 bwt
 bwt
@@ -80396,24 +80719,24 @@ lWL
 lWL
 lWL
 lWL
-aZQ
-aZQ
-bgj
-aIL
-aIL
-aZQ
-aZQ
-aZQ
+avm
+avm
+lNw
+bUA
+bUA
+avm
+avm
+avm
 vSn
-aZQ
+avm
 aCI
 aCI
 aCI
 aCI
 aCI
-aZQ
-bhm
-aZQ
+avm
+bAo
+avm
 bzA
 hIZ
 boi
@@ -80654,23 +80977,23 @@ lWL
 lWL
 lWL
 bqo
-aIL
-aIL
+bUA
+bUA
 tjY
 tZz
 tZz
 tZz
 tZz
 vSn
-aZQ
-aZQ
-buf
-aZQ
-buf
-aZQ
-aZQ
-aIL
-aZQ
+avm
+avm
+qmL
+avm
+qmL
+avm
+avm
+bUA
+avm
 maa
 wDj
 bCG
@@ -80911,12 +81234,12 @@ lWL
 lWL
 lWL
 bqo
-aIL
+bUA
 bhg
 bhf
 tZz
-aIL
-aZQ
+bUA
+avm
 bmk
 vSn
 vSn
@@ -80926,8 +81249,8 @@ vSn
 vSn
 vSn
 vSn
-aIL
-aZQ
+bUA
+avm
 bzC
 wDj
 bCH
@@ -81168,23 +81491,23 @@ lWL
 lWL
 lWL
 bqo
-aIL
-aIL
-sFi
+bUA
+bUA
+gpC
 tZz
-aIL
-aZQ
-aZQ
-aZQ
-aZQ
-aZQ
-aZQ
-aZQ
-aZQ
-aZQ
+bUA
+avm
+avm
+avm
+avm
+avm
+avm
+avm
+avm
+avm
 vSn
-bhm
-aZQ
+bAo
+avm
 bzD
 wDj
 bCI
@@ -81424,24 +81747,24 @@ lWL
 lWL
 lWL
 lWL
-aZQ
-aZQ
+avm
+avm
 uwA
-aIL
+bUA
 tZz
-aZQ
-aZQ
+avm
+avm
 lWL
 lWL
-aZQ
-bgj
-aZQ
+avm
+lNw
+avm
 brp
 brp
-aZQ
+avm
 vSn
-aIL
-aZQ
+bUA
+avm
 bzE
 bBi
 bCJ
@@ -81682,23 +82005,23 @@ lWL
 lWL
 lWL
 aCI
-aZQ
-aZQ
-aZQ
+avm
+avm
+avm
 tZz
-aZQ
+avm
 lWL
 lWL
 lWL
-aZQ
-aZQ
-aZQ
+avm
+avm
+avm
 brq
-aIL
-aZQ
+bUA
+avm
 vSn
-aIL
-aZQ
+bUA
+avm
 bzF
 bCL
 bCK
@@ -81931,7 +82254,7 @@ aFk
 aSl
 aTz
 aUN
-aIL
+bUA
 aXe
 fEG
 lWL
@@ -81940,22 +82263,22 @@ lWL
 lWL
 aCI
 lWL
-aZQ
+avm
 bhj
 tZz
-aZQ
-aZQ
+avm
+avm
 lWL
 lWL
 lWL
-aZQ
+avm
 bqp
 brr
-aIL
+bUA
 bGR
 vSn
 pac
-aZQ
+avm
 bzG
 sSI
 bCH
@@ -82188,7 +82511,7 @@ aFk
 aSm
 aTA
 hkC
-aIL
+bUA
 aXf
 fEG
 lWL
@@ -82197,21 +82520,21 @@ lWL
 lWL
 aCI
 lWL
-aZQ
+avm
 hFD
 uEQ
-bhm
-aZQ
+bAo
+avm
 lWL
 lWL
 lWL
-aZQ
-aZQ
+avm
+avm
 brs
-aIL
-aZQ
+bUA
+avm
 vSn
-wtj
+ktk
 lZG
 bwC
 kOl
@@ -82443,9 +82766,9 @@ lWL
 lWL
 sZd
 aSn
-aIL
-aIL
-aIL
+bUA
+bUA
+bUA
 aXg
 fEG
 lWL
@@ -82454,22 +82777,22 @@ aGV
 efM
 aLZ
 lWL
-aZQ
-aIL
+avm
+bUA
 tZz
-aIL
+bUA
 bqo
 lWL
 lWL
 lWL
 lWL
-aZQ
-aZQ
+avm
+avm
 bsx
-aZQ
-aIL
-aIL
-aZQ
+avm
+bUA
+bUA
+avm
 bzI
 tHI
 bCN
@@ -82688,9 +83011,9 @@ lWL
 aCI
 sZd
 aHO
-aIL
+bUA
 iYW
-aIL
+bUA
 aMa
 aLk
 tZf
@@ -82701,32 +83024,32 @@ tZf
 tZf
 rHE
 aRd
-aIL
+bUA
 aVM
 fHr
 tZf
 tZf
 iCJ
 bcc
-aIL
+bUA
 bes
 aJY
-aZQ
+avm
 biM
 tZz
 biM
-aZQ
+avm
 lWL
 lWL
 lWL
 lWL
 lWL
-aZQ
+avm
 bqo
-aZQ
+avm
 bqo
-aZQ
-aZQ
+avm
+avm
 byb
 byb
 byb
@@ -82971,8 +83294,8 @@ aNq
 nrE
 tZz
 tZz
-aIL
-aZQ
+bUA
+avm
 lWL
 lWL
 lWL
@@ -83204,7 +83527,7 @@ sZd
 aHQ
 inn
 vSn
-aIL
+bUA
 aMb
 fHr
 rVS
@@ -83225,11 +83548,11 @@ bcd
 gvD
 bet
 bfh
-aZQ
-bpl
-aIL
+avm
+gou
+bUA
 bhj
-aZQ
+avm
 lWL
 lWL
 lWL
@@ -83482,10 +83805,10 @@ bce
 efM
 beu
 lWL
-aZQ
-aZQ
+avm
+avm
 blT
-aZQ
+avm
 bqo
 lWL
 lWL
@@ -83739,11 +84062,11 @@ lWL
 lWL
 aCI
 lWL
-aZQ
-bhm
-aIL
-aIL
-aZQ
+avm
+bAo
+bUA
+bUA
+avm
 lWL
 lWL
 lWL
@@ -83996,11 +84319,11 @@ lWL
 lWL
 aCI
 lWL
-aZQ
-aZQ
+avm
+avm
 aKc
-aZQ
-aZQ
+avm
+avm
 lWL
 lWL
 lWL
@@ -86574,7 +86897,7 @@ dRs
 aCI
 buf
 wqU
-adj
+cGF
 aZQ
 brz
 wIu
@@ -87330,7 +87653,7 @@ aTG
 aVS
 aVU
 aYC
-ayu
+bhN
 baQ
 aYZ
 bck
@@ -87563,7 +87886,7 @@ ayY
 ayY
 ayY
 ayY
-ayY
+nYo
 ayY
 ayY
 ayY
@@ -87587,7 +87910,7 @@ aTH
 aVS
 aVV
 aXn
-ayu
+bhN
 aYC
 baR
 bcl
@@ -87844,7 +88167,7 @@ aRj
 aVS
 aVW
 gcL
-ayu
+bhN
 aYC
 aYC
 bcm
@@ -88080,7 +88403,7 @@ ayY
 ayY
 adh
 adh
-adh
+wdw
 aFq
 ayo
 ayo
@@ -88584,7 +88907,7 @@ adQ
 adQ
 bsV
 apx
-aRI
+iiB
 abT
 abT
 abT
@@ -88833,7 +89156,7 @@ anR
 aoG
 apy
 rdQ
-bUA
+amx
 arR
 uZn
 tbk
@@ -88847,20 +89170,20 @@ azb
 azD
 aAq
 cli
-vVh
+dFe
 uAa
 cUG
 uAa
 vDV
 bwM
-bYf
+gNn
 vVh
-dHf
+vVh
 vVh
 bwP
 aLr
 nZw
-vVh
+bsO
 ebD
 xsN
 vfg
@@ -89090,7 +89413,7 @@ anj
 aoI
 apz
 apz
-bUA
+amx
 arS
 apx
 atM
@@ -89104,7 +89427,7 @@ azc
 azc
 azc
 akG
-akG
+cTq
 akG
 gjY
 akG
@@ -89347,7 +89670,7 @@ anT
 kwX
 apA
 apA
-bUA
+amx
 arT
 agS
 atM
@@ -89361,7 +89684,7 @@ bug
 bug
 bug
 bug
-aBD
+ood
 bug
 nrc
 aiT
@@ -89604,11 +89927,11 @@ qdz
 aoJ
 aCZ
 eHB
-bUA
-abT
-abT
-abT
-abT
+amx
+adQ
+adQ
+adQ
+adQ
 adQ
 qbm
 cfu
@@ -89618,7 +89941,7 @@ cfu
 cfu
 cfu
 cfu
-ujh
+fen
 cfu
 cfu
 cfu
@@ -89861,7 +90184,7 @@ anV
 aAp
 apB
 aqk
-bUA
+amx
 arU
 asS
 atN
@@ -89874,7 +90197,7 @@ bsV
 mxO
 bsV
 uWA
-bsV
+xfI
 sxG
 rwd
 bsV
@@ -89906,7 +90229,7 @@ fem
 crA
 bdv
 bey
-fem
+lIk
 fem
 gnj
 uSP
@@ -90114,11 +90437,11 @@ akK
 alJ
 aiY
 aLF
-bUA
+amx
 aoL
-bUA
-bUA
-bUA
+amx
+amx
+amx
 lHM
 lHM
 lHM
@@ -90137,7 +90460,7 @@ aCm
 tFV
 tFV
 tFV
-adQ
+atd
 azu
 azu
 azu
@@ -90154,11 +90477,11 @@ aNy
 aNy
 aNy
 aNy
-bsV
+sjq
 gSF
 gjY
 gjY
-gjY
+hla
 gjY
 gjY
 gjY
@@ -90415,7 +90738,7 @@ bsV
 jcU
 bug
 bug
-bug
+bOA
 bug
 bug
 aiT
@@ -90672,7 +90995,7 @@ roC
 cfd
 apx
 apx
-apx
+bmp
 apx
 apx
 apx
@@ -90927,10 +91250,10 @@ mUn
 aNy
 cJA
 cfd
-apx
-ydt
-aLi
-ydt
+cfu
+qLI
+hon
+wyt
 ydt
 ydt
 auw
@@ -92203,17 +92526,17 @@ azu
 azu
 azu
 jqM
-jqM
-jqM
-jqM
-jqM
-jqM
-jqM
-ddZ
-ddZ
+wDz
+wDz
+wDz
+wDz
+wDz
+wDz
+sjk
+sjk
 aQS
-ddZ
-ddZ
+sjk
+sjk
 aZV
 oBt
 bcu
@@ -92467,10 +92790,10 @@ aRt
 aRt
 aEQ
 tTD
-blZ
+mcq
 jcF
 jRv
-ddZ
+sjk
 sap
 rwS
 bcv
@@ -92727,7 +93050,7 @@ aTP
 aUU
 ktU
 aXA
-ddZ
+sjk
 bEC
 rwS
 tpC
@@ -92975,16 +93298,16 @@ aIk
 aMR
 jqM
 aRB
-blZ
+mcq
 aRB
-blZ
-blZ
+mcq
+mcq
 aSH
 aTQ
 aTQ
 def
 aXB
-ddZ
+sjk
 aZY
 bbf
 aYQ
@@ -93241,7 +93564,7 @@ aRt
 aUV
 gnI
 aXC
-ddZ
+sjk
 aZZ
 bbr
 bcx
@@ -93755,7 +94078,7 @@ def
 dBZ
 def
 afV
-ddZ
+sjk
 iNa
 aLU
 oOu
@@ -94002,17 +94325,17 @@ aFE
 aFE
 aFE
 jqM
-jqM
-jqM
-jqM
-jqM
+wDz
+wDz
+wDz
+wDz
 aWn
-ddZ
-ddZ
-ddZ
-ddZ
-ddZ
-ddZ
+sjk
+sjk
+sjk
+sjk
+sjk
+sjk
 fkZ
 bab
 aUX
@@ -94216,12 +94539,12 @@ aCI
 aeG
 aEG
 aBU
-lWL
-agV
-ais
-ais
-ais
-ajT
+eFN
+acE
+acE
+acE
+acE
+acE
 alW
 alS
 alW
@@ -94235,12 +94558,12 @@ atc
 atb
 atW
 awY
-axc
-axc
-axc
-axc
+atW
+atW
+atW
+atW
 ayv
-aBO
+azU
 azQ
 aAC
 aBu
@@ -94262,11 +94585,11 @@ aFv
 aHk
 bEw
 pBK
-jqM
+wDz
 bgx
-ddZ
-aBX
-ddZ
+sjk
+xKm
+sjk
 aWp
 aXF
 aYT
@@ -94472,12 +94795,12 @@ lWL
 aCI
 aeG
 aEG
-aBU
-aBU
-acE
-acE
-acE
-acE
+agv
+agv
+agv
+upX
+agv
+agv
 acE
 acE
 waD
@@ -94494,7 +94817,7 @@ atX
 auP
 caz
 awy
-sjk
+caz
 axS
 ayx
 azU
@@ -94519,11 +94842,11 @@ aFv
 aHl
 aIk
 aIk
-jqM
+wDz
 dNe
-ddZ
-ddZ
-ddZ
+sjk
+sjk
+sjk
 aWq
 jOp
 nhF
@@ -94732,7 +95055,7 @@ aEG
 agv
 agv
 agv
-fcs
+nCB
 ait
 ajf
 ajV
@@ -94754,7 +95077,7 @@ awz
 axe
 qwk
 ayy
-aBO
+azU
 azS
 aAB
 aAB
@@ -94776,11 +95099,11 @@ aFv
 aHl
 aIk
 aIk
-jqM
+wDz
 bgx
-aoH
+izr
 aTU
-ddZ
+sjk
 aWr
 aXR
 bag
@@ -95005,7 +95328,7 @@ bwV
 aZb
 bwV
 atX
-qwk
+wmE
 avC
 atX
 axf
@@ -95033,11 +95356,11 @@ aFv
 aHm
 aPo
 aJf
-jqM
+wDz
 bgx
-aoH
+izr
 aTV
-ddZ
+sjk
 aWs
 aXR
 jCg
@@ -95290,11 +95613,11 @@ aFv
 aHn
 aIh
 aPT
-jqM
+wDz
 bgx
-ddZ
-ddZ
-ddZ
+sjk
+sjk
+sjk
 aWt
 aXR
 bag
@@ -95547,11 +95870,11 @@ aNG
 pQt
 mGK
 aPU
-jqM
+wDz
 gFc
-ddZ
+sjk
 aTW
-ddZ
+sjk
 aWu
 aXI
 aYV
@@ -95808,8 +96131,8 @@ aQz
 aRw
 aSK
 aTX
-ddZ
-ddZ
+sjk
+sjk
 aUX
 aUX
 aYW
@@ -96061,12 +96384,12 @@ aNH
 tkt
 uNx
 aPW
-jqM
+wDz
 bgx
-ddZ
+sjk
 cux
 aUY
-ddZ
+sjk
 pYa
 aYW
 bah
@@ -96318,12 +96641,12 @@ aFv
 aHo
 aIi
 aJh
-jqM
+wDz
 bgx
-ddZ
+sjk
 afo
 azV
-ddZ
+sjk
 pYa
 aYW
 bai
@@ -96575,12 +96898,12 @@ aFv
 aJf
 aPp
 aHm
-jqM
+wDz
 bgx
 aSL
 aUa
 aVa
-ddZ
+sjk
 lWL
 aUX
 aYW
@@ -96832,12 +97155,12 @@ aFv
 aIk
 aIk
 aHl
-jqM
+wDz
 bgx
-ddZ
+sjk
 aUb
 aVa
-ddZ
+sjk
 lWL
 lWL
 lWL
@@ -97089,12 +97412,12 @@ aFv
 aIk
 aIk
 aHl
-jqM
+wDz
 bgx
-ddZ
-ddZ
+sjk
+sjk
 cux
-ddZ
+sjk
 lWL
 lWL
 lWL
@@ -97325,7 +97648,7 @@ blZ
 lAC
 rGt
 ddZ
-nWr
+aCI
 ddZ
 ddZ
 blZ
@@ -97346,12 +97669,12 @@ aFv
 baA
 aUD
 aJi
-jqM
+wDz
 bgx
 aSM
-ddZ
+sjk
 cux
-ddZ
+sjk
 lWL
 lWL
 lWL
@@ -97591,24 +97914,24 @@ blZ
 aEi
 aoH
 eWN
-jqM
-jqM
-jqM
-jqM
-jqM
-jqM
-jqM
-jqM
-jqM
-jqM
-jqM
-jqM
-jqM
+wDz
+wDz
+wDz
+wDz
+wDz
+wDz
+wDz
+wDz
+wDz
+wDz
+wDz
+wDz
+wDz
 bgx
 rsC
-ddZ
+sjk
 aVb
-ddZ
+sjk
 lWL
 lWL
 lWL
@@ -97848,10 +98171,10 @@ blZ
 blZ
 ddZ
 eWN
-eWN
-eWN
-eWN
-eWN
+lIy
+oNq
+oNq
+oNq
 aKB
 aLz
 bWJ
@@ -97862,8 +98185,8 @@ aFF
 aFF
 aFF
 mYZ
-gaP
-ddZ
+wJu
+sjk
 aVd
 aCI
 lWL
@@ -98105,22 +98428,22 @@ blZ
 ddZ
 ddZ
 ddZ
-ddZ
-ddZ
-ddZ
-rGt
+sjk
+sjk
+sjk
+rxQ
 aKC
 anu
-ddZ
-ddZ
-ddZ
-ddZ
-xof
-blZ
-blZ
+sjk
+sjk
+sjk
+sjk
+fTf
+mcq
+mcq
 bao
-ddZ
-ddZ
+sjk
+sjk
 aVd
 pYa
 pYa
@@ -98364,19 +98687,19 @@ aCI
 lWL
 lWL
 lWL
-ddZ
-xof
+sjk
+fTf
 aKD
-blZ
-xof
+mcq
+fTf
 aOB
 aNI
-blZ
-rGt
-blZ
-blZ
+mcq
+rxQ
+mcq
+mcq
 bao
-ddZ
+sjk
 pYa
 aVe
 aWw
@@ -98621,21 +98944,21 @@ aCI
 lWL
 lWL
 aEV
-ddZ
-ddZ
+sjk
+sjk
 aKE
-ddZ
-ddZ
-ddZ
-ddZ
+sjk
+sjk
+sjk
+sjk
 aOB
-ddZ
-ddZ
-ddZ
+sjk
+sjk
+sjk
 bao
-ddZ
-btv
-ddZ
+sjk
+fcs
+sjk
 aCI
 aCI
 lWL
@@ -98884,16 +99207,16 @@ aKF
 aEV
 aEV
 lWL
-ddZ
-xof
-ddZ
+sjk
+fTf
+sjk
 lWL
-ddZ
+sjk
 bao
-ddZ
+sjk
 aUc
-ddZ
-ddZ
+sjk
+sjk
 bbq
 lWL
 lWL
@@ -99141,11 +99464,11 @@ aKG
 aLB
 aIo
 lWL
-ddZ
-ddZ
-ddZ
+sjk
+sjk
+sjk
 lWL
-ddZ
+sjk
 bao
 aSP
 aUd
@@ -99402,12 +99725,12 @@ lWL
 lWL
 aCI
 lWL
-ddZ
+sjk
 bao
-ddZ
-blZ
-ddZ
-ddZ
+sjk
+mcq
+sjk
+sjk
 bbq
 lWL
 lWL
@@ -99659,11 +99982,11 @@ aCI
 aCI
 aCI
 aCI
-ddZ
+sjk
 bao
-ddZ
-btv
-ddZ
+sjk
+fcs
+sjk
 aCI
 aCI
 lWL
@@ -99915,11 +100238,11 @@ lWL
 lWL
 lWL
 lWL
-ddZ
-ddZ
+sjk
+sjk
 aRA
-ddZ
-ddZ
+sjk
+sjk
 qKB
 aCI
 lWL
@@ -100171,13 +100494,13 @@ lWL
 lWL
 lWL
 lWL
-ddZ
-ddZ
+sjk
+sjk
 aRB
 cgQ
 aSQ
-ddZ
-ddZ
+sjk
+sjk
 aCI
 lWL
 lWL
@@ -100428,13 +100751,13 @@ lWL
 lWL
 lWL
 lWL
-ddZ
+sjk
 aPX
 aRB
 cgQ
 aRB
 aUe
-ddZ
+sjk
 aCI
 lWL
 lWL
@@ -100685,13 +101008,13 @@ lWL
 lWL
 lWL
 lWL
-btv
+fcs
 aPY
 aQB
 aRC
 aQC
 aUf
-btv
+fcs
 lWL
 lWL
 lWL
@@ -100942,13 +101265,13 @@ lWL
 lWL
 lWL
 lWL
-ddZ
+sjk
 aPZ
 aRB
 rkH
 aRB
 aUg
-ddZ
+sjk
 lWL
 lWL
 lWL
@@ -101199,13 +101522,13 @@ lWL
 lWL
 lWL
 lWL
-ddZ
-ddZ
-btv
+sjk
+sjk
+fcs
 rfL
-btv
-ddZ
-ddZ
+fcs
+sjk
+sjk
 lWL
 lWL
 lWL
@@ -101457,11 +101780,11 @@ lWL
 lWL
 lWL
 qKB
-ddZ
+sjk
 bWj
 aRE
 aRB
-ddZ
+sjk
 pYa
 lWL
 lWL
@@ -101714,11 +102037,11 @@ lWL
 lWL
 lWL
 lWL
-ddZ
-btv
+sjk
+fcs
 bwW
-btv
-ddZ
+fcs
+sjk
 lWL
 lWL
 lWL

--- a/StationMaps/DiscStation/DiscStation.dmm
+++ b/StationMaps/DiscStation/DiscStation.dmm
@@ -50,7 +50,7 @@
 /area/station/security/execution/transfer)
 "abP" = (
 /obj/machinery/status_display/ai/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "abQ" = (
 /obj/machinery/power/tracker,
@@ -66,11 +66,11 @@
 "abU" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "abV" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/satellite)
 "abW" = (
 /obj/machinery/camera/directional/north{
@@ -78,7 +78,10 @@
 	network = list("aicore")
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "abX" = (
 /obj/structure/cable,
@@ -89,7 +92,7 @@
 "acb" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/porta_turret/ai,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "acc" = (
 /turf/closed/wall,
@@ -124,6 +127,17 @@
 "acE" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/fore)
+"acF" = (
+/obj/machinery/door/airlock/external,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "acH" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -154,20 +168,23 @@
 	pixel_x = 3;
 	pixel_y = -23
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "acP" = (
-/obj/machinery/door/window{
-	dir = 1;
-	name = "AI Core Door";
-	req_access_txt = "16"
-	},
 /obj/machinery/flasher/directional/south{
 	id = "AI";
 	pixel_x = 26
 	},
 /obj/machinery/holopad/secure,
-/turf/open/floor/iron,
+/obj/machinery/door/window{
+	atom_integrity = 300;
+	base_state = "leftsecure";
+	dir = 1;
+	icon_state = "leftsecure";
+	name = "Primary AI Core Access";
+	req_access = list("ai_upload")
+	},
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "acQ" = (
 /obj/structure/window/reinforced{
@@ -176,7 +193,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "acT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -207,9 +224,6 @@
 	},
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/mask/breath,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "acY" = (
@@ -218,8 +232,7 @@
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "acZ" = (
-/obj/structure/table,
-/obj/item/paper/pamphlet,
+/obj/structure/closet/secure_closet/exile,
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "ada" = (
@@ -271,7 +284,17 @@
 	name = "Private Channel";
 	pixel_x = -8
 	},
-/turf/open/floor/iron,
+/obj/machinery/door/window{
+	atom_integrity = 300;
+	base_state = "rightsecure";
+	dir = 4;
+	icon_state = "rightsecure";
+	layer = 4.1;
+	name = "Secondary AI Core Access";
+	pixel_x = 4;
+	req_access = list("ai_upload")
+	},
+/turf/open/floor/circuit/green,
 /area/station/ai_monitored/turret_protected/ai)
 "adj" = (
 /obj/structure/cable,
@@ -297,12 +320,12 @@
 	name = "Custom Channel";
 	pixel_y = -8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/circuit/green,
 /area/station/ai_monitored/turret_protected/ai)
 "adl" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/holopad/secure,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "adm" = (
 /obj/effect/landmark/start/ai/secondary,
@@ -324,16 +347,26 @@
 	name = "Private Channel";
 	pixel_x = 8
 	},
-/turf/open/floor/iron,
+/obj/machinery/door/window{
+	atom_integrity = 300;
+	base_state = "leftsecure";
+	dir = 8;
+	icon_state = "leftsecure";
+	layer = 4.1;
+	name = "Tertiary AI Core Access";
+	pixel_x = -3;
+	req_access = list("ai_upload")
+	},
+/turf/open/floor/circuit/green,
 /area/station/ai_monitored/turret_protected/ai)
 "adn" = (
 /obj/machinery/atmospherics/components/tank/air,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "ado" = (
 /obj/machinery/atmospherics/components/tank,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "adr" = (
 /obj/structure/disposalpipe/segment{
@@ -355,16 +388,13 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/item/stack/medical/ointment,
-/obj/item/stack/medical/bruise_pack,
 /obj/item/reagent_containers/glass/bottle/multiver,
 /obj/item/reagent_containers/syringe/epinephrine{
 	pixel_x = -1;
 	pixel_y = 2
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
+/obj/item/stack/medical/mesh,
+/obj/item/stack/medical/suture,
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "adw" = (
@@ -403,7 +433,7 @@
 /area/station/maintenance/starboard/fore)
 "adE" = (
 /obj/machinery/recharge_station,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/satellite)
 "adG" = (
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -421,7 +451,7 @@
 	charge = 5e+006
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/satellite)
 "adM" = (
 /obj/structure/table,
@@ -432,21 +462,21 @@
 	network = list("minisat")
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "adN" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 0;
 	name = "Air Out"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "adO" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "adP" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
@@ -490,20 +520,17 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "aec" = (
 /obj/structure/table,
-/obj/item/storage/fancy/donut_box,
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/light/directional/east,
 /obj/machinery/camera/directional/east{
 	c_tag = "Gateway Storage";
 	pixel_y = -22
 	},
+/obj/item/paper/pamphlet,
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "aee" = (
@@ -529,7 +556,7 @@
 /obj/item/stack/sheet/mineral/plasma,
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/satellite)
 "ael" = (
 /obj/machinery/camera/directional/west{
@@ -537,7 +564,7 @@
 	network = list("aicore")
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "aeo" = (
 /obj/machinery/ai_slipper{
@@ -545,14 +572,14 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
 "aeq" = (
 /obj/structure/rack,
 /obj/item/clothing/head/welding,
 /obj/item/wrench,
 /obj/item/crowbar/red,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "aer" = (
 /obj/machinery/light/directional/east,
@@ -580,9 +607,9 @@
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "aey" = (
-/obj/structure/closet/l3closet/scientist,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/cable,
+/obj/machinery/computer/gateway_control{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/command/gateway)
@@ -654,7 +681,7 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/multitool,
 /obj/machinery/light/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/satellite)
 "aeM" = (
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -662,7 +689,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/satellite)
 "aeN" = (
 /obj/machinery/turretid{
@@ -672,27 +700,27 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/satellite)
 "aeR" = (
 /obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "aeS" = (
 /obj/machinery/holopad,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "aeT" = (
 /obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "aeU" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/porta_turret/ai,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "aeW" = (
 /obj/structure/cable,
@@ -725,8 +753,10 @@
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "afe" = (
-/obj/machinery/door/window{
-	dir = 8
+/obj/machinery/button/door/directional/south{
+	id = "gateshutter";
+	name = "Gateway Shutter Control";
+	req_access = list("command")
 	},
 /turf/open/floor/iron,
 /area/station/command/gateway)
@@ -776,8 +806,9 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/science/genetics,
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
 /turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "afv" = (
@@ -786,18 +817,18 @@
 	name = "MiniSat Antechamber Turret Shutter Control";
 	pixel_x = 25;
 	pixel_y = -6;
-	req_access_txt = "17;65"
+	req_access = list("ai_upload")
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "afx" = (
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
-/turf/open/floor/iron,
+/turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
 "afy" = (
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -881,7 +912,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "agl" = (
 /obj/machinery/camera/autoname/directional/west,
@@ -890,19 +921,20 @@
 /area/station/hallway/primary/starboard)
 "agn" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters{
+/obj/machinery/door/poddoor/shutters/window{
 	id = "gateshutter";
 	name = "Gateway Access Shutter"
 	},
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "agu" = (
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
 	name = "Medbay"
 	},
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/effect/mapping_helpers/airlock/access/any/science/genetics,
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
 "agv" = (
@@ -927,7 +959,7 @@
 	c_tag = "MiniSat Ante Turrets";
 	network = list("minisat")
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "agK" = (
 /turf/open/floor/iron,
@@ -951,14 +983,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "agR" = (
-/obj/machinery/button/door{
-	id = "gateshutter";
-	name = "Gateway Shutter Control";
-	pixel_y = 26;
-	req_access_txt = "19"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "agS" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
@@ -1022,7 +1049,6 @@
 /area/station/maintenance/starboard/fore)
 "ahx" = (
 /obj/structure/grille,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -1074,7 +1100,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "ahZ" = (
 /obj/machinery/door/firedoor,
@@ -1172,8 +1198,8 @@
 	name = "Port Docking Bay 1"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "med-maint-pass"
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
@@ -1182,7 +1208,7 @@
 	name = "MiniSat Antechamber"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "aiK" = (
 /obj/effect/landmark/start/roboticist,
@@ -1288,10 +1314,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "ajq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/grille/broken,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/area/station/maintenance/port)
 "ajr" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
@@ -1301,16 +1333,16 @@
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "ajt" = (
 /obj/item/kirbyplants/random,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "aju" = (
 /obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "ajv" = (
 /obj/machinery/computer/message_monitor,
 /obj/machinery/light/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "ajx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -1318,15 +1350,21 @@
 	id = "AIante";
 	name = "MiniSat Antechamber Turret Shutter Control";
 	pixel_y = 25;
-	req_access_txt = "17;65"
+	req_access = list("ai_upload")
 	},
 /obj/effect/landmark/start/cyborg,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "ajz" = (
 /obj/machinery/computer/station_alert,
 /obj/machinery/light/directional/north,
-/turf/open/floor/iron,
+/obj/machinery/turretid{
+	control_area = "/area/station/ai_monitored/turret_protected/aisat_interior";
+	name = "Antechamber Turret Control";
+	req_access = list("minisat");
+	pixel_y = 30
+	},
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "ajB" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -1447,7 +1485,7 @@
 	uses = 10
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
 "akn" = (
 /obj/item/stack/rods/ten,
@@ -1465,7 +1503,7 @@
 	c_tag = "MiniSat Lobby West";
 	network = list("minisat")
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "akt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1483,7 +1521,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "akA" = (
 /obj/structure/cable,
@@ -1614,7 +1652,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "alC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
@@ -1726,7 +1764,7 @@
 "amc" = (
 /obj/machinery/newscaster/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
 "amd" = (
 /obj/item/clothing/suit/fire/atmos,
@@ -1736,10 +1774,10 @@
 /area/station/maintenance/port/fore)
 "ame" = (
 /obj/machinery/light/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "amk" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "aml" = (
 /obj/structure/transit_tube/junction/flipped{
@@ -1858,20 +1896,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
 "amY" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/button/door{
-	id = "teledoor";
-	name = "AI Satellite Teleport Shutters Control";
-	pixel_y = -25;
-	req_access_txt = "17;65"
+/obj/machinery/atmospherics/components/tank/air{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/station/ai_monitored/turret_protected/aisat/foyer)
+/turf/open/floor/plating,
+/area/station/maintenance/central)
 "ana" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -1986,7 +2024,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "anM" = (
 /obj/machinery/door/poddoor/shutters{
@@ -1994,7 +2032,7 @@
 	name = "AI Satellite Teleport Access"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "anO" = (
 /obj/structure/cable,
@@ -2121,23 +2159,30 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "aox" = (
 /obj/machinery/button/door{
 	id = "teledoor";
 	name = "AI Satellite Teleport Shutters Control";
-	pixel_y = 25;
-	req_access_txt = "17;65"
+	pixel_y = 24;
+	req_access = list("ai_upload")
 	},
 /obj/effect/spawner/random/engineering/tracking_beacon,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "aoy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/machinery/button/door{
+	id = "teledoor";
+	name = "AI Satellite Teleport Shutters Control";
+	pixel_y = -24;
+	req_access = list("ai_upload")
+	},
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "aoz" = (
 /obj/structure/transit_tube,
@@ -2276,21 +2321,21 @@
 "app" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "apq" = (
 /obj/structure/chair/office,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "apr" = (
 /obj/machinery/bluespace_beacon,
 /obj/machinery/holopad/secure,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "apt" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "apu" = (
 /obj/effect/landmark/start/depsec/engineering,
@@ -2402,7 +2447,7 @@
 /obj/structure/chair/pew/right{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "aqb" = (
 /obj/structure/cable,
@@ -2417,19 +2462,21 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "aqd" = (
-/obj/machinery/computer/teleporter,
-/turf/open/floor/iron,
+/obj/machinery/computer/teleporter{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "aqe" = (
 /obj/machinery/teleport/station,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "aqf" = (
 /obj/machinery/teleport/hub,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "aqj" = (
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -2727,7 +2774,7 @@
 /area/station/hallway/primary/port)
 "arD" = (
 /obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "arE" = (
 /obj/effect/turf_decal/delivery,
@@ -2794,7 +2841,7 @@
 /area/station/hallway/primary/starboard)
 "arU" = (
 /obj/machinery/light/directional/west,
-/obj/machinery/requests_console/directional/west,
+/obj/machinery/requests_console/auto_name/directional/west,
 /turf/open/floor/iron,
 /area/station/science/lab)
 "arV" = (
@@ -2882,7 +2929,7 @@
 /area/station/maintenance/department/electrical)
 "asp" = (
 /obj/machinery/light/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "asq" = (
 /obj/structure/cable,
@@ -2935,7 +2982,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "asI" = (
 /obj/docking_port/stationary/random{
@@ -2946,7 +2993,7 @@
 /area/space/nearstation)
 "asJ" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "asK" = (
 /obj/structure/sign/warning/secure_area,
@@ -3016,7 +3063,6 @@
 	},
 /obj/machinery/requests_console{
 	department = "Science";
-	departmentType = 2;
 	name = "Science Requests Console";
 	pixel_y = -30
 	},
@@ -3370,7 +3416,8 @@
 /obj/item/stock_parts/scanning_module,
 /obj/machinery/button/door{
 	id = "rnd";
-	name = "Research Shutters"
+	name = "Research Shutters";
+	pixel_y = -24
 	},
 /turf/open/floor/iron,
 /area/station/science/lab)
@@ -3530,7 +3577,7 @@
 /obj/machinery/door/window/right/directional/south{
 	dir = 1;
 	name = "Research and Development Desk";
-	req_access_txt = "7"
+	req_access = list("science")
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "rnd";
@@ -3558,7 +3605,7 @@
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/radio/off,
-/obj/machinery/requests_console/directional/east,
+/obj/machinery/requests_console/auto_name/directional/east,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/science)
 "avB" = (
@@ -3844,7 +3891,7 @@
 /obj/item/clothing/gloves/color/latex,
 /obj/item/healthanalyzer,
 /obj/item/clothing/glasses/hud/health,
-/obj/machinery/requests_console/directional/north,
+/obj/machinery/requests_console/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/medical/virology)
 "axp" = (
@@ -4187,7 +4234,11 @@
 /obj/machinery/computer/aifixer{
 	dir = 4
 	},
-/obj/machinery/requests_console/directional/north,
+/obj/machinery/requests_console/directional/north{
+	announcementConsole = 1;
+	department = "Research Director's Desk";
+	name = "Research Director's Requests Console"
+	},
 /obj/structure/window/spawner/west,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/rd)
@@ -4377,7 +4428,7 @@
 /area/station/science/genetics)
 "aAl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "aAm" = (
 /obj/structure/closet/emcloset,
@@ -4407,7 +4458,6 @@
 /area/station/hallway/primary/starboard)
 "aAr" = (
 /obj/machinery/light/directional/west,
-/obj/structure/festivus,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/rd)
 "aAs" = (
@@ -4705,7 +4755,6 @@
 /obj/machinery/light/directional/south,
 /obj/machinery/requests_console{
 	department = "Science";
-	departmentType = 2;
 	name = "Science RC";
 	pixel_y = -30
 	},
@@ -4903,7 +4952,7 @@
 /turf/open/floor/plating,
 /area/station/construction)
 "aCW" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "aCY" = (
 /obj/structure/frame/machine,
@@ -4940,6 +4989,14 @@
 "aDc" = (
 /turf/closed/wall,
 /area/station/science/lab)
+"aDe" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "aDg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -5054,6 +5111,10 @@
 /obj/machinery/light/directional/west,
 /obj/item/radio/intercom/directional/west,
 /obj/item/radio/headset/headset_medsci,
+/obj/item/storage/box/disks{
+	pixel_x = 6;
+	pixel_y = 3
+	},
 /turf/open/floor/iron,
 /area/station/science/genetics)
 "aDC" = (
@@ -5132,8 +5193,8 @@
 /area/station/science/research)
 "aDS" = (
 /obj/machinery/door/window/left/directional/east{
-	name = "Medical Delivery";
-	req_access_txt = "5"
+	name = "Research Delivery";
+	req_access = list("science")
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -5698,7 +5759,7 @@
 	},
 /obj/item/storage/belt/utility,
 /obj/item/reagent_containers/glass/beaker/large,
-/obj/machinery/requests_console/directional/north,
+/obj/machinery/requests_console/auto_name/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "aGt" = (
@@ -5819,6 +5880,11 @@
 	c_tag = "CMO's Office";
 	network = list("ss13","medbay")
 	},
+/obj/machinery/requests_console/directional/west{
+	announcementConsole = 1;
+	department = "Chief Medical Officer's Desk";
+	name = "Chief Medical Officer's Requests Console"
+	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/cmo)
 "aGM" = (
@@ -5875,6 +5941,9 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/tank/air{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "aGZ" = (
@@ -5912,10 +5981,10 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "aHh" = (
-/obj/machinery/requests_console/directional/north,
+/obj/machinery/requests_console/auto_name/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
 "aHj" = (
 /obj/structure/table/reinforced,
@@ -5944,6 +6013,7 @@
 	name = "containment blast door"
 	},
 /obj/structure/window/reinforced/fulltile,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "aHn" = (
@@ -5952,22 +6022,23 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "aHo" = (
 /obj/structure/window/reinforced,
 /obj/structure/table/reinforced,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "aHp" = (
-/obj/structure/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "misclab";
-	name = "test chamber blast door"
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 1"
 	},
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
+/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "aHr" = (
 /obj/machinery/mineral/stacking_unit_console{
 	machinedir = 8
@@ -5976,7 +6047,7 @@
 /area/station/maintenance/disposal)
 "aHs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "aHt" = (
 /obj/machinery/conveyor{
@@ -6025,13 +6096,13 @@
 /turf/open/floor/iron,
 /area/station/medical/virology)
 "aHG" = (
-/obj/structure/table,
 /obj/machinery/light/directional/east,
 /obj/item/storage/box/monkeycubes,
 /obj/item/storage/box/gloves{
 	pixel_x = 5;
 	pixel_y = 1
 	},
+/obj/structure/table/glass,
 /turf/open/floor/iron,
 /area/station/science/genetics)
 "aHJ" = (
@@ -6058,7 +6129,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "aHM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "aHN" = (
@@ -6122,6 +6195,7 @@
 /area/station/science/robotics/lab)
 "aIa" = (
 /obj/item/wrench,
+/obj/structure/sign/warning/xeno_mining/directional/west,
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
 "aIb" = (
@@ -6140,19 +6214,20 @@
 	dir = 8;
 	icon_state = "right";
 	name = "Containment Pen";
-	req_access_txt = "55"
+	req_access = list("xenobiology")
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio3";
 	name = "containment blast door"
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "aIh" = (
 /obj/machinery/door/window/left/directional/north{
 	dir = 8;
 	name = "Containment Pen";
-	req_access_txt = "55"
+	req_access = list("xenobiology")
 	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
@@ -6162,7 +6237,7 @@
 	dir = 4;
 	icon_state = "right";
 	name = "Containment Pen";
-	req_access_txt = "55"
+	req_access = list("xenobiology")
 	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
@@ -6170,12 +6245,13 @@
 /obj/machinery/door/window/left/directional/north{
 	dir = 4;
 	name = "Containment Pen";
-	req_access_txt = "55"
+	req_access = list("xenobiology")
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio8";
 	name = "containment blast door"
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "aIk" = (
@@ -6445,7 +6521,7 @@
 /obj/machinery/door/window/brigdoor{
 	dir = 1;
 	name = "Secure Creature Pen";
-	req_access = list("research")
+	req_access = list("xenobiology")
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
@@ -6456,7 +6532,6 @@
 	name = "test chamber blast door"
 	},
 /obj/structure/window/reinforced/fulltile,
-/obj/structure/sign/warning/xeno_mining,
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
@@ -6598,6 +6673,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/light/floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "aJV" = (
@@ -6618,6 +6694,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/light/floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "aJY" = (
@@ -6651,6 +6728,9 @@
 "aKc" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "aKf" = (
@@ -6673,7 +6753,7 @@
 "aKj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "aKl" = (
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
@@ -6707,6 +6787,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/floor,
 /turf/open/floor/plating,
 /area/station/construction)
 "aKr" = (
@@ -6715,7 +6796,7 @@
 	base_state = "left";
 	icon_state = "left";
 	name = "Robotics Desk";
-	req_access_txt = "29"
+	req_access = list("robotics")
 	},
 /obj/item/paper_bin{
 	pixel_x = -3;
@@ -6950,7 +7031,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "aLn" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "aLo" = (
@@ -6958,10 +7041,6 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "aLp" = (
@@ -7078,16 +7157,15 @@
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
 "aLT" = (
-/obj/machinery/door/window/left/directional/east{
-	dir = 8;
-	name = "Medical Delivery";
-	req_access_txt = "5"
-	},
 /obj/structure/window/reinforced{
 	dir = 1;
 	layer = 2.9
 	},
 /obj/structure/window/reinforced,
+/obj/machinery/door/window/left/directional/west{
+	name = "Medical Delivery";
+	req_access = list("medical")
+	},
 /turf/open/floor/iron,
 /area/station/medical/storage)
 "aLU" = (
@@ -7194,24 +7272,26 @@
 	dir = 8;
 	icon_state = "right";
 	name = "Containment Pen";
-	req_access_txt = "55"
+	req_access = list("xenobiology")
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio2";
 	name = "containment blast door"
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "aMp" = (
 /obj/machinery/door/window/left/directional/north{
 	dir = 4;
 	name = "Containment Pen";
-	req_access_txt = "55"
+	req_access = list("xenobiology")
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio7";
 	name = "containment blast door"
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "aMq" = (
@@ -7825,24 +7905,26 @@
 	dir = 8;
 	icon_state = "right";
 	name = "Containment Pen";
-	req_access_txt = "55"
+	req_access = list("xenobiology")
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio1";
 	name = "containment blast door"
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "aPp" = (
 /obj/machinery/door/window/left/directional/north{
 	dir = 4;
 	name = "Containment Pen";
-	req_access_txt = "55"
+	req_access = list("xenobiology")
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio6";
 	name = "containment blast door"
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "aPq" = (
@@ -7851,7 +7933,6 @@
 	},
 /obj/machinery/requests_console/directional/south{
 	department = "Service Hall";
-	departmentType = 2;
 	name = "Service Hall Requests Console"
 	},
 /turf/open/floor/iron,
@@ -7872,6 +7953,11 @@
 /obj/machinery/computer/telecomms/server{
 	network = "tcommsat";
 	dir = 4
+	},
+/obj/machinery/requests_console/directional/south{
+	announcementConsole = 1;
+	department = "Telecomms Admin";
+	name = "Telecomms Requests Console"
 	},
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
@@ -8007,14 +8093,11 @@
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
 "aQe" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay"
+/obj/machinery/computer/atmos_control/nocontrol/master{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/iron,
-/area/station/medical/medbay/central)
+/area/station/engineering/atmos/office)
 "aQg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8271,6 +8354,7 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Gravity Generator Room"
 	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "aRj" = (
@@ -8299,7 +8383,7 @@
 	id = "Skynet_launch";
 	name = "Mech Bay Shutters";
 	pixel_y = -26;
-	req_access_txt = list("robotics")
+	req_access = list("robotics")
 	},
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
@@ -8465,7 +8549,7 @@
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
 "aSe" = (
-/obj/machinery/telecomms/message_server,
+/obj/machinery/telecomms/message_server/preset,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "aSf" = (
@@ -8552,15 +8636,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "aSw" = (
-/obj/machinery/light_switch{
-	pixel_x = 23;
-	pixel_y = 23
+/obj/structure/chair/office/light{
+	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/engineering/gravity_generator)
+/area/station/science/genetics)
 "aSx" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Gravity Generator"
@@ -8842,7 +8922,7 @@
 	id = "Skynet_launch";
 	name = "Mech Bay Shutters";
 	pixel_y = 26;
-	req_access_txt = list("robotics")
+	req_access = list("robotics")
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -8951,12 +9031,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
-"aUj" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/ai_monitored/turret_protected/ai)
 "aUk" = (
 /obj/machinery/vending/wallmed/directional/south,
 /turf/open/floor/iron,
@@ -9461,7 +9535,6 @@
 /area/station/maintenance/department/medical)
 "aWz" = (
 /obj/structure/grille,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -9763,7 +9836,6 @@
 /area/station/medical/treatment_center)
 "aYf" = (
 /obj/machinery/light_switch/directional/south,
-/obj/structure/table,
 /obj/item/storage/box/bodybags,
 /obj/item/pen,
 /obj/item/storage/box/rxglasses{
@@ -9774,6 +9846,7 @@
 /obj/machinery/camera/autoname/directional/west{
 	network = list("ss13","medbay")
 	},
+/obj/structure/table/glass,
 /turf/open/floor/iron,
 /area/station/science/genetics)
 "aYg" = (
@@ -9832,7 +9905,8 @@
 	id = "bridge blast";
 	name = "Bridge Blast Doors";
 	pixel_x = 8;
-	pixel_y = 38
+	pixel_y = 38;
+	req_access = list("command")
 	},
 /obj/structure/chair/comfy/brown{
 	color = "#486091";
@@ -9856,6 +9930,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/floor,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "aYB" = (
@@ -10011,24 +10086,24 @@
 /obj/item/dest_tagger,
 /obj/item/paper_bin/carbon,
 /obj/item/toy/figure/qm,
-/turf/open/floor/iron,
+/turf/open/floor/carpet/red,
 /area/station/cargo/qm)
 "aZT" = (
 /obj/structure/closet/secure_closet/quartermaster,
-/turf/open/floor/iron,
+/turf/open/floor/carpet/red,
 /area/station/cargo/qm)
 "aZU" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/light/directional/north,
 /obj/machinery/modular_computer/console/preset/id,
-/turf/open/floor/iron,
+/turf/open/floor/carpet/red,
 /area/station/cargo/qm)
 "aZV" = (
 /obj/machinery/camera/autoname/directional/north,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /obj/structure/filingcabinet/chestdrawer,
-/turf/open/floor/iron,
+/turf/open/floor/carpet/red,
 /area/station/cargo/qm)
 "aZW" = (
 /obj/structure/cable,
@@ -10057,6 +10132,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bag" = (
@@ -10207,11 +10283,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /obj/machinery/door/airlock/external/glass,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "baK" = (
@@ -10259,8 +10333,12 @@
 	pixel_y = 4
 	},
 /obj/item/pen/red,
-/obj/machinery/requests_console/directional/west,
-/turf/open/floor/iron,
+/obj/machinery/requests_console/directional/west{
+	announcementConsole = 1;
+	department = "Quartermaster's Desk";
+	name = "Quartermaster's Requests Console"
+	},
+/turf/open/floor/carpet/red,
 /area/station/cargo/qm)
 "bbb" = (
 /obj/structure/chair/office{
@@ -10270,10 +10348,10 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/quartermaster,
-/turf/open/floor/iron,
+/turf/open/floor/carpet/red,
 /area/station/cargo/qm)
 "bbe" = (
-/turf/open/floor/iron,
+/turf/open/floor/carpet/red,
 /area/station/cargo/qm)
 "bbf" = (
 /obj/machinery/door/firedoor,
@@ -10460,6 +10538,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/tank/air,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "bce" = (
@@ -10512,7 +10591,7 @@
 /obj/machinery/status_display/supply{
 	pixel_x = -32
 	},
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/station/cargo/qm)
 "bcs" = (
 /obj/structure/table,
@@ -10528,24 +10607,24 @@
 /obj/item/gps{
 	gpstag = "QM0"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/station/cargo/qm)
 "bct" = (
 /obj/machinery/computer/security/qm{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/station/cargo/qm)
 "bcu" = (
 /obj/machinery/computer/cargo{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/station/cargo/qm)
 "bcv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/station/cargo/qm)
 "bcx" = (
 /obj/machinery/vending/wardrobe/cargo_wardrobe,
@@ -10644,7 +10723,7 @@
 	base_state = "right";
 	icon_state = "right";
 	name = "Core Modules";
-	req_access_txt = "20"
+	req_access = list("ai_upload")
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -10773,14 +10852,14 @@
 /area/station/hallway/primary/port)
 "bdz" = (
 /obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/station/cargo/qm)
 "bdA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
 /obj/machinery/light_switch/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/station/cargo/qm)
 "bdC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -10788,7 +10867,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/station/cargo/qm)
 "bdF" = (
 /obj/machinery/vending/cigarette,
@@ -10798,7 +10877,7 @@
 /obj/structure/table,
 /obj/item/folder/yellow,
 /obj/item/pen,
-/obj/machinery/requests_console/directional/south,
+/obj/machinery/requests_console/auto_name/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bdI" = (
@@ -10838,7 +10917,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/service/chapel_office,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
 "bdO" = (
 /turf/closed/wall/r_wall,
@@ -10968,6 +11047,9 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "beu" = (
@@ -11033,7 +11115,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "beI" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "beJ" = (
 /obj/structure/disposalpipe/segment{
@@ -11279,6 +11361,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/light/floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "bfQ" = (
@@ -11309,7 +11392,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "bfZ" = (
 /obj/machinery/door/firedoor,
@@ -11372,7 +11455,8 @@
 	location = "QM #1"
 	},
 /mob/living/simple_animal/bot/mulebot,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/textured,
 /area/station/cargo/storage)
 "bgw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11556,7 +11640,8 @@
 	location = "QM #2"
 	},
 /mob/living/simple_animal/bot/mulebot,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/textured,
 /area/station/cargo/storage)
 "bhN" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -11768,11 +11853,13 @@
 	location = "QM #3"
 	},
 /mob/living/simple_animal/bot/mulebot,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/textured,
 /area/station/cargo/storage)
 "bjj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/wood,
 /area/station/cargo/qm)
 "bjn" = (
 /obj/structure/bodycontainer/morgue,
@@ -11890,7 +11977,7 @@
 /obj/machinery/door/window{
 	dir = 1;
 	name = "High-Risk Modules";
-	req_access_txt = "20"
+	req_access = list("ai_upload")
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -11997,7 +12084,7 @@
 /obj/machinery/door/window/left/directional/west{
 	dir = 4;
 	name = "Cargo Desk";
-	req_access_txt = list("cargo")
+	req_access = list("cargo")
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12053,6 +12140,10 @@
 /obj/machinery/conveyor_switch/oneway{
 	id = "QMLoad";
 	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/railing{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
@@ -12112,7 +12203,7 @@
 /turf/open/floor/iron,
 /area/station/medical/pharmacy)
 "bkL" = (
-/obj/machinery/smartfridge/chemistry,
+/obj/machinery/smartfridge/chemistry/preloaded,
 /turf/closed/wall,
 /area/station/medical/pharmacy)
 "bkM" = (
@@ -12120,8 +12211,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/right/directional/east{
 	dir = 2;
-	name = "Chemistry Desk";
-	req_access_txt = "5; 33"
+	name = "Pharmacy Desk";
+	req_access = list("pharmacy")
 	},
 /turf/open/floor/iron,
 /area/station/medical/pharmacy)
@@ -12138,7 +12229,8 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/effect/mapping_helpers/airlock/access/any/science/genetics,
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
 /turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "bkS" = (
@@ -12261,8 +12353,12 @@
 "bls" = (
 /obj/structure/plasticflaps,
 /obj/machinery/conveyor{
-	dir = 4;
-	id = "QMLoad2"
+	dir = 8;
+	id = "QMLoad"
+	},
+/obj/machinery/door/poddoor{
+	id = "QMLoaddoor2";
+	name = "supply dock loading door"
 	},
 /turf/open/floor/plating,
 /area/station/cargo/storage)
@@ -12287,16 +12383,19 @@
 /area/space/nearstation)
 "blv" = (
 /obj/machinery/light/small/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/carpet/lone{
+	dir = 4
+	},
 /area/station/service/chapel)
 "blw" = (
 /obj/effect/landmark/start/chaplain,
-/obj/machinery/holopad,
 /turf/open/floor/carpet/lone,
 /area/station/service/chapel)
 "blx" = (
 /obj/machinery/light/small/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/carpet/lone{
+	dir = 1
+	},
 /area/station/service/chapel)
 "bly" = (
 /obj/machinery/door/airlock{
@@ -12425,17 +12524,17 @@
 /turf/open/floor/wood,
 /area/station/maintenance/port)
 "blS" = (
-/turf/open/floor/wood{
-	tag = "icon-wood-broken4";
-	icon_state = "wood-broken4"
-	},
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/wood,
 /area/station/maintenance/port)
 "blT" = (
-/turf/open/floor/wood{
-	tag = "icon-wood-broken5";
-	icon_state = "wood-broken5"
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
 	},
-/area/station/maintenance/port)
+/turf/open/floor/plating,
+/area/station/maintenance/central)
 "blV" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood,
@@ -12554,7 +12653,7 @@
 "bmE" = (
 /obj/structure/altar_of_gods,
 /obj/item/storage/book/bible,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "bmI" = (
 /obj/machinery/airalarm/directional/east,
@@ -12639,10 +12738,17 @@
 /turf/open/floor/wood,
 /area/station/maintenance/port)
 "bnb" = (
-/turf/open/floor/wood{
-	tag = "icon-wood-broken6";
-	icon_state = "wood-broken6"
+/obj/structure/window/reinforced{
+	dir = 4
 	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/light/floor,
+/turf/open/floor/plating,
 /area/station/maintenance/port)
 "bnd" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -12701,8 +12807,21 @@
 /obj/machinery/computer/cargo{
 	dir = 8
 	},
-/obj/machinery/status_display/supply{
-	pixel_x = 32
+/obj/machinery/button/door/directional/west{
+	id = "QMLoaddoor";
+	layer = 4;
+	name = "Loading Doors";
+	pixel_y = -8;
+	req_access = list("cargo");
+	pixel_x = 24
+	},
+/obj/machinery/button/door/directional/west{
+	id = "QMLoaddoor2";
+	layer = 4;
+	name = "Loading Doors";
+	pixel_y = 8;
+	req_access = list("cargo");
+	pixel_x = 24
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
@@ -12802,28 +12921,22 @@
 /turf/open/floor/wood,
 /area/station/maintenance/port)
 "bnV" = (
-/turf/open/floor/wood{
-	tag = "icon-wood-broken2";
-	icon_state = "wood-broken2"
-	},
-/area/station/maintenance/port)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "bnW" = (
 /obj/structure/chair/stool/directional/north,
 /turf/open/floor/wood,
 /area/station/maintenance/port)
 "bnY" = (
 /obj/structure/chair/stool/directional/north,
-/turf/open/floor/wood{
-	tag = "icon-wood-broken5";
-	icon_state = "wood-broken5"
-	},
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/wood,
 /area/station/maintenance/port)
 "bnZ" = (
-/turf/open/floor/wood{
-	tag = "icon-wood-broken7";
-	icon_state = "wood-broken7"
-	},
-/area/station/maintenance/port)
+/obj/structure/marker_beacon/burgundy,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "boa" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plating,
@@ -12890,6 +13003,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
 "bov" = (
@@ -12900,6 +13014,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "boy" = (
@@ -12912,6 +13027,7 @@
 /obj/machinery/conveyor_switch/oneway{
 	id = "QMUnload"
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "boA" = (
@@ -12937,14 +13053,13 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "boG" = (
 /obj/machinery/reagentgrinder,
 /obj/machinery/light/directional/west,
 /obj/machinery/requests_console{
 	department = "Chemistry";
-	departmentType = 2;
 	name = "Chemistry RC";
 	pixel_x = -30
 	},
@@ -12962,8 +13077,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/right/directional/east{
 	dir = 8;
-	name = "Chemistry Desk";
-	req_access_txt = "5; 33"
+	name = "Pharmacy Desk";
+	req_access = list("pharmacy")
 	},
 /turf/open/floor/iron,
 /area/station/medical/pharmacy)
@@ -12972,11 +13087,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "boN" = (
-/turf/open/floor/wood{
-	tag = "icon-wood-broken3";
-	icon_state = "wood-broken3"
-	},
-/area/station/maintenance/port)
+/obj/structure/sign/warning/xeno_mining/directional/east,
+/turf/open/floor/plating,
+/area/station/science/xenobiology)
 "boO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -13006,7 +13119,6 @@
 /obj/machinery/camera/directional/west{
 	c_tag = "Captain's Office"
 	},
-/obj/machinery/requests_console/directional/west,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "boY" = (
@@ -13108,6 +13220,10 @@
 	dir = 4;
 	id = "QMLoad"
 	},
+/obj/machinery/door/poddoor{
+	id = "QMLoaddoor";
+	name = "supply dock loading door"
+	},
 /turf/open/floor/plating,
 /area/station/cargo/storage)
 "bpA" = (
@@ -13133,7 +13249,7 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "bpF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -13352,13 +13468,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/access/all/supply/shipping,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "bqF" = (
 /obj/machinery/button/door{
 	id = "qm_warehouse";
 	name = "Warehouse Shutters";
-	pixel_y = -28
+	pixel_y = -28;
+	req_access = list("cargo")
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -13377,19 +13495,18 @@
 /area/station/cargo/storage)
 "bqI" = (
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "bqK" = (
-/turf/open/floor/carpet{
-	tag = "icon-carpetsymbol (EAST)";
-	icon_state = "carpetsymbol";
-	dir = 4
-	},
+/turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "bqM" = (
 /obj/machinery/door/morgue{
 	name = "Confession Booth (Chaplain)";
-	req_access_txt = list("crematorium")
+	req_access = list("chapel_office")
 	},
 /turf/open/floor/iron,
 /area/station/service/chapel)
@@ -13437,7 +13554,7 @@
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "bqX" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/satellite)
 "bqZ" = (
 /turf/closed/wall,
@@ -13479,8 +13596,7 @@
 "brj" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
-	name = "Teleport Access";
-	req_access_txt = "17"
+	name = "Teleport Access"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/teleporter,
 /obj/structure/cable,
@@ -13581,16 +13697,16 @@
 "brD" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/door/window/left/directional/west{
 	dir = 4;
 	name = "Cargo Desk";
-	req_access_txt = "50"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+	req_access = list("cargo")
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
@@ -13679,7 +13795,7 @@
 /obj/structure/chair,
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/light/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "brR" = (
 /obj/effect/landmark/start/hangover,
@@ -13691,7 +13807,7 @@
 /obj/structure/chair/pew{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "brW" = (
 /obj/structure/grille,
@@ -13721,8 +13837,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/right/directional/east{
 	dir = 8;
-	name = "Chemistry Desk";
-	req_access_txt = "5; 33"
+	name = "Pharmacy Desk";
+	req_access = list("pharmacy")
 	},
 /obj/item/folder/white,
 /obj/item/pen,
@@ -13866,7 +13982,8 @@
 /obj/machinery/button/door{
 	id = "qm_warehouse";
 	name = "Warehouse Shutters";
-	pixel_y = 28
+	pixel_y = 28;
+	req_access = list("cargo")
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -13889,12 +14006,12 @@
 /area/station/cargo/warehouse)
 "bsT" = (
 /obj/structure/window,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "bsU" = (
 /obj/structure/window,
 /obj/effect/landmark/xeno_spawn,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "bsV" = (
 /turf/open/floor/iron,
@@ -13904,18 +14021,14 @@
 /obj/machinery/computer/pod/old/mass_driver_controller/chapelgun{
 	pixel_y = 30
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "btc" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Chapel East"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet{
-	tag = "icon-carpetsymbol (NORTH)";
-	icon_state = "carpetsymbol";
-	dir = 1
-	},
+/turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "btd" = (
 /obj/machinery/firealarm/directional/south,
@@ -13923,7 +14036,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "btg" = (
 /obj/machinery/door/morgue{
@@ -14157,20 +14270,26 @@
 /area/station/service/chapel/funeral)
 "bus" = (
 /obj/structure/sign/warning/vacuum/external,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "but" = (
 /obj/machinery/door/window/left/directional/east,
 /obj/machinery/mass_driver/chapelgun{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "buu" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Chapel Mass Driver"
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "buw" = (
 /obj/machinery/door/firedoor,
@@ -14178,11 +14297,7 @@
 	name = "Chapel"
 	},
 /obj/structure/cable,
-/turf/open/floor/carpet{
-	tag = "icon-carpetsymbol (NORTHEAST)";
-	icon_state = "carpetsymbol";
-	dir = 5
-	},
+/turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "buy" = (
 /obj/machinery/computer/operating{
@@ -14210,7 +14325,8 @@
 /obj/machinery/button/door{
 	id = "fumehood";
 	name = "Fume Hood Shutters";
-	pixel_x = 23
+	pixel_x = 24;
+	req_access = list("plumbing")
 	},
 /turf/open/floor/iron,
 /area/station/medical/pharmacy)
@@ -14391,39 +14507,39 @@
 /obj/structure/window{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "bvy" = (
 /obj/structure/closet/crate/coffin,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "bvz" = (
 /obj/structure/closet/crate/coffin,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "bvB" = (
 /obj/machinery/door/airlock{
 	name = "Mass Driver"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/chapel_office,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "bvD" = (
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "bvE" = (
 /obj/machinery/light/small/directional/north,
-/obj/machinery/requests_console/directional/north,
+/obj/machinery/requests_console/auto_name/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "bvF" = (
 /obj/machinery/camera/directional/north{
@@ -14433,12 +14549,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "bvG" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/turf/open/floor/iron,
+/turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "bvH" = (
 /turf/closed/wall,
@@ -14465,7 +14581,6 @@
 /turf/open/floor/plating,
 /area/station/medical/chemistry)
 "bvQ" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
 	name = "Chemistry Lab"
 	},
@@ -14487,7 +14602,7 @@
 /area/station/ai_monitored/command/storage/eva)
 "bvT" = (
 /obj/machinery/suit_storage_unit/standard_unit,
-/obj/machinery/requests_console/directional/north,
+/obj/machinery/requests_console/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "bvU" = (
@@ -14601,9 +14716,10 @@
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
 "bwC" = (
-/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bwD" = (
 /obj/structure/table/wood,
@@ -14678,7 +14794,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "bxc" = (
 /obj/structure/disposalpipe/segment{
@@ -14687,7 +14803,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "bxd" = (
 /obj/machinery/door/airlock/glass{
@@ -14755,7 +14871,7 @@
 "bxo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/holopad/secure,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "bxp" = (
 /obj/effect/turf_decal/stripes/line{
@@ -14800,10 +14916,8 @@
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
 "bxy" = (
-/obj/structure/table/wood,
 /obj/machinery/light/small/directional/west,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/camera/detective,
+/obj/structure/closet/secure_closet/detective,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
 "bxz" = (
@@ -14816,6 +14930,7 @@
 	},
 /obj/item/storage/box/evidence,
 /obj/item/flashlight/seclite,
+/obj/item/camera/detective,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
 "bxA" = (
@@ -14881,8 +14996,12 @@
 /area/station/command/heads_quarters/hop)
 "bxN" = (
 /obj/machinery/light/directional/north,
-/obj/machinery/requests_console/directional/north,
 /obj/machinery/computer/accounting,
+/obj/machinery/requests_console/directional/north{
+	announcementConsole = 1;
+	department = "Head of Personnel's Desk";
+	name = "Head of Personnel's Requests Console"
+	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
 "bxO" = (
@@ -15016,20 +15135,20 @@
 	pixel_y = 10
 	},
 /obj/item/storage/photo_album/chapel,
-/turf/open/floor/iron,
+/turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "byu" = (
 /obj/structure/table/wood,
 /obj/item/pen,
 /obj/item/reagent_containers/food/drinks/bottle/holywater,
-/turf/open/floor/iron,
+/turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "byv" = (
 /obj/structure/table/wood,
 /obj/item/nullrod,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "byw" = (
 /obj/structure/table,
@@ -15092,7 +15211,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "byM" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "byN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -15111,7 +15230,7 @@
 "byQ" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
-/obj/machinery/requests_console/directional/north,
+/obj/machinery/requests_console/auto_name/directional/north,
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
@@ -15215,12 +15334,10 @@
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
 "bzj" = (
-/obj/machinery/vending/cart{
-	req_access_txt = "57"
-	},
 /obj/machinery/camera/directional/north{
 	c_tag = "HoP office"
 	},
+/obj/machinery/vending/cart,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "bzk" = (
@@ -15313,7 +15430,7 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Primary Tool Storage"
 	},
-/obj/machinery/requests_console/directional/north,
+/obj/machinery/requests_console/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bzF" = (
@@ -15447,21 +15564,21 @@
 	pixel_x = -2;
 	pixel_y = 5
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "bAg" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /obj/effect/landmark/start/chaplain,
-/turf/open/floor/iron,
+/turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "bAi" = (
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "bAj" = (
 /obj/structure/table,
@@ -15527,6 +15644,7 @@
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/storage/secure/safe/directional/east,
 /obj/structure/cable,
+/obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/carpet,
 /area/station/security/detectives_office)
 "bAC" = (
@@ -15748,7 +15866,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "bBE" = (
 /obj/structure/table,
@@ -15956,20 +16074,21 @@
 	id = "hop";
 	name = "Privacy Shutters";
 	pixel_y = 8;
-	req_access_txt = "3";
-	pixel_x = 24
+	pixel_x = 24;
+	req_access = list("hop")
 	},
 /obj/machinery/button/door{
 	id = "hopqueue";
 	name = "Queue Shutters";
 	pixel_y = -2;
-	req_access_txt = "3";
-	pixel_x = 24
+	pixel_x = 24;
+	req_access = list("hop")
 	},
 /obj/machinery/button/flasher{
 	id = "hopflash";
 	pixel_x = 34;
-	pixel_y = 8
+	pixel_y = 8;
+	req_access = list("hop")
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
@@ -16159,7 +16278,9 @@
 /area/station/maintenance/starboard/aft)
 "bDr" = (
 /obj/machinery/door/window{
-	dir = 4
+	dir = 4;
+	req_access = list("bar");
+	name = "Escape Bar"
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
@@ -16191,7 +16312,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "bDC" = (
 /obj/structure/table/wood,
@@ -16266,7 +16387,7 @@
 	dir = 1;
 	icon_state = "rightsecure";
 	name = "Head of Personnel's Desk";
-	req_access_txt = list("hop")
+	req_access = list("hop")
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/left/directional/north{
@@ -16423,7 +16544,7 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "bEC" = (
 /obj/machinery/pdapainter/supply,
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/station/cargo/qm)
 "bEE" = (
 /obj/effect/turf_decal/tile/red{
@@ -16462,7 +16583,7 @@
 	id = "evaescape";
 	name = "E.V.A. Escape Shutter Control";
 	pixel_y = -24;
-	req_access_txt = list("command")
+	req_access = list("command")
 	},
 /obj/machinery/light_switch/directional/south{
 	pixel_x = 10
@@ -16479,7 +16600,7 @@
 /obj/machinery/door/window/left/directional/north{
 	name = "RCD Storage";
 	pixel_x = 1;
-	req_access_txt = list("command")
+	req_access = list("command")
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -16490,7 +16611,7 @@
 /obj/machinery/door/window/left/directional/north{
 	name = "Magboot Storage";
 	pixel_x = -1;
-	req_access_txt = list("command")
+	req_access = list("command")
 	},
 /obj/structure/rack{
 	dir = 8;
@@ -16508,13 +16629,14 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "bEO" = (
 /obj/machinery/door/window/left/directional/north{
 	name = "Jetpack Storage";
 	pixel_x = -1;
-	req_access_txt = list("command")
+	req_access = list("command")
 	},
 /obj/structure/rack{
 	dir = 8;
@@ -17046,9 +17168,9 @@
 "bGW" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
-/obj/machinery/door/window{
-	name = "Arrivals Checkpoint";
-	req_access_txt = "1"
+/obj/machinery/door/window/left/directional/south{
+	req_access = list("security");
+	name = "Arrivals Security Checkpoint"
 	},
 /obj/machinery/door/poddoor/shutters{
 	id = "secpost1"
@@ -17067,7 +17189,8 @@
 /area/station/hallway/secondary/entry)
 "bHb" = (
 /obj/item/kirbyplants/random,
-/turf/open/floor/iron,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "bHc" = (
 /obj/effect/turf_decal/tile/red{
@@ -17098,10 +17221,14 @@
 	id = "evaescape";
 	name = "E.V.A. Escape Shutter Control";
 	pixel_y = 24;
-	req_access_txt = list("command")
+	req_access = list("command")
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"bHx" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "bHE" = (
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron,
@@ -17169,7 +17296,7 @@
 "bIj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/requests_console/directional/north,
+/obj/machinery/requests_console/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bIk" = (
@@ -17286,16 +17413,15 @@
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "bJf" = (
-/obj/machinery/modular_computer/console/preset/cargochat/cargo,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "bJg" = (
-/obj/structure/rack,
-/obj/item/tank/internals/oxygen,
-/obj/item/tank/internals/oxygen,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
 /obj/machinery/light/small/directional/east,
+/obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bJi" = (
@@ -17488,13 +17614,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "bKj" = (
-/obj/machinery/door/window/left/directional/south{
-	name = "Chemistry Desk";
-	req_access = list("pharmacy");
-	dir = 1
-	},
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/window/left/directional/north{
+	name = "Chemistry Desk";
+	req_access = list("plumbing")
+	},
 /turf/open/floor/iron,
 /area/station/medical/chemistry)
 "bKl" = (
@@ -17580,7 +17705,8 @@
 /obj/machinery/button/door{
 	id = "evaarrival";
 	name = "E.V.A. Arrival Shutter Control";
-	pixel_x = 26
+	pixel_x = 26;
+	req_access = list("command")
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
@@ -17594,10 +17720,9 @@
 "bKG" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
-/obj/machinery/door/window{
-	dir = 1;
-	name = "Arrivals Checkpoint";
-	req_access_txt = "1"
+/obj/machinery/door/window/left/directional/north{
+	name = "Arrivals Security Checkpoint";
+	req_access = list("security")
 	},
 /obj/machinery/door/poddoor/shutters{
 	id = "secpost1"
@@ -17876,13 +18001,13 @@
 /area/station/service/janitor)
 "bMv" = (
 /obj/machinery/door/airlock{
-	name = "Custodial Closet";
-	req_access_txt = "26"
+	name = "Custodial Closet"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/landmark/navigate_destination/janitor,
+/obj/effect/mapping_helpers/airlock/access/all/service/janitor,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "bMy" = (
@@ -18030,7 +18155,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "bNb" = (
 /obj/structure/cable,
@@ -18156,7 +18281,7 @@
 /area/station/security)
 "bNC" = (
 /obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/station/security/lockers)
 "bND" = (
 /obj/structure/closet/secure_closet/security/sec,
@@ -18774,7 +18899,7 @@
 /obj/item/grenade/chem_grenade/cleaner,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/requests_console/directional/south,
+/obj/machinery/requests_console/auto_name/directional/south,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "bQA" = (
@@ -18811,16 +18936,16 @@
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "bQF" = (
-/obj/machinery/door/window/left/directional/west{
-	name = "Janitoral Delivery";
-	req_access_txt = "26"
-	},
 /obj/structure/window/reinforced{
 	dir = 1;
 	layer = 2.9
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/left/directional/west{
+	name = "Janitorial Delivery";
+	req_access = list("janitor")
+	},
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "bQG" = (
@@ -19170,7 +19295,7 @@
 "bSC" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "bSE" = (
 /obj/structure/lattice,
@@ -19235,8 +19360,8 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/north{
 	name = "Atmospherics Desk";
-	req_access_txt = "24";
-	dir = 2
+	dir = 2;
+	req_access = list("atmospherics")
 	},
 /obj/item/folder/yellow,
 /obj/item/folder/yellow,
@@ -19331,7 +19456,7 @@
 /obj/item/book/manual/hydroponics_pod_people,
 /obj/item/paper/guides/jobs/hydroponics,
 /obj/structure/table/glass,
-/obj/machinery/requests_console/directional/west,
+/obj/machinery/requests_console/auto_name/directional/west,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "bTo" = (
@@ -20371,7 +20496,7 @@
 /area/station/service/bar)
 "bXT" = (
 /obj/machinery/light/directional/south,
-/obj/machinery/requests_console/directional/south,
+/obj/machinery/requests_console/auto_name/directional/south,
 /obj/machinery/chem_master/condimaster{
 	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
 	name = "HoochMaster Deluxe"
@@ -20797,14 +20922,15 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/east{
 	name = "Kitchen Window";
-	req_access_txt = list("kitchen")
+	req_access = list("kitchen")
 	},
 /obj/machinery/door/firedoor,
 /obj/item/paper,
 /obj/machinery/door/window/left/directional/east{
 	dir = 8;
 	name = "Hydroponics Window";
-	req_one_access_txt = list("hydroponics")
+	req_one_access_txt = list("hydroponics");
+	req_access = list("hydroponics")
 	},
 /turf/open/floor/iron,
 /area/station/service/kitchen)
@@ -21104,7 +21230,7 @@
 /area/station/service/kitchen)
 "cbp" = (
 /obj/machinery/processor,
-/obj/machinery/requests_console/directional/east,
+/obj/machinery/requests_console/auto_name/directional/east,
 /turf/open/floor/iron,
 /area/station/service/kitchen)
 "cbr" = (
@@ -21132,9 +21258,7 @@
 /turf/open/floor/wood,
 /area/station/service/bar)
 "cbA" = (
-/obj/structure/closet/secure_closet/bar{
-	req_access_txt = "25"
-	},
+/obj/structure/closet/secure_closet/bar,
 /turf/open/floor/wood,
 /area/station/service/bar)
 "cbB" = (
@@ -21286,7 +21410,7 @@
 /obj/machinery/door/window/brigdoor{
 	dir = 8;
 	name = "Brig Control Desk";
-	req_access_txt = "3"
+	req_access = list("armory")
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -21586,7 +21710,8 @@
 	id = "Secure Gate";
 	name = "Brig Lockdown";
 	pixel_x = 6;
-	pixel_y = 7
+	pixel_y = 7;
+	req_access = list("security")
 	},
 /obj/machinery/button/door{
 	desc = "A door remote control switch for the interior brig doors.";
@@ -21598,10 +21723,9 @@
 	req_access = list("security")
 	},
 /obj/machinery/button/door{
-	desc = "A door remote control switch for the exterior brig doors.";
-	id = "outerbrig";
-	name = "Brig Exterior Door Control";
-	normaldoorcontrol = 1;
+	desc = "Controls the shutters over the brig windows.";
+	id = "briglockdown";
+	name = "Brig Lockdown Control";
 	pixel_x = -6;
 	pixel_y = -2;
 	req_access = list("security")
@@ -21734,16 +21858,16 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "cdZ" = (
-/obj/machinery/door/window/left/directional/south{
-	dir = 1;
-	name = "Kitchen Delivery";
-	req_access_txt = "28"
-	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 8
+	},
+/obj/machinery/door/window/left/directional/south{
+	dir = 1;
+	name = "Kitchen Delivery";
+	req_access = list("kitchen")
 	},
 /turf/open/floor/iron,
 /area/station/service/kitchen/coldroom)
@@ -21751,7 +21875,7 @@
 /obj/machinery/door/window/left/directional/south{
 	dir = 1;
 	name = "Bar Delivery";
-	req_access_txt = "25"
+	req_access = list("bar")
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -22212,7 +22336,6 @@
 	id = "theater_curtains";
 	name = "curtain control";
 	pixel_y = 7;
-	req_access = list("theatre");
 	pixel_x = 5
 	},
 /turf/open/floor/iron,
@@ -22326,7 +22449,7 @@
 /obj/machinery/door/window/brigdoor{
 	dir = 4;
 	name = "Brig Control Desk";
-	req_access_txt = list("armory")
+	req_access = list("armory")
 	},
 /obj/item/paper,
 /obj/machinery/door/firedoor,
@@ -22738,6 +22861,7 @@
 /area/station/maintenance/port/aft)
 "cin" = (
 /obj/structure/grille/broken,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "cip" = (
@@ -22802,12 +22926,9 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "ciB" = (
-/obj/machinery/airalarm/directional/east{
-	desc = "This particular atmos control unit appears to have no access restrictions.";
-	locked = 0;
-	name = "all-access air alarm";
-	req_access = "0";
-	req_one_access = "0"
+/obj/machinery/airalarm/unlocked{
+	dir = 4;
+	pixel_x = 24
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
@@ -22902,7 +23023,6 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "ciY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -23108,11 +23228,11 @@
 /area/station/security/execution/transfer)
 "cjU" = (
 /obj/machinery/button/door{
-	id = "permacell2";
-	name = "Cell 2 Lockdown";
+	id = "permacell3";
+	name = "Cell 3 Lockdown";
 	pixel_x = -4;
 	pixel_y = 25;
-	req_access_txt = "2"
+	req_access = list("security")
 	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
@@ -23122,7 +23242,7 @@
 	name = "Cell 1 Lockdown";
 	pixel_x = -4;
 	pixel_y = 25;
-	req_access_txt = "2"
+	req_access = list("security")
 	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
@@ -23208,6 +23328,7 @@
 /area/station/command/heads_quarters/hos)
 "ckl" = (
 /obj/machinery/airalarm/directional/east,
+/obj/structure/closet/secure_closet/hos,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "ckm" = (
@@ -24120,8 +24241,12 @@
 /obj/machinery/computer/med_data/laptop{
 	dir = 8
 	},
-/obj/machinery/requests_console/directional/east,
 /obj/item/radio/intercom/directional/south,
+/obj/machinery/requests_console/directional/east{
+	announcementConsole = 1;
+	department = "Head of Security's Desk";
+	name = "Head of Security Requests Console"
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "coZ" = (
@@ -24801,7 +24926,7 @@
 "crN" = (
 /obj/structure/closet/crate/coffin,
 /obj/machinery/light/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "crO" = (
 /obj/structure/disposalpipe/segment,
@@ -25273,14 +25398,13 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Engineering Access"
 	},
-/obj/machinery/light/small/directional/north,
+/obj/structure/closet/radiation,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "ctS" = (
 /obj/structure/filingcabinet,
 /obj/machinery/requests_console{
 	department = "Security";
-	departmentType = 5;
 	name = "Security Post RC";
 	pixel_x = -32
 	},
@@ -25359,12 +25483,12 @@
 /obj/machinery/door/window/brigdoor{
 	dir = 8;
 	name = "Justice Chamber";
-	req_access_txt = list("armory")
+	req_access = list("armory")
 	},
 /obj/machinery/door/window/brigdoor{
 	dir = 4;
 	name = "Justice Chamber";
-	req_access_txt = list("armory")
+	req_access = list("armory")
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/preopen{
@@ -25405,12 +25529,9 @@
 	pixel_y = 5
 	},
 /obj/item/reagent_containers/dropper,
-/obj/machinery/airalarm/directional/east{
-	desc = "This particular atmos control unit appears to have no access restrictions.";
-	locked = 0;
-	name = "all-access air alarm";
-	req_access = "0";
-	req_one_access = "0"
+/obj/machinery/airalarm/unlocked{
+	dir = 4;
+	pixel_x = 24
 	},
 /turf/open/floor/iron,
 /area/station/security/execution/education)
@@ -25608,7 +25729,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/engine_equipment,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "cvy" = (
@@ -25755,13 +25876,15 @@
 	id = "SecJusticeChamber";
 	name = "Justice Vents";
 	pixel_x = -26;
-	pixel_y = -8
+	pixel_y = -8;
+	req_access = list("armory")
 	},
 /obj/machinery/button/door{
 	id = "executionfireblast";
 	name = "Blast Doors";
 	pixel_x = -26;
-	pixel_y = 8
+	pixel_y = 8;
+	req_access = list("brig")
 	},
 /obj/machinery/atmospherics/components/binary/volume_pump{
 	dir = 1
@@ -25883,7 +26006,6 @@
 	id = "Engineering";
 	name = "engineering security door"
 	},
-/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cwQ" = (
@@ -26322,7 +26444,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cyX" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "cyY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -26892,7 +27014,8 @@
 	id = "Secure Storage";
 	name = "Secure Storage";
 	pixel_x = 8;
-	pixel_y = 23
+	pixel_y = 23;
+	req_access = list("engine_equip")
 	},
 /obj/machinery/button/door{
 	id = "ceprivacy";
@@ -27050,7 +27173,7 @@
 /obj/machinery/modular_computer/console/preset/id{
 	dir = 4
 	},
-/obj/machinery/requests_console/directional/west,
+/obj/machinery/requests_console/auto_name/directional/west,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
@@ -27474,7 +27597,7 @@
 /area/station/engineering/supermatter/room)
 "cFj" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/machinery/requests_console/directional/north,
+/obj/machinery/requests_console/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cFk" = (
@@ -27810,16 +27933,23 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "cHz" = (
-/obj/structure/flora/tree/pine/xmas,
-/turf/open/floor/carpet,
-/area/station/service/chapel)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "cHA" = (
-/obj/structure/flora/tree/pine/xmas,
-/turf/open/floor/iron,
-/area/station/service/bar)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "cHB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -27945,6 +28075,10 @@
 /obj/structure/sign/poster/official/random/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"cRe" = (
+/obj/machinery/rnd/bepis,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "cSu" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Atmospherics Plasma Tank"
@@ -28056,9 +28190,17 @@
 /obj/structure/cable/layer3,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"dgL" = (
+/obj/machinery/requests_console/directional/east{
+	announcementConsole = 1;
+	department = "Captain's Desk";
+	name = "Captain's Requests Console"
+	},
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/captain)
 "dhe" = (
 /obj/machinery/light/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "die" = (
 /obj/machinery/holopad,
@@ -28088,7 +28230,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "dkW" = (
 /obj/structure/cable,
@@ -28202,7 +28344,8 @@
 /obj/structure/sign/poster/official/work_for_a_future{
 	pixel_x = -32
 	},
-/turf/open/floor/iron,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/wood,
 /area/station/cargo/qm)
 "dum" = (
 /obj/machinery/holopad,
@@ -28215,8 +28358,8 @@
 	name = "Port Docking Bay 1"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "med-maint-pass1"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
@@ -28230,6 +28373,9 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"dAv" = (
+/turf/open/floor/iron/dark,
+/area/station/service/chapel)
 "dAE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28297,6 +28443,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
+"dIB" = (
+/obj/effect/spawner/random/maintenance,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "dIW" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4
@@ -28342,7 +28493,7 @@
 "dQe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "dQm" = (
 /obj/structure/flora/bush/grassy/style_random,
@@ -28392,6 +28543,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/janitor)
+"dYP" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "dZG" = (
 /obj/item/flashlight/lamp,
 /obj/structure/table,
@@ -28418,6 +28573,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/medical/virology)
+"edn" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "eej" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28455,6 +28617,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
+"eji" = (
+/turf/open/floor/iron/chapel{
+	dir = 5
+	},
+/area/station/service/chapel)
 "eks" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -28502,7 +28669,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "emb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
@@ -28516,6 +28683,11 @@
 /obj/structure/transit_tube/diagonal/topleft,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"enQ" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "enV" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/grunge{
@@ -28683,6 +28855,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"eED" = (
+/obj/structure/marker_beacon/purple,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "eFp" = (
 /obj/machinery/door/airlock/external{
 	name = "External Docking Port"
@@ -28737,7 +28913,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "eKd" = (
 /obj/structure/cable,
@@ -28747,6 +28923,11 @@
 /obj/machinery/power/supermatter_crystal/engine,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
+"eLv" = (
+/turf/open/floor/iron/chapel{
+	dir = 10
+	},
+/area/station/service/chapel)
 "eLF" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Xenobiology - Cell 5";
@@ -28774,7 +28955,7 @@
 /area/station/hallway/primary/central/aft)
 "eOW" = (
 /obj/machinery/holopad,
-/turf/open/floor/iron,
+/turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "ePD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -28794,6 +28975,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"eQq" = (
+/obj/structure/grille/broken,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
 "eQI" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -28854,10 +29040,9 @@
 /turf/open/floor/iron,
 /area/station/science/lab)
 "eUT" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/medical/psychology)
 "eVd" = (
@@ -28866,6 +29051,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
 "eVe" = (
@@ -28902,7 +29088,7 @@
 	uses = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
 "eYV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -28921,6 +29107,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security)
+"fah" = (
+/turf/open/floor/iron/chapel,
+/area/station/service/chapel)
 "fai" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28998,7 +29187,9 @@
 /area/station/maintenance/department/electrical)
 "fhE" = (
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/chapel{
+	dir = 9
+	},
 /area/station/service/chapel)
 "fhR" = (
 /obj/structure/window/reinforced,
@@ -29021,6 +29212,7 @@
 	name = "Mining Office"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/mining,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "fma" = (
@@ -29069,6 +29261,10 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"fnv" = (
+/obj/structure/marker_beacon/cerulean,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "fob" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -29124,9 +29320,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external/glass,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "ftD" = (
@@ -29149,6 +29347,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"fvm" = (
+/turf/open/floor/iron/chapel{
+	dir = 4
+	},
+/area/station/service/chapel)
 "fvp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29250,12 +29453,12 @@
 /area/station/maintenance/department/medical)
 "fKB" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/poddoor/shutters/window{
 	id = "gateshutter";
 	name = "Gateway Access Shutter"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "fKX" = (
@@ -29556,11 +29759,12 @@
 /turf/open/floor/plating,
 /area/station/command/bridge)
 "gqP" = (
-/obj/machinery/atmospherics/components/binary/pump/off{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/grille/broken,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/port/aft)
 "gra" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -29572,6 +29776,10 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
+"gsS" = (
+/obj/machinery/holopad,
+/turf/open/floor/iron/dark,
+/area/station/service/chapel)
 "gtw" = (
 /obj/machinery/computer/security/telescreen/interrogation{
 	pixel_y = 32
@@ -29603,10 +29811,10 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "gvq" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
-	},
-/area/station/maintenance/central)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/command/gateway)
 "gvu" = (
 /obj/structure/chair{
 	dir = 1
@@ -29625,9 +29833,7 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "gvD" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/components/binary/pump/on,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "gwH" = (
@@ -29652,10 +29858,19 @@
 	},
 /obj/machinery/button/door/directional/west{
 	id = "secpost1";
-	name = "Shutter Controls"
+	name = "Shutter Controls";
+	req_access = list("security")
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"gzr" = (
+/obj/machinery/button/door/directional/north{
+	id = "gateshutter";
+	name = "Gateway Shutter Control";
+	req_access = list("command")
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "gAq" = (
 /obj/structure/closet/secure_closet/medical2,
 /turf/open/floor/iron,
@@ -29678,6 +29893,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security)
+"gCD" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "gCT" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "EscapeBarShutters";
@@ -29702,7 +29921,7 @@
 /obj/structure/chair/pew/left{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "gFc" = (
 /obj/structure/disposalpipe/segment{
@@ -29718,9 +29937,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/pumproom)
+"gFQ" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "gGH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
-/obj/structure/cable,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/service/hydroponics/garden)
@@ -29777,7 +30001,7 @@
 /area/station/maintenance/department/science)
 "gOy" = (
 /obj/item/kirbyplants/random,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "gOQ" = (
 /obj/machinery/door/airlock/maintenance{
@@ -29961,7 +30185,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/holopad/secure,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "hjc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -30031,7 +30255,7 @@
 /area/station/cargo/storage)
 "hsm" = (
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "huJ" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -30164,6 +30388,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"hOM" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "hPP" = (
 /obj/structure/table,
 /obj/item/storage/medkit/fire{
@@ -30206,13 +30441,13 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/satellite)
 "hTP" = (
 /obj/structure/transit_tube/station/dispenser{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "hUu" = (
 /obj/effect/landmark/event_spawn,
@@ -30256,7 +30491,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "hZP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30301,7 +30536,7 @@
 /area/station/cargo/miningdock)
 "ihg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "ihv" = (
 /obj/structure/cable,
@@ -30328,6 +30563,7 @@
 /area/station/command/bridge)
 "ijy" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "ijN" = (
@@ -30375,12 +30611,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "inn" = (
-/obj/structure/grille/broken,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8
+	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/science)
+/area/station/maintenance/central)
 "iny" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -30583,6 +30821,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/service/general,
+/obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "iOF" = (
@@ -30595,9 +30834,7 @@
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain)
 "iOI" = (
-/obj/machinery/atmospherics/components/binary/tank_compressor{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/binary/tank_compressor,
 /turf/open/floor/iron,
 /area/station/science/ordnance)
 "iOT" = (
@@ -30617,7 +30854,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "iTm" = (
 /obj/effect/turf_decal/stripes/line{
@@ -30655,6 +30892,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
+"iXk" = (
+/obj/structure/marker_beacon/indigo,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "iXM" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -30669,6 +30910,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
+"iYV" = (
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "iYW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -30811,12 +31056,18 @@
 "jqM" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/science)
+"jqX" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "jtH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/small/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "jtP" = (
 /obj/machinery/door/airlock/maintenance,
@@ -31088,12 +31339,10 @@
 /area/station/medical/abandoned)
 "kcv" = (
 /obj/machinery/vending/wardrobe/chef_wardrobe,
-/obj/machinery/button/door/directional/north{
+/obj/machinery/button/door/directional/east{
 	id = "kitchen";
 	name = "Counter Shutters Control";
-	req_access = list("kitchen");
-	pixel_y = 0;
-	pixel_x = 24
+	req_access = list("kitchen")
 	},
 /turf/open/floor/iron,
 /area/station/service/kitchen)
@@ -31135,8 +31384,8 @@
 	name = "Port Docking Bay 1"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "med-maint-pass2"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
@@ -31163,6 +31412,18 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"kjL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/computer/security/telescreen{
+	dir = 8;
+	name = "Telecomms Camera Monitor";
+	network = list("tcomms");
+	pixel_x = 26
+	},
+/turf/open/floor/iron,
+/area/station/tcommsat/computer)
 "kkp" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/plaque{
@@ -31193,6 +31454,19 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"koo" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/light/floor,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "kpJ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/status_display/evac/directional/east,
@@ -31239,7 +31513,7 @@
 /area/station/hallway/primary/starboard)
 "kqL" = (
 /obj/machinery/light/directional/west,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "krU" = (
 /turf/open/floor/iron/recharge_floor,
@@ -31335,7 +31609,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "kDj" = (
 /obj/machinery/light/built/directional/east,
@@ -31394,9 +31668,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "kJy" = (
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/camera/directional/north{
+	c_tag = "Vault - Exterior"
 	},
+/turf/open/floor/iron,
 /area/station/maintenance/central)
 "kKi" = (
 /obj/effect/landmark/event_spawn,
@@ -31428,6 +31706,12 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"kRv" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "kUa" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31600,6 +31884,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
+"lpe" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/floor,
+/turf/open/floor/plating,
+/area/station/construction)
 "lrC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -31627,11 +31922,12 @@
 	id_tag = "MedbayFoyer";
 	name = "Medbay"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/effect/mapping_helpers/airlock/access/any/science/genetics,
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
 "lzC" = (
@@ -31757,6 +32053,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
+"lPy" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "lPC" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -31826,7 +32133,6 @@
 "lXv" = (
 /obj/machinery/requests_console{
 	department = "Medbay";
-	departmentType = 1;
 	name = "Medbay RC";
 	pixel_y = -30
 	},
@@ -31857,6 +32163,7 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "mcQ" = (
@@ -31867,6 +32174,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/medical/surgery/theatre)
+"meR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
+"mfp" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/command/gateway)
 "mfA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31908,6 +32227,19 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"mha" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/item/stack/package_wrap,
+/obj/item/stack/package_wrap{
+	pixel_y = 2
+	},
+/obj/item/stack/package_wrap{
+	pixel_y = 5
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "mhe" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
 	dir = 4
@@ -31930,6 +32262,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"mkl" = (
+/obj/machinery/requests_console/directional/west{
+	announcementConsole = 1;
+	department = "Bridge";
+	name = "Bridge Requests Console"
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "mmB" = (
 /obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31941,6 +32281,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "medbay-passthrough"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/medical/psychology)
 "mmE" = (
@@ -31990,6 +32331,7 @@
 "mrV" = (
 /obj/machinery/door/firedoor,
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "msY" = (
@@ -32024,7 +32366,7 @@
 /area/station/engineering/supermatter)
 "mwG" = (
 /obj/machinery/vending/wardrobe/chap_wardrobe,
-/turf/open/floor/iron,
+/turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "mxi" = (
 /obj/machinery/light/directional/west,
@@ -32092,6 +32434,11 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
+"mHP" = (
+/turf/open/floor/iron/chapel{
+	dir = 1
+	},
+/area/station/service/chapel)
 "mIl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32132,11 +32479,8 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "mOi" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /obj/machinery/holopad,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "mOA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32390,7 +32734,7 @@
 "nnI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "nnR" = (
 /obj/item/kirbyplants/random,
@@ -32421,9 +32765,10 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "npu" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/machinery/door/airlock/public/glass{
+	name = "Gateway Chamber"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/command/gateway,
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "nqr" = (
@@ -32431,11 +32776,6 @@
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
-"nqC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/central)
 "nrc" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -32467,11 +32807,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet{
-	tag = "icon-carpetsymbol (NORTHEAST)";
-	icon_state = "carpetsymbol";
-	dir = 5
-	},
+/turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "nsP" = (
 /obj/structure/cable,
@@ -32491,7 +32827,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "num" = (
 /obj/effect/landmark/start/station_engineer,
@@ -32689,11 +33025,19 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/explab)
+"nRa" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "nSg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "nSv" = (
 /obj/structure/cable,
@@ -32763,7 +33107,11 @@
 /turf/open/floor/plating,
 /area/station/security/execution/transfer)
 "obk" = (
-/obj/machinery/requests_console/directional/south,
+/obj/machinery/requests_console/directional/south{
+	department = "Chief Engineer's Desk";
+	announcementConsole = 1;
+	name = "Chief Engineer's Requests Console"
+	},
 /obj/machinery/pdapainter/engineering,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
@@ -32803,6 +33151,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "oeA" = (
@@ -32914,6 +33265,14 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"ouh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "ouR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32953,7 +33312,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/holopad,
-/turf/open/floor/iron,
+/turf/open/floor/carpet/red,
 /area/station/cargo/qm)
 "oCl" = (
 /obj/machinery/holopad,
@@ -33067,7 +33426,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "oMQ" = (
 /obj/machinery/door/airlock/command/glass{
@@ -33180,7 +33539,7 @@
 /area/station/medical/psychology)
 "oYp" = (
 /obj/machinery/light/directional/east,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "oYE" = (
 /obj/effect/landmark/start/cyborg,
@@ -33193,6 +33552,7 @@
 /area/station/engineering/atmos)
 "oZR" = (
 /obj/structure/grille/broken,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "pac" = (
@@ -33208,6 +33568,9 @@
 	},
 /obj/item/holosign_creator/robot_seat/restaurant,
 /obj/structure/desk_bell,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/service/kitchen)
 "paW" = (
@@ -33229,6 +33592,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "pbo" = (
@@ -33435,16 +33799,12 @@
 /area/space/nearstation)
 "pFL" = (
 /obj/machinery/holopad/secure,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/satellite)
 "pFT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/station/maintenance/central)
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "pGT" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -33543,6 +33903,10 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"pSe" = (
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "pSA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33622,7 +33986,7 @@
 /area/station/hallway/secondary/entry)
 "qaU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "qce" = (
 /obj/structure/cable,
@@ -33653,6 +34017,10 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/wood,
 /area/station/service/library/lounge)
+"qfq" = (
+/obj/structure/closet/l3closet/scientist,
+/turf/open/floor/iron,
+/area/station/command/gateway)
 "qhw" = (
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 4
@@ -33806,16 +34174,18 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/hallway/primary/port)
+"qyi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "qyx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security)
-"qzh" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
 "qzm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34014,6 +34384,16 @@
 /obj/structure/bed/dogbed/mcgriff,
 /turf/open/floor/iron,
 /area/station/security/warden)
+"qXH" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "QMUnload"
+	},
+/obj/machinery/status_display/supply{
+	pixel_y = -32
+	},
+/turf/open/floor/plating,
+/area/station/cargo/storage)
 "qYD" = (
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
@@ -34033,7 +34413,6 @@
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "rbk" = (
@@ -34099,6 +34478,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"rkD" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "rkH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -34106,7 +34490,7 @@
 "rkI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "rme" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34182,11 +34566,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"rwG" = (
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "rwS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/station/cargo/qm)
 "rxM" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -34336,7 +34723,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/station/cargo/qm)
 "rNb" = (
 /obj/effect/turf_decal/stripes/line{
@@ -34413,7 +34800,7 @@
 /area/station/science/ordnance/burnchamber)
 "rYp" = (
 /obj/machinery/holopad/secure,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "rZi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -34433,7 +34820,7 @@
 /area/station/science/ordnance)
 "sap" = (
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/station/cargo/qm)
 "saT" = (
 /obj/machinery/light/directional/south,
@@ -34651,7 +35038,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "sxD" = (
 /obj/structure/chair,
@@ -34746,7 +35133,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "sHI" = (
 /obj/machinery/door/airlock/security/glass{
@@ -34777,10 +35164,14 @@
 "sKi" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/security)
+"sKn" = (
+/obj/machinery/space_heater,
+/turf/open/floor/wood,
+/area/station/maintenance/port)
 "sKp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/satellite)
 "sKu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34818,6 +35209,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/floor,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "sSE" = (
@@ -35004,7 +35396,7 @@
 /obj/structure/cable,
 /obj/machinery/power/port_gen/pacman,
 /obj/machinery/power/terminal,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/satellite)
 "tnU" = (
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
@@ -35019,11 +35411,14 @@
 /area/station/maintenance/central)
 "tpv" = (
 /obj/structure/grille,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"tpC" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/wood,
+/area/station/cargo/qm)
 "tpP" = (
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
@@ -35053,6 +35448,14 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
+"tva" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "tvb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -35089,6 +35492,19 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
+"tzn" = (
+/turf/open/floor/iron/chapel{
+	dir = 8
+	},
+/area/station/service/chapel)
+"tzQ" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "maint-service-pass-1"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/central)
 "tAZ" = (
 /obj/structure/chair{
 	dir = 1
@@ -35114,18 +35530,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "tHI" = (
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "tJR" = (
 /obj/machinery/button/door{
 	id = "EscapeBarShutters";
 	name = "Escape Bar Shutter Control";
-	req_access_txt = "18";
-	pixel_x = 24
+	pixel_x = 24;
+	req_access = list("bar")
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
@@ -35162,6 +35580,8 @@
 	},
 /obj/item/kirbyplants/random,
 /obj/item/radio/intercom/directional/south,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
 "tQl" = (
@@ -35259,12 +35679,9 @@
 /turf/closed/wall,
 /area/station/security/prison/toilet)
 "ubO" = (
-/obj/machinery/airalarm/directional/east{
-	desc = "This particular atmos control unit appears to have no access restrictions.";
-	locked = 0;
-	name = "all-access air alarm";
-	req_access = "0";
-	req_one_access = "0"
+/obj/machinery/airalarm/unlocked{
+	dir = 4;
+	pixel_x = 24
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
@@ -35311,6 +35728,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/research)
+"unt" = (
+/obj/machinery/button/door{
+	id = "permacell2";
+	name = "Cell 2 Lockdown";
+	pixel_x = -4;
+	pixel_y = 25;
+	req_access = list("security")
+	},
+/turf/open/floor/iron,
+/area/station/security/execution/transfer)
 "uou" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
@@ -35413,6 +35840,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/station/maintenance/port/aft)
+"uAm" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "uAO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35521,9 +35954,16 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/storage/tcomms)
+"uME" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/command/gateway)
 "uMJ" = (
 /obj/structure/chair,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "uMM" = (
 /obj/structure/chair/comfy/brown{
@@ -35787,12 +36227,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/pumproom)
+"vDt" = (
+/obj/structure/cable,
+/turf/open/floor/carpet/red,
+/area/station/service/chapel)
 "vEa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/holopad,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "vEk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35826,6 +36270,12 @@
 /obj/structure/chair/stool/directional/east,
 /turf/open/floor/iron,
 /area/station/security/prison)
+"vHg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "vIh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -35999,12 +36449,9 @@
 /area/station/command/bridge)
 "wik" = (
 /obj/machinery/light/directional/east,
-/obj/machinery/airalarm/directional/east{
-	desc = "This particular atmos control unit appears to have no access restrictions.";
-	locked = 0;
-	name = "all-access air alarm";
-	req_access = "0";
-	req_one_access = "0"
+/obj/machinery/airalarm/unlocked{
+	dir = 4;
+	pixel_x = 24
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
@@ -36140,6 +36587,14 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
+"wzV" = (
+/obj/machinery/door/poddoor/shutters/window{
+	id = "gateshutter";
+	name = "Gateway Access Shutter"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/command/gateway)
 "wAA" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
@@ -36221,7 +36676,7 @@
 	c_tag = "Security Post - Medbay";
 	network = list("ss13","medbay")
 	},
-/obj/machinery/requests_console/directional/north,
+/obj/machinery/requests_console/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "wSW" = (
@@ -36358,10 +36813,19 @@
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain)
-"xnQ" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+"xnz" = (
+/turf/open/floor/iron/chapel{
+	dir = 6
 	},
+/area/station/service/chapel)
+"xnQ" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "maint-service-pass-1"
+	},
+/turf/open/floor/plating,
 /area/station/maintenance/central)
 "xpm" = (
 /turf/open/floor/iron,
@@ -36641,7 +37105,7 @@
 	charge = 5e+006
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "xYO" = (
 /obj/machinery/modular_computer/console/preset/id{
@@ -46641,7 +47105,7 @@ boC
 bpC
 boC
 hsm
-bDh
+bqK
 acc
 elF
 cyX
@@ -46892,13 +47356,13 @@ lWL
 aCI
 lWL
 bkB
-bsV
-bsV
+mHP
+tzn
 gEV
 gEV
 gEV
 gEV
-bsV
+dAv
 acc
 bvD
 cyX
@@ -47149,8 +47613,8 @@ lWL
 aCI
 bvH
 bvH
-bsV
-bsV
+fvm
+fah
 brS
 brS
 brS
@@ -47406,8 +47870,8 @@ lWL
 aCI
 bkB
 blv
-bsV
-bsV
+dAv
+gsS
 aqa
 aqa
 aqa
@@ -47664,11 +48128,11 @@ aCI
 bkB
 blw
 bmE
-bDh
-bDh
-bDh
 bqK
-bDh
+bqK
+bqK
+bqK
+bqK
 btc
 acc
 bvG
@@ -47920,8 +48384,8 @@ lWL
 aCI
 bkB
 blx
-bsV
-bsV
+dAv
+dAv
 gEV
 gEV
 gEV
@@ -47957,14 +48421,14 @@ cAS
 cdk
 cAa
 cAa
-cAa
+agR
 cin
-cAa
+agR
 cAa
 cjC
 cAa
 cAa
-cin
+cjC
 cAa
 cAa
 cAa
@@ -48178,7 +48642,7 @@ bvH
 bvH
 bvH
 fhE
-bsV
+eLv
 brS
 brS
 brS
@@ -48221,7 +48685,7 @@ aZj
 uKj
 aZj
 aZj
-raS
+gqP
 aZj
 aZj
 aZj
@@ -48434,8 +48898,8 @@ bvH
 bjn
 bsV
 jWB
-bsV
-bsV
+eji
+xnz
 aqa
 aqa
 aqa
@@ -48693,16 +49157,16 @@ bsV
 bvH
 bvH
 oYp
-bDh
-bDh
-bDh
+bqK
+bqK
+bqK
 bSC
-xSg
+vDt
 buw
 xSg
 bxe
 bDh
-cHz
+bDh
 dqO
 bvH
 bKT
@@ -49704,10 +50168,10 @@ cNW
 bDP
 aqN
 aqN
-aqN
+bnV
 oZR
-aqN
-aqN
+bnV
+bnV
 aqN
 aqN
 aqN
@@ -52269,7 +52733,7 @@ aNj
 aNj
 aNj
 aIq
-aQe
+agu
 aNh
 aNh
 khu
@@ -52588,7 +53052,7 @@ cix
 chf
 mgh
 swH
-qzh
+loa
 coQ
 wSW
 wSW
@@ -53613,7 +54077,7 @@ bUk
 vfK
 bWV
 bYB
-cjU
+unt
 chf
 loa
 chm
@@ -53794,13 +54258,13 @@ ayf
 pPt
 aAi
 aGT
-aGT
 aCA
+aGT
 aDC
 aGT
 bgC
 aGT
-aGT
+aCA
 aGT
 aWO
 aNj
@@ -54308,8 +54772,8 @@ azv
 azv
 uOc
 aGT
-aGT
 aCB
+aGT
 aGT
 nwT
 pnt
@@ -54569,9 +55033,9 @@ aCg
 aFX
 aDF
 gyK
+aGT
 aFf
-aGT
-aGT
+aSw
 aHG
 aAi
 ayL
@@ -56665,7 +57129,7 @@ jzi
 bqV
 bGt
 bLv
-buD
+enQ
 btQ
 bxw
 bKq
@@ -56857,7 +57321,7 @@ auU
 ajl
 amM
 ale
-amb
+ajn
 auU
 aCI
 aCI
@@ -56922,7 +57386,7 @@ bpW
 qoh
 bGt
 bLv
-buD
+buF
 btQ
 bxx
 byJ
@@ -57368,7 +57832,7 @@ aCI
 aCI
 ahR
 atu
-atu
+dxF
 gEj
 alf
 amM
@@ -57435,8 +57899,8 @@ bjH
 bpX
 bqW
 bGt
-bLv
-buF
+hOM
+bGt
 btQ
 bxz
 dAW
@@ -57625,7 +58089,7 @@ lWL
 aCI
 ahR
 atu
-ajn
+auU
 adP
 aWB
 atu
@@ -57910,7 +58374,7 @@ aBC
 aBC
 aBC
 ayi
-bcU
+baE
 aUx
 ayi
 ayi
@@ -57949,7 +58413,7 @@ beb
 beb
 beb
 bGt
-oed
+acF
 bGt
 lWL
 lWL
@@ -58178,7 +58642,7 @@ aLY
 aNo
 aNo
 aOk
-aSa
+kjL
 aPC
 aQo
 aQV
@@ -58207,7 +58671,7 @@ lWL
 lWL
 pYa
 dHk
-pYa
+bnZ
 lWL
 lWL
 bDE
@@ -58719,7 +59183,7 @@ lWL
 lWL
 qtV
 lWL
-pYa
+eED
 dHk
 pYa
 lWL
@@ -59231,8 +59695,8 @@ lWL
 lWL
 qtV
 lWL
-bGt
-bGt
+lWL
+lWL
 bGt
 bLv
 bGt
@@ -59489,10 +59953,10 @@ qtV
 lWL
 bGt
 bGt
-bLv
-bLv
-bLv
-bLv
+bGt
+bGt
+lPy
+bGt
 bLv
 bLv
 bLv
@@ -59681,7 +60145,7 @@ lWL
 aCI
 auU
 auU
-ajq
+akh
 auU
 auU
 lWL
@@ -59747,10 +60211,10 @@ lWL
 bGt
 bLv
 bLv
-bGt
-bGt
-bGt
-bGt
+qyi
+qyi
+qyi
+aMI
 bGt
 bGt
 bGt
@@ -59770,7 +60234,7 @@ bQx
 nil
 kaG
 bUz
-bVR
+aQe
 bVR
 ggT
 aCI
@@ -60005,9 +60469,9 @@ bGt
 bLv
 bGt
 bGt
-bsf
-bsf
-bwb
+bqZ
+bqZ
+bqZ
 bxD
 byQ
 bAD
@@ -60261,7 +60725,7 @@ bjK
 bGt
 bqb
 bGt
-bsf
+bwb
 btB
 btB
 bsf
@@ -60458,9 +60922,9 @@ alj
 amd
 atu
 auU
-pYa
+fnv
 oVB
-pYa
+fnv
 auU
 auU
 ahR
@@ -60714,11 +61178,11 @@ auU
 auU
 auU
 atu
-aiD
+khd
 pYa
 eDG
 pYa
-aiD
+aHp
 arG
 atu
 atD
@@ -60770,7 +61234,7 @@ lWL
 lWL
 bGt
 bGt
-boP
+sKn
 boP
 btA
 bLv
@@ -60972,9 +61436,9 @@ lWL
 auU
 ahR
 auU
-pYa
+eED
 oVB
-pYa
+eED
 auU
 auU
 ahR
@@ -60995,7 +61459,7 @@ lWL
 lWL
 ayi
 aAm
-bcU
+cHA
 bcU
 ayi
 aIB
@@ -61028,7 +61492,7 @@ lWL
 bjK
 blQ
 bmX
-bnV
+blS
 boP
 bqd
 bGt
@@ -61285,7 +61749,7 @@ bGt
 bGt
 blR
 bmY
-bnb
+blS
 boP
 bqe
 bGt
@@ -61797,10 +62261,10 @@ lWL
 lWL
 bjK
 bkW
-blT
+blS
 bmZ
 boP
-boN
+blS
 bqf
 bGt
 bsl
@@ -62057,7 +62521,7 @@ bkX
 boP
 bmY
 boP
-bnb
+blS
 bqf
 bGt
 bsm
@@ -62814,7 +63278,7 @@ tZf
 tZf
 pYa
 dDo
-pYa
+bnZ
 tZf
 tZf
 tZf
@@ -62826,8 +63290,8 @@ rVS
 bGt
 bGt
 bGt
-bnb
-bnZ
+blS
+blS
 btA
 bLv
 bGt
@@ -63061,20 +63525,20 @@ aIA
 aIA
 aIA
 aIA
+koo
 aIA
 aIA
 aIA
 aIA
-aIA
-aIA
-aIA
+cHz
+koo
 fsF
 nvu
 gUX
 nvu
 baJ
-bbW
-bbW
+bnb
+ajq
 bbW
 bbW
 bfP
@@ -63309,7 +63773,7 @@ lWL
 lWL
 sZd
 aGk
-bcU
+kRv
 kqi
 bcU
 aKa
@@ -63326,7 +63790,7 @@ rVS
 rVS
 rVS
 rVS
-pYa
+eED
 jub
 pYa
 rVS
@@ -65632,7 +66096,7 @@ lWL
 lWL
 pYa
 dDo
-pYa
+bnZ
 lWL
 lWL
 lWL
@@ -66144,7 +66608,7 @@ lWL
 lWL
 lWL
 lWL
-pYa
+eED
 jub
 pYa
 lWL
@@ -66672,7 +67136,7 @@ aYr
 cid
 baO
 fAw
-bwn
+mkl
 bwn
 bwn
 bff
@@ -67380,9 +67844,9 @@ abR
 abR
 aCW
 afx
-aCW
-aCW
-aCW
+rwG
+rwG
+rwG
 eYE
 abP
 abR
@@ -67455,7 +67919,7 @@ bmb
 bnd
 bog
 pbo
-bpa
+dgL
 brg
 bAZ
 btW
@@ -67635,8 +68099,8 @@ aCI
 abR
 abR
 abU
-asJ
-asJ
+aCW
+rwG
 acO
 abR
 abR
@@ -67892,8 +68356,8 @@ ylN
 abR
 abR
 xYn
-aUj
-asJ
+aCW
+rwG
 acP
 adk
 abR
@@ -67909,7 +68373,7 @@ ajx
 tHD
 rYp
 ihg
-amY
+aoy
 aoq
 aox
 apr
@@ -67938,7 +68402,7 @@ aBy
 aBy
 dHk
 dDo
-pYa
+bnZ
 lWL
 lWL
 lWL
@@ -68014,7 +68478,7 @@ rjn
 bWh
 cxe
 ctP
-ctP
+cBl
 cwP
 cxT
 cAB
@@ -68150,7 +68614,7 @@ abR
 abR
 abW
 asJ
-asJ
+pFT
 acQ
 abR
 abR
@@ -68168,7 +68632,7 @@ amk
 ihg
 ihg
 anM
-aoy
+jqX
 amk
 aqf
 aoq
@@ -68408,9 +68872,9 @@ abR
 abR
 aCW
 akj
-asJ
-asJ
-asJ
+pFT
+pFT
+pFT
 aeo
 abP
 abR
@@ -68450,7 +68914,7 @@ lWL
 lWL
 lWL
 bbq
-pYa
+eED
 jub
 kNb
 lWL
@@ -69698,7 +70162,7 @@ bdO
 adM
 aeq
 djZ
-afy
+tva
 bLH
 bLH
 bhO
@@ -70244,7 +70708,7 @@ lWL
 lWL
 pYa
 dDo
-pYa
+bnZ
 lWL
 lWL
 lWL
@@ -70756,7 +71220,7 @@ lWL
 lWL
 lWL
 lWL
-pYa
+eED
 jub
 pYa
 lWL
@@ -72600,10 +73064,10 @@ brs
 aIL
 aZQ
 vSn
-nqC
+wtj
 lZG
-krX
-krX
+bwC
+bwC
 cbF
 krX
 krX
@@ -72856,9 +73320,9 @@ aZQ
 aZQ
 bsx
 aZQ
-adj
-bwC
-byb
+aIL
+aIL
+aZQ
 bzI
 tHI
 bCN
@@ -73354,7 +73818,7 @@ ftD
 aNq
 nrE
 tZz
-tZz
+bgA
 tZz
 aNq
 nrE
@@ -73591,9 +74055,9 @@ lWL
 aCI
 sZd
 aHQ
-aIL
+inn
 vSn
-gqP
+aIL
 aMb
 fHr
 rVS
@@ -73615,7 +74079,7 @@ gvD
 bet
 bfh
 aZQ
-aIL
+bpl
 aIL
 bhj
 aZQ
@@ -73848,7 +74312,7 @@ lWL
 aCI
 lWL
 rHE
-aRd
+amY
 aKf
 aLo
 aMc
@@ -73872,9 +74336,9 @@ efM
 beu
 lWL
 aZQ
-aIL
-biM
-aIL
+aZQ
+blT
+aZQ
 bqo
 lWL
 lWL
@@ -74621,7 +75085,7 @@ lWL
 lWL
 pYa
 kNb
-pYa
+iXk
 lWL
 lWL
 aCI
@@ -75133,7 +75597,7 @@ lWL
 aCI
 lWL
 lWL
-pYa
+eED
 kNb
 pYa
 lWL
@@ -75415,7 +75879,7 @@ aCI
 lWL
 lWL
 aZQ
-aKc
+tzQ
 aZQ
 buf
 buf
@@ -75648,7 +76112,7 @@ ayo
 lWL
 lWL
 aIQ
-aKm
+lpe
 fEG
 lWL
 lWL
@@ -75673,7 +76137,7 @@ lWL
 lWL
 buf
 adj
-adj
+xnQ
 adj
 adj
 adj
@@ -76473,7 +76937,7 @@ bOk
 bPC
 bOk
 bOi
-cHA
+bOi
 bOi
 bTC
 bbs
@@ -77152,7 +77616,7 @@ adT
 aew
 apx
 yjd
-cfu
+olW
 cfu
 cfu
 apx
@@ -77409,7 +77873,7 @@ lWL
 adQ
 afb
 mxO
-lAa
+ani
 apx
 cfu
 apx
@@ -77666,7 +78130,7 @@ acD
 acD
 acD
 acD
-ani
+acD
 apx
 cfu
 apx
@@ -77922,9 +78386,9 @@ afd
 afd
 aex
 afc
-acD
-acD
-agR
+afL
+wzV
+apx
 cfu
 apx
 apx
@@ -77971,7 +78435,7 @@ aRj
 aRj
 aRj
 aRi
-aSw
+fHu
 aTH
 aVS
 aVV
@@ -78179,7 +78643,7 @@ ads
 afd
 uHX
 aez
-afL
+mfp
 agn
 apx
 gjY
@@ -78688,14 +79152,14 @@ aCI
 aCI
 acp
 acD
-afd
-afd
-afd
-afd
+gvq
+gvq
+gvq
+gvq
 npu
-afd
-agn
-apx
+acD
+acD
+gzr
 gjY
 apx
 apx
@@ -78951,7 +79415,7 @@ adZ
 aey
 afe
 acD
-acD
+apx
 apx
 gjY
 apx
@@ -79013,7 +79477,7 @@ bmi
 bmi
 bmi
 bmi
-exz
+kJy
 bmi
 bmi
 bmi
@@ -79205,7 +79669,7 @@ acD
 acY
 afd
 afd
-aez
+uME
 aUk
 acD
 apx
@@ -79264,8 +79728,8 @@ apx
 cfd
 aZQ
 baV
-kJy
-xnQ
+aIL
+aIL
 aIL
 aIL
 aIL
@@ -79521,7 +79985,7 @@ gjY
 cfd
 bya
 bdl
-pFT
+bdl
 bdl
 bew
 bdl
@@ -79720,7 +80184,7 @@ ada
 adx
 aec
 aeB
-afd
+qfq
 acD
 apx
 vZV
@@ -79778,7 +80242,7 @@ gjY
 aYN
 aZQ
 baX
-gvq
+aIL
 aIL
 aIL
 aIL
@@ -80239,7 +80703,7 @@ ahz
 agv
 ahz
 aEG
-agv
+nCB
 aiY
 alI
 akJ
@@ -80496,7 +80960,7 @@ agv
 agv
 ahz
 ahx
-agv
+nCB
 aiY
 ajK
 akK
@@ -80753,7 +81217,7 @@ ahz
 ahz
 ahz
 aEG
-agv
+nCB
 aiY
 ajL
 oRU
@@ -83119,7 +83583,7 @@ aXA
 ddZ
 bEC
 rwS
-bbe
+tpC
 rLd
 aZY
 bny
@@ -84127,7 +84591,7 @@ aEI
 aEI
 aEI
 ioA
-aIc
+boN
 aJb
 aFE
 aIk
@@ -84407,15 +84871,15 @@ bab
 aUX
 aUX
 aUX
-bJf
+cRe
 bbg
 bbg
 bbg
+dIB
 bbg
-bbg
+rkD
 bmx
-bbg
-awK
+nRa
 boy
 bqF
 csx
@@ -84668,11 +85132,11 @@ bbg
 bbg
 bbg
 bbg
+pSe
 eMM
+pSe
 bbg
-bbg
-bbg
-awK
+bJf
 bbg
 mRP
 csx
@@ -84927,9 +85391,9 @@ bbg
 bbg
 ijy
 bbg
-bbg
+dIB
 hrZ
-awK
+aDe
 bbg
 bqG
 csx
@@ -85183,11 +85647,11 @@ bbg
 bbg
 bbg
 bbg
-bbg
+uAm
 bbg
 hrZ
 bbg
-bbg
+gFQ
 bqH
 csx
 ckS
@@ -85413,15 +85877,15 @@ aFC
 aFv
 aHm
 aIg
-aHp
+aJf
 aFv
 aHm
 aMo
-aHp
+aJf
 aFv
 aHm
 aPo
-aHp
+aJf
 jqM
 bgx
 aoH
@@ -85436,12 +85900,12 @@ bag
 bdJ
 aUX
 bbg
-bbg
-bbg
-bbg
+bHx
+dYP
+iYV
 bky
 blr
-bbg
+vHg
 hrZ
 boz
 bpy
@@ -85696,12 +86160,12 @@ aZZ
 bgv
 bhK
 bjg
-bbg
+edn
 blr
-bbg
+vHg
 hrZ
-bbg
-bpy
+gCD
+qXH
 aYR
 csx
 bou
@@ -85925,15 +86389,15 @@ aEf
 liO
 aEI
 aGD
-aEI
+aQG
 aEI
 aEI
 aKz
-aEI
+aQG
 aEI
 aEI
 aNG
-aEI
+aQG
 aEI
 aPU
 jqM
@@ -85949,15 +86413,15 @@ aXR
 bcA
 bdL
 aUX
+mha
 bbg
 bbg
 bbg
-bbg
-bbg
+edn
 blr
-hrZ
+ouh
 bnE
-hrZ
+meR
 bpy
 aYR
 kuT
@@ -86180,18 +86644,18 @@ azU
 aDp
 aEI
 eTp
-aEI
+aQG
 mrV
-aEI
-aEI
-aEI
-aEI
-aEI
-aEI
-aEI
-aEI
-aEI
-aEI
+aQG
+aQG
+aQG
+aQG
+aQG
+aQG
+aQG
+aQG
+aQG
+aQG
 aPV
 aQz
 aRw
@@ -86439,15 +86903,15 @@ aEg
 lCD
 wcm
 aGE
-aEI
+aQG
 aEI
 aEI
 aKA
-aEI
+aQG
 aEI
 aEI
 aNH
-aEI
+aQG
 aEI
 aPW
 jqM
@@ -86953,15 +87417,15 @@ aqb
 aqb
 eWN
 jqM
-aHp
+aJf
 aIj
 aHm
 aFv
-aHp
+aJf
 aMp
 aHm
 aFv
-aHp
+aJf
 aPp
 aHm
 jqM
@@ -87203,9 +87667,9 @@ ddZ
 blZ
 aoH
 blZ
-blZ
-aoH
-blZ
+qLF
+eQq
+qLF
 blZ
 blZ
 eWN
@@ -87461,7 +87925,7 @@ btv
 ddZ
 blZ
 blZ
-inn
+aoH
 ayW
 blZ
 aoH

--- a/StationMaps/DiscStation/DiscStation.dmm
+++ b/StationMaps/DiscStation/DiscStation.dmm
@@ -19,6 +19,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
 /area/station/solars/starboard/fore)
+"abx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "abC" = (
 /obj/machinery/power/solar{
 	id = "forestarboard";
@@ -87,6 +96,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "acb" = (
@@ -114,6 +126,13 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/station/solars/port/fore)
+"acw" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security/prison)
 "acA" = (
 /obj/docking_port/stationary/random{
 	id = "pod_1_lavaland";
@@ -202,7 +221,9 @@
 /area/station/command/gateway)
 "acU" = (
 /obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/gateway)
 "acV" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
@@ -224,21 +245,33 @@
 	},
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/mask/breath,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "acY" = (
 /obj/structure/closet/secure_closet/medical1,
 /obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "acZ" = (
 /obj/structure/closet/secure_closet/exile,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "ada" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "adb" = (
@@ -378,7 +411,7 @@
 /area/station/hallway/primary/central)
 "ads" = (
 /obj/machinery/gateway/centerstation,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/command/gateway)
 "adt" = (
 /turf/closed/wall/r_wall,
@@ -395,15 +428,24 @@
 	},
 /obj/item/stack/medical/mesh,
 /obj/item/stack/medical/suture,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "adw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "adx" = (
 /obj/structure/table,
 /obj/machinery/recharger,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "adz" = (
@@ -428,7 +470,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "adD" = (
-/obj/structure/rack,
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "adE" = (
@@ -440,6 +482,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security)
 "adH" = (
@@ -520,17 +563,25 @@
 	dir = 8;
 	layer = 2.9
 	},
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "aec" = (
-/obj/structure/table,
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/light/directional/east,
 /obj/machinery/camera/directional/east{
 	c_tag = "Gateway Storage";
 	pixel_y = -22
 	},
-/obj/item/paper/pamphlet,
+/obj/structure/tank_dispenser/oxygen{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "aee" = (
@@ -585,6 +636,9 @@
 /obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/purple/opposingcorners{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "aet" = (
@@ -593,6 +647,9 @@
 "aeu" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
+/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "aew" = (
@@ -604,12 +661,17 @@
 /area/station/hallway/primary/starboard)
 "aex" = (
 /obj/machinery/light/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/gateway)
 "aey" = (
 /obj/structure/cable,
 /obj/machinery/computer/gateway_control{
 	dir = 4
+	},
+/obj/item/paper/pamphlet,
+/obj/effect/turf_decal/bot{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/command/gateway)
@@ -617,6 +679,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "aeB" = (
@@ -633,6 +696,9 @@
 /obj/item/flashlight,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "aeD" = (
@@ -662,7 +728,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
 "aeJ" = (
 /obj/effect/landmark/blobstart,
@@ -734,11 +800,17 @@
 "aeZ" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "afb" = (
 /obj/structure/sign/warning/pods{
 	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
@@ -750,13 +822,18 @@
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "afd" = (
-/turf/open/floor/iron,
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/gateway)
 "afe" = (
 /obj/machinery/button/door/directional/south{
 	id = "gateshutter";
 	name = "Gateway Shutter Control";
 	req_access = list("command")
+	},
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/command/gateway)
@@ -769,10 +846,14 @@
 /area/station/maintenance/starboard/fore)
 "afj" = (
 /obj/item/stack/rods/ten,
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "afn" = (
 /obj/machinery/bluespace_vendor/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "afo" = (
@@ -809,7 +890,8 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/science/genetics,
 /obj/effect/mapping_helpers/airlock/access/any/medical/general,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "afv" = (
 /obj/machinery/button/door{
@@ -873,6 +955,7 @@
 /area/station/hallway/primary/starboard)
 "afL" = (
 /obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "afN" = (
@@ -917,6 +1000,9 @@
 "agl" = (
 /obj/machinery/camera/autoname/directional/west,
 /obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "agn" = (
@@ -927,6 +1013,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/gateway)
+"agr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "agu" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
@@ -935,7 +1028,8 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /obj/effect/mapping_helpers/airlock/access/any/science/genetics,
 /obj/effect/mapping_helpers/airlock/access/any/medical/general,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "agv" = (
 /turf/open/floor/plating,
@@ -962,7 +1056,8 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "agK" = (
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/purple/corner,
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "agN" = (
 /obj/structure/closet/crate/science{
@@ -971,15 +1066,19 @@
 /obj/item/mod/core/standard,
 /obj/item/mod/core/standard,
 /obj/item/mod/core/standard,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "agO" = (
-/turf/open/floor/iron,
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "agP" = (
 /obj/structure/transit_tube/station/dispenser{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "agR" = (
@@ -1025,7 +1124,7 @@
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "ahh" = (
 /obj/structure/sign/departments/xenobio/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "ahi" = (
 /obj/structure/sign/warning/secure_area,
@@ -1063,11 +1162,14 @@
 	network = list("ss13","rd");
 	c_tag = "Ordnance Lab North"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "ahD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "ahG" = (
 /obj/machinery/igniter/incinerator_ordmix,
@@ -1112,7 +1214,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "aib" = (
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
+/turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "aic" = (
 /turf/closed/wall,
@@ -1121,13 +1224,19 @@
 /turf/closed/wall,
 /area/station/maintenance/starboard/fore)
 "ail" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "aio" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/storage)
 "aiq" = (
 /obj/machinery/door/airlock/research/glass/incinerator/ordmix_interior{
@@ -1216,7 +1325,7 @@
 /area/station/science/robotics/lab)
 "aiL" = (
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "aiP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1224,8 +1333,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "aiS" = (
-/obj/machinery/newscaster/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "aiT" = (
@@ -1249,7 +1358,10 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/burnchamber)
 "ajc" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -1375,8 +1487,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "ajJ" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 8
+	},
 /obj/effect/landmark/navigate_destination/med,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white/corner{
+	dir = 4
+	},
 /area/station/medical/medbay/lobby)
 "ajK" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -1390,20 +1507,23 @@
 	network = list("ss13","rd")
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/server)
 "ajM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/server)
 "ajN" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/server)
 "ajO" = (
 /turf/closed/wall,
@@ -1420,8 +1540,17 @@
 	pixel_y = -3
 	},
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"ajQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "ajR" = (
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1433,7 +1562,8 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "medbay-passthrough"
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "ajT" = (
 /turf/closed/wall/r_wall,
@@ -1459,8 +1589,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "akb" = (
-/obj/structure/closet,
-/obj/effect/spawner/random/maintenance,
+/obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "akc" = (
@@ -1487,6 +1616,10 @@
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
+"akl" = (
+/obj/structure/sign/poster/contraband/random/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
 "akn" = (
 /obj/item/stack/rods/ten,
 /turf/open/floor/plating,
@@ -1495,6 +1628,18 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"akp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"akq" = (
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "aks" = (
 /obj/structure/chair{
 	dir = 4
@@ -1508,7 +1653,7 @@
 "akt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/security/medical)
 "akz" = (
 /obj/structure/chair{
@@ -1525,6 +1670,9 @@
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "akA" = (
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "akC" = (
@@ -1539,6 +1687,9 @@
 /area/station/hallway/primary/starboard)
 "akH" = (
 /obj/machinery/vending/cigarette,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "akJ" = (
@@ -1551,16 +1702,19 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/rd,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/server)
 "akM" = (
 /obj/structure/chair/office/light,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/server)
 "akN" = (
 /obj/machinery/light/small/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/server)
 "akO" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible/layer2{
@@ -1573,20 +1727,26 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "akR" = (
 /obj/machinery/portable_atmospherics/pump,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "akS" = (
 /obj/structure/closet/bombcloset,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "akT" = (
 /obj/machinery/light/directional/north,
 /obj/structure/closet/bombcloset,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "akU" = (
 /obj/machinery/camera/directional/north{
@@ -1594,7 +1754,10 @@
 	network = list("ss13","rd")
 	},
 /obj/structure/sign/warning/cold_temp/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/purple{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "akX" = (
 /obj/structure/rack,
@@ -1612,10 +1775,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "alb" = (
-/obj/structure/rack{
-	dir = 1
-	},
-/obj/effect/spawner/random/maintenance,
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "alc" = (
@@ -1642,6 +1802,7 @@
 /area/station/maintenance/port/fore)
 "alj" = (
 /obj/effect/decal/cleanable/oil,
+/obj/structure/sign/poster/contraband/random/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "alk" = (
@@ -1665,10 +1826,16 @@
 "alF" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/emergency,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "alG" = (
 /obj/machinery/vending/coffee,
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "alH" = (
@@ -1693,23 +1860,28 @@
 	dir = 1
 	},
 /obj/machinery/light_switch/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/server)
 "alM" = (
 /obj/structure/table,
 /obj/item/folder/white,
 /obj/item/pen,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/server)
 "alP" = (
 /obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "alR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "alS" = (
 /obj/machinery/door/airlock/research/glass{
@@ -1758,9 +1930,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "amb" = (
-/obj/item/rack_parts,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/station/science/auxlab)
 "amc" = (
 /obj/machinery/newscaster/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1794,11 +1966,15 @@
 	tag = "icon-direction_bridge (EAST)";
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "amq" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/server)
 "amr" = (
 /obj/structure/cable,
@@ -1806,12 +1982,16 @@
 /area/station/maintenance/solars/port/fore)
 "amu" = (
 /obj/structure/chair/office/light,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "amv" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/vending/cola,
 /obj/machinery/status_display/evac/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "amx" = (
@@ -1824,37 +2004,41 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/science/rd,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/server)
 "amz" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/machinery/light_switch/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "amC" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "amD" = (
 /obj/machinery/computer/atmos_control/ordnancemix{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "amF" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "amG" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/modular_computer/console/preset/cargochat/science{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "amJ" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2,
@@ -1877,10 +2061,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "amP" = (
-/obj/effect/decal/cleanable/cobweb{
-	tag = "icon-cobweb2";
-	icon_state = "cobweb2"
-	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
@@ -1923,7 +2104,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/ordnance)
 "anc" = (
 /obj/structure/transit_tube/horizontal,
@@ -1932,6 +2113,9 @@
 "ane" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "anh" = (
@@ -1943,27 +2127,33 @@
 /obj/structure/chair{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "anj" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
 "ank" = (
 /obj/structure/sign/warning/no_smoking/directional/north,
 /obj/machinery/atmospherics/components/tank/oxygen{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
 "ano" = (
 /obj/structure/closet/firecloset,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/purple/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "ant" = (
 /obj/machinery/light_switch/directional/west,
 /obj/structure/closet/emcloset,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "anu" = (
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -1975,10 +2165,15 @@
 	dir = 8
 	},
 /obj/machinery/meter,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "anw" = (
-/obj/effect/spawner/random/vending/snackvend,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "anx" = (
@@ -2042,17 +2237,20 @@
 /area/station/hallway/primary/starboard)
 "anP" = (
 /obj/structure/transit_tube/curved/flipped,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "anR" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/portable_atmospherics/canister/plasma,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
 "anT" = (
 /obj/effect/decal/cleanable/oil,
 /obj/item/cigbutt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
 "anV" = (
 /obj/machinery/light/small/directional/east,
@@ -2060,7 +2258,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
 "anX" = (
 /obj/machinery/light/directional/west,
@@ -2068,18 +2266,21 @@
 	network = list("ss13","rd")
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/purple/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "aoe" = (
 /obj/machinery/camera/autoname/directional/north{
 	network = list("ss13","rd")
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "aog" = (
 /obj/machinery/airalarm/directional/west,
 /obj/structure/closet/firecloset,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "aoh" = (
 /obj/machinery/firealarm/directional/east,
@@ -2088,7 +2289,10 @@
 	},
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/box/red,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "aoi" = (
 /obj/machinery/door/airlock/maintenance,
@@ -2113,7 +2317,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aol" = (
-/obj/machinery/vending/assist,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "aom" = (
@@ -2121,16 +2331,21 @@
 /obj/machinery/airalarm/directional/north{
 	locked = 0
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "aoo" = (
-/obj/structure/sign/warning/pods{
-	pixel_y = 32
+/obj/structure/sign/warning/pods/directional/north,
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "aop" = (
 /obj/structure/transit_tube/curved,
+/obj/effect/turf_decal/tile/purple/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "aoq" = (
@@ -2197,7 +2412,11 @@
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /obj/machinery/light/small/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
 "aoH" = (
 /obj/structure/grille,
@@ -2205,19 +2424,27 @@
 /area/station/maintenance/department/science)
 "aoI" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
 "aoJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
 "aoK" = (
 /obj/structure/cable,
-/obj/machinery/newscaster/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "aoL" = (
@@ -2233,16 +2460,17 @@
 	name = "Ordnance Lab Shutters"
 	},
 /obj/machinery/door/firedoor/heavy,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/caution/stand_clear/red,
+/turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
 "aoU" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "aoV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/explab)
 "aoW" = (
 /obj/machinery/newscaster/directional/south,
@@ -2259,6 +2487,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/science/ordnance)
 "apa" = (
@@ -2267,7 +2498,8 @@
 /obj/structure/table,
 /obj/item/binoculars,
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "apb" = (
 /obj/machinery/computer/pod/old/mass_driver_controller/ordnancedriver{
@@ -2277,13 +2509,15 @@
 	c_tag = "Ordnance Launch Site";
 	network = list("ss13","rd")
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "apc" = (
 /obj/machinery/doppler_array{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "apd" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -2291,6 +2525,9 @@
 /area/station/science/ordnance/bomb)
 "ape" = (
 /obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "apg" = (
@@ -2298,6 +2535,7 @@
 /obj/structure/transit_tube/station/dispenser{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/purple/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "aph" = (
@@ -2347,15 +2585,15 @@
 /area/station/hallway/primary/starboard)
 "apy" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
 "apz" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
 "apA" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
 "apB" = (
 /obj/machinery/firealarm/directional/east,
@@ -2363,13 +2601,13 @@
 /obj/machinery/computer/atmos_alert{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
 "apE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/lab)
 "apH" = (
 /obj/machinery/door/firedoor/heavy,
@@ -2383,14 +2621,20 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "apJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"apK" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "apL" = (
 /obj/machinery/door/airlock/research{
 	name = "Ordnance Launch Room"
@@ -2402,10 +2646,15 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "apM" = (
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/purple/filled/arrow_ccw,
+/obj/effect/turf_decal/trimline/purple/filled/arrow_cw{
+	dir = 1
+	},
+/obj/structure/sign/warning/vacuum/external/directional/south,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "apO" = (
 /obj/structure/chair{
@@ -2414,13 +2663,16 @@
 /obj/machinery/computer/security/telescreen/ordnance{
 	pixel_x = 30
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "apP" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/engineering/break_room)
 "apR" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance,
@@ -2434,6 +2686,7 @@
 /obj/structure/transit_tube/curved/flipped{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "apY" = (
@@ -2481,38 +2734,40 @@
 "aqj" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
 "aqk" = (
 /obj/machinery/portable_atmospherics/scrubber/huge,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
 "aqm" = (
 /obj/machinery/light/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "aqr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "aqs" = (
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/turf_decal/box/red,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "aqu" = (
 /obj/structure/window/reinforced,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "aqv" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /obj/structure/window/reinforced,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "aqw" = (
 /obj/item/flashlight/lamp,
@@ -2558,14 +2813,23 @@
 "aqG" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "aqH" = (
 /obj/machinery/vending/coffee,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "aqI" = (
 /obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "aqJ" = (
@@ -2588,6 +2852,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "aqP" = (
@@ -2597,7 +2864,13 @@
 "aqS" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/lab)
 "aqT" = (
 /obj/structure/table,
@@ -2609,7 +2882,10 @@
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/clothing/glasses/welding,
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/lab)
 "aqU" = (
 /obj/structure/table,
@@ -2627,7 +2903,10 @@
 	network = list("ss13","rd")
 	},
 /obj/machinery/newscaster/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/lab)
 "aqV" = (
 /obj/item/folder/white,
@@ -2636,14 +2915,20 @@
 /obj/item/disk/tech_disk,
 /obj/item/disk/design_disk,
 /obj/item/disk/design_disk,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/lab)
 "aqW" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
 /obj/item/stock_parts/cell/high,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/lab)
 "aqX" = (
 /obj/item/kirbyplants{
@@ -2651,12 +2936,22 @@
 	name = "Photosynthetic Potted plant";
 	tag = "icon-plant-07"
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/purple/corner,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/lab)
 "aqY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/science/lab)
+"arb" = (
+/obj/effect/turf_decal/trimline/blue/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "ard" = (
 /obj/machinery/firealarm/directional/west,
 /obj/structure/table,
@@ -2669,14 +2964,15 @@
 	pixel_x = 7;
 	pixel_y = 9
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "arf" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
 /obj/effect/turf_decal/box,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "arg" = (
 /obj/machinery/camera/directional/east{
@@ -2684,7 +2980,7 @@
 	network = list("ss13","rd")
 	},
 /obj/machinery/atmospherics/components/trinary/filter/flipped,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "arh" = (
 /obj/structure/rack,
@@ -2711,19 +3007,26 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "ark" = (
-/obj/structure/closet,
 /obj/item/stock_parts/matter_bin,
+/obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "arl" = (
 /obj/machinery/mass_driver/ordnance{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/purple/filled/arrow_ccw,
+/obj/effect/turf_decal/trimline/purple/filled/warning{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "arm" = (
-/obj/structure/sign/warning/vacuum/external,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/purple/filled/arrow_ccw,
+/obj/effect/turf_decal/trimline/purple/filled/arrow_cw{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "aro" = (
 /obj/machinery/door/poddoor/massdriver_ordnance,
@@ -2770,6 +3073,9 @@
 /obj/structure/sign/directions/medical/directional/west{
 	dir = 2
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "arD" = (
@@ -2779,6 +3085,9 @@
 "arE" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/sign/directions/security{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -2797,6 +3106,9 @@
 /area/station/hallway/primary/starboard)
 "arQ" = (
 /obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "arR" = (
@@ -2842,17 +3154,21 @@
 "arU" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/requests_console/auto_name/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/lab)
 "arV" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/science/lab)
 "arX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/lab)
 "asd" = (
 /obj/item/assembly/prox_sensor{
@@ -2871,12 +3187,14 @@
 	pixel_y = 2
 	},
 /obj/structure/table/reinforced,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "ase" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/scientist,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "asf" = (
 /obj/structure/table/reinforced,
@@ -2884,7 +3202,8 @@
 /obj/item/screwdriver{
 	pixel_y = 10
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "ash" = (
 /obj/structure/cable,
@@ -2903,7 +3222,8 @@
 	},
 /obj/machinery/light_switch/directional/east,
 /obj/machinery/light/small/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/office)
 "asl" = (
 /obj/structure/chair{
@@ -2938,13 +3258,22 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
+"asr" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "ast" = (
 /obj/machinery/camera/autoname/directional/south{
 	network = list("ss13","medbay")
 	},
 /obj/structure/bed/roller,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "asv" = (
 /obj/structure/cable,
@@ -2956,6 +3285,7 @@
 "asx" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "asy" = (
@@ -2963,11 +3293,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "asA" = (
 /obj/structure/closet/toolcloset,
 /obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "asF" = (
@@ -2996,8 +3328,8 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "asK" = (
-/obj/structure/sign/warning/secure_area,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/warning/docking,
 /turf/open/floor/plating,
 /area/station/hallway/primary/starboard)
 "asO" = (
@@ -3005,19 +3337,24 @@
 /area/station/science/lab)
 "asP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured,
 /area/station/science/research)
 "asS" = (
 /obj/machinery/rnd/destructive_analyzer,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/lab)
 "asU" = (
 /obj/machinery/rnd/production/techfab/department/science,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/lab)
 "asW" = (
 /obj/machinery/holopad,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/lab)
 "asX" = (
 /obj/machinery/door/firedoor/heavy,
@@ -3025,7 +3362,14 @@
 	id = "rnd2";
 	name = "research lab shutters"
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/trimline/purple/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/science/lab)
 "asY" = (
 /obj/item/assembly/signaler{
@@ -3044,7 +3388,8 @@
 	pixel_y = -2
 	},
 /obj/structure/table/reinforced,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "asZ" = (
 /obj/item/transfer_valve{
@@ -3067,7 +3412,8 @@
 	pixel_y = -30
 	},
 /obj/structure/table/reinforced,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "ata" = (
 /obj/item/assembly/timer{
@@ -3084,18 +3430,19 @@
 	},
 /obj/item/assembly/timer,
 /obj/structure/table/reinforced,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "atb" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "atc" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "atd" = (
 /turf/closed/wall/r_wall,
@@ -3173,7 +3520,8 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/science/general,
 /obj/effect/landmark/navigate_destination/research,
-/turf/open/floor/iron,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "atx" = (
 /turf/closed/wall,
@@ -3188,6 +3536,7 @@
 /obj/item/clothing/suit/hazardvest,
 /obj/item/multitool,
 /obj/effect/spawner/random/maintenance,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "atA" = (
@@ -3252,16 +3601,21 @@
 /obj/machinery/computer/rdconsole{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/lab)
 "atO" = (
 /obj/machinery/rnd/production/circuit_imprinter/department/science,
 /obj/item/reagent_containers/glass/beaker/sulfuric,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/lab)
 "atV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/science/lab)
 "atW" = (
 /turf/closed/wall/r_wall,
@@ -3284,7 +3638,8 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "auc" = (
 /turf/open/floor/plating,
@@ -3322,6 +3677,7 @@
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency,
 /obj/machinery/light_switch/directional/west,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "aup" = (
@@ -3329,11 +3685,13 @@
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/storage/box/lights/mixed,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "aur" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "aus" = (
@@ -3341,34 +3699,41 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/rods/fifty,
 /obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "auv" = (
 /obj/machinery/door/firedoor/heavy,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "auw" = (
 /obj/structure/sign/departments/cargo/directional/east,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "auz" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/status_display/evac/directional/west,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "auA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white/textured,
 /area/station/science/research)
 "auC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/lab)
 "auD" = (
 /obj/structure/table/glass,
@@ -3382,7 +3747,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
 /area/station/science/lab)
 "auE" = (
 /obj/structure/table/glass,
@@ -3395,12 +3764,14 @@
 	pixel_y = 2
 	},
 /obj/item/reagent_containers/dropper,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
 /area/station/science/lab)
 "auF" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/scientist,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
 /area/station/science/lab)
 "auG" = (
 /obj/structure/table/glass,
@@ -3419,7 +3790,8 @@
 	name = "Research Shutters";
 	pixel_y = -24
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
 /area/station/science/lab)
 "auH" = (
 /obj/structure/table/glass,
@@ -3427,16 +3799,29 @@
 /obj/item/stock_parts/matter_bin,
 /obj/machinery/firealarm/directional/south,
 /obj/item/toy/figure/scientist,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
 /area/station/science/lab)
 "auI" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/purple/corner{
+	dir = 4
+	},
+/obj/structure/table/glass,
+/obj/item/experi_scanner{
+	pixel_x = -4
+	},
+/obj/item/experi_scanner,
+/obj/item/experi_scanner{
+	pixel_x = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
 /area/station/science/lab)
 "auJ" = (
 /obj/machinery/light/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "auL" = (
 /obj/structure/reagent_dispensers/wall/peppertank{
@@ -3444,7 +3829,8 @@
 	},
 /obj/machinery/airalarm/directional/north,
 /obj/structure/closet/secure_closet/security/science,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "auM" = (
 /obj/machinery/camera/directional/north{
@@ -3452,7 +3838,8 @@
 	network = list("ss13","rd")
 	},
 /obj/machinery/computer/security,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "auN" = (
 /obj/structure/table,
@@ -3463,14 +3850,15 @@
 /obj/item/screwdriver{
 	pixel_y = 10
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "auP" = (
 /obj/structure/closet/crate,
 /obj/item/target,
 /obj/item/target,
 /obj/item/target,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/auxlab)
 "auQ" = (
 /turf/open/floor/iron,
@@ -3480,7 +3868,7 @@
 /obj/item/target/alien,
 /obj/item/target/alien,
 /obj/item/target/alien,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/auxlab)
 "auS" = (
 /turf/closed/wall/r_wall,
@@ -3539,6 +3927,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "avj" = (
@@ -3551,6 +3942,9 @@
 /area/station/hallway/primary/port)
 "avo" = (
 /obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "avt" = (
@@ -3588,49 +3982,53 @@
 /area/station/science/lab)
 "avw" = (
 /obj/item/kirbyplants/photosynthetic,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "avy" = (
 /obj/effect/landmark/start/depsec/science,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "avz" = (
 /obj/structure/chair/office{
 	dir = 4
 	},
 /obj/effect/landmark/start/depsec/science,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "avA" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/radio/off,
 /obj/machinery/requests_console/auto_name/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "avB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/auxlab)
 "avC" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Firing Range";
 	network = list("ss13","rd")
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/auxlab)
 "avD" = (
 /obj/machinery/light/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/auxlab)
 "avE" = (
 /obj/structure/closet/crate,
 /obj/item/target/syndicate,
 /obj/item/target/syndicate,
 /obj/item/target/syndicate,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/auxlab)
 "avF" = (
 /obj/structure/table/wood,
@@ -3683,6 +4081,16 @@
 /obj/item/reagent_containers/blood/random,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"avT" = (
+/obj/machinery/door/firedoor/heavy,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"awd" = (
+/turf/open/floor/iron/checker,
+/area/station/service/theater)
 "awh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3696,11 +4104,17 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/heavy,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "awl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
@@ -3710,7 +4124,8 @@
 	c_tag = "Research Entrance";
 	network = list("ss13","rd")
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "awu" = (
 /obj/machinery/door/firedoor,
@@ -3730,7 +4145,8 @@
 /obj/effect/landmark/start/depsec/science,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "aww" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -3738,24 +4154,26 @@
 	},
 /obj/effect/landmark/start/depsec/science,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "awx" = (
 /obj/effect/landmark/start/depsec/science,
 /obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "awy" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/holopad,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/auxlab)
 "awz" = (
 /obj/structure/rack,
 /obj/item/gun/energy/laser/practice,
 /obj/item/clothing/ears/earmuffs,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/auxlab)
 "awA" = (
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
@@ -3784,6 +4202,9 @@
 /obj/structure/chair{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "awM" = (
@@ -3809,7 +4230,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "awU" = (
 /obj/machinery/door/airlock/research{
@@ -3819,10 +4243,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/science/general,
-/turf/open/floor/iron,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "awV" = (
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/lab)
 "awY" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -3830,7 +4256,8 @@
 /area/station/security/checkpoint/science)
 "awZ" = (
 /obj/structure/filingcabinet,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "axa" = (
 /obj/machinery/computer/secure_data{
@@ -3839,7 +4266,8 @@
 /obj/machinery/light/directional/south,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "axb" = (
 /obj/structure/table,
@@ -3849,7 +4277,8 @@
 	},
 /obj/item/pen,
 /obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "axc" = (
 /turf/closed/wall,
@@ -3859,32 +4288,48 @@
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/auxlab)
 "axf" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron,
 /area/station/science/auxlab)
 "axg" = (
 /obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/station/science/auxlab)
 "axj" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "axk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "axm" = (
 /obj/machinery/computer/pandemic,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "axn" = (
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "axo" = (
 /obj/structure/table/glass,
@@ -3892,7 +4337,10 @@
 /obj/item/healthanalyzer,
 /obj/item/clothing/glasses/hud/health,
 /obj/machinery/requests_console/auto_name/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "axp" = (
 /obj/structure/table/glass,
@@ -3903,14 +4351,21 @@
 /obj/item/reagent_containers/dropper,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/structure/reagent_dispensers/wall/virusfood/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "axq" = (
 /obj/item/bedsheet,
 /obj/structure/bed,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "axs" = (
 /obj/machinery/light/small/directional/north,
@@ -3931,10 +4386,16 @@
 /area/station/science/genetics)
 "axz" = (
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "axD" = (
 /obj/machinery/camera/autoname/directional/south,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "axE" = (
@@ -3950,6 +4411,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/bluespace_vendor/directional/south,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "axL" = (
@@ -3960,6 +4424,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "axQ" = (
@@ -3967,13 +4434,15 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "axR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "axS" = (
 /obj/machinery/camera/directional/west{
@@ -3982,7 +4451,7 @@
 	},
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/auxlab)
 "axT" = (
 /obj/effect/landmark/blobstart,
@@ -3999,7 +4468,7 @@
 "axV" = (
 /obj/structure/table,
 /obj/machinery/light/small/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "axX" = (
 /obj/machinery/door/firedoor,
@@ -4009,20 +4478,20 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/virology,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aya" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "ayd" = (
 /obj/machinery/door/airlock/virology/glass{
 	name = "Monkey Pen"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/virology,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aye" = (
 /turf/open/floor/grass,
@@ -4039,8 +4508,7 @@
 /turf/closed/wall,
 /area/station/maintenance/port/central)
 "ayn" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "ayo" = (
 /turf/closed/wall,
@@ -4054,6 +4522,9 @@
 "ayq" = (
 /obj/machinery/light/directional/west,
 /obj/structure/window,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "ayu" = (
@@ -4069,6 +4540,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/science/general,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/science/auxlab)
 "ayw" = (
@@ -4082,13 +4554,12 @@
 	},
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/auxlab)
 "ayy" = (
 /obj/structure/table/reinforced,
-/obj/machinery/light/directional/east,
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/white,
 /area/station/science/auxlab)
 "ayB" = (
 /obj/item/stack/sheet/cardboard,
@@ -4106,22 +4577,23 @@
 /area/station/maintenance/department/science)
 "ayD" = (
 /obj/structure/closet/secure_closet/personal/patient,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "ayE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "ayF" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/medical/virology)
 "ayK" = (
-/obj/machinery/light/directional/east,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "ayL" = (
 /obj/machinery/light/directional/east,
@@ -4129,7 +4601,10 @@
 /obj/item/stack/medical/mesh,
 /obj/item/stack/medical/suture,
 /obj/item/stack/medical/gauze,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "ayM" = (
 /obj/structure/window/reinforced{
@@ -4213,12 +4688,12 @@
 	pixel_x = -2;
 	pixel_y = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "aze" = (
 /obj/structure/rack,
 /obj/item/aicard,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "azf" = (
 /obj/structure/rack,
@@ -4228,7 +4703,7 @@
 /obj/item/paicard{
 	pixel_x = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "azg" = (
 /obj/machinery/computer/aifixer{
@@ -4240,23 +4715,21 @@
 	name = "Research Director's Requests Console"
 	},
 /obj/structure/window/spawner/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "azi" = (
-/obj/structure/table,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/machinery/computer/security/telescreen/research,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "azj" = (
-/obj/structure/table,
-/obj/item/folder/white,
-/obj/item/stamp/rd{
-	pixel_x = 3;
-	pixel_y = -2
+/obj/machinery/computer/rdconsole{
+	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "azk" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -4277,7 +4750,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "azu" = (
 /turf/closed/wall/r_wall,
@@ -4313,13 +4786,15 @@
 	dir = 4
 	},
 /obj/structure/window/spawner/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "azI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "azJ" = (
 /obj/structure/chair/office/light{
@@ -4327,11 +4802,15 @@
 	},
 /obj/effect/landmark/start/research_director,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "azK" = (
-/obj/structure/table,
-/turf/open/floor/iron,
+/obj/machinery/modular_computer/console/preset/research{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "azM" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -4339,18 +4818,27 @@
 /area/station/science/explab)
 "azN" = (
 /obj/machinery/module_duplicator,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/explab)
 "azO" = (
 /obj/machinery/airalarm/directional/north,
 /obj/structure/rack,
 /obj/item/integrated_circuit/loaded/speech_relay,
 /obj/item/integrated_circuit/loaded/hello_world,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/explab)
 "azP" = (
 /obj/machinery/component_printer,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/explab)
 "azQ" = (
 /obj/machinery/camera/directional/north{
@@ -4360,19 +4848,28 @@
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/explab)
 "azR" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/item/pen,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/explab)
 "azS" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/experimentor,
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/explab)
 "azT" = (
 /turf/open/floor/engine,
@@ -4409,19 +4906,19 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aAd" = (
-/obj/machinery/light/directional/east,
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/obj/effect/turf_decal/tile/blue/diagonal_centre,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "aAh" = (
 /obj/structure/table,
 /obj/machinery/microwave{
 	pixel_y = 6
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aAi" = (
 /turf/closed/wall/r_wall,
@@ -4446,7 +4943,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
 "aAq" = (
 /obj/item/kirbyplants{
@@ -4458,11 +4959,16 @@
 /area/station/hallway/primary/starboard)
 "aAr" = (
 /obj/machinery/light/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "aAs" = (
 /obj/machinery/suit_storage_unit/rd,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple/diagonal_centre,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/command/heads_quarters/rd)
 "aAu" = (
 /obj/machinery/computer/robotics{
@@ -4470,11 +4976,15 @@
 	},
 /obj/structure/window/spawner,
 /obj/structure/window/spawner/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "aAw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "aAx" = (
@@ -4484,7 +4994,13 @@
 	pixel_y = 9
 	},
 /obj/item/pen,
-/turf/open/floor/iron,
+/obj/item/folder/white,
+/obj/item/stamp/rd{
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "aAA" = (
 /obj/machinery/door/firedoor/heavy,
@@ -4498,14 +5014,14 @@
 /turf/open/floor/iron,
 /area/station/science/explab)
 "aAB" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/explab)
 "aAC" = (
 /obj/structure/chair/office/light{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/explab)
 "aAE" = (
 /obj/machinery/rnd/experimentor,
@@ -4543,13 +5059,13 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/virology,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aAU" = (
 /obj/effect/landmark/start/virologist,
 /obj/structure/cable,
 /obj/structure/chair/stool/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aAV" = (
 /obj/structure/table,
@@ -4558,12 +5074,18 @@
 	pixel_y = 3
 	},
 /obj/machinery/newscaster/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aAX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "aAY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4582,6 +5104,9 @@
 	tag = "icon-camera (NORTHWEST)";
 	dir = 6
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "aBb" = (
@@ -4598,6 +5123,9 @@
 "aBd" = (
 /obj/machinery/firealarm/directional/west,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "aBf" = (
@@ -4610,10 +5138,18 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "aBl" = (
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "aBm" = (
 /obj/machinery/door/airlock/command/glass{
@@ -4623,19 +5159,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/science/rd,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/rd)
 "aBs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/explab)
 "aBu" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/explab)
 "aBv" = (
 /obj/structure/rack,
@@ -4646,7 +5183,10 @@
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aBy" = (
 /obj/structure/lattice/catwalk,
@@ -4657,7 +5197,7 @@
 /area/space/nearstation)
 "aBA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "aBB" = (
 /obj/structure/bedsheetbin{
@@ -4667,7 +5207,14 @@
 /obj/item/clothing/mask/muzzle,
 /obj/structure/table/glass,
 /obj/machinery/light/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
 /area/station/science/genetics)
 "aBC" = (
 /obj/structure/table,
@@ -4689,18 +5236,22 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "aBI" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "aBK" = (
 /obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/pdapainter/research,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "aBL" = (
 /obj/structure/table,
@@ -4718,7 +5269,8 @@
 	network = list("ss13","rd")
 	},
 /obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "aBM" = (
 /obj/machinery/holopad,
@@ -4726,13 +5278,15 @@
 	pixel_y = -24
 	},
 /obj/machinery/light/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "aBN" = (
 /obj/machinery/light_switch/directional/south,
 /obj/item/kirbyplants/dead,
 /obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "aBO" = (
 /turf/closed/wall,
@@ -4742,14 +5296,16 @@
 /obj/structure/cable,
 /obj/structure/table/reinforced,
 /obj/item/mmi,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/turf/open/floor/iron/white,
 /area/station/science/explab)
 "aBQ" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/structure/table/reinforced,
 /obj/item/compact_remote,
 /obj/item/compact_remote,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
 /area/station/science/explab)
 "aBR" = (
 /obj/machinery/light/directional/south,
@@ -4760,7 +5316,8 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/controller,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
 /area/station/science/explab)
 "aBS" = (
 /obj/machinery/airalarm/directional/south,
@@ -4772,7 +5329,8 @@
 /obj/item/multitool/circuit{
 	pixel_x = -8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
 /area/station/science/explab)
 "aBT" = (
 /obj/machinery/firealarm/directional/south,
@@ -4788,7 +5346,8 @@
 	pixel_x = -4;
 	pixel_y = -2
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
 /area/station/science/explab)
 "aBU" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
@@ -4806,7 +5365,11 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
 /area/station/science/explab)
 "aBW" = (
 /obj/structure/closet/crate{
@@ -4822,37 +5385,53 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "aBY" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Virology Break Room";
-	network = list("ss13","medbay")
-	},
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/storage/secure/safe/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aCb" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aCc" = (
 /obj/structure/table,
 /obj/item/hand_labeler,
 /obj/item/radio/headset/headset_med,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/camera/autoname/directional/east,
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aCd" = (
 /obj/machinery/computer/scan_consolenew{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/genetics)
 "aCg" = (
 /obj/machinery/computer/scan_consolenew{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
 /area/station/science/genetics)
 "aCi" = (
 /obj/item/stack/rods/ten,
@@ -4868,11 +5447,18 @@
 "aCm" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/rd)
+"aCn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "aCr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "aCu" = (
 /obj/structure/table,
@@ -4891,36 +5477,51 @@
 	},
 /obj/item/pen/red,
 /obj/machinery/light/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aCz" = (
 /obj/machinery/dna_scannernew,
 /obj/machinery/light_switch{
 	pixel_x = -23
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/genetics)
 "aCA" = (
 /obj/structure/chair/office/light{
 	dir = 8
 	},
 /obj/effect/landmark/start/geneticist,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/genetics)
 "aCB" = (
 /obj/structure/chair/office/light{
 	dir = 4
 	},
 /obj/effect/landmark/start/geneticist,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/genetics)
 "aCD" = (
 /obj/structure/window,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "aCG" = (
 /obj/machinery/airalarm/directional/east,
 /obj/structure/window,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "aCH" = (
@@ -4939,6 +5540,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/sign/poster/contraband/tools{
+	pixel_y = -32
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aCS" = (
@@ -4957,13 +5561,16 @@
 "aCY" = (
 /obj/structure/frame/machine,
 /obj/item/wirecutters,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured,
 /area/station/science/research)
 "aCZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
 "aDa" = (
 /obj/structure/rack,
@@ -4979,12 +5586,18 @@
 	c_tag = "Research Storage";
 	network = list("ss13","rd")
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured,
 /area/station/science/research)
 "aDb" = (
 /obj/structure/closet/crate,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured,
 /area/station/science/research)
 "aDc" = (
 /turf/closed/wall,
@@ -5005,11 +5618,17 @@
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aDj" = (
 /obj/structure/chair/stool,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aDk" = (
 /obj/structure/table,
@@ -5018,7 +5637,10 @@
 	pixel_y = 2
 	},
 /obj/item/storage/box/syringes,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aDl" = (
 /obj/structure/table,
@@ -5027,13 +5649,19 @@
 	pixel_y = 3
 	},
 /obj/item/extinguisher,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aDm" = (
 /obj/structure/table,
 /obj/item/storage/box/monkeycubes,
 /obj/item/storage/box/monkeycubes,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aDn" = (
 /obj/structure/table,
@@ -5048,20 +5676,32 @@
 	},
 /obj/machinery/light/directional/north,
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aDo" = (
 /obj/machinery/monkey_recycler,
 /obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aDp" = (
 /obj/machinery/processor/slime,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aDq" = (
 /obj/machinery/smartfridge/extract,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aDt" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -5095,11 +5735,14 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/virology,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aDA" = (
 /obj/machinery/vending/medical,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aDB" = (
 /obj/item/storage/box/rxglasses{
@@ -5115,21 +5758,27 @@
 	pixel_x = 6;
 	pixel_y = 3
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/genetics)
 "aDC" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/genetics)
 "aDD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/machinery/holopad,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/genetics)
 "aDF" = (
 /obj/item/reagent_containers/dropper,
@@ -5150,7 +5799,11 @@
 	pixel_y = -1
 	},
 /obj/item/radio/headset/headset_medsci,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
 /area/station/science/genetics)
 "aDG" = (
 /obj/item/kirbyplants{
@@ -5200,13 +5853,13 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white/textured,
 /area/station/science/research)
 "aDU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/scientist,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white/textured,
 /area/station/science/research)
 "aDW" = (
 /obj/machinery/door/airlock/research{
@@ -5216,7 +5869,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/science/general,
-/turf/open/floor/iron,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "aEb" = (
 /obj/machinery/door/firedoor,
@@ -5240,11 +5894,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aEg" = (
 /obj/machinery/light_switch/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aEh" = (
 /obj/structure/rack,
@@ -5285,14 +5939,16 @@
 /area/station/maintenance/port/fore)
 "aEm" = (
 /obj/structure/grille/broken,
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aEn" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aEo" = (
 /obj/structure/closet/secure_closet/medical1,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/green/half/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aEp" = (
 /obj/machinery/door_buttons/airlock_controller{
@@ -5307,17 +5963,19 @@
 	pixel_x = -4;
 	pixel_y = -24
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/green/half/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aEr" = (
 /obj/machinery/iv_drip,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/green/anticorner/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aEs" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/genetics)
 "aEu" = (
 /obj/item/kirbyplants{
@@ -5332,12 +5990,14 @@
 /area/station/tcommsat/server)
 "aEz" = (
 /obj/machinery/drone_dispenser,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white/textured,
 /area/station/science/research)
 "aEB" = (
 /obj/structure/frame/machine,
 /obj/item/stack/cable_coil,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white/textured,
 /area/station/science/research)
 "aEC" = (
 /obj/structure/rack,
@@ -5345,19 +6005,27 @@
 	pixel_y = 5
 	},
 /obj/item/storage/toolbox/mechanical,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white/textured,
 /area/station/science/research)
+"aED" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/escape)
 "aEE" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/camera/autoname/directional/south{
 	network = list("ss13","rd")
 	},
 /obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "aEF" = (
 /obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "aEG" = (
 /obj/structure/cable,
@@ -5367,6 +6035,11 @@
 /area/station/maintenance/starboard/fore)
 "aEH" = (
 /obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "aEI" = (
@@ -5375,7 +6048,7 @@
 "aEN" = (
 /obj/structure/chair/office/light,
 /obj/effect/landmark/start/scientist,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aEP" = (
 /obj/machinery/door/airlock/maintenance{
@@ -5427,19 +6100,30 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/virology,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/green/fourcorners,
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aFc" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/machinery/vending/wardrobe/gene_wardrobe,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/genetics)
 "aFe" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
 /area/station/science/genetics)
 "aFf" = (
 /obj/structure/table,
@@ -5449,7 +6133,11 @@
 	req_one_access_txt = list("detective","medical","genetics")
 	},
 /obj/item/toy/figure/geneticist,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
 /area/station/science/genetics)
 "aFh" = (
 /obj/structure/rack,
@@ -5497,7 +6185,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/science/robotics,
-/turf/open/floor/iron,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "aFv" = (
 /turf/closed/wall,
@@ -5508,29 +6197,38 @@
 	network = list("ss13","rd","xeno")
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aFy" = (
 /obj/structure/closet/l3closet/scientist,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aFz" = (
 /obj/structure/closet,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aFA" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/computer/camera_advanced/xenobio{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aFB" = (
 /obj/structure/table/glass,
 /obj/item/folder/white,
 /obj/item/pen,
 /obj/machinery/requests_console/auto_name/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aFC" = (
 /obj/structure/table/glass,
@@ -5538,13 +6236,15 @@
 	pixel_x = 1;
 	pixel_y = 9
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aFD" = (
 /obj/machinery/computer/camera_advanced/xenobio{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aFE" = (
 /turf/closed/wall/r_wall,
@@ -5633,7 +6333,10 @@
 /obj/machinery/light/directional/north,
 /obj/machinery/light_switch/directional/north,
 /obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "aFR" = (
 /obj/item/computer_hardware/hard_drive/portable/medical{
@@ -5649,7 +6352,10 @@
 	pixel_y = 2
 	},
 /obj/structure/table/glass,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "aFS" = (
 /obj/structure/table/glass,
@@ -5659,7 +6365,10 @@
 	pixel_x = -2;
 	pixel_y = 5
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "aFT" = (
 /obj/structure/closet/secure_closet/chief_medical,
@@ -5668,15 +6377,21 @@
 	},
 /obj/item/storage/secure/safe/directional/north,
 /obj/machinery/computer/security/telescreen/entertainment/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "aFU" = (
 /obj/structure/sink{
-	dir = 8;
+	dir = 4;
 	pixel_x = -12;
 	pixel_y = 2
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aFW" = (
 /obj/structure/closet/emcloset,
@@ -5684,11 +6399,18 @@
 	c_tag = "Virology Airlock";
 	network = list("ss13","medbay")
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aFX" = (
 /obj/machinery/dna_scannernew,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
 /area/station/science/genetics)
 "aFZ" = (
 /obj/structure/grille,
@@ -5700,6 +6422,9 @@
 "aGa" = (
 /obj/structure/window{
 	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
@@ -5749,7 +6474,7 @@
 /area/station/construction)
 "aGr" = (
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "aGs" = (
 /obj/structure/table,
@@ -5760,18 +6485,18 @@
 /obj/item/storage/belt/utility,
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/machinery/requests_console/auto_name/directional/north,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "aGt" = (
-/obj/machinery/rnd/production/circuit_imprinter/department/science,
-/turf/open/floor/iron/dark,
+/obj/machinery/vending/wardrobe/robo_wardrobe,
+/turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "aGu" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags,
 /obj/item/pen,
 /obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "aGv" = (
 /obj/structure/rack{
@@ -5792,20 +6517,25 @@
 	},
 /obj/item/clothing/glasses/welding,
 /obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "aGw" = (
 /obj/item/kirbyplants/photosynthetic,
 /obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "aGx" = (
 /obj/machinery/light_switch/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/station/science/robotics/lab)
+"aGy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/checker,
+/area/station/service/theater)
 "aGz" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/security/telescreen{
@@ -5824,7 +6554,7 @@
 /area/station/science/xenobiology)
 "aGD" = (
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aGE" = (
 /obj/machinery/door/firedoor,
@@ -5833,7 +6563,7 @@
 	c_tag = "Xenobiology Pens";
 	network = list("ss13","rd","xeno")
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aGF" = (
 /obj/structure/sign/warning/biohazard,
@@ -5885,20 +6615,26 @@
 	department = "Chief Medical Officer's Desk";
 	name = "Chief Medical Officer's Requests Console"
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "aGM" = (
 /obj/structure/chair/office/light{
 	dir = 1
 	},
 /obj/effect/landmark/start/chief_medical_officer,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "aGO" = (
 /obj/machinery/airalarm/directional/west,
 /obj/structure/closet/l3closet,
 /obj/machinery/light/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aGQ" = (
 /obj/machinery/airalarm/directional/west,
@@ -5906,15 +6642,24 @@
 /obj/machinery/computer/scan_consolenew{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/genetics)
 "aGT" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/genetics)
 "aGU" = (
 /obj/machinery/camera/autoname{
 	tag = "icon-camera (NORTHEAST)";
 	dir = 10
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
@@ -5956,7 +6701,7 @@
 "aHa" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "aHb" = (
 /obj/structure/chair/office/light{
@@ -5964,9 +6709,10 @@
 	},
 /obj/effect/landmark/start/roboticist,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "aHc" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "aHg" = (
@@ -5978,6 +6724,7 @@
 /obj/structure/table,
 /obj/machinery/light/directional/west,
 /obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "aHh" = (
@@ -5988,7 +6735,7 @@
 /area/station/ai_monitored/turret_protected/ai)
 "aHj" = (
 /obj/structure/table/reinforced,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aHk" = (
 /obj/structure/disposalpipe/trunk{
@@ -6023,13 +6770,13 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aHo" = (
 /obj/structure/window/reinforced,
 /obj/structure/table/reinforced,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aHp" = (
 /obj/machinery/door/airlock/external{
@@ -6072,6 +6819,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "aHx" = (
@@ -6080,7 +6830,10 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "aHy" = (
 /mob/living/simple_animal/pet/cat/runtime,
@@ -6089,11 +6842,15 @@
 	dir = 8;
 	pixel_x = 30
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "aHB" = (
 /obj/structure/closet/l3closet,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/green/anticorner/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aHG" = (
 /obj/machinery/light/directional/east,
@@ -6103,7 +6860,14 @@
 	pixel_y = 1
 	},
 /obj/structure/table/glass,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
 /area/station/science/genetics)
 "aHJ" = (
 /obj/structure/window/reinforced{
@@ -6139,6 +6903,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "aHO" = (
@@ -6181,7 +6948,15 @@
 	network = list("ss13","rd")
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/button/door/directional/north{
+	id = "robotics";
+	name = "Robotics Privacy Control";
+	pixel_x = -24;
+	req_access = list("robotics");
+	pixel_y = -6
+	},
+/turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "aHZ" = (
 /obj/structure/table,
@@ -6191,7 +6966,12 @@
 /obj/item/assembly/flash/handheld,
 /obj/item/assembly/flash/handheld,
 /obj/item/assembly/flash/handheld,
-/turf/open/floor/iron/dark,
+/obj/machinery/ecto_sniffer{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "aIa" = (
 /obj/item/wrench,
@@ -6229,7 +7009,7 @@
 	name = "Containment Pen";
 	req_access = list("xenobiology")
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aIi" = (
 /obj/machinery/door/window/left/directional/north{
@@ -6239,7 +7019,7 @@
 	name = "Containment Pen";
 	req_access = list("xenobiology")
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aIj" = (
 /obj/machinery/door/window/left/directional/north{
@@ -6298,7 +7078,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aIr" = (
 /obj/machinery/modular_computer/console/preset/id{
@@ -6306,20 +7087,26 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "aIs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "aIt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "aIu" = (
 /obj/machinery/door_buttons/access_button{
@@ -6339,8 +7126,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/virology,
 /obj/structure/cable,
-/obj/effect/landmark/navigate_destination,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aIv" = (
 /obj/machinery/door/firedoor,
@@ -6353,7 +7139,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/landmark/navigate_destination,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/genetics)
 "aIx" = (
 /obj/machinery/portable_atmospherics/scrubber,
@@ -6493,6 +7279,7 @@
 /area/station/science/robotics/lab)
 "aIZ" = (
 /obj/machinery/mecha_part_fabricator,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "aJa" = (
@@ -6501,6 +7288,8 @@
 /obj/item/mmi,
 /obj/item/mmi,
 /obj/item/radio/intercom/directional/east,
+/obj/item/paicard,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "aJb" = (
@@ -6510,6 +7299,9 @@
 /area/station/science/xenobiology)
 "aJc" = (
 /obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "aJd" = (
@@ -6540,7 +7332,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aJi" = (
 /obj/structure/disposalpipe/trunk{
@@ -6553,6 +7345,9 @@
 /area/station/science/xenobiology)
 "aJj" = (
 /obj/machinery/bluespace_vendor/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "aJm" = (
@@ -6593,6 +7388,9 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
 "aJv" = (
@@ -6607,8 +7405,8 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/fore)
 "aJx" = (
-/obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
+/obj/effect/spawner/random/structure/table_or_rack,
 /turf/open/floor/iron,
 /area/station/maintenance/port/fore)
 "aJy" = (
@@ -6620,28 +7418,42 @@
 /obj/machinery/computer/crew{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "aJA" = (
 /obj/structure/chair/office/light{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
+/turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "aJD" = (
 /obj/machinery/suit_storage_unit/cmo,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/dark_blue/fourcorners,
+/turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "aJH" = (
 /obj/machinery/vending/medical,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "aJI" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aJO" = (
 /obj/machinery/door/airlock/maintenance,
@@ -6813,6 +7625,7 @@
 "aKs" = (
 /obj/effect/landmark/start/roboticist,
 /obj/structure/chair/stool/directional/west,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "aKw" = (
@@ -6831,6 +7644,7 @@
 	amount = 10
 	},
 /obj/item/stack/cable_coil,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "aKx" = (
@@ -6847,7 +7661,7 @@
 "aKz" = (
 /obj/machinery/light/directional/west,
 /obj/structure/sign/warning/electric_shock/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aKA" = (
 /obj/structure/sink{
@@ -6855,7 +7669,7 @@
 	pixel_x = 11
 	},
 /obj/structure/sign/warning/electric_shock/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aKB" = (
 /obj/item/shard,
@@ -6922,7 +7736,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "aKJ" = (
-/obj/machinery/vending/cigarette,
+/obj/effect/spawner/random/vending/colavend,
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "aKM" = (
@@ -6931,10 +7749,13 @@
 	},
 /obj/structure/cable,
 /obj/machinery/newscaster/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/escape)
 "aKN" = (
 /obj/structure/sign/poster/official/random/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "aKO" = (
@@ -6948,14 +7769,23 @@
 	},
 /obj/structure/table/glass,
 /obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "aKT" = (
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "aKU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "aLa" = (
@@ -6965,11 +7795,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aLb" = (
 /obj/machinery/stasis,
 /obj/machinery/defibrillator_mount/directional/east,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "aLc" = (
@@ -7007,6 +7838,9 @@
 "aLh" = (
 /obj/structure/chair{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
@@ -7049,10 +7883,14 @@
 "aLr" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "aLs" = (
 /obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "aLu" = (
@@ -7072,6 +7910,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "aLy" = (
@@ -7119,7 +7958,10 @@
 	dir = 10
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "aLF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
@@ -7129,7 +7971,7 @@
 /area/station/science/ordnance/storage)
 "aLI" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "aLM" = (
 /obj/machinery/door/airlock/command/glass{
@@ -7141,7 +7983,7 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/navigate_destination,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "aLN" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -7149,12 +7991,14 @@
 /area/station/command/heads_quarters/cmo)
 "aLO" = (
 /obj/machinery/light/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aLQ" = (
 /obj/machinery/holopad,
-/turf/open/floor/iron,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aLT" = (
 /obj/structure/window/reinforced{
@@ -7166,7 +8010,10 @@
 	name = "Medical Delivery";
 	req_access = list("medical")
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/storage)
 "aLU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7174,6 +8021,9 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
+	},
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
@@ -7186,6 +8036,9 @@
 "aLX" = (
 /obj/machinery/light/directional/east,
 /obj/effect/spawner/random/vending/snackvend,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "aLY" = (
@@ -7238,7 +8091,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "aMh" = (
-/obj/machinery/vending/wardrobe/robo_wardrobe,
+/obj/machinery/rnd/production/circuit_imprinter/department/science,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "aMk" = (
@@ -7254,12 +8108,14 @@
 /area/station/science/robotics/lab)
 "aMl" = (
 /obj/effect/landmark/start/roboticist,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "aMm" = (
 /obj/structure/table,
 /obj/item/retractor,
 /obj/item/hemostat,
+/obj/item/cautery,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "aMn" = (
@@ -7295,9 +8151,11 @@
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "aMq" = (
-/obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/station/hallway/secondary/exit)
+/area/station/hallway/primary/starboard)
 "aMs" = (
 /obj/machinery/door/airlock/external{
 	name = "Arrival Airlock";
@@ -7316,16 +8174,23 @@
 /turf/open/floor/plating,
 /area/station/cargo/drone_bay)
 "aMu" = (
-/obj/structure/chair/stool/bar/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/chair/stool/bar/directional/south,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "aMv" = (
 /obj/structure/sign/poster/official/random/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "aMD" = (
 /obj/effect/spawner/random/vending/colavend,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "aME" = (
@@ -7378,6 +8243,7 @@
 /obj/item/radio/headset/headset_sci{
 	pixel_x = -3
 	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "aMO" = (
@@ -7436,31 +8302,40 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aNf" = (
-/obj/machinery/light/directional/east,
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
 /obj/machinery/defibrillator_mount/directional/east,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "aNg" = (
 /turf/closed/wall,
 /area/station/medical/medbay/lobby)
 "aNh" = (
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "aNi" = (
 /obj/structure/bed/roller,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aNj" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aNk" = (
 /obj/machinery/vending/coffee,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aNl" = (
 /obj/machinery/light/directional/north,
@@ -7470,12 +8345,18 @@
 /obj/machinery/camera/autoname/directional/north{
 	network = list("ss13","medbay")
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "aNm" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
@@ -7486,10 +8367,12 @@
 	name = "Medbay"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "aNo" = (
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "aNq" = (
 /obj/structure/window/reinforced{
@@ -7522,16 +8405,13 @@
 /turf/closed/wall/r_wall,
 /area/station/science/robotics/mechbay)
 "aNB" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	name = "Mech Bay"
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/station/science/robotics/mechbay)
+/area/station/cargo/miningdock)
 "aNC" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -7563,43 +8443,51 @@
 	network = list("ss13","rd","xeno")
 	},
 /obj/structure/sign/warning/electric_shock/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aNH" = (
 /obj/machinery/light/directional/east,
 /obj/structure/sign/warning/electric_shock/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aNI" = (
 /obj/item/clothing/glasses/welding,
 /obj/item/weldingtool,
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "aNJ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/status_display/evac/directional/west,
 /obj/structure/chair{
 	dir = 4
 	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "aNL" = (
 /obj/structure/sign/poster/official/random/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "aNM" = (
 /obj/structure/sign/poster/official/random/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "aNO" = (
 /obj/machinery/vending/wardrobe/science_wardrobe,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "aNQ" = (
 /obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "aNS" = (
 /obj/structure/table,
@@ -7612,13 +8500,16 @@
 /obj/machinery/camera/autoname/directional/west{
 	network = list("ss13","medbay")
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aNU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aNZ" = (
 /obj/effect/spawner/structure/window,
@@ -7626,7 +8517,8 @@
 /area/station/medical/storage)
 "aOd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "aOg" = (
 /obj/structure/grille/broken,
@@ -7644,17 +8536,20 @@
 /obj/machinery/computer/message_monitor{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "aOj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "aOk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "aOl" = (
 /obj/machinery/telecomms/broadcaster/preset_right,
@@ -7718,7 +8613,9 @@
 /obj/structure/disposalpipe/sorting/mail{
 	sortType = 4
 	},
-/obj/item/stack/sheet/plasteel,
+/obj/structure/fluff/broken_flooring{
+	icon_state = "singular"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "aOA" = (
@@ -7742,24 +8639,35 @@
 "aOD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/holopad,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "aOG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/structure/tank_holder/extinguisher,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "aOH" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aOI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aOL" = (
 /turf/closed/wall,
@@ -7775,39 +8683,55 @@
 	network = list("ss13","medbay")
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/storage)
 "aON" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/light/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/storage)
 "aOO" = (
 /obj/structure/closet/secure_closet/medical3,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/storage)
 "aOP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "aOQ" = (
 /obj/machinery/vending/wardrobe/viro_wardrobe,
-/obj/machinery/camera/autoname/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aOR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "aOS" = (
 /obj/machinery/reagentgrinder,
 /obj/structure/table,
+/obj/structure/sign/poster/official/random/directional/east,
+/obj/effect/turf_decal/tile/neutral/diagonal_centre,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "aOT" = (
@@ -7817,14 +8741,16 @@
 	pixel_y = 3
 	},
 /obj/machinery/light/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "aOU" = (
 /obj/structure/chair/office{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "aOW" = (
 /obj/machinery/camera/directional/west{
@@ -7849,7 +8775,9 @@
 /area/space/nearstation)
 "aPb" = (
 /obj/machinery/gravity_generator/main/station,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "aPd" = (
 /obj/structure/lattice,
@@ -7885,8 +8813,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "aPl" = (
-/obj/item/stack/tile/iron,
 /obj/structure/disposalpipe/junction/flip,
+/obj/structure/fluff/broken_flooring{
+	dir = 4;
+	icon_state = "pile"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "aPm" = (
@@ -7935,18 +8866,24 @@
 	department = "Service Hall";
 	name = "Service Hall Requests Console"
 	},
+/obj/effect/spawner/random/trash/caution_sign,
+/obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "aPv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "aPy" = (
 /obj/structure/table,
 /obj/machinery/microwave{
 	pixel_y = 6
 	},
+/obj/effect/turf_decal/tile/neutral/diagonal_centre,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "aPA" = (
@@ -7959,21 +8896,24 @@
 	department = "Telecomms Admin";
 	name = "Telecomms Requests Console"
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "aPB" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Telecoms Computers";
 	network = list("ss13","tcomms")
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "aPC" = (
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "aPE" = (
 /obj/machinery/telecomms/server/presets/supply,
@@ -7991,7 +8931,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "aPJ" = (
 /obj/structure/disposalpipe/segment{
@@ -8000,6 +8940,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/plaque/static_plaque/golden/commission/disc,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "aPK" = (
@@ -8034,10 +8975,12 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "aPR" = (
-/obj/item/stack/tile/iron,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1;
 	sortType = 11
+	},
+/obj/structure/fluff/broken_flooring{
+	icon_state = "singular"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
@@ -8050,11 +8993,14 @@
 "aPT" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aPU" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aPV" = (
 /obj/machinery/light/directional/south,
@@ -8063,11 +9009,17 @@
 	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aPW" = (
 /obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aPX" = (
 /obj/machinery/computer/station_alert,
@@ -8096,46 +9048,56 @@
 /obj/machinery/computer/atmos_control/nocontrol/master{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "aQg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/storage)
 "aQh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/storage)
 "aQi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/storage)
 "aQj" = (
 /obj/effect/landmark/start/virologist,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aQk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/storage)
 "aQl" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/storage)
 "aQm" = (
-/obj/machinery/chem_dispenser/drinks,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 8
+	},
 /obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/neutral/diagonal_centre,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "aQn" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "aQo" = (
 /obj/machinery/door/airlock/command/glass{
@@ -8146,7 +9108,8 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "aQp" = (
 /obj/machinery/telecomms/server/presets/service,
@@ -8168,7 +9131,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "aQu" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -8186,7 +9149,10 @@
 /obj/structure/disposalpipe/sorting/mail{
 	sortType = 7
 	},
-/obj/item/stack/tile/iron,
+/obj/structure/fluff/broken_flooring{
+	dir = 4;
+	icon_state = "singular"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "aQy" = (
@@ -8215,6 +9181,9 @@
 	req_access = list("brig_entrance")
 	},
 /obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
 "aQE" = (
@@ -8222,22 +9191,21 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/box,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "aQF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "aQG" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "aQH" = (
-/obj/structure/closet/crate/medical,
 /obj/item/stack/cable_coil,
-/obj/effect/spawner/random/maintenance,
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "aQI" = (
@@ -8252,24 +9220,33 @@
 /obj/machinery/vending/wallmed{
 	pixel_y = 28
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "aQK" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "aQN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "aQO" = (
 /obj/structure/table,
 /obj/item/hand_labeler,
 /obj/item/gun/syringe,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/storage)
 "aQP" = (
 /obj/structure/table,
@@ -8278,7 +9255,7 @@
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/glasses/hud/health,
 /obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/storage)
 "aQS" = (
 /obj/machinery/door/airlock/maintenance,
@@ -8297,18 +9274,21 @@
 /obj/item/screwdriver{
 	pixel_y = 10
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "aQU" = (
 /obj/machinery/light/small/directional/west,
-/turf/open/floor/iron,
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "aQV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "aRa" = (
 /obj/machinery/telecomms/receiver/preset_right,
@@ -8343,18 +9323,25 @@
 "aRe" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "aRf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "aRi" = (
 /obj/machinery/firealarm/directional/east,
-/obj/machinery/camera/directional/east{
-	c_tag = "Gravity Generator Room"
-	},
 /obj/machinery/light_switch/directional/north,
+/obj/machinery/camera/autoname/directional/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "aRj" = (
@@ -8364,11 +9351,17 @@
 /obj/structure/table,
 /obj/item/clothing/head/radiation,
 /obj/item/screwdriver,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "aRl" = (
 /obj/structure/table,
 /obj/item/clothing/suit/radiation,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "aRo" = (
@@ -8376,18 +9369,12 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "aRp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/button/door{
-	id = "Skynet_launch";
-	name = "Mech Bay Shutters";
-	pixel_y = -26;
-	req_access = list("robotics")
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
-/area/station/science/robotics/mechbay)
+/area/station/hallway/primary/port)
 "aRr" = (
 /obj/machinery/light_switch/directional/south,
 /obj/effect/turf_decal/stripes/corner{
@@ -8451,24 +9438,30 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
-"aRH" = (
-/obj/structure/chair/stool/bar/directional/north,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
-"aRI" = (
-/obj/structure/window{
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/secondary/exit)
+/area/station/hallway/secondary/exit/departure_lounge)
+"aRH" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair/stool/bar/directional/north,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
+"aRI" = (
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/gravity_generator)
 "aRJ" = (
 /obj/item/stack/sheet/cardboard,
 /obj/item/flashlight,
 /obj/effect/spawner/random/maintenance,
+/obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "aRK" = (
@@ -8480,7 +9473,10 @@
 	dir = 1
 	},
 /obj/machinery/light/small/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "aRM" = (
 /obj/machinery/door/airlock/medical{
@@ -8489,7 +9485,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "aRQ" = (
 /turf/open/floor/iron/dark/telecomms,
@@ -8507,21 +9504,26 @@
 	pixel_y = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "aRU" = (
 /turf/closed/wall,
 /area/station/medical/surgery/theatre)
 "aRV" = (
 /obj/machinery/medical_kiosk,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aRY" = (
 /obj/machinery/computer/telecomms/monitor{
 	network = "tcommsat";
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "aRZ" = (
 /obj/structure/chair/office{
@@ -8530,13 +9532,15 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "aSa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "aSb" = (
 /obj/machinery/door/airlock/engineering/glass{
@@ -8546,7 +9550,10 @@
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
 /obj/effect/landmark/navigate_destination/tcomms,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "aSe" = (
 /obj/machinery/telecomms/message_server/preset,
@@ -8639,7 +9646,11 @@
 /obj/structure/chair/office/light{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
 /area/station/science/genetics)
 "aSx" = (
 /obj/machinery/door/airlock/engineering{
@@ -8727,6 +9738,9 @@
 /obj/structure/sign/poster/official/report_crimes{
 	pixel_y = -32
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "aSS" = (
@@ -8745,13 +9759,19 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "aSY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/storage)
 "aSZ" = (
 /obj/structure/chair{
@@ -8759,11 +9779,14 @@
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/diagonal_centre,
+/obj/effect/turf_decal/tile/blue/diagonal_edge,
+/turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "aTa" = (
 /obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "aTb" = (
 /obj/effect/spawner/structure/window,
@@ -8771,13 +9794,15 @@
 /area/station/medical/surgery/theatre)
 "aTc" = (
 /obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "aTd" = (
 /obj/structure/table,
 /obj/item/hemostat,
 /obj/machinery/vending/wallmed/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "aTe" = (
 /obj/structure/table,
@@ -8786,19 +9811,22 @@
 	},
 /obj/item/circular_saw,
 /obj/machinery/light/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "aTf" = (
 /obj/structure/table,
 /obj/item/retractor,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "aTg" = (
 /obj/structure/table,
 /obj/item/cautery{
 	pixel_x = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "aTi" = (
 /turf/closed/wall,
@@ -8807,17 +9835,20 @@
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "tcomms-passthrough"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "aTl" = (
 /obj/structure/table,
 /obj/item/radio/off,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "aTo" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -8841,6 +9872,14 @@
 /obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"aTu" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "aTv" = (
 /obj/effect/turf_decal/tile/dark_blue/fourcorners,
 /obj/structure/chair/comfy/brown{
@@ -8885,11 +9924,15 @@
 "aTC" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "aTD" = (
 /obj/machinery/airalarm/directional/south,
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "aTE" = (
@@ -8897,12 +9940,13 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "aTF" = (
-/obj/machinery/light/directional/south,
 /obj/structure/cable,
 /obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "aTG" = (
@@ -8910,32 +9954,30 @@
 	charge = 5e+006
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "aTH" = (
 /obj/structure/table,
 /obj/item/pen/blue,
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "aTL" = (
-/obj/machinery/button/door{
-	id = "Skynet_launch";
-	name = "Mech Bay Shutters";
-	pixel_y = 26;
-	req_access = list("robotics")
-	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/hallway/secondary/entry)
 "aTN" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/effect/turf_decal/trimline/purple/corner{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "aTO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -9029,10 +10071,15 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "aUk" = (
 /obj/machinery/vending/wallmed/directional/south,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "aUp" = (
@@ -9041,11 +10088,15 @@
 	},
 /obj/effect/landmark/start/depsec/medical,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "aUv" = (
 /obj/machinery/light/small/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "aUw" = (
 /obj/structure/table,
@@ -9055,7 +10106,8 @@
 	c_tag = "Telecoms Lobby";
 	network = list("ss13","tcomms")
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "aUx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9068,7 +10120,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "aUz" = (
 /obj/machinery/power/smes/engineering,
@@ -9197,7 +10250,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "aUZ" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "aVa" = (
 /obj/machinery/iv_drip,
@@ -9232,7 +10285,8 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/office)
 "aVg" = (
 /obj/machinery/bluespace_vendor/directional/north,
@@ -9243,43 +10297,58 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/diagonal_centre,
+/obj/effect/turf_decal/tile/blue/diagonal_edge,
+/turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "aVm" = (
 /obj/structure/chair,
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "aVn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "aVo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "aVp" = (
 /obj/structure/table/optable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "aVq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "aVr" = (
 /obj/structure/table,
 /obj/item/surgicaldrill,
 /obj/item/blood_filter,
 /obj/item/bonesetter,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "aVs" = (
 /obj/structure/chair{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
@@ -9290,12 +10359,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
-/turf/open/floor/iron,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "tcomms-passthrough"
+	},
+/turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "aVC" = (
 /obj/machinery/camera/directional/west{
@@ -9413,6 +10482,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/random/structure/table_or_rack,
 /obj/effect/spawner/random/maintenance,
+/obj/structure/sign/departments/medbay/directional/north,
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
 "aVX" = (
@@ -9484,11 +10554,26 @@
 	pixel_x = 3;
 	pixel_y = -7
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "aWq" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "aWr" = (
@@ -9496,15 +10581,33 @@
 /obj/machinery/status_display/supply{
 	pixel_y = 32
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "aWs" = (
 /obj/machinery/computer/security/mining,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "aWt" = (
 /obj/machinery/light/directional/north,
 /obj/structure/closet/secure_closet/miner,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "aWu" = (
@@ -9516,6 +10619,13 @@
 	pixel_y = -3
 	},
 /obj/item/storage/toolbox/emergency,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "aWw" = (
@@ -9545,23 +10655,32 @@
 /area/station/maintenance/port/fore)
 "aWD" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/diagonal_centre,
+/obj/effect/turf_decal/tile/blue/diagonal_edge,
+/turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "aWE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "aWG" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/latex,
 /obj/item/clothing/mask/surgical,
 /obj/item/clothing/suit/apron/surgical,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "aWH" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/vending/cigarette,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "aWI" = (
@@ -9586,7 +10705,10 @@
 	network = list("ss13","medbay")
 	},
 /obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "aWT" = (
 /obj/machinery/light/directional/west,
@@ -9600,8 +10722,8 @@
 /area/station/command/bridge)
 "aWV" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
-/obj/machinery/modular_computer/console/preset/engineering,
 /obj/structure/cable,
+/obj/machinery/computer/atmos_alert,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "aWW" = (
@@ -9708,7 +10830,7 @@
 /area/station/medical/abandoned)
 "aXp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "aXw" = (
 /obj/machinery/exodrone_launcher,
@@ -9722,17 +10844,25 @@
 /obj/structure/chair{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "aXy" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "aXz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
 "aXA" = (
@@ -9761,17 +10891,25 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"aXD" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/service/theater)
 "aXF" = (
 /obj/structure/chair/office{
 	dir = 8
 	},
 /obj/effect/landmark/start/shaft_miner,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "aXG" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
+/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "aXI" = (
@@ -9779,11 +10917,16 @@
 	c_tag = "Mining Office"
 	},
 /obj/machinery/mineral/equipment_vendor,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "aXK" = (
 /obj/machinery/modular_computer/console/preset/civilian,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "aXN" = (
@@ -9802,7 +10945,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "aXR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "aXT" = (
@@ -9823,7 +10966,8 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "aYe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9832,7 +10976,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "aYf" = (
 /obj/machinery/light_switch/directional/south,
@@ -9847,16 +10995,27 @@
 	network = list("ss13","medbay")
 	},
 /obj/structure/table/glass,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/genetics)
 "aYg" = (
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "aYh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "aYl" = (
 /obj/machinery/door/airlock/engineering{
@@ -9867,8 +11026,9 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
-/turf/open/floor/iron,
-/area/station/tcommsat/computer)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tcomms)
 "aYm" = (
 /turf/closed/wall/r_wall,
 /area/station/tcommsat/server)
@@ -9956,6 +11116,9 @@
 /area/station/maintenance/starboard/aft)
 "aYN" = (
 /obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "aYQ" = (
@@ -9978,11 +11141,21 @@
 "aYT" = (
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "aYV" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "aYW" = (
@@ -10021,25 +11194,48 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white/side{
+	dir = 8
+	},
 /area/station/medical/medbay/lobby)
 "aZr" = (
 /obj/effect/landmark/xeno_spawn,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/neutral/end{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
 /area/station/medical/morgue)
 "aZs" = (
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/diagonal_centre,
+/obj/effect/turf_decal/tile/blue/diagonal_edge,
+/turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "aZt" = (
 /obj/structure/filingcabinet,
 /obj/machinery/newscaster/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "aZx" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/station/engineering/storage/tcomms)
+"aZy" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "aZz" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/electrical,
@@ -10065,7 +11261,7 @@
 "aZK" = (
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "aZL" = (
 /obj/effect/spawner/random/trash/box,
@@ -10090,6 +11286,7 @@
 /area/station/cargo/qm)
 "aZT" = (
 /obj/structure/closet/secure_closet/quartermaster,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/carpet/red,
 /area/station/cargo/qm)
 "aZU" = (
@@ -10108,6 +11305,9 @@
 "aZW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
 "aZY" = (
@@ -10116,6 +11316,9 @@
 /area/station/cargo/qm)
 "aZZ" = (
 /obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "baa" = (
@@ -10139,12 +11342,14 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bah" = (
-/obj/item/stack/ore/iron,
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bai" = (
 /obj/structure/closet/crate,
 /obj/machinery/light/small/directional/east,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "baj" = (
@@ -10156,6 +11361,9 @@
 "bal" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "ban" = (
@@ -10167,7 +11375,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/escape)
 "bao" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10188,7 +11396,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "bav" = (
 /obj/structure/cable,
@@ -10222,14 +11430,17 @@
 	},
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/light/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "bay" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "baz" = (
 /obj/machinery/door/airlock/medical{
@@ -10243,7 +11454,8 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "baA" = (
 /obj/machinery/light/directional/east,
@@ -10251,11 +11463,15 @@
 /area/station/science/xenobiology)
 "baC" = (
 /obj/structure/window/spawner/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "baD" = (
 /obj/structure/window/spawner,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "baE" = (
 /obj/machinery/space_heater,
@@ -10277,6 +11493,7 @@
 /area/station/engineering/storage/tcomms)
 "baI" = (
 /obj/machinery/vending/engivend,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
 /area/station/engineering/storage/tcomms)
 "baJ" = (
@@ -10362,6 +11579,7 @@
 /obj/machinery/door/airlock/command/glass{
 	name = "Quartermaster's Office"
 	},
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron,
 /area/station/cargo/qm)
 "bbg" = (
@@ -10385,7 +11603,8 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "bbo" = (
 /obj/machinery/door/airlock/external{
@@ -10414,13 +11633,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "bbs" = (
 /obj/structure/chair/stool/directional/east,
 /obj/structure/sign/poster/official/random/directional/south,
-/turf/open/floor/iron,
-/area/station/service/bar)
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "bbu" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating,
@@ -10428,7 +11650,10 @@
 "bbx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "bby" = (
 /turf/closed/wall,
@@ -10439,7 +11664,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "bbC" = (
 /turf/closed/wall,
@@ -10452,12 +11680,22 @@
 	dir = 4
 	},
 /obj/machinery/defibrillator_mount/directional/west,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "bbI" = (
 /obj/machinery/iv_drip,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"bbK" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security/execution/transfer)
 "bbL" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -10468,17 +11706,26 @@
 /obj/item/book/manual/wiki/security_space_law,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "bbM" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "bbN" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "bbO" = (
 /turf/closed/wall,
@@ -10488,6 +11735,7 @@
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "bbQ" = (
@@ -10519,6 +11767,9 @@
 /area/station/maintenance/port)
 "bcb" = (
 /obj/machinery/vending/cigarette,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "bcc" = (
@@ -10557,6 +11808,7 @@
 /obj/machinery/light/small/built/directional/west,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/iron/white,
 /area/station/medical/abandoned)
 "bck" = (
@@ -10628,19 +11880,34 @@
 /area/station/cargo/qm)
 "bcx" = (
 /obj/machinery/vending/wardrobe/cargo_wardrobe,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "bcz" = (
 /obj/machinery/light_switch/directional/west,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bcA" = (
 /obj/structure/closet/secure_closet/miner,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bcB" = (
 /obj/item/stack/ore/silver,
 /obj/item/stack/ore/silver,
+/obj/effect/turf_decal/delivery,
+/obj/item/stack/ore/iron,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bcC" = (
@@ -10648,6 +11915,7 @@
 	c_tag = "Mining Dock External"
 	},
 /obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bcD" = (
@@ -10660,6 +11928,7 @@
 /obj/machinery/atmospherics/components/tank{
 	dir = 1
 	},
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "bcG" = (
@@ -10667,6 +11936,13 @@
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
+"bcI" = (
+/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "bcL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10685,16 +11961,22 @@
 "bcQ" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/depsec/medical,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "bcR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/landmark/start/depsec/medical,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "bcS" = (
 /obj/structure/reagent_dispensers/wall/peppertank/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "bcU" = (
 /turf/open/floor/plating,
@@ -10706,7 +11988,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
 /turf/open/floor/plating,
-/area/station/engineering/storage/tcomms)
+/area/station/maintenance/port/central)
 "bcY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -10769,6 +12051,9 @@
 /area/station/command/bridge)
 "bdj" = (
 /obj/machinery/vending/medical,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "bdl" = (
@@ -10823,6 +12108,7 @@
 /area/station/medical/abandoned)
 "bdt" = (
 /obj/machinery/computer/piratepad_control/civilian,
+/obj/effect/turf_decal/trimline/brown/filled/corner,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "bdu" = (
@@ -10832,6 +12118,9 @@
 /area/station/security/brig)
 "bdv" = (
 /obj/machinery/vending/clothing,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "bdw" = (
@@ -10871,6 +12160,9 @@
 /area/station/cargo/qm)
 "bdF" = (
 /obj/machinery/vending/cigarette,
+/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "bdG" = (
@@ -10878,6 +12170,14 @@
 /obj/item/folder/yellow,
 /obj/item/pen,
 /obj/machinery/requests_console/auto_name/directional/south,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/item/toy/figure/miner,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bdI" = (
@@ -10885,15 +12185,30 @@
 	c_tag = "Mining"
 	},
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/structure/closet/wardrobe/miner,
+/obj/item/storage/backpack/satchel/explorer,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bdJ" = (
-/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/storage/medkit/regular,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bdK" = (
 /obj/machinery/light/directional/south,
 /obj/structure/ore_box,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bdL" = (
@@ -10907,6 +12222,13 @@
 	pixel_x = -5
 	},
 /obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bdN" = (
@@ -10931,29 +12253,48 @@
 /area/station/maintenance/department/medical)
 "bdQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/cryo)
+"bdR" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "bdS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "bdT" = (
 /obj/machinery/medical_kiosk,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "bdY" = (
 /obj/structure/closet/secure_closet/security/med,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "bdZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/depsec/medical,
 /obj/effect/landmark/start/depsec/medical,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "bea" = (
 /obj/machinery/airalarm/directional/east,
@@ -10962,7 +12303,10 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/depsec/medical,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "beb" = (
 /turf/closed/wall,
@@ -10974,7 +12318,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/service/cafeteria)
+/area/station/maintenance/port/central)
 "bed" = (
 /turf/closed/wall/r_wall,
 /area/station/service/cafeteria)
@@ -11003,6 +12347,9 @@
 "bej" = (
 /obj/structure/sign/poster/official/random/directional/south,
 /obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bel" = (
@@ -11031,6 +12378,12 @@
 /area/station/command/bridge)
 "beq" = (
 /obj/machinery/vending/boozeomat,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "bes" = (
@@ -11074,6 +12427,9 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "bez" = (
@@ -11081,7 +12437,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/landmark/start/depsec/medical,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "beB" = (
 /turf/open/floor/iron,
@@ -11103,6 +12459,9 @@
 "beF" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Cargo Bay North"
+	},
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
@@ -11145,7 +12504,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "beS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -11197,6 +12557,12 @@
 	},
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"bfc" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/break_room)
 "bfd" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/turretid{
@@ -11207,6 +12573,9 @@
 	},
 /obj/machinery/camera/directional/west{
 	c_tag = "AI Upload Exterior"
+	},
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
@@ -11238,6 +12607,9 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Cargo Bay MULES"
 	},
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "bfw" = (
@@ -11256,17 +12628,22 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/anesthetic_mix,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "bfA" = (
 /obj/structure/table/glass,
 /obj/item/book/manual/wiki/medicine,
 /obj/item/clothing/neck/stethoscope,
 /obj/item/wrench/medical,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "bfB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "bfC" = (
@@ -11277,11 +12654,17 @@
 	dir = 2
 	},
 /obj/machinery/disposal/bin,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "bfF" = (
 /obj/structure/bed/roller,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "bfG" = (
 /obj/machinery/door/firedoor,
@@ -11376,8 +12759,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance,
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "bfT" = (
@@ -11411,11 +12793,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "bgg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "bgh" = (
 /obj/machinery/light/directional/north,
@@ -11423,7 +12809,8 @@
 	c_tag = "Command EVA"
 	},
 /obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "bgj" = (
 /obj/structure/closet,
@@ -11433,6 +12820,9 @@
 "bgo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
@@ -11461,7 +12851,8 @@
 "bgw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/tank_dispenser,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "bgx" = (
 /obj/structure/disposalpipe/segment{
@@ -11480,6 +12871,7 @@
 /obj/item/wrench,
 /obj/item/screwdriver,
 /obj/structure/table_frame,
+/obj/structure/sign/poster/contraband/random/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "bgA" = (
@@ -11493,7 +12885,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/genetics)
 "bgI" = (
 /turf/closed/wall,
@@ -11502,7 +12894,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bgQ" = (
 /obj/structure/chair/wood{
@@ -11532,10 +12924,14 @@
 /area/station/science/server)
 "bgW" = (
 /obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "bgY" = (
 /obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "bhb" = (
@@ -11546,7 +12942,8 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/eva,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "bhc" = (
 /obj/structure/table/wood,
@@ -11557,7 +12954,8 @@
 /obj/structure/table,
 /obj/item/tank/jetpack/carbondioxide,
 /obj/item/tank/jetpack/carbondioxide,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "bhf" = (
 /obj/structure/table,
@@ -11570,6 +12968,7 @@
 /area/station/maintenance/central)
 "bhh" = (
 /obj/structure/sign/warning/vacuum/external/directional/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "bhj" = (
@@ -11603,12 +13002,20 @@
 	network = list("vault");
 	c_tag = "Vault"
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot_white/left,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "bhv" = (
 /obj/structure/filingcabinet,
 /obj/item/folder/documents,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot_white/left,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "bhD" = (
 /obj/structure/window/reinforced,
@@ -11624,6 +13031,9 @@
 "bhG" = (
 /obj/machinery/status_display/supply{
 	pixel_x = -32
+	},
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
@@ -11643,6 +13053,16 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/textured,
 /area/station/cargo/storage)
+"bhM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
 "bhN" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11653,11 +13073,14 @@
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "bhS" = (
 /obj/machinery/light/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "bhT" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "bhX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11669,11 +13092,18 @@
 "bhZ" = (
 /obj/structure/window/spawner/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "bid" = (
 /obj/item/kirbyplants/random,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "bie" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -11750,6 +13180,9 @@
 /obj/structure/table/wood,
 /obj/machinery/recharger,
 /obj/item/melee/chainofcommand,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain)
 "biu" = (
@@ -11775,17 +13208,23 @@
 /obj/machinery/camera/directional/west{
 	c_tag = "Command North"
 	},
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "biB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "biD" = (
 /obj/machinery/suit_storage_unit/standard_unit,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "biM" = (
 /obj/structure/grille,
@@ -11795,10 +13234,12 @@
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/command/nuke_storage)
 "biT" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/nuclearbomb/selfdestruct{
 	layer = 2
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/box/red,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "biW" = (
 /obj/structure/cable,
@@ -11814,6 +13255,8 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/command/nuke_storage)
 "biY" = (
+/obj/effect/turf_decal/tile/brown/opposingcorners,
+/obj/structure/sign/warning/secure_area/directional/west,
 /turf/open/floor/iron,
 /area/station/maintenance/central)
 "bjb" = (
@@ -11840,10 +13283,16 @@
 /area/station/cargo/office)
 "bje" = (
 /obj/machinery/autolathe,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "bjf" = (
 /obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "bjg" = (
@@ -11861,17 +13310,27 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/cargo/qm)
+"bjk" = (
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "bjn" = (
 /obj/structure/bodycontainer/morgue,
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "bjo" = (
 /obj/machinery/light/small/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "bjp" = (
-/obj/structure/bodycontainer/crematorium,
-/turf/open/floor/iron,
+/obj/structure/bodycontainer/crematorium{
+	id = "crematoriumChapel"
+	},
+/turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "bjr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
@@ -11882,7 +13341,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "bjt" = (
 /obj/structure/cable,
@@ -11893,7 +13353,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "bju" = (
 /obj/effect/turf_decal/trimline/white/filled/shrink_ccw{
@@ -11911,22 +13371,31 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "bjx" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "bjA" = (
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "bjB" = (
 /obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bjE" = (
 /obj/machinery/camera/autoname/directional/south{
@@ -11945,7 +13414,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "bjH" = (
 /turf/open/floor/wood,
@@ -12028,11 +13498,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "bkd" = (
 /obj/machinery/ore_silo,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "bke" = (
 /obj/structure/closet/secure_closet/freezer/money,
@@ -12041,15 +13518,21 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
 /obj/item/clothing/head/bearpelt,
 /obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/effect/turf_decal/bot_white/right,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "bkf" = (
 /obj/structure/closet/crate/goldcrate,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/effect/turf_decal/bot_white/right,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "bkg" = (
 /obj/structure/closet/crate/silvercrate,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
+/obj/effect/turf_decal/bot_white/right,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "bki" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -12058,6 +13541,7 @@
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "bkl" = (
 /obj/machinery/light/small/directional/east,
+/obj/effect/turf_decal/tile/brown/opposingcorners,
 /turf/open/floor/iron,
 /area/station/maintenance/central)
 "bkm" = (
@@ -12069,6 +13553,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security)
 "bko" = (
@@ -12100,6 +13587,9 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/cargo_technician,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "bku" = (
@@ -12121,6 +13611,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "bkw" = (
@@ -12134,6 +13627,9 @@
 	dir = 8
 	},
 /obj/machinery/disposal/bin,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "bky" = (
@@ -12141,10 +13637,10 @@
 	id = "QMLoad";
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line,
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/brown/filled/arrow_cw,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "bkz" = (
@@ -12157,16 +13653,20 @@
 /turf/open/floor/plating,
 /area/station/service/chapel)
 "bkD" = (
-/obj/machinery/button/crematorium{
-	pixel_x = 23
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
+/obj/machinery/button/crematorium{
+	id = "crematoriumChapel";
+	pixel_x = 24
+	},
+/turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "bkE" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "bkF" = (
@@ -12200,7 +13700,8 @@
 /obj/effect/mapping_helpers/airlock/access/any/medical/pharmacy,
 /obj/effect/mapping_helpers/airlock/access/any/medical/chemistry,
 /obj/effect/landmark/navigate_destination,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
+/turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "bkL" = (
 /obj/machinery/smartfridge/chemistry/preloaded,
@@ -12231,7 +13732,8 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/science/genetics,
 /obj/effect/mapping_helpers/airlock/access/any/medical/general,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "bkS" = (
 /obj/machinery/firealarm/directional/west,
@@ -12291,10 +13793,7 @@
 /area/station/maintenance/port)
 "bkX" = (
 /obj/machinery/vending/boozeomat,
-/obj/effect/decal/cleanable/cobweb{
-	tag = "icon-cobweb2";
-	icon_state = "cobweb2"
-	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron,
 /area/station/maintenance/port)
 "bkZ" = (
@@ -12326,14 +13825,27 @@
 /obj/machinery/computer/cargo/request{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "blm" = (
 /obj/machinery/computer/cargo{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
+"blo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/ai_monitored/command/storage/eva)
 "blp" = (
 /obj/structure/table,
 /obj/item/clipboard,
@@ -12341,6 +13853,9 @@
 /obj/item/multitool,
 /obj/item/stack/package_wrap,
 /obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "blr" = (
@@ -12404,52 +13919,68 @@
 /obj/effect/mapping_helpers/airlock/access/all/service/crematorium,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/maintenance/department/medical)
 "blB" = (
 /obj/structure/bodycontainer/morgue,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "blC" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/neutral/end{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
 /area/station/medical/morgue)
 "blE" = (
 /obj/structure/table/glass,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /obj/item/storage/box/beakers,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
+/turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "blF" = (
 /obj/structure/closet/secure_closet/research_director,
 /obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "blG" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "blH" = (
 /obj/machinery/chem_heater{
 	pixel_x = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "blI" = (
 /obj/structure/chair/office/light{
 	dir = 1
 	},
 /obj/effect/landmark/start/chemist,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "blJ" = (
 /obj/machinery/chem_dispenser,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "blM" = (
 /obj/structure/table/reinforced,
@@ -12460,18 +13991,20 @@
 /obj/item/storage/medkit/regular{
 	pixel_y = -1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "blN" = (
 /obj/structure/chair/office/light,
 /obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/diagonal_centre,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "blO" = (
 /obj/machinery/computer/med_data{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/diagonal_centre,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "blP" = (
 /obj/structure/table/wood,
@@ -12540,10 +14073,7 @@
 /turf/open/floor/wood,
 /area/station/maintenance/port)
 "blW" = (
-/obj/effect/decal/cleanable/cobweb{
-	tag = "icon-cobweb2";
-	icon_state = "cobweb2"
-	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -12611,12 +14141,18 @@
 /area/station/hallway/primary/starboard)
 "bmt" = (
 /obj/structure/filingcabinet/filingcabinet,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "bmv" = (
 /obj/structure/table,
 /obj/item/storage/medkit/regular,
 /obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "bmx" = (
@@ -12659,7 +14195,7 @@
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "bmJ" = (
 /obj/item/clothing/glasses/science{
@@ -12675,27 +14211,28 @@
 	network = list("ss13","medbay")
 	},
 /obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
+/turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "bmM" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "bmN" = (
 /obj/machinery/chem_master{
 	pixel_x = -2
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "bmP" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/glass/bottle/epinephrine,
 /obj/item/reagent_containers/syringe,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "bmQ" = (
 /obj/structure/table/reinforced,
 /obj/structure/desk_bell,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "bmR" = (
 /obj/structure/table/reinforced,
@@ -12704,12 +14241,12 @@
 /obj/item/reagent_containers/food/drinks/britcup{
 	desc = "Kingston's personal cup."
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "bmS" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "bmV" = (
 /obj/machinery/door/window{
@@ -12771,6 +14308,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "bnt" = (
@@ -12797,6 +14337,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/newscaster/directional/east,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "bnE" = (
@@ -12823,6 +14366,9 @@
 	req_access = list("cargo");
 	pixel_x = 24
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "bnG" = (
@@ -12845,13 +14391,13 @@
 "bnN" = (
 /obj/effect/landmark/blobstart,
 /obj/machinery/light/small/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "bnO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "bnP" = (
 /obj/item/assembly/timer{
@@ -12897,11 +14443,17 @@
 /obj/item/grenade/chem_grenade,
 /obj/item/grenade/chem_grenade,
 /obj/item/book/manual/wiki/grenades,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
+/turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "bnR" = (
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/blue/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white/side{
+	dir = 8
+	},
 /area/station/medical/medbay/lobby)
 "bnS" = (
 /obj/machinery/light/small/directional/west,
@@ -13004,6 +14556,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
 "bov" = (
@@ -13027,7 +14580,7 @@
 /obj/machinery/conveyor_switch/oneway{
 	id = "QMUnload"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/brown/filled/arrow_ccw,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "boA" = (
@@ -13064,13 +14617,17 @@
 	pixel_x = -30
 	},
 /obj/structure/table/glass,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
+/turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "boH" = (
 /obj/structure/chair/office/light{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "boI" = (
 /obj/structure/table/reinforced,
@@ -13097,8 +14654,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/station/commons/lounge)
 "boP" = (
 /turf/open/floor/wood,
 /area/station/maintenance/port)
@@ -13109,7 +14668,7 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "boV" = (
 /obj/structure/filingcabinet,
@@ -13121,6 +14680,13 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
+"boX" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "boY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood,
@@ -13139,23 +14705,26 @@
 /obj/structure/table,
 /obj/item/beacon,
 /obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/teleporter)
 "bpf" = (
 /obj/structure/closet/crate,
 /obj/item/crowbar,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/teleporter)
 "bpg" = (
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/teleporter)
 "bph" = (
 /obj/machinery/computer/teleporter{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/command/teleporter)
 "bpl" = (
 /obj/machinery/space_heater,
@@ -13170,6 +14739,9 @@
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "QMDeliver"
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
@@ -13191,6 +14763,9 @@
 "bpr" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
+/obj/effect/turf_decal/arrows{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "bps" = (
@@ -13261,7 +14836,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/neutral/end{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
 /area/station/medical/morgue)
 "bpK" = (
 /obj/item/stack/sheet/mineral/plasma{
@@ -13274,14 +14854,18 @@
 /obj/item/reagent_containers/glass/bottle/epinephrine,
 /obj/item/reagent_containers/glass/bottle/multiver,
 /obj/item/storage/pill_bottle/epinephrine,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
+/turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "bpL" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "bpM" = (
 /obj/structure/disposalpipe/segment{
@@ -13290,17 +14874,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "bpN" = (
 /obj/machinery/chem_mass_spec,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "bpP" = (
 /obj/structure/chair{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "bpS" = (
 /obj/structure/disposalpipe/segment,
@@ -13344,10 +14928,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "bqd" = (
-/obj/item/stack/sheet/iron,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/stack/sheet/iron/five,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "bqe" = (
@@ -13358,10 +14942,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "bqf" = (
-/obj/item/stack/sheet/glass,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/stack/sheet/glass{
+	amount = 5
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "bqg" = (
@@ -13387,18 +14973,22 @@
 /obj/item/hand_tele,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/teleporter)
 "bqm" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/station/commons/lounge)
 "bqn" = (
 /obj/machinery/teleport/station,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/command/teleporter)
 "bqo" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -13454,6 +15044,9 @@
 /area/station/commons/fitness/recreation/entertainment)
 "bqy" = (
 /obj/machinery/bluespace_vendor/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "bqz" = (
@@ -13479,25 +15072,32 @@
 	req_access = list("cargo")
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/brown/half/contrasted,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "bqG" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Cargo Bay South"
 	},
+/obj/effect/turf_decal/tile/brown/half/contrasted,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "bqH" = (
 /obj/machinery/light/directional/south,
 /obj/effect/landmark/start/cargo_technician,
 /obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown/half/contrasted,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "bqI" = (
 /obj/structure/extinguisher_cabinet/directional/south,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/trimline/brown/filled/arrow_cw{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/brown/half/contrasted,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "bqK" = (
@@ -13520,7 +15120,10 @@
 	pixel_x = -23
 	},
 /obj/machinery/vending/wardrobe/chem_wardrobe,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "bqP" = (
 /obj/structure/table,
@@ -13532,15 +15135,22 @@
 	pixel_x = 8;
 	pixel_y = 2
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "bqS" = (
 /obj/structure/chair,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "bqU" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "bqV" = (
@@ -13575,6 +15185,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain/private)
 "brf" = (
@@ -13591,6 +15202,9 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "bri" = (
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "brj" = (
@@ -13603,20 +15217,23 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/navigate_destination/teleporter,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/teleporter)
 "brk" = (
 /obj/machinery/light_switch/directional/south,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/teleporter)
 "brm" = (
 /obj/structure/rack,
 /obj/item/tank/internals/oxygen,
 /obj/item/clothing/mask/gas,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/teleporter)
 "brn" = (
 /obj/machinery/light/directional/south,
@@ -13624,11 +15241,12 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/teleporter)
 "bro" = (
 /obj/machinery/teleport/hub,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/command/teleporter)
 "brp" = (
 /obj/structure/chair/comfy/black{
@@ -13718,6 +15336,7 @@
 	dir = 4;
 	sortType = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "brF" = (
@@ -13754,6 +15373,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "brJ" = (
@@ -13818,18 +15438,25 @@
 /obj/structure/table,
 /obj/machinery/light/small/directional/east,
 /obj/item/storage/backpack/duffelbag/med/surgery,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "brY" = (
 /obj/structure/table,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "brZ" = (
 /obj/structure/chair/office/light{
 	dir = 4
 	},
 /obj/effect/landmark/start/chemist,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "bsa" = (
 /obj/structure/table/reinforced,
@@ -13852,7 +15479,7 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Negotiations Room"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "bsk" = (
 /obj/structure/closet/secure_closet/courtroom,
@@ -13877,6 +15504,9 @@
 /obj/structure/chair{
 	name = "Judge"
 	},
+/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "bso" = (
@@ -13888,13 +15518,16 @@
 	c_tag = "Courtroom"
 	},
 /obj/machinery/status_display/evac/directional/north,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "bsq" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "bss" = (
 /obj/machinery/light/small/directional/north,
@@ -13913,6 +15546,9 @@
 "bsv" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Command South"
+	},
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
@@ -13952,6 +15588,7 @@
 	id = "PackageSort1"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "bsF" = (
@@ -13966,9 +15603,11 @@
 	id = "PackageSort2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "bsI" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "bsJ" = (
@@ -13976,6 +15615,8 @@
 	id = "PackageSort3"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "bsL" = (
@@ -13988,6 +15629,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "bsM" = (
@@ -13997,11 +15639,13 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "bsP" = (
 /obj/effect/spawner/random/structure/crate_empty,
 /obj/effect/spawner/random/maintenance/two,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "bsT" = (
@@ -14014,8 +15658,14 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "bsV" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/chair/sofa/bench{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/station/service/chapel)
+/area/station/hallway/primary/port)
 "bsW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/computer/pod/old/mass_driver_controller/chapelgun{
@@ -14063,11 +15713,13 @@
 	pixel_x = -2;
 	pixel_y = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/office)
 "btj" = (
 /obj/structure/table/optable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "btk" = (
 /obj/structure/table,
@@ -14076,24 +15728,31 @@
 	},
 /obj/item/storage/box/beakers,
 /obj/structure/noticeboard/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "btl" = (
 /obj/structure/chair/stool/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "btn" = (
 /obj/machinery/light/directional/south,
 /obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "bts" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "btv" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -14106,13 +15765,13 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "btC" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "btF" = (
 /obj/machinery/door/firedoor,
@@ -14123,11 +15782,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "btI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/security/courtroom)
@@ -14139,17 +15801,26 @@
 	listening = 0;
 	name = "Station Intercom (Court)"
 	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "btK" = (
 /obj/structure/table/wood,
 /obj/item/gavelblock,
 /obj/item/gavelhammer,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "btL" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "btN" = (
@@ -14160,7 +15831,8 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "btO" = (
 /obj/machinery/light/directional/east,
@@ -14168,7 +15840,7 @@
 	name = "Court Cell";
 	req_access = list("brig")
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "btQ" = (
 /turf/closed/wall/r_wall,
@@ -14248,20 +15920,24 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "bum" = (
 /obj/effect/spawner/random/structure/crate_empty,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "buo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "bup" = (
 /obj/item/stack/sheet/cardboard,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "bur" = (
@@ -14303,7 +15979,8 @@
 /obj/machinery/computer/operating{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "buz" = (
 /obj/machinery/firealarm/directional/south,
@@ -14318,7 +15995,10 @@
 	},
 /obj/item/construction/plumbing,
 /obj/item/stack/sheet/iron/fifty,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "buB" = (
 /obj/machinery/light/directional/east,
@@ -14328,11 +16008,11 @@
 	pixel_x = 24;
 	req_access = list("plumbing")
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "buD" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance,
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "buE" = (
@@ -14354,13 +16034,13 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "buI" = (
 /obj/structure/chair{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "buN" = (
 /obj/effect/landmark/start/lawyer,
@@ -14416,6 +16096,9 @@
 "bvd" = (
 /obj/structure/chair/comfy/black,
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /turf/open/floor/carpet,
 /area/station/command/meeting_room)
 "bvg" = (
@@ -14458,6 +16141,9 @@
 	pixel_x = -32
 	},
 /obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "bvr" = (
@@ -14467,7 +16153,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "bvs" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -14500,6 +16189,7 @@
 /obj/item/stock_parts/cell{
 	maxcharge = 2000
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "bvx" = (
@@ -14563,6 +16253,10 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/carpet,
 /area/station/service/chapel)
+"bvJ" = (
+/obj/structure/sign/poster/contraband/random/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "bvL" = (
 /obj/machinery/light/directional/north,
 /obj/structure/chair,
@@ -14589,7 +16283,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bvR" = (
 /obj/structure/table,
@@ -14598,17 +16292,23 @@
 	pixel_y = -1
 	},
 /obj/item/stack/rods/fifty,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "bvT" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/requests_console/auto_name/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "bvU" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/suit_storage_unit/standard_unit,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "bvV" = (
 /obj/effect/landmark/event_spawn,
@@ -14619,18 +16319,24 @@
 /area/station/security/interrogation)
 "bwb" = (
 /obj/item/kirbyplants/random,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "bwe" = (
 /obj/structure/chair{
 	dir = 4;
 	name = "Prosecution"
 	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "bwf" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "bwg" = (
@@ -14644,12 +16350,18 @@
 "bwh" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "bwi" = (
 /obj/structure/chair{
 	dir = 8;
 	name = "Defense"
+	},
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/security/courtroom)
@@ -14693,6 +16405,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
 /turf/open/floor/carpet,
 /area/station/command/meeting_room)
 "bww" = (
@@ -14709,6 +16424,9 @@
 /obj/structure/chair/comfy/black{
 	dir = 8
 	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/station/command/meeting_room)
 "bwz" = (
@@ -14719,6 +16437,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bwD" = (
@@ -14751,6 +16470,9 @@
 /area/station/service/library)
 "bwM" = (
 /obj/machinery/status_display/evac/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "bwN" = (
@@ -14762,6 +16484,9 @@
 /area/station/hallway/primary/starboard)
 "bwP" = (
 /obj/effect/spawner/random/vending/snackvend,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "bwQ" = (
@@ -14828,9 +16553,15 @@
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "bxh" = (
-/obj/machinery/mechpad,
+/obj/machinery/button/door{
+	id = "EscapeBarShutters";
+	name = "Escape Bar Shutter Control";
+	pixel_x = 24;
+	req_access = list("bar")
+	},
+/obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
-/area/station/science/robotics/mechbay)
+/area/station/hallway/secondary/exit/departure_lounge)
 "bxi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -14842,11 +16573,17 @@
 /area/station/service/chapel)
 "bxk" = (
 /obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
 "bxl" = (
 /obj/structure/chair{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
@@ -14855,7 +16592,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bxn" = (
 /obj/structure/table,
@@ -14866,7 +16607,9 @@
 /obj/item/radio/off,
 /obj/item/radio/off,
 /obj/item/multitool,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "bxo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -14960,21 +16703,26 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/service/lawoffice)
 "bxG" = (
 /obj/structure/table/wood,
 /obj/item/paper,
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "bxI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "bxJ" = (
 /obj/structure/table/wood,
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "bxL" = (
@@ -15016,6 +16764,9 @@
 	pixel_y = 5
 	},
 /obj/machinery/status_display/ai/directional/north,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
 "bxP" = (
@@ -15037,6 +16788,9 @@
 "bxV" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "bxX" = (
@@ -15060,6 +16814,7 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/command/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/effect/mapping_helpers/airlock/access/any/supply/vault,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "byb" = (
@@ -15083,6 +16838,9 @@
 /area/station/service/library)
 "byj" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "byk" = (
@@ -15099,6 +16857,9 @@
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
@@ -15168,7 +16929,10 @@
 /area/station/service/chapel)
 "byB" = (
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "byC" = (
 /obj/machinery/camera/directional/east{
@@ -15180,12 +16944,17 @@
 	network = list("Toxins");
 	use_power = 0
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "byD" = (
 /obj/structure/table,
 /obj/item/stack/sheet/plasteel/twenty,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "byG" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -15196,6 +16965,9 @@
 /area/station/ai_monitored/command/storage/eva)
 "byI" = (
 /obj/effect/spawner/random/vending/snackvend,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "byJ" = (
@@ -15287,7 +17059,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "bzb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -15319,6 +17091,9 @@
 /obj/item/folder/blue,
 /obj/item/stamp/hop,
 /obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
 "bzh" = (
@@ -15375,6 +17150,9 @@
 "bzt" = (
 /obj/machinery/airalarm/directional/east,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "bzu" = (
@@ -15389,10 +17167,14 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
 /turf/open/floor/carpet,
 /area/station/command/meeting_room)
 "bzx" = (
 /obj/machinery/holopad,
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet,
 /area/station/command/meeting_room)
 "bzz" = (
@@ -15401,6 +17183,7 @@
 /area/station/command/meeting_room)
 "bzA" = (
 /obj/machinery/vending/assist,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bzC" = (
@@ -15411,12 +17194,14 @@
 	pixel_y = 5
 	},
 /obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bzD" = (
 /obj/structure/table,
 /obj/item/t_scanner,
 /obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bzE" = (
@@ -15431,6 +17216,7 @@
 	c_tag = "Primary Tool Storage"
 	},
 /obj/machinery/requests_console/auto_name/directional/north,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bzF" = (
@@ -15442,6 +17228,7 @@
 	pixel_x = 4
 	},
 /obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bzG" = (
@@ -15449,10 +17236,12 @@
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
 /obj/machinery/light_switch/directional/north,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bzI" = (
 /obj/machinery/vending/tool,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bzK" = (
@@ -15487,18 +17276,20 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/service/library)
 "bzS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bzT" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "PackageSortEnd"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "bzU" = (
@@ -15519,24 +17310,39 @@
 /area/station/cargo/sorting)
 "bzW" = (
 /obj/effect/spawner/random/entertainment/arcade,
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bzX" = (
 /obj/effect/spawner/random/vending/snackvend,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bzY" = (
 /obj/machinery/vending/cigarette,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bzZ" = (
 /obj/machinery/vending/coffee,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bAa" = (
 /obj/machinery/light/directional/north,
 /obj/effect/spawner/random/vending/colavend,
 /obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bAb" = (
@@ -15605,7 +17411,7 @@
 "bAr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/station/ai_monitored/command/storage/eva)
 "bAs" = (
 /obj/machinery/door/firedoor,
@@ -15651,8 +17457,13 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research{
+	name = "Mech Bay"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/science/robotics/mechbay)
 "bAD" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -15701,7 +17512,7 @@
 /area/station/security/courtroom)
 "bAO" = (
 /obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "bAQ" = (
 /obj/structure/disposalpipe/segment{
@@ -15722,6 +17533,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/command/hop,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/station/maintenance/port)
 "bAS" = (
@@ -15743,6 +17557,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "bridge"
 	},
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "bBf" = (
@@ -15760,6 +17577,7 @@
 	dir = 4
 	},
 /obj/machinery/holopad,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bBk" = (
@@ -15844,11 +17662,17 @@
 /area/station/cargo/sorting)
 "bBx" = (
 /obj/machinery/status_display/evac/directional/east,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "bBy" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bBC" = (
@@ -15860,7 +17684,8 @@
 /obj/structure/chair/office/light{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/office)
 "bBD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -15876,10 +17701,16 @@
 /area/station/service/chapel)
 "bBF" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/end{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "bBH" = (
 /obj/machinery/rnd/production/protolathe/department/engineering,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "bBJ" = (
@@ -15888,6 +17719,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "bBL" = (
@@ -15903,6 +17735,9 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Escape North";
 	pixel_y = -22
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
@@ -15920,10 +17755,13 @@
 /obj/item/stack/rods/fifty,
 /obj/item/stack/rods/fifty,
 /obj/machinery/light/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "bBS" = (
 /obj/structure/tank_dispenser,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "bBT" = (
@@ -15938,6 +17776,7 @@
 /obj/structure/table,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "bBV" = (
@@ -16009,15 +17848,18 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "bCk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "bCl" = (
 /obj/machinery/light/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "bCm" = (
 /obj/structure/disposalpipe/segment,
@@ -16032,6 +17874,9 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "bCo" = (
@@ -16039,10 +17884,19 @@
 /obj/item/stack/package_wrap,
 /obj/structure/table/wood,
 /obj/item/storage/secure/briefcase,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "bCp" = (
 /obj/machinery/photocopier,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "bCq" = (
@@ -16093,16 +17947,25 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "bCw" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
 /turf/open/floor/carpet,
 /area/station/command/meeting_room)
 "bCy" = (
 /obj/structure/filingcabinet/chestdrawer{
 	pixel_y = 6
 	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
 "bCz" = (
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "bCB" = (
@@ -16119,6 +17982,8 @@
 /area/station/command/meeting_room)
 "bCG" = (
 /obj/effect/landmark/start/assistant,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bCH" = (
@@ -16127,6 +17992,8 @@
 	pixel_x = -2;
 	pixel_y = -1
 	},
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bCI" = (
@@ -16140,6 +18007,8 @@
 	pixel_y = -7
 	},
 /obj/item/screwdriver,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bCJ" = (
@@ -16148,21 +18017,28 @@
 	pixel_x = 1;
 	pixel_y = -1
 	},
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bCK" = (
 /obj/structure/table,
 /obj/item/wrench,
 /obj/item/analyzer,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bCL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bCN" = (
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/light/directional/east,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bCO" = (
@@ -16213,6 +18089,9 @@
 "bCV" = (
 /obj/structure/cable,
 /obj/machinery/status_display/evac/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bCX" = (
@@ -16236,7 +18115,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/holopad,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "bDh" = (
 /turf/open/floor/carpet,
@@ -16247,13 +18127,13 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit/departure_lounge)
 "bDk" = (
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/maintenance/department/security)
 "bDl" = (
-/obj/structure/chair/stool/bar/directional/east,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "bDm" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -16277,27 +18157,33 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "bDr" = (
-/obj/machinery/door/window{
-	dir = 4;
-	req_access = list("bar");
-	name = "Escape Bar"
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/area/station/hallway/primary/starboard)
 "bDt" = (
-/obj/machinery/vending/boozeomat,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/area/station/hallway/primary/central)
 "bDu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "bDv" = (
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bDw" = (
 /obj/structure/filingcabinet/security,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/escape)
 "bDx" = (
 /obj/structure/table,
@@ -16305,7 +18191,9 @@
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/crowbar,
 /obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "bDA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -16398,11 +18286,15 @@
 	id = "hop";
 	name = "privacy shutters"
 	},
+/obj/structure/desk_bell,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/hop)
 "bDU" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
 /turf/open/floor/carpet,
 /area/station/command/meeting_room)
 "bDV" = (
@@ -16419,6 +18311,9 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
 "bDY" = (
@@ -16427,6 +18322,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/assistant,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bEc" = (
@@ -16490,6 +18386,9 @@
 /area/station/hallway/secondary/service)
 "bEm" = (
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bEo" = (
@@ -16497,6 +18396,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bEu" = (
@@ -16515,7 +18417,7 @@
 	dir = 8
 	},
 /obj/structure/closet/secure_closet/security,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/escape)
 "bEy" = (
 /obj/effect/turf_decal/trimline/white/filled/arrow_cw{
@@ -16530,16 +18432,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bEA" = (
-/obj/structure/chair/stool/bar/directional/east,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "bEB" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/chair{
 	dir = 4
 	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "bEC" = (
@@ -16553,12 +18453,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "bEH" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Escape Bar";
-	pixel_y = -22
+/obj/effect/turf_decal/trimline/purple/corner{
+	dir = 1
 	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "bEI" = (
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/iron/fifty,
@@ -16573,7 +18472,9 @@
 	pixel_y = -1
 	},
 /obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "bEJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -16588,11 +18489,15 @@
 /obj/machinery/light_switch/directional/south{
 	pixel_x = 10
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "bEL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "bEM" = (
@@ -16605,7 +18510,12 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "bEN" = (
 /obj/machinery/door/window/left/directional/north{
@@ -16630,7 +18540,9 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "bEO" = (
 /obj/machinery/door/window/left/directional/north{
@@ -16654,7 +18566,9 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "bEP" = (
 /obj/machinery/light/small/directional/south,
@@ -16684,7 +18598,7 @@
 /area/station/security/detectives_office)
 "bES" = (
 /obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "bEW" = (
 /obj/structure/chair{
@@ -16718,13 +18632,16 @@
 "bFc" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/vending/assist,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bFd" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Courtroom Observation"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "bFf" = (
 /obj/effect/spawner/random/vending/colavend,
@@ -16733,11 +18650,13 @@
 "bFh" = (
 /obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/bot,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bFi" = (
 /obj/machinery/status_display/evac/directional/north,
 /obj/effect/turf_decal/bot,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bFj" = (
@@ -16745,10 +18664,12 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/bot,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bFk" = (
 /obj/effect/turf_decal/bot,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bFl" = (
@@ -16761,6 +18682,7 @@
 	c_tag = "HoP line"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bFm" = (
@@ -16805,10 +18727,12 @@
 /obj/item/stack/package_wrap,
 /obj/item/stack/package_wrap,
 /obj/item/stack/package_wrap,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bFw" = (
 /obj/structure/reagent_dispensers/watertank,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bFx" = (
@@ -16819,21 +18743,26 @@
 	pixel_y = 4
 	},
 /obj/item/clothing/gloves/color/fyellow,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bFy" = (
 /obj/structure/table,
 /obj/item/storage/belt/utility,
 /obj/item/storage/medkit/regular,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bFz" = (
 /obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bFC" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bFD" = (
@@ -16912,8 +18841,18 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
 "bGa" = (
-/obj/machinery/rnd/production/techfab/department/medical,
-/turf/open/floor/iron,
+/obj/structure/table,
+/obj/item/storage/belt/medical{
+	pixel_y = 2
+	},
+/obj/item/storage/belt/medical{
+	pixel_y = 2
+	},
+/obj/item/storage/belt/medical{
+	pixel_y = 2
+	},
+/obj/item/clothing/neck/stethoscope,
+/turf/open/floor/iron/white,
 /area/station/medical/storage)
 "bGe" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -17053,7 +18992,7 @@
 	name = "Courtroom"
 	},
 /obj/effect/landmark/navigate_destination/court,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "bGz" = (
 /obj/machinery/door/airlock/maintenance,
@@ -17103,6 +19042,8 @@
 /obj/machinery/door/airlock/glass{
 	name = "Primary Tool Storage"
 	},
+/obj/effect/landmark/navigate_destination,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bGL" = (
@@ -17117,6 +19058,10 @@
 "bGN" = (
 /obj/machinery/camera/autoname/directional/south,
 /obj/structure/sign/poster/official/random/directional/south,
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bGO" = (
@@ -17130,6 +19075,7 @@
 "bGP" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/station/service/library)
 "bGR" = (
@@ -17141,25 +19087,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "bGS" = (
-/obj/structure/sign/directions/science{
-	tag = "icon-direction_sci (NORTH)";
-	dir = 1
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/obj/structure/sign/directions{
-	dir = 1;
-	icon_state = "direction_supply";
-	pixel_y = 8;
-	tag = "icon-direction_supply (NORTH)"
-	},
-/obj/structure/sign/directions/security{
-	dir = 8;
-	pixel_y = -8;
-	tag = "icon-direction_sec (WEST)"
-	},
-/turf/closed/wall,
-/area/station/maintenance/central)
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "bGT" = (
 /obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "bGU" = (
@@ -17196,10 +19133,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/escape)
 "bHe" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/escape)
 "bHg" = (
 /obj/structure/window{
@@ -17213,6 +19150,9 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "bHm" = (
 /obj/structure/sign/poster/official/random/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "bHr" = (
@@ -17223,6 +19163,12 @@
 	pixel_y = 24;
 	req_access = list("command")
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "bHx" = (
@@ -17231,6 +19177,9 @@
 /area/station/cargo/storage)
 "bHE" = (
 /obj/machinery/camera/autoname/directional/north,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bHG" = (
@@ -17239,34 +19188,67 @@
 /area/station/hallway/primary/central)
 "bHH" = (
 /obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bHK" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/camera/autoname/directional/north,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bHL" = (
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"bHM" = (
+/obj/effect/turf_decal/bot_white/right,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/engineering/gravity_generator)
 "bHN" = (
 /obj/structure/chair,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bHP" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"bHT" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "bHY" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/camera/autoname/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bHZ" = (
-/obj/machinery/vending/assist,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
+/obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bIe" = (
@@ -17341,24 +19323,37 @@
 	dir = 4;
 	pixel_x = 25
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/freezerchamber)
 "bIt" = (
-/obj/structure/table,
-/obj/item/storage/medkit/regular,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/area/station/hallway/primary/port)
 "bIu" = (
 /obj/machinery/modular_computer/console/preset/cargochat/cargo,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "bIx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
 "bIB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
@@ -17391,8 +19386,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"bIX" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "bIY" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 1
@@ -17404,6 +19404,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "bJd" = (
@@ -17482,7 +19485,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/dark_blue/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "bJz" = (
 /obj/machinery/firealarm/directional/east,
@@ -17597,6 +19603,9 @@
 /area/station/hallway/secondary/entry)
 "bKc" = (
 /obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bKd" = (
@@ -17611,6 +19620,9 @@
 "bKg" = (
 /obj/machinery/light/directional/south,
 /obj/structure/sign/poster/official/random/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "bKj" = (
@@ -17629,7 +19641,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "bKo" = (
 /obj/machinery/atmospherics/pipe/color_adapter,
@@ -17708,6 +19721,9 @@
 	pixel_x = 26;
 	req_access = list("command")
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "bKF" = (
@@ -17758,6 +19774,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
+"bKP" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "bKQ" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -17767,6 +19792,9 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "bKU" = (
 /obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "bKW" = (
@@ -17774,6 +19802,10 @@
 /area/station/commons/storage/emergency/port)
 "bKY" = (
 /obj/machinery/light/directional/south,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/structure/sign/departments/security/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "bLe" = (
@@ -17781,10 +19813,16 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bLf" = (
 /obj/effect/spawner/random/vending/colavend,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bLg" = (
@@ -17792,11 +19830,17 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bLh" = (
 /obj/structure/window{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
@@ -17818,6 +19862,9 @@
 /obj/structure/window{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bLl" = (
@@ -17826,16 +19873,25 @@
 /area/station/hallway/primary/central)
 "bLo" = (
 /obj/machinery/camera/autoname/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bLs" = (
 /obj/structure/chair{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bLt" = (
 /obj/machinery/vending/snack,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bLv" = (
@@ -17845,16 +19901,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "bLw" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/turf/open/floor/iron/large,
+/area/station/engineering/engine_smes)
 "bLA" = (
 /obj/structure/window{
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bLB" = (
@@ -17897,22 +19953,34 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/white,
 /area/station/security/medical)
 "bLY" = (
-/obj/structure/chair{
-	dir = 4
-	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "bLZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "bMa" = (
-/obj/machinery/bluespace_vendor/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/station/hallway/secondary/exit)
+/area/station/hallway/primary/starboard)
 "bMc" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/camera/directional/east{
@@ -17920,6 +19988,9 @@
 	pixel_y = -22
 	},
 /obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
 "bMd" = (
@@ -18006,7 +20077,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/landmark/navigate_destination/janitor,
 /obj/effect/mapping_helpers/airlock/access/all/service/janitor,
 /turf/open/floor/iron,
 /area/station/service/janitor)
@@ -18048,11 +20118,17 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "bMF" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "bMG" = (
@@ -18094,12 +20170,16 @@
 "bML" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/station/commons/lounge)
 "bMM" = (
 /obj/structure/sign/barsign,
 /turf/closed/wall,
-/area/station/service/bar)
+/area/station/commons/lounge)
 "bMN" = (
 /turf/closed/wall,
 /area/station/service/bar)
@@ -18112,7 +20192,7 @@
 	},
 /obj/structure/window/fulltile,
 /turf/open/floor/plating,
-/area/station/service/bar)
+/area/station/commons/lounge)
 "bMP" = (
 /turf/closed/wall,
 /area/station/service/theater)
@@ -18137,7 +20217,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "bMV" = (
 /obj/machinery/camera/directional/north{
@@ -18149,6 +20230,9 @@
 /obj/machinery/light/directional/south,
 /obj/machinery/status_display/evac/directional/south,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bNa" = (
@@ -18170,10 +20254,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "bNd" = (
-/obj/structure/table,
-/obj/item/storage/dice,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/area/station/cargo/storage)
 "bNe" = (
 /obj/structure/flora/bush/grassy/style_random,
 /obj/structure/flora/bush/lavendergrass/style_random,
@@ -18186,13 +20272,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/science/explab)
 "bNi" = (
-/obj/machinery/chem_master/condimaster{
-	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
-	name = "HoochMaster Deluxe"
-	},
+/obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "bNj" = (
@@ -18222,6 +20308,9 @@
 /obj/machinery/light/small/directional/west,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/station/security/brig)
 "bNr" = (
@@ -18233,6 +20322,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/station/security/brig)
 "bNu" = (
@@ -18262,22 +20354,30 @@
 /obj/item/assembly/timer,
 /obj/item/restraints/handcuffs,
 /obj/item/restraints/handcuffs,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
 /area/station/security)
 "bNz" = (
 /obj/structure/closet/bombcloset,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
 /area/station/security)
 "bNA" = (
 /obj/structure/closet/wardrobe/red,
 /obj/machinery/camera/directional/north{
 	c_tag = "Security Locker Room"
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
 /area/station/security)
 "bNB" = (
 /obj/structure/closet/l3closet/security,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
 /area/station/security)
 "bNC" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -18287,7 +20387,8 @@
 /obj/structure/closet/secure_closet/security/sec,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "bNE" = (
 /obj/structure/rack,
@@ -18296,7 +20397,8 @@
 	pixel_x = -2;
 	pixel_y = -2
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "bNF" = (
 /turf/closed/wall/r_wall,
@@ -18304,6 +20406,9 @@
 "bNG" = (
 /obj/structure/chair{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
@@ -18316,6 +20421,9 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
@@ -18379,6 +20487,9 @@
 /area/station/hallway/primary/central/aft)
 "bOa" = (
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "bOb" = (
@@ -18387,6 +20498,10 @@
 /obj/item/plant_analyzer,
 /obj/item/reagent_containers/glass/bucket,
 /obj/structure/table/glass,
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "bOd" = (
@@ -18395,6 +20510,10 @@
 	dir = 8
 	},
 /obj/structure/reagent_dispensers/watertank/high,
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "bOe" = (
@@ -18403,11 +20522,19 @@
 	dir = 4
 	},
 /obj/structure/reagent_dispensers/watertank/high,
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "bOf" = (
 /obj/machinery/reagentgrinder,
 /obj/structure/table/glass,
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "bOg" = (
@@ -18419,6 +20546,10 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Botany North"
 	},
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "bOh" = (
@@ -18427,25 +20558,29 @@
 /obj/item/food/grown/citrus/orange,
 /obj/item/food/grown/grapes,
 /obj/structure/table/glass,
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "bOi" = (
-/turf/open/floor/iron,
-/area/station/service/bar)
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "bOj" = (
 /obj/structure/table,
 /obj/item/kirbyplants/random,
-/turf/open/floor/iron,
-/area/station/service/bar)
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "bOk" = (
 /obj/structure/table,
-/turf/open/floor/iron,
-/area/station/service/bar)
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "bOl" = (
 /obj/machinery/light/directional/north,
 /obj/structure/table,
-/turf/open/floor/iron,
-/area/station/service/bar)
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "bOm" = (
 /obj/structure/rack,
 /obj/item/toy/katana,
@@ -18500,6 +20635,10 @@
 	},
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/item/storage/crayons{
+	pixel_x = 2;
+	pixel_y = 2
+	},
 /turf/open/floor/iron,
 /area/station/service/theater)
 "bOt" = (
@@ -18514,6 +20653,7 @@
 /obj/structure/mirror/directional/north,
 /obj/effect/spawner/random/entertainment/musical_instrument,
 /obj/effect/spawner/random/trash/soap,
+/obj/item/bikehorn,
 /turf/open/floor/iron,
 /area/station/service/theater)
 "bOv" = (
@@ -18549,6 +20689,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "bOA" = (
@@ -18559,6 +20702,9 @@
 "bOC" = (
 /obj/structure/sign/plaques/kiddie/library{
 	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
@@ -18589,7 +20735,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "bOL" = (
 /obj/machinery/door/poddoor/shutters{
@@ -18605,6 +20751,9 @@
 	dir = 8
 	},
 /obj/machinery/newscaster/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
 "bOQ" = (
@@ -18622,6 +20771,7 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/emergency/port)
 "bOT" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "bOU" = (
@@ -18648,16 +20798,24 @@
 /obj/item/melee/baton/security/loaded,
 /obj/machinery/light/directional/west,
 /obj/machinery/newscaster/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
 /area/station/security)
 "bPd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/security)
 "bPe" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security)
 "bPf" = (
@@ -18666,7 +20824,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "bPg" = (
 /obj/machinery/light/directional/east,
@@ -18677,7 +20835,8 @@
 	pixel_y = 3
 	},
 /obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "bPi" = (
 /obj/structure/table,
@@ -18728,12 +20887,12 @@
 /area/station/service/hydroponics)
 "bPC" = (
 /obj/structure/chair/comfy/beige,
-/turf/open/floor/iron,
-/area/station/service/bar)
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "bPD" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/east,
-/turf/open/floor/iron,
-/area/station/service/bar)
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "bPE" = (
 /obj/item/rack_parts,
 /obj/item/wrench,
@@ -18784,6 +20943,16 @@
 	},
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
+"bQc" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron,
+/area/station/engineering/storage)
 "bQe" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
@@ -18830,6 +20999,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/station/security/brig)
 "bQp" = (
@@ -18837,6 +21009,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/station/security/brig)
 "bQs" = (
@@ -18852,11 +21027,14 @@
 	pixel_y = 10
 	},
 /obj/item/wirecutters,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
 /area/station/security)
 "bQv" = (
 /obj/machinery/vending/security,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "bQw" = (
 /obj/structure/rack,
@@ -18867,7 +21045,8 @@
 	pixel_y = 3
 	},
 /obj/item/storage/box/trackimp,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "bQx" = (
 /obj/structure/chair{
@@ -18875,6 +21054,9 @@
 	},
 /obj/machinery/camera/directional/west{
 	c_tag = "Atmospherics Lounge"
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
@@ -18983,6 +21165,10 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "bQU" = (
@@ -18996,14 +21182,14 @@
 /obj/structure/chair/comfy/beige{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/service/bar)
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "bQX" = (
 /obj/structure/chair/comfy/beige{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/station/service/bar)
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "bQY" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron,
@@ -19024,9 +21210,12 @@
 /turf/open/floor/iron,
 /area/station/service/theater)
 "bRe" = (
-/obj/structure/closet/gmcloset,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/closet/crate,
+/obj/item/disk/holodisk,
+/obj/item/disk/holodisk,
+/obj/item/disk/holodisk,
 /turf/open/floor/iron,
 /area/station/service/theater)
 "bRf" = (
@@ -19067,6 +21256,9 @@
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/effect/landmark/navigate_destination,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "bRn" = (
@@ -19100,11 +21292,12 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/escape)
 "bRy" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "bRz" = (
@@ -19112,25 +21305,29 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "bRA" = (
-/obj/structure/chair{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/machinery/light/directional/west,
-/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/area/station/hallway/primary/starboard)
 "bRB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "bRD" = (
 /obj/machinery/light/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bRF" = (
 /obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
 "bRG" = (
@@ -19208,12 +21405,16 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bRZ" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "bSd" = (
@@ -19222,16 +21423,18 @@
 /area/station/service/hydroponics)
 "bSf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/station/service/bar)
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "bSi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/station/service/bar)
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "bSj" = (
 /obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron,
-/area/station/service/bar)
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "bSl" = (
 /obj/structure/falsewall,
 /turf/open/floor/iron,
@@ -19290,7 +21493,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "bSC" = (
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -19304,6 +21508,12 @@
 "bSG" = (
 /obj/structure/sign/poster/official/random/directional/south,
 /obj/machinery/camera/autoname/directional/south,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "bSH" = (
@@ -19313,6 +21523,10 @@
 "bSI" = (
 /obj/machinery/light/directional/east,
 /obj/item/kirbyplants/random,
+/obj/structure/sign/poster/official/random/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
 "bSJ" = (
@@ -19325,11 +21539,20 @@
 	name = "Cell 1";
 	pixel_x = -32
 	},
+/obj/effect/turf_decal/trimline/red/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security/brig)
 "bST" = (
 /obj/vehicle/ridden/secway,
 /obj/item/key/security,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security)
 "bSU" = (
@@ -19340,7 +21563,8 @@
 	name = "Evidence Bag 1"
 	},
 /obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/security)
 "bSV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -19350,11 +21574,13 @@
 	},
 /obj/item/storage/secure/safe/directional/north,
 /obj/effect/landmark/blobstart,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/security)
 "bSW" = (
 /obj/structure/closet/secure_closet/evidence,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/security)
 "bSY" = (
 /obj/structure/table/reinforced,
@@ -19376,14 +21602,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "bSZ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Hydroponics"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
-/obj/effect/landmark/navigate_destination/hydro,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
-/area/station/service/hydroponics)
+/area/station/ai_monitored/command/storage/eva)
 "bTa" = (
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Atmospherics Monitoring"
@@ -19397,11 +21619,17 @@
 /area/station/engineering/atmos/office)
 "bTb" = (
 /obj/structure/closet/secure_closet/atmospherics,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bTc" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/machinery/light/directional/north,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bTd" = (
@@ -19410,14 +21638,23 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bTf" = (
 /obj/machinery/suit_storage_unit/atmos,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bTg" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bTi" = (
@@ -19449,6 +21686,9 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "North Central Aft Hall"
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "bTn" = (
@@ -19457,6 +21697,10 @@
 /obj/item/paper/guides/jobs/hydroponics,
 /obj/structure/table/glass,
 /obj/machinery/requests_console/auto_name/directional/west,
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "bTo" = (
@@ -19497,6 +21741,11 @@
 /area/station/service/hydroponics)
 "bTt" = (
 /obj/machinery/biogenerator,
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "bTu" = (
@@ -19504,6 +21753,11 @@
 	desc = "Used to separate out liquids - useful for purifying botanical extracts. Also dispenses condiments.";
 	name = "SapMaster XP"
 	},
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "bTv" = (
@@ -19512,6 +21766,10 @@
 	pixel_x = 11
 	},
 /obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "bTw" = (
@@ -19527,8 +21785,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/iron,
-/area/station/service/bar)
+/area/station/commons/lounge)
 "bTA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -19537,8 +21797,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/chair/stool/bar/directional/south,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
-/area/station/service/bar)
+/area/station/commons/lounge)
 "bTB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -19547,28 +21808,29 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/chair/stool/bar/directional/south,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
-/area/station/service/bar)
+/area/station/commons/lounge)
 "bTC" = (
 /obj/structure/chair/stool/directional/east,
-/turf/open/floor/iron,
-/area/station/service/bar)
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "bTF" = (
 /obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron,
-/area/station/service/bar)
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "bTG" = (
 /obj/structure/table/wood,
 /obj/item/clothing/head/soft/mime,
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/checker,
 /area/station/service/theater)
 "bTI" = (
 /obj/machinery/door/airlock/wood{
 	name = "Stage Left"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/theatre,
-/turf/open/floor/iron,
+/turf/open/floor/iron/checker,
 /area/station/service/theater)
 "bTJ" = (
 /turf/open/floor/wood,
@@ -19590,6 +21852,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/service/theatre,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/service/theater)
 "bTM" = (
@@ -19604,6 +21870,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/obj/item/toy/crayon/spraycan/lubecan,
 /turf/open/floor/iron,
 /area/station/service/theater)
 "bTO" = (
@@ -19619,6 +21890,9 @@
 /area/station/service/hydroponics/garden)
 "bTT" = (
 /obj/structure/sign/departments/science/directional/east,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "bTU" = (
@@ -19642,7 +21916,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "bUd" = (
 /obj/structure/window{
@@ -19660,10 +21935,12 @@
 /area/station/security/checkpoint/escape)
 "bUh" = (
 /obj/machinery/atmospherics/components/tank/air,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/maintenance/department/security)
 "bUi" = (
 /obj/machinery/power/port_gen/pacman,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security)
 "bUj" = (
@@ -19672,11 +21949,14 @@
 	amount = 10;
 	layer = 2.9
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/maintenance/department/security)
 "bUk" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "bUl" = (
@@ -19684,6 +21964,8 @@
 	c_tag = "Brig Cell One"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "bUo" = (
@@ -19703,6 +21985,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron,
 /area/station/security)
 "bUu" = (
@@ -19721,7 +22004,8 @@
 	},
 /obj/machinery/airalarm/directional/west,
 /obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/security)
 "bUx" = (
 /obj/structure/extinguisher_cabinet/directional/north,
@@ -19735,10 +22019,14 @@
 	name = "Evidence Bag 5"
 	},
 /obj/effect/spawner/random/maintenance,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/plating,
 /area/station/security)
 "bUz" = (
 /obj/structure/tank_dispenser,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "bUA" = (
@@ -19749,11 +22037,17 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Atmospherics - Control Room"
 	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "bUE" = (
 /obj/machinery/computer/station_alert,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "bUF" = (
@@ -19769,6 +22063,9 @@
 	pixel_y = -1
 	},
 /obj/structure/table,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "bUG" = (
@@ -19800,10 +22097,18 @@
 "bUR" = (
 /obj/machinery/light/directional/west,
 /obj/structure/closet/secure_closet/freezer/fridge,
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "bUT" = (
 /obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "bUU" = (
@@ -19818,7 +22123,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/landmark/navigate_destination/kitchen,
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "bUV" = (
 /turf/closed/wall,
@@ -19836,7 +22141,7 @@
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = 3
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "bUX" = (
 /obj/structure/table/reinforced,
@@ -19846,18 +22151,19 @@
 	name = "Serving Hatch"
 	},
 /obj/item/food/pie/cream,
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "bUY" = (
 /obj/structure/table/reinforced,
-/obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /obj/structure/displaycase/forsale/kitchen{
 	pixel_y = 8
 	},
+/obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "bUZ" = (
 /obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "bVa" = (
@@ -19865,19 +22171,21 @@
 /obj/item/clothing/head/that{
 	throwing = 1
 	},
+/obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "bVb" = (
 /obj/structure/table/reinforced,
 /obj/structure/disposalpipe/segment,
 /obj/item/holosign_creator/robot_seat/bar,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "bVe" = (
 /obj/machinery/computer/slot_machine,
 /obj/structure/sign/poster/official/random/directional/south,
-/turf/open/floor/iron,
-/area/station/service/bar)
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "bVf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -19885,7 +22193,7 @@
 /obj/machinery/camera/directional/west{
 	c_tag = "Stage Left"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/checker,
 /area/station/service/theater)
 "bVh" = (
 /obj/machinery/light/small/directional/west,
@@ -19921,6 +22229,11 @@
 /obj/structure/sign/poster/contraband/clown{
 	pixel_x = 32
 	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/service/theater)
 "bVm" = (
@@ -19946,9 +22259,11 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "bVt" = (
-/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/station/hallway/secondary/exit)
+/area/station/hallway/primary/starboard)
 "bVu" = (
 /obj/machinery/door/airlock/glass{
 	name = "Chapel"
@@ -20012,6 +22327,9 @@
 	dir = 8
 	},
 /obj/machinery/computer/security/telescreen/entertainment/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
 "bVF" = (
@@ -20022,6 +22340,7 @@
 	name = "Cell 1";
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "bVI" = (
@@ -20031,26 +22350,26 @@
 /obj/item/radio/off,
 /obj/machinery/light_switch/directional/east,
 /obj/structure/table,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "bVL" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/modular_computer/console/preset/cargochat/security{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "bVM" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Brig North East"
 	},
-/obj/machinery/computer/department_orders/security{
-	dir = 1
-	},
+/obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "bVN" = (
 /obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/security)
 "bVP" = (
@@ -20061,7 +22380,8 @@
 	name = "Evidence Bag 3"
 	},
 /obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/security)
 "bVQ" = (
 /obj/structure/closet{
@@ -20071,11 +22391,15 @@
 	name = "Evidence Bag 4"
 	},
 /obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/security)
 "bVR" = (
 /obj/machinery/computer/atmos_control{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
@@ -20122,6 +22446,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "bWi" = (
@@ -20132,6 +22457,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/clothing/head/cone,
+/obj/effect/turf_decal/stripes/end{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "bWj" = (
@@ -20158,14 +22486,29 @@
 	dir = 4
 	},
 /obj/machinery/newscaster/directional/west,
+/obj/effect/turf_decal/tile/yellow/diagonal_centre,
 /turf/open/floor/iron,
-/area/station/maintenance/department/engine/atmos)
+/area/station/hallway/primary/central/aft)
+"bWp" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security/prison)
 "bWq" = (
 /obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "bWs" = (
 /obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "bWt" = (
@@ -20173,7 +22516,7 @@
 /obj/machinery/microwave{
 	pixel_y = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "bWu" = (
 /obj/structure/table,
@@ -20182,14 +22525,14 @@
 	},
 /obj/machinery/light/directional/north,
 /obj/machinery/light_switch/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "bWv" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 30
 	},
 /obj/machinery/food_cart,
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "bWw" = (
 /obj/structure/disposalpipe/segment{
@@ -20198,14 +22541,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "bWx" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "bWz" = (
 /obj/machinery/door/firedoor,
@@ -20215,39 +22558,43 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/bar,
 /obj/effect/mapping_helpers/airlock/access/any/service/bar,
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "bWA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "bWC" = (
 /obj/machinery/computer/slot_machine,
 /obj/machinery/computer/security/telescreen/entertainment/directional/east,
-/turf/open/floor/iron,
-/area/station/service/bar)
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "bWD" = (
 /obj/structure/table/wood,
 /obj/item/clothing/glasses/monocle,
 /obj/item/clothing/head/fedora,
 /obj/machinery/light/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron/checker,
 /area/station/service/theater)
 "bWE" = (
 /obj/effect/landmark/start/mime,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/checker,
 /area/station/service/theater)
 "bWF" = (
 /obj/effect/landmark/start/clown,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/service/theater)
 "bWG" = (
@@ -20255,6 +22602,11 @@
 /obj/item/clothing/gloves/boxing,
 /obj/item/clothing/head/rabbitears,
 /obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/obj/item/toy/figure/clown,
 /turf/open/floor/iron,
 /area/station/service/theater)
 "bWJ" = (
@@ -20270,16 +22622,15 @@
 "bWN" = (
 /obj/machinery/light/directional/north,
 /obj/structure/sign/departments/chemistry/directional/north,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "bWO" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/light/directional/east,
-/obj/machinery/status_display/evac/directional/east,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "bWP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -20292,6 +22643,9 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Escape South";
 	pixel_y = -22
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
@@ -20306,6 +22660,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/security)
 "bWV" = (
@@ -20313,6 +22670,8 @@
 	id = "Cell 3";
 	name = "Cell 3 Locker"
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "bWW" = (
@@ -20343,6 +22702,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/security_officer,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security)
 "bXf" = (
@@ -20353,7 +22715,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security)
 "bXg" = (
 /obj/structure/table,
@@ -20362,10 +22724,13 @@
 /obj/item/storage/box/donkpockets,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security)
 "bXh" = (
 /obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -20377,11 +22742,16 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security)
+"bXk" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/engineering/storage/tcomms)
 "bXm" = (
 /obj/machinery/light/small/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/security)
 "bXo" = (
 /obj/structure/cable,
@@ -20396,18 +22766,22 @@
 /obj/structure/table,
 /obj/item/storage/box,
 /obj/item/storage/box,
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "bXq" = (
 /obj/machinery/light/directional/south,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bXr" = (
 /obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "bXs" = (
 /obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "bXu" = (
@@ -20433,6 +22807,7 @@
 "bXB" = (
 /obj/structure/closet/radiation,
 /obj/structure/sign/warning/radiation/directional/south,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "bXD" = (
@@ -20456,8 +22831,9 @@
 "bXH" = (
 /obj/machinery/vending/assist,
 /obj/machinery/status_display/evac/directional/west,
+/obj/effect/turf_decal/tile/yellow/diagonal_centre,
 /turf/open/floor/iron,
-/area/station/maintenance/department/engine/atmos)
+/area/station/hallway/primary/central/aft)
 "bXL" = (
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/iron,
@@ -20485,6 +22861,7 @@
 	pixel_y = -24
 	},
 /obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "bXS" = (
@@ -20492,6 +22869,7 @@
 /obj/machinery/chem_dispenser/drinks/beer{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "bXT" = (
@@ -20501,6 +22879,7 @@
 	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
 	name = "HoochMaster Deluxe"
 	},
+/obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "bXU" = (
@@ -20508,6 +22887,7 @@
 /obj/machinery/camera/directional/south{
 	c_tag = "Bar"
 	},
+/obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "bXV" = (
@@ -20516,12 +22896,14 @@
 	dir = 1
 	},
 /obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "bXW" = (
 /obj/machinery/light_switch/directional/south,
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "bXY" = (
@@ -20532,6 +22914,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "bXZ" = (
@@ -20540,15 +22923,16 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/service/bar)
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "bYa" = (
 /obj/structure/table/wood,
 /obj/item/clothing/mask/animal/pig,
 /obj/item/instrument/violin{
 	pixel_x = -5
 	},
-/turf/open/floor/iron,
+/obj/item/toy/crayon/spraycan/mimecan,
+/turf/open/floor/iron/checker,
 /area/station/service/theater)
 "bYc" = (
 /obj/structure/curtain/cloth/fancy/mechanical/start_closed{
@@ -20563,10 +22947,20 @@
 /obj/item/food/breadslice/banana,
 /obj/item/clothing/mask/animal/horsehead,
 /obj/item/toy/dummy,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/service/theater)
 "bYf" = (
 /obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/chair/sofa/bench/right{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "bYh" = (
@@ -20580,10 +22974,21 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"bYj" = (
+/obj/machinery/light/directional/north,
+/obj/machinery/camera/autoname/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "bYl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "bYv" = (
@@ -20595,7 +23000,7 @@
 /area/station/service/hydroponics/garden)
 "bYw" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/escape)
 "bYx" = (
 /obj/structure/sign/warning/secure_area,
@@ -20605,6 +23010,7 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Security Backup Control"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security)
 "bYA" = (
@@ -20614,33 +23020,21 @@
 /turf/closed/wall,
 /area/station/security/brig)
 "bYF" = (
-/obj/structure/table/reinforced,
-/obj/item/crowbar,
-/obj/item/screwdriver{
-	pixel_y = 10
-	},
-/obj/item/wirecutters,
-/obj/item/radio/off,
-/obj/machinery/button/flasher{
-	id = "secentranceflasher";
-	name = "Brig Entrance Flasher";
-	pixel_y = 27;
-	req_access = list("security");
-	pixel_x = -6
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/security/warden)
+/area/station/hallway/primary/port)
 "bYG" = (
-/obj/machinery/computer/secure_data,
-/obj/machinery/newscaster/directional/north,
-/turf/open/floor/iron,
-/area/station/security/warden)
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "bYH" = (
 /obj/machinery/light/directional/east,
-/obj/structure/closet/secure_closet/warden,
 /obj/machinery/firealarm/directional/east,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
+/turf/closed/wall,
 /area/station/security/warden)
 "bYI" = (
 /obj/structure/table,
@@ -20650,7 +23044,7 @@
 	pixel_y = 5
 	},
 /obj/item/stack/package_wrap,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security)
 "bYJ" = (
 /obj/structure/table,
@@ -20659,12 +23053,15 @@
 	pixel_y = 7
 	},
 /obj/item/storage/box/deputy,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security)
 "bYL" = (
 /obj/structure/table,
 /obj/machinery/microwave{
 	pixel_y = 6
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/security)
@@ -20674,17 +23071,20 @@
 /obj/item/storage/box/evidence,
 /obj/item/storage/box/evidence,
 /obj/item/hand_labeler,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/security)
 "bYN" = (
 /obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/security)
 "bYO" = (
 /obj/structure/filingcabinet/security{
 	pixel_x = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/security)
 "bYP" = (
 /obj/machinery/camera/directional/west{
@@ -20703,7 +23103,7 @@
 /mob/living/simple_animal/parrot/poly,
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "bYZ" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/mix_input{
@@ -20716,8 +23116,9 @@
 	dir = 4
 	},
 /obj/machinery/computer/security/telescreen/entertainment/directional/west,
+/obj/effect/turf_decal/tile/yellow/diagonal_centre,
 /turf/open/floor/iron,
-/area/station/maintenance/department/engine/atmos)
+/area/station/hallway/primary/central/aft)
 "bZb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -20729,33 +23130,33 @@
 /area/station/service/hydroponics)
 "bZf" = (
 /obj/machinery/smartfridge,
-/turf/closed/wall,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "bZi" = (
 /obj/structure/table,
 /obj/item/storage/bag/tray,
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "bZj" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets,
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "bZk" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "bZl" = (
 /obj/effect/landmark/start/cook,
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "bZm" = (
 /obj/machinery/vending/dinnerware,
 /obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "bZn" = (
 /obj/machinery/door/airlock{
@@ -20765,12 +23166,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/station/service/bar)
 "bZp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "bZr" = (
 /obj/machinery/flasher{
@@ -20788,6 +23189,10 @@
 /area/station/engineering/supermatter)
 "bZt" = (
 /obj/structure/dresser,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/service/theater)
 "bZx" = (
@@ -20817,13 +23222,15 @@
 /area/station/maintenance/department/security)
 "bZE" = (
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "bZG" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Brig Cell two"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "bZJ" = (
@@ -20849,6 +23256,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/newscaster/directional/north,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/security/warden)
 "bZO" = (
@@ -20862,6 +23273,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/station/security/warden)
 "bZP" = (
@@ -20874,6 +23289,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron,
 /area/station/security/warden)
 "bZQ" = (
@@ -20892,11 +23308,17 @@
 	},
 /obj/machinery/light/directional/east,
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security)
 "bZU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/chair/stool/directional/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "bZV" = (
@@ -20932,14 +23354,14 @@
 	req_one_access_txt = list("hydroponics");
 	req_access = list("hydroponics")
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "cac" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "cae" = (
 /obj/machinery/griddle,
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "caf" = (
 /obj/item/book/manual/chef_recipes{
@@ -20948,23 +23370,23 @@
 	},
 /obj/item/stack/package_wrap,
 /obj/structure/table,
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "cag" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "cah" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "cai" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
 "caj" = (
 /obj/structure/sink/kitchen{
@@ -20973,7 +23395,7 @@
 	pixel_y = 28
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
 "cak" = (
 /obj/machinery/gibber,
@@ -20981,7 +23403,7 @@
 	c_tag = "Cold Room"
 	},
 /obj/machinery/light/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
 "cal" = (
 /obj/structure/sink/kitchen{
@@ -20990,11 +23412,11 @@
 	pixel_y = 28
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
 "cam" = (
 /obj/structure/kitchenspike,
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
 "can" = (
 /turf/open/floor/wood,
@@ -21043,6 +23465,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "cax" = (
@@ -21054,10 +23479,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "caz" = (
-/obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair/stool/bar/directional/south,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/area/station/commons/lounge)
 "caB" = (
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security)
 "caC" = (
@@ -21065,6 +23495,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "caE" = (
@@ -21075,16 +23507,41 @@
 	name = "Cell 2";
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "caI" = (
 /obj/machinery/computer/crew{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/security/warden)
 "caJ" = (
 /obj/structure/rack,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
+/obj/item/clothing/mask/gas/sechailer{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/gas/sechailer{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/gas/sechailer{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/gas/sechailer{
+	pixel_x = -3;
+	pixel_y = -3
+	},
 /obj/item/clothing/mask/gas/sechailer{
 	pixel_x = -3;
 	pixel_y = -3
@@ -21115,11 +23572,15 @@
 /area/station/ai_monitored/turret_protected/ai_upload)
 "caQ" = (
 /obj/machinery/suit_storage_unit/security,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
 /area/station/security)
 "caR" = (
 /obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
 /area/station/security)
 "caS" = (
 /obj/structure/table/wood,
@@ -21173,21 +23634,37 @@
 	name = "Hydros";
 	req_one_access_txt = list("hydroponics")
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "cbe" = (
 /obj/structure/closet/secure_closet/hydroponics,
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "cbf" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/machinery/light_switch/directional/south,
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "cbg" = (
 /obj/machinery/newscaster/directional/south,
 /obj/machinery/light/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/service/theater)
 "cbh" = (
 /obj/structure/closet/crate/hydroponics,
@@ -21195,12 +23672,21 @@
 	c_tag = "Botany South"
 	},
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "cbi" = (
 /obj/machinery/vending/hydroseeds{
 	slogan_delay = 700
 	},
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "cbj" = (
@@ -21211,12 +23697,20 @@
 /obj/item/cultivator,
 /obj/machinery/light/directional/south,
 /obj/structure/rack,
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "cbk" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "cbl" = (
@@ -21226,29 +23720,29 @@
 	pixel_y = 3
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "cbp" = (
 /obj/machinery/processor,
 /obj/machinery/requests_console/auto_name/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "cbr" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
 "cbt" = (
 /obj/machinery/chem_master/condimaster{
 	name = "CondiMaster Neo"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
 "cbu" = (
 /mob/living/simple_animal/hostile/retaliate/goat{
 	name = "Pete"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
 "cbz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -21299,6 +23793,7 @@
 /obj/effect/landmark/start/assistant,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "cbG" = (
@@ -21317,6 +23812,9 @@
 /area/station/service/theater)
 "cbK" = (
 /obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "cbL" = (
@@ -21368,6 +23866,9 @@
 /area/station/hallway/secondary/exit)
 "cbV" = (
 /obj/effect/spawner/random/entertainment/arcade,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
 "cbW" = (
@@ -21378,11 +23879,15 @@
 /obj/machinery/atmospherics/components/tank{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/maintenance/department/security)
 "ccc" = (
 /obj/machinery/computer/prisoner/management{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/security/warden)
@@ -21397,6 +23902,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security/warden)
 "ccg" = (
@@ -21423,6 +23931,9 @@
 /area/station/security/warden)
 "cch" = (
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/security)
 "cci" = (
@@ -21432,6 +23943,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security)
 "ccj" = (
@@ -21442,7 +23956,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security)
 "cck" = (
 /obj/structure/table,
@@ -21459,13 +23973,16 @@
 	pixel_x = -5;
 	pixel_y = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security)
 "ccl" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /obj/effect/landmark/start/security_officer,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/security)
 "ccm" = (
@@ -21481,7 +23998,8 @@
 /obj/machinery/camera/directional/south{
 	c_tag = "Security - EVA Storage"
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/security)
 "ccp" = (
 /turf/open/floor/engine/air,
@@ -21500,8 +24018,8 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "ccx" = (
-/obj/machinery/computer/department_orders/engineering{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
@@ -21537,7 +24055,7 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/item/hand_labeler,
 /obj/item/stack/package_wrap,
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "ccE" = (
 /obj/structure/table,
@@ -21553,11 +24071,12 @@
 /obj/item/reagent_containers/food/condiment/saltshaker{
 	pixel_x = -3
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "ccF" = (
 /obj/machinery/deepfryer,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "ccG" = (
 /obj/machinery/camera/directional/south{
@@ -21565,26 +24084,27 @@
 	},
 /obj/item/radio/intercom/directional/south,
 /obj/machinery/deepfryer,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "ccH" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "ccI" = (
 /obj/machinery/computer/chef_order{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "ccJ" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "ccL" = (
 /obj/machinery/door/airlock{
@@ -21596,7 +24116,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/station/service/kitchen)
 "ccQ" = (
 /obj/machinery/door/airlock{
@@ -21604,7 +24124,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/bar,
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
 "ccS" = (
 /obj/structure/table/wood,
@@ -21659,6 +24179,9 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Fitness East"
 	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "cdh" = (
@@ -21696,11 +24219,20 @@
 	name = "Cell 3";
 	pixel_x = -32
 	},
+/obj/effect/turf_decal/trimline/red/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/security/brig)
 "cdv" = (
 /obj/machinery/computer/security{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
 	},
 /turf/open/floor/iron,
 /area/station/security/warden)
@@ -21730,6 +24262,9 @@
 	pixel_y = -2;
 	req_access = list("security")
 	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/security/warden)
 "cdy" = (
@@ -21739,19 +24274,22 @@
 /obj/structure/table,
 /obj/item/restraints/handcuffs,
 /obj/item/radio/off,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security)
 "cdB" = (
 /obj/structure/table,
 /obj/item/folder/red,
 /obj/item/storage/secure/briefcase,
 /obj/item/storage/fancy/donut_box,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security)
 "cdC" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/light_switch/directional/east,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security)
 "cdD" = (
@@ -21813,6 +24351,7 @@
 "cdQ" = (
 /obj/structure/cable,
 /obj/structure/sign/warning/radiation/directional/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cdR" = (
@@ -21869,7 +24408,7 @@
 	name = "Kitchen Delivery";
 	req_access = list("kitchen")
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
 "ceb" = (
 /obj/machinery/door/window/left/directional/south{
@@ -21883,18 +24422,18 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
 "cec" = (
 /obj/machinery/icecream_vat,
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
 "ced" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/firealarm/directional/east,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
 "cee" = (
 /obj/machinery/door/airlock/wood{
@@ -21903,7 +24442,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/service/theatre,
-/turf/open/floor/iron,
+/turf/open/floor/iron/checker,
 /area/station/service/theater)
 "cef" = (
 /obj/effect/spawner/structure/window,
@@ -21958,8 +24497,8 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "ceo" = (
-/obj/structure/table,
 /obj/effect/spawner/random/maintenance,
+/obj/effect/spawner/random/structure/table_or_rack,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "cep" = (
@@ -21968,14 +24507,16 @@
 "cev" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/security/processing)
 "cew" = (
 /obj/machinery/computer/prisoner{
 	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/security/processing)
 "cex" = (
 /obj/structure/bed,
@@ -21986,7 +24527,13 @@
 	c_tag = "Prison Sanitatium";
 	network = list("ss13","prison")
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/security/medical)
 "cey" = (
 /obj/item/reagent_containers/syringe,
@@ -22004,14 +24551,26 @@
 /obj/item/reagent_containers/dropper,
 /obj/structure/table,
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/security/medical)
 "ceA" = (
 /obj/machinery/newscaster/directional/north,
 /obj/structure/cable,
 /obj/machinery/computer/med_data/laptop,
 /obj/structure/table,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/security/medical)
 "ceB" = (
 /obj/structure/cable,
@@ -22025,19 +24584,31 @@
 	pixel_x = -4;
 	pixel_y = 2
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/security/medical)
 "ceC" = (
 /obj/machinery/vending/wallmed/directional/north,
 /obj/structure/bed,
 /obj/item/bedsheet,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/turf/open/floor/iron/white,
 /area/station/security/medical)
 "ceD" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Brig Cell three"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "ceF" = (
@@ -22047,6 +24618,9 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security/warden)
 "ceH" = (
@@ -22058,6 +24632,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/security)
@@ -22071,7 +24648,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security)
 "ceJ" = (
 /obj/structure/table,
@@ -22084,7 +24661,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security)
 "ceK" = (
 /obj/structure/chair{
@@ -22097,6 +24674,9 @@
 /obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/security)
 "ceL" = (
@@ -22115,6 +24695,9 @@
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security)
 "ceN" = (
@@ -22129,7 +24712,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/plating,
-/area/station/security)
+/area/station/maintenance/aft)
 "ceO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22146,6 +24729,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "ceR" = (
@@ -22199,6 +24783,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "cfb" = (
@@ -22318,7 +24905,8 @@
 	frequency = 1489;
 	name = "Theater headset"
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/service/theater)
 "cfx" = (
 /obj/structure/table,
@@ -22338,29 +24926,34 @@
 	pixel_y = 7;
 	pixel_x = 5
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/service/theater)
 "cfy" = (
 /obj/structure/chair/office{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/service/theater)
 "cfz" = (
 /obj/structure/musician/piano,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/service/theater)
 "cfA" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/service/theater)
 "cfB" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Theater Control"
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/service/theater)
 "cfH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -22370,6 +24963,9 @@
 /area/station/commons/fitness/recreation)
 "cfI" = (
 /obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "cfJ" = (
@@ -22387,8 +24983,9 @@
 /area/station/service/hydroponics/garden)
 "cfN" = (
 /obj/effect/landmark/navigate_destination/bar,
-/turf/open/floor/iron,
-/area/station/service/bar)
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "cfO" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Terrarium South"
@@ -22405,29 +25002,34 @@
 /area/station/maintenance/port/aft)
 "cfW" = (
 /obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "cfX" = (
 /obj/structure/chair/office{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/security/processing)
 "cfY" = (
 /obj/machinery/computer/shuttle/labor{
 	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/security/processing)
 "cgb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/security/medical)
 "cgc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/security/medical)
 "cge" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22437,6 +25039,7 @@
 	name = "Cell 3";
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "cgi" = (
@@ -22462,6 +25065,9 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/warden,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/security/warden)
 "cgk" = (
@@ -22474,6 +25080,9 @@
 	name = "Prison Monitor";
 	network = list("prison");
 	pixel_x = 30
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/security/warden)
@@ -22501,6 +25110,12 @@
 /area/station/engineering/atmos)
 "cgv" = (
 /obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "cgw" = (
@@ -22532,6 +25147,7 @@
 /area/station/engineering/atmos)
 "cgD" = (
 /obj/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "cgE" = (
@@ -22546,10 +25162,7 @@
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "cgK" = (
-/obj/effect/decal/cleanable/cobweb{
-	tag = "icon-cobweb2";
-	icon_state = "cobweb2"
-	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -22593,6 +25206,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "cgQ" = (
@@ -22602,7 +25218,10 @@
 /area/station/maintenance/department/science)
 "cgR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "cgS" = (
 /obj/structure/disposalpipe/junction/flip{
@@ -22612,6 +25231,9 @@
 /area/station/commons/fitness/recreation)
 "cgU" = (
 /obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -22701,23 +25323,30 @@
 "chh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/security/processing)
 "chj" = (
 /obj/machinery/computer/security/labor{
 	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/security/processing)
 "chk" = (
 /obj/item/folder/red,
 /obj/item/pen,
 /obj/structure/table,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/turf/open/floor/iron/white,
 /area/station/security/medical)
 "chm" = (
 /obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "chp" = (
@@ -22725,36 +25354,32 @@
 /obj/item/clothing/gloves/color/latex,
 /obj/item/clothing/mask/surgical,
 /obj/item/reagent_containers/spray/cleaner,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/white,
 /area/station/security/medical)
 "cht" = (
-/obj/structure/table,
 /obj/structure/cable,
+/obj/machinery/computer/secure_data{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/station/security/warden)
 "chu" = (
-/obj/structure/rack,
-/obj/item/clothing/mask/gas/sechailer{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/clothing/mask/gas/sechailer{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/clothing/mask/gas/sechailer{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
+/obj/structure/closet/secure_closet/warden,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron,
 /area/station/security/warden)
 "chv" = (
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/station/security/warden)
 "chz" = (
@@ -22807,6 +25432,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"chQ" = (
+/obj/machinery/vending/cigarette,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "chR" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
@@ -22836,6 +25468,9 @@
 "cic" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Fitness West"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
@@ -22868,6 +25503,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/security/brig)
 "cir" = (
@@ -22896,7 +25534,8 @@
 /turf/open/floor/plating,
 /area/station/security/processing)
 "ciw" = (
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/security/processing)
 "cix" = (
 /obj/machinery/door/firedoor,
@@ -22907,7 +25546,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/security/medical)
 "ciy" = (
 /turf/closed/wall/r_wall,
@@ -22917,6 +25556,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/security/brig)
 "ciA" = (
@@ -22930,6 +25572,9 @@
 	dir = 4;
 	pixel_x = 24
 	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security/brig)
 "ciC" = (
@@ -22941,6 +25586,7 @@
 	name = "Secure Gear Storage"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron,
 /area/station/security/warden)
 "ciF" = (
@@ -22976,15 +25622,17 @@
 /area/station/engineering/atmos)
 "ciM" = (
 /obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "ciN" = (
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 8
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/area/station/hallway/primary/starboard)
 "ciO" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
 	dir = 8
@@ -23047,12 +25695,18 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "cjh" = (
 /obj/effect/decal/cleanable/oil/streak,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "cji" = (
@@ -23086,14 +25740,17 @@
 	name = "Fitness Ring"
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation)
 "cjq" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation)
 "cjs" = (
 /obj/structure/window/reinforced{
@@ -23105,7 +25762,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation)
 "cju" = (
 /obj/machinery/door/firedoor,
@@ -23119,6 +25776,9 @@
 /area/station/commons/fitness/recreation)
 "cjv" = (
 /obj/effect/landmark/navigate_destination/dockarrival,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "cjx" = (
@@ -23133,7 +25793,7 @@
 /area/station/commons/fitness/recreation/entertainment)
 "cjy" = (
 /obj/machinery/light/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "cjA" = (
 /obj/structure/rack,
@@ -23184,6 +25844,9 @@
 /area/station/security)
 "cjG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "cjH" = (
@@ -23197,7 +25860,8 @@
 	c_tag = "Gulag Shuttle Dock";
 	network = list("ss13","prison")
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/security/processing)
 "cjK" = (
 /turf/closed/wall/r_wall,
@@ -23212,10 +25876,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/processing)
 "cjO" = (
 /obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "cjP" = (
@@ -23224,6 +25891,9 @@
 	network = list("ss13","prison")
 	},
 /obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "cjU" = (
@@ -23234,6 +25904,9 @@
 	pixel_y = 25;
 	req_access = list("security")
 	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "cjV" = (
@@ -23243,6 +25916,9 @@
 	pixel_x = -4;
 	pixel_y = 25;
 	req_access = list("security")
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
@@ -23284,16 +25960,25 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "cka" = (
 /obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security/brig)
 "ckc" = (
 /obj/item/grenade/barrier,
 /obj/machinery/light/small/directional/north,
 /obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
 "ckd" = (
@@ -23303,6 +25988,9 @@
 "ckf" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/emergency,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
 "ckg" = (
@@ -23311,7 +25999,6 @@
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/hos)
 "ckh" = (
-/obj/structure/chair,
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -23352,6 +26039,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "ckw" = (
@@ -23383,11 +26073,15 @@
 "ckF" = (
 /obj/structure/table,
 /obj/structure/cable,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "ckG" = (
 /obj/machinery/light/directional/south,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "ckL" = (
@@ -23404,7 +26098,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation)
 "ckR" = (
 /turf/open/floor/iron/dark,
@@ -23413,6 +26107,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "ckT" = (
@@ -23422,14 +26117,18 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "ckW" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "ckX" = (
 /obj/structure/disposalpipe/segment,
@@ -23443,6 +26142,9 @@
 "clc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "clh" = (
@@ -23460,6 +26162,9 @@
 /obj/structure/window{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "clj" = (
@@ -23471,6 +26176,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security/brig)
 "cll" = (
@@ -23479,15 +26187,18 @@
 	c_tag = "Security - Secure Gear Storage"
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
 "clp" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Secure Gear Storage"
-	},
 /obj/effect/mapping_helpers/airlock/access/all/security/hos,
-/turf/open/floor/iron,
+/obj/machinery/door/airlock/command{
+	name = "Head of Security's Office"
+	},
+/turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "clq" = (
 /obj/machinery/light_switch{
@@ -23571,7 +26282,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation)
 "clO" = (
 /obj/machinery/exodrone_launcher,
@@ -23602,6 +26313,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"clV" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet,
+/area/station/service/library)
 "cmh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23617,10 +26333,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
 "cmn" = (
 /obj/machinery/light/directional/east,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
 "cmo" = (
@@ -23705,6 +26425,9 @@
 /area/station/engineering/atmos)
 "cmH" = (
 /obj/machinery/status_display/evac/directional/east,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "cmJ" = (
@@ -23801,11 +26524,11 @@
 	tag = "icon-shower (EAST)";
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
 "cmY" = (
 /obj/machinery/light/small/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
 "cmZ" = (
 /obj/machinery/shower{
@@ -23813,30 +26536,31 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/assistant,
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
 "cna" = (
 /obj/structure/urinal/directional/north,
 /obj/machinery/light_switch/directional/west,
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
 "cnb" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
 "cnc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
 "cnd" = (
 /obj/machinery/door/airlock{
 	id_tag = "Toilet3";
 	name = "Unit 3"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
 "cne" = (
 /obj/machinery/recharge_station,
@@ -23848,7 +26572,8 @@
 	normaldoorcontrol = 1;
 	specialfunctions = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
 "cnf" = (
 /obj/structure/bedsheetbin,
@@ -23868,6 +26593,7 @@
 /area/station/commons/dorms)
 "cnj" = (
 /obj/structure/closet/crate/bin,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "cnk" = (
@@ -23887,6 +26613,9 @@
 /area/station/commons/dorms)
 "cnn" = (
 /obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "cnp" = (
@@ -23897,11 +26626,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation)
 "cnq" = (
 /obj/structure/window/reinforced,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation)
 "cnr" = (
 /obj/machinery/door/window/right/directional/east{
@@ -23910,7 +26639,10 @@
 	name = "Fitness Ring"
 	},
 /obj/structure/window/reinforced,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation)
 "cns" = (
 /obj/structure/cable,
@@ -23940,6 +26672,9 @@
 /area/station/command/heads_quarters/hos)
 "cnG" = (
 /obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
 "cnH" = (
@@ -23947,14 +26682,16 @@
 /area/station/ai_monitored/security/armory)
 "cnJ" = (
 /obj/machinery/airalarm/directional/south,
-/mob/living/simple_animal/bot/secbot/beepsky/officer{
-	name = "Officer Bopsky"
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
 	},
+/mob/living/simple_animal/bot/secbot/beepsky/armsky,
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
 "cnK" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
+/obj/machinery/keycard_auth/directional/west,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hos)
 "cnL" = (
@@ -23965,6 +26702,10 @@
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hos)
 "cnM" = (
+/obj/item/folder/red,
+/obj/structure/table/wood,
+/obj/item/folder/red,
+/obj/structure/cable,
 /obj/item/phone{
 	desc = "Supposedly a direct line to NanoTrasen Central Command. It's not even plugged in.";
 	pixel_x = -3;
@@ -23974,8 +26715,6 @@
 	pixel_x = 5;
 	pixel_y = -1
 	},
-/obj/structure/table/wood,
-/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hos)
 "cnO" = (
@@ -24044,6 +26783,7 @@
 "coe" = (
 /obj/structure/chair/stool/directional/west,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "cog" = (
@@ -24101,20 +26841,21 @@
 	pixel_y = 2
 	},
 /obj/structure/mirror/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
 "cot" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
 "cou" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
 "cov" = (
 /obj/machinery/door/airlock{
@@ -24150,6 +26891,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/machinery/door/firedoor,
 /obj/effect/landmark/navigate_destination/engineering,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "coI" = (
@@ -24210,18 +26952,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
 "coV" = (
-/obj/structure/table/wood,
-/obj/item/folder/red,
-/obj/item/folder/red,
-/obj/machinery/keycard_auth{
-	pixel_y = 10
-	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/machinery/newscaster/directional/south,
+/obj/machinery/pdapainter/security,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hos)
 "coW" = (
@@ -24279,6 +27017,8 @@
 /obj/item/tank/internals/emergency_oxygen/engi,
 /obj/item/tank/internals/emergency_oxygen/engi,
 /obj/machinery/light/directional/south,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cpf" = (
@@ -24286,6 +27026,9 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "cpg" = (
@@ -24357,26 +27100,26 @@
 	dir = 4
 	},
 /obj/structure/mirror/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
 "cpv" = (
 /obj/item/bikehorn/rubberducky,
 /obj/effect/landmark/xeno_spawn,
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
 "cpw" = (
 /obj/machinery/shower{
 	tag = "icon-shower (WEST)";
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
 "cpx" = (
 /obj/machinery/door/airlock{
 	id_tag = "Toilet2";
 	name = "Unit 2"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
 "cpy" = (
 /obj/structure/toilet{
@@ -24391,7 +27134,8 @@
 	normaldoorcontrol = 1;
 	specialfunctions = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
 "cpz" = (
 /obj/machinery/light/small/directional/north,
@@ -24435,16 +27179,25 @@
 "cpD" = (
 /obj/structure/closet/boxinggloves,
 /obj/effect/landmark/start/hangover/closet,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "cpE" = (
 /obj/structure/closet/lasertag/blue,
 /obj/effect/landmark/start/hangover/closet,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "cpF" = (
 /obj/structure/closet/lasertag/red,
 /obj/effect/landmark/start/hangover/closet,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "cpG" = (
@@ -24452,6 +27205,9 @@
 /obj/machinery/light/directional/south,
 /obj/item/clothing/shoes/jackboots,
 /obj/effect/landmark/start/hangover/closet,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "cpH" = (
@@ -24460,6 +27216,9 @@
 	},
 /obj/structure/closet/masks,
 /obj/effect/landmark/start/hangover/closet,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "cpJ" = (
@@ -24467,13 +27226,16 @@
 	dir = 9
 	},
 /obj/structure/sign/warning/pods/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "cpM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "cpR" = (
 /obj/structure/cable,
@@ -24517,6 +27279,7 @@
 	dir = 4
 	},
 /obj/item/bedsheet/red,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
 "cqb" = (
@@ -24552,12 +27315,18 @@
 /obj/machinery/camera/motion/directional/north{
 	c_tag = "Armory"
 	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
 "cqj" = (
 /obj/machinery/flasher/portable,
 /obj/machinery/flasher/portable,
 /obj/structure/reagent_dispensers/wall/peppertank/directional/north,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
 "cql" = (
@@ -24570,11 +27339,17 @@
 /area/station/maintenance/aft)
 "cqs" = (
 /obj/machinery/space_heater,
+/obj/effect/turf_decal/trimline/yellow/filled/shrink_ccw{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cqx" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "cqz" = (
@@ -24640,7 +27415,7 @@
 /area/station/commons/dorms)
 "cqL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
 "cqM" = (
 /obj/machinery/door/airlock/glass{
@@ -24649,21 +27424,27 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
 "cqP" = (
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "cqQ" = (
-/obj/structure/closet/secure_closet/injection{
-	name = "educational injections"
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "cqR" = (
 /obj/effect/landmark/start/prisoner,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
+/obj/structure/toilet/greyscale{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/security/prison/safe)
 "cqS" = (
@@ -24687,11 +27468,16 @@
 /obj/item/storage/box/rubbershot,
 /obj/item/storage/box/rubbershot,
 /obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "cqY" = (
 /obj/machinery/flasher/portable,
 /obj/machinery/flasher/portable,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
 "cqZ" = (
@@ -24701,7 +27487,8 @@
 	pixel_x = 5;
 	pixel_y = -5
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "cra" = (
 /obj/structure/closet/crate,
@@ -24714,6 +27501,7 @@
 /area/station/maintenance/aft)
 "crb" = (
 /obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "crc" = (
@@ -24721,6 +27509,7 @@
 /obj/machinery/camera/directional/south{
 	c_tag = "Atmost South West"
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cre" = (
@@ -24735,6 +27524,7 @@
 	},
 /obj/machinery/light/directional/west,
 /obj/item/multitool,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "crf" = (
@@ -24744,6 +27534,7 @@
 /obj/item/t_scanner,
 /obj/item/t_scanner,
 /obj/item/t_scanner,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "crg" = (
@@ -24755,17 +27546,20 @@
 	pixel_y = 2
 	},
 /obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "crh" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cri" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "crl" = (
@@ -24844,6 +27638,9 @@
 	},
 /obj/structure/sign/poster/official/random/directional/west,
 /obj/machinery/camera/autoname/directional/west,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "crB" = (
@@ -24855,16 +27652,16 @@
 /area/station/commons/dorms)
 "crC" = (
 /obj/machinery/light/small/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
 "crD" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Showers"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
 "crE" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
 "crF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -24872,14 +27669,14 @@
 	},
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/light/small/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
 "crG" = (
 /obj/machinery/door/airlock{
 	id_tag = "Toilet1";
 	name = "Unit 1"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
 "crH" = (
 /obj/structure/toilet{
@@ -24894,7 +27691,9 @@
 	normaldoorcontrol = 1;
 	specialfunctions = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
 "crI" = (
 /obj/structure/cable,
@@ -24961,7 +27760,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "crV" = (
-/obj/structure/closet/crate,
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "crZ" = (
@@ -24980,7 +27779,10 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "csc" = (
 /obj/structure/cable,
@@ -25022,11 +27824,15 @@
 /area/station/security/prison/safe)
 "csf" = (
 /obj/structure/closet/secure_closet/armory2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "csg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
@@ -25035,6 +27841,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
 "csi" = (
@@ -25046,7 +27853,8 @@
 /obj/item/storage/box/trackimp,
 /obj/item/storage/lockbox/loyalty,
 /obj/item/reagent_containers/glass/bottle/morphine,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "csj" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -25067,6 +27875,7 @@
 	name = "Engineering Corridor"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "csr" = (
@@ -25077,6 +27886,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "cst" = (
@@ -25086,6 +27896,7 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "csu" = (
@@ -25096,6 +27907,8 @@
 	},
 /obj/item/storage/belt/utility,
 /obj/item/clothing/gloves/color/yellow,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "csv" = (
@@ -25111,8 +27924,18 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
+"csD" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "csE" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen";
@@ -25142,6 +27965,7 @@
 /obj/item/clothing/head/cone{
 	pixel_y = -10
 	},
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "csI" = (
@@ -25209,13 +28033,21 @@
 /area/station/hallway/primary/central)
 "csW" = (
 /obj/machinery/light/small/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/closet/secure_closet/injection{
+	name = "educational injections"
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "csZ" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/security/prison)
 "cta" = (
@@ -25223,6 +28055,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/security/prison)
 "ctc" = (
@@ -25231,7 +28066,10 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron/cafeteria,
 /area/station/security/prison/toilet)
 "ctd" = (
 /obj/structure/rack,
@@ -25245,7 +28083,8 @@
 	pixel_x = 2
 	},
 /obj/machinery/light/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "cte" = (
 /obj/structure/rack,
@@ -25258,7 +28097,8 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "ctg" = (
 /obj/structure/rack,
@@ -25273,7 +28113,8 @@
 	},
 /obj/item/storage/box/teargas,
 /obj/item/gun/energy/e_gun/dragnet,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "cth" = (
 /obj/structure/rack,
@@ -25285,7 +28126,8 @@
 /obj/item/clothing/head/helmet/alt,
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/machinery/light/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "cti" = (
 /obj/structure/table,
@@ -25317,20 +28159,32 @@
 /area/station/maintenance/aft)
 "ctr" = (
 /obj/machinery/light_switch/directional/west,
+/obj/effect/turf_decal/tile/yellow/opposingcorners{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "ctv" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "ctw" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "ctx" = (
 /obj/effect/spawner/random/vending/snackvend,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "cty" = (
@@ -25339,33 +28193,54 @@
 	c_tag = "Canister Storage"
 	},
 /obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "ctz" = (
 /obj/structure/chair,
 /obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "ctA" = (
 /obj/structure/table,
 /obj/item/clothing/glasses/meson,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "ctE" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "ctF" = (
 /obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "ctG" = (
 /obj/structure/chair,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "ctH" = (
 /obj/effect/spawner/random/entertainment/arcade,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "ctJ" = (
@@ -25373,15 +28248,24 @@
 	c_tag = "Engineering Cutthrough"
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "ctK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "ctL" = (
 /obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "ctN" = (
@@ -25392,6 +28276,10 @@
 /area/station/cargo/drone_bay)
 "ctP" = (
 /obj/structure/closet/radiation,
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "ctR" = (
@@ -25399,6 +28287,9 @@
 	c_tag = "Engineering Access"
 	},
 /obj/structure/closet/radiation,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "ctS" = (
@@ -25424,14 +28315,13 @@
 /area/station/maintenance/starboard/aft)
 "ctZ" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/commons/dorms)
+/area/station/maintenance/starboard/aft)
 "cuc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -25496,7 +28386,7 @@
 	layer = 2.9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "cux" = (
 /obj/structure/disposalpipe/segment{
@@ -25533,7 +28423,9 @@
 	dir = 4;
 	pixel_x = 24
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "cuA" = (
 /obj/structure/table,
@@ -25555,7 +28447,10 @@
 	name = "Unisex Restroom"
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron/cafeteria,
 /area/station/security/prison/toilet)
 "cuH" = (
 /obj/machinery/shower{
@@ -25565,7 +28460,10 @@
 /obj/item/soap,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron/cafeteria,
 /area/station/security/prison/toilet)
 "cuI" = (
 /obj/structure/rack,
@@ -25574,7 +28472,8 @@
 	pixel_y = -5
 	},
 /obj/item/gun/ballistic/shotgun/riot,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "cuJ" = (
 /obj/structure/rack,
@@ -25587,19 +28486,22 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "cuK" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "cuL" = (
 /obj/machinery/airalarm/directional/south,
 /obj/structure/rack,
 /obj/item/gun/energy/ionrifle,
 /obj/item/clothing/suit/armor/laserproof,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "cuM" = (
 /obj/structure/rack,
@@ -25609,7 +28511,8 @@
 /obj/item/clothing/head/helmet/riot,
 /obj/item/clothing/head/helmet/riot,
 /obj/item/clothing/head/helmet/riot,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "cuN" = (
 /turf/open/floor/plating,
@@ -25684,6 +28587,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "cvl" = (
@@ -25889,13 +28795,18 @@
 /obj/machinery/atmospherics/components/binary/volume_pump{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "cwg" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp,
 /obj/structure/reagent_dispensers/wall/peppertank/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "cwh" = (
 /obj/machinery/camera/directional/west{
@@ -25936,6 +28847,7 @@
 "cwo" = (
 /obj/effect/spawner/random/entertainment/arcade,
 /obj/machinery/computer/security/telescreen/entertainment/directional/east,
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "cwp" = (
@@ -25953,14 +28865,23 @@
 /area/station/maintenance/aft)
 "cwz" = (
 /obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "cwB" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "cwC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
@@ -25968,10 +28889,17 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "cwI" = (
 /obj/machinery/light_switch/directional/south,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "cwK" = (
@@ -25987,18 +28915,25 @@
 /obj/structure/chair{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "cwM" = (
 /obj/structure/table,
 /obj/item/toy/cards/deck,
 /obj/machinery/newscaster/directional/south,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "cwN" = (
 /obj/structure/chair{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "cwP" = (
@@ -26006,6 +28941,7 @@
 	id = "Engineering";
 	name = "engineering security door"
 	},
+/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cwQ" = (
@@ -26014,6 +28950,7 @@
 	name = "engineering security door"
 	},
 /obj/structure/sign/warning/radiation/directional/south,
+/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cwS" = (
@@ -26055,12 +28992,18 @@
 	dir = 4
 	},
 /obj/machinery/disposal/bin,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "cwY" = (
 /obj/machinery/light/directional/north,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/bot{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
@@ -26079,6 +29022,9 @@
 /obj/item/clothing/mask/breath,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "cxc" = (
@@ -26095,11 +29041,17 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/item/stack/rods/fifty,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "cxd" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "cxe" = (
@@ -26109,12 +29061,14 @@
 /obj/machinery/computer/station_alert,
 /obj/structure/cable,
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "cxg" = (
 /obj/machinery/modular_computer/console/preset/engineering,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "cxi" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -26186,10 +29140,16 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "cxE" = (
 /obj/structure/sign/warning/radiation/directional/south,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "cxF" = (
@@ -26200,8 +29160,16 @@
 	pixel_y = 2
 	},
 /obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
 /area/station/security/execution/education)
+"cxK" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "cxN" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -26209,7 +29177,10 @@
 	pixel_y = 7
 	},
 /obj/item/pen,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
 "cxO" = (
 /obj/structure/table,
@@ -26260,11 +29231,17 @@
 /area/station/engineering/main)
 "cxX" = (
 /obj/machinery/rnd/production/circuit_imprinter,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "cxY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
@@ -26275,6 +29252,9 @@
 /obj/machinery/light/directional/north,
 /obj/structure/cable,
 /obj/structure/sign/warning/no_smoking/directional/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "cyb" = (
@@ -26283,6 +29263,9 @@
 	},
 /obj/effect/landmark/start/station_engineer,
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "cyd" = (
@@ -26331,19 +29314,21 @@
 "cyq" = (
 /obj/machinery/seed_extractor,
 /obj/machinery/light/small/directional/west,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/security/prison)
 "cyr" = (
-/obj/structure/sink/kitchen{
-	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
-	name = "old sink";
-	pixel_y = 28
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "cys" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
@@ -26355,7 +29340,10 @@
 	},
 /obj/item/clothing/head/chefhat,
 /obj/machinery/light/small/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
 "cyA" = (
 /obj/structure/chair{
@@ -26370,15 +29358,16 @@
 /area/station/maintenance/aft)
 "cyC" = (
 /obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/engineering/break_room)
 "cyD" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/engineering/break_room)
 "cyE" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/box/corners,
+/turf/open/floor/iron/dark/textured,
 /area/station/engineering/break_room)
 "cyF" = (
 /obj/machinery/shieldgen,
@@ -26401,13 +29390,24 @@
 /area/station/engineering/main)
 "cyM" = (
 /obj/structure/reagent_dispensers/watertank,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cyN" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/camera/autoname/directional/north,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"cyO" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/chair/sofa/bench/right{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "cyP" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil{
@@ -26415,16 +29415,21 @@
 	pixel_y = -7
 	},
 /obj/item/stack/cable_coil,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cyQ" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/iron/fifty,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cyS" = (
 /obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cyT" = (
@@ -26432,15 +29437,20 @@
 	dir = 4
 	},
 /obj/structure/reagent_dispensers/fueltank/large,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "cyU" = (
 /obj/machinery/vending/engivend,
 /obj/machinery/camera/autoname/directional/north,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cyV" = (
 /obj/machinery/vending/tool,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cyX" = (
@@ -26450,11 +29460,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "cze" = (
 /obj/machinery/light/directional/north,
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
 "czi" = (
@@ -26472,27 +29484,31 @@
 "czn" = (
 /obj/machinery/hydroponics/constructable,
 /obj/item/seeds/ambrosia,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/security/prison)
 "czo" = (
 /obj/item/reagent_containers/glass/bucket,
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "czp" = (
 /obj/machinery/hydroponics/constructable,
 /obj/item/seeds/glowshroom,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "czr" = (
-/obj/structure/closet,
 /obj/item/storage/box/donkpockets,
-/obj/effect/spawner/random/maintenance,
+/obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "czs" = (
-/obj/structure/closet/crate,
 /obj/item/assembly/infra,
-/obj/effect/spawner/random/maintenance,
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "czx" = (
@@ -26528,6 +29544,13 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/station/engineering/main)
+"czJ" = (
+/obj/machinery/camera/autoname/directional/south,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "czM" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -26537,6 +29560,9 @@
 "czO" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "czP" = (
@@ -26544,6 +29570,9 @@
 /obj/item/stock_parts/cell/high,
 /obj/item/stock_parts/cell/high,
 /obj/machinery/cell_charger,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "czQ" = (
@@ -26551,34 +29580,52 @@
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/airlock_painter,
 /obj/item/wrench,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "czS" = (
 /obj/structure/closet/crate/solarpanel_small,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "czT" = (
-/obj/structure/tank_dispenser,
+/obj/machinery/suit_storage_unit/engine,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "czU" = (
-/obj/machinery/suit_storage_unit/engine,
+/obj/structure/tank_dispenser,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "czW" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "SMES Room West"
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
 "czX" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/large,
 /area/station/engineering/engine_smes)
 "czZ" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "SMES Room"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
@@ -26601,15 +29648,21 @@
 /obj/machinery/hydroponics/constructable,
 /obj/item/cultivator,
 /obj/item/seeds/carrot,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/security/prison)
 "cAe" = (
 /obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "cAf" = (
 /obj/machinery/hydroponics/constructable,
 /obj/item/plant_analyzer,
+/obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "cAg" = (
@@ -26618,6 +29671,7 @@
 	c_tag = "Prison Hydroponics";
 	network = list("ss13","prison")
 	},
+/obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "cAh" = (
@@ -26626,15 +29680,18 @@
 	name = "\improper sustenance vendor";
 	product_slogans = "Enjoy your meal.;Enough calories to support any worker."
 	},
+/obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "cAi" = (
 /obj/structure/table,
 /obj/machinery/computer/libraryconsole/bookmanagement,
+/obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "cAj" = (
 /obj/machinery/vending/coffee,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "cAk" = (
@@ -26642,14 +29699,13 @@
 /obj/machinery/microwave{
 	pixel_y = 6
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
 "cAl" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
-	},
-/obj/effect/spawner/random/maintenance,
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "cAm" = (
@@ -26710,6 +29766,13 @@
 /obj/structure/cable,
 /turf/open/space/basic,
 /area/station/solars/port/fore)
+"cAE" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "cAJ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
@@ -26723,6 +29786,7 @@
 "cAL" = (
 /obj/structure/table/reinforced,
 /obj/structure/desk_bell,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "cAN" = (
@@ -26829,6 +29893,9 @@
 /area/station/command/heads_quarters/ce)
 "cBl" = (
 /obj/machinery/light/directional/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cBm" = (
@@ -26845,6 +29912,7 @@
 	},
 /obj/item/pen,
 /obj/item/storage/medkit/fire,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cBq" = (
@@ -26856,6 +29924,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cBr" = (
@@ -26883,6 +29952,9 @@
 "cBw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
 "cBy" = (
@@ -26894,6 +29966,7 @@
 /obj/item/clothing/suit/hazardvest,
 /obj/item/tank/internals/emergency_oxygen/engi,
 /obj/item/tank/internals/emergency_oxygen/engi,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cBA" = (
@@ -26901,6 +29974,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cBC" = (
@@ -26908,17 +29984,26 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cBG" = (
 /obj/machinery/light_switch{
 	pixel_x = -23
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
 "cBI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
@@ -26986,24 +30071,25 @@
 /area/station/maintenance/aft)
 "cCm" = (
 /obj/machinery/suit_storage_unit/ce,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "cCn" = (
 /obj/machinery/holopad,
 /obj/machinery/light_switch/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "cCo" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/keycard_auth/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "cCq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
 /obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "cCr" = (
 /obj/machinery/disposal/bin,
@@ -27024,7 +30110,8 @@
 	pixel_y = 23
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "cCs" = (
 /obj/structure/grille,
@@ -27042,11 +30129,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cCv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
@@ -27067,6 +30160,7 @@
 	pixel_x = 1;
 	pixel_y = 5
 	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cCy" = (
@@ -27079,6 +30173,7 @@
 	pixel_x = 8
 	},
 /obj/machinery/light/directional/south,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cCB" = (
@@ -27105,7 +30200,7 @@
 "cCG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white/textured,
 /area/station/science/research)
 "cCK" = (
 /obj/machinery/door/airlock/engineering{
@@ -27169,13 +30264,17 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"cCZ" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "cDa" = (
 /obj/machinery/modular_computer/console/preset/id{
 	dir = 4
 	},
 /obj/machinery/requests_console/auto_name/directional/west,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "cDb" = (
 /obj/structure/table/reinforced,
@@ -27185,10 +30284,13 @@
 	},
 /obj/item/stamp/ce,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "cDc" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "cDf" = (
 /obj/machinery/door/airlock/command/glass{
@@ -27214,6 +30316,9 @@
 "cDq" = (
 /obj/structure/cable,
 /obj/machinery/camera/autoname/directional/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cDr" = (
@@ -27309,26 +30414,30 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "cDF" = (
 /obj/structure/chair/office/light{
 	dir = 4
 	},
 /obj/effect/landmark/start/chief_engineer,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "cDG" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/yellow,
 /obj/item/paper/monitorkey,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "cDH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "cDI" = (
 /obj/structure/table/reinforced,
@@ -27338,7 +30447,8 @@
 	},
 /obj/item/stock_parts/cell/high,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "cDJ" = (
 /obj/structure/grille,
@@ -27352,6 +30462,9 @@
 /area/station/command/heads_quarters/ce)
 "cDK" = (
 /obj/machinery/camera/autoname/directional/south,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cDN" = (
@@ -27361,6 +30474,8 @@
 	pixel_x = -3;
 	pixel_y = -2
 	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cDO" = (
@@ -27384,10 +30499,15 @@
 "cDX" = (
 /obj/machinery/light/directional/south,
 /obj/structure/sign/warning/vacuum/external/directional/south,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cEa" = (
 /obj/structure/closet/firecloset,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cEg" = (
@@ -27433,11 +30553,15 @@
 /obj/item/pen,
 /obj/effect/spawner/random/entertainment/cigarette_pack,
 /obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "cEy" = (
 /obj/structure/closet/secure_closet/engineering_chief,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "cEz" = (
 /obj/item/computer_hardware/hard_drive/portable/engineering{
@@ -27453,7 +30577,8 @@
 /obj/item/computer_hardware/hard_drive/portable/atmos,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "cEA" = (
 /obj/machinery/door/airlock/external{
@@ -27485,6 +30610,7 @@
 /obj/structure/table,
 /obj/item/crowbar/large,
 /obj/item/storage/box/lights/mixed,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cEI" = (
@@ -27499,6 +30625,7 @@
 	pixel_x = -3;
 	pixel_y = 5
 	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cEJ" = (
@@ -27515,20 +30642,24 @@
 	pixel_x = -3;
 	pixel_y = -3
 	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cEK" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/machinery/light/directional/south,
 /obj/machinery/camera/autoname/directional/south,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cEL" = (
 /obj/structure/closet/secure_closet/engineering_personal,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cEM" = (
 /obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cEO" = (
@@ -27598,6 +30729,7 @@
 "cFj" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/requests_console/auto_name/directional/north,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cFk" = (
@@ -27672,7 +30804,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "cFV" = (
 /obj/machinery/mecha_part_fabricator,
@@ -27729,6 +30861,13 @@
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
+"cGp" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/security)
 "cGr" = (
 /obj/item/shard{
 	icon_state = "small"
@@ -27871,7 +31010,8 @@
 "cHp" = (
 /obj/machinery/pdapainter/medbay,
 /obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/dark_blue/fourcorners,
+/turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "cHq" = (
 /obj/machinery/light/directional/south,
@@ -27882,16 +31022,21 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "cHr" = (
 /obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "cHs" = (
 /obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "cHt" = (
 /obj/structure/lattice,
@@ -27953,12 +31098,15 @@
 "cHB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "cHC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "cHE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
@@ -27975,6 +31123,12 @@
 "cHP" = (
 /turf/open/floor/plating,
 /area/station/engineering/main)
+"cHU" = (
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "cHV" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/o2,
 /turf/open/floor/iron,
@@ -27984,8 +31138,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"cJn" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/storage)
 "cKb" = (
 /obj/machinery/button/door{
 	id = "rdordnance";
@@ -27993,7 +31155,10 @@
 	pixel_x = -24;
 	req_access = list("rd")
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/purple/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "cKc" = (
 /obj/structure/window/reinforced{
@@ -28005,7 +31170,10 @@
 /area/station/hallway/primary/port)
 "cKB" = (
 /obj/machinery/medical_kiosk,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "cLi" = (
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
@@ -28022,6 +31190,10 @@
 	dir = 1
 	},
 /obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "cMq" = (
@@ -28038,17 +31210,41 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
+"cNe" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"cNu" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "cNW" = (
 /obj/structure/closet/secure_closet/psychology,
 /obj/item/toy/figure/psychologist,
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
+"cOi" = (
+/obj/machinery/status_display/evac/directional/west,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "cOu" = (
 /obj/machinery/door/airlock/wood{
 	name = "Backstage"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/theatre,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/service/theater)
 "cOI" = (
 /obj/structure/table,
@@ -28061,34 +31257,76 @@
 	pixel_x = -3;
 	pixel_y = -3
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/storage)
+"cPx" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/station/maintenance/port/aft)
 "cPD" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "cPL" = (
 /obj/machinery/light/directional/north,
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"cPR" = (
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "cQM" = (
 /obj/structure/sign/poster/official/random/directional/west,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "cRe" = (
 /obj/machinery/rnd/bepis,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"cRr" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/surgery/theatre)
 "cSu" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Atmospherics Plasma Tank"
 	},
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
+"cSA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/freezer,
+/area/station/commons/toilet/locker)
+"cSW" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "cTs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "cTx" = (
@@ -28099,6 +31337,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
+"cUQ" = (
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
+"cUT" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "cXe" = (
 /obj/structure/cable,
 /obj/structure/sign/departments/engineering/directional/south,
@@ -28110,12 +31356,35 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"cYn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/ai_monitored/security/armory)
+"cZk" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/central)
+"cZy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "cZZ" = (
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain)
 "dam" = (
 /obj/machinery/camera/autoname/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "dao" = (
@@ -28127,12 +31396,22 @@
 /obj/machinery/power/energy_accumulator/grounding_rod/anchored,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
+"daK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "dbe" = (
 /obj/machinery/status_display/ai/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "dcJ" = (
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "ddZ" = (
@@ -28172,14 +31451,19 @@
 "dgf" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
 "dgu" = (
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "dgy" = (
 /obj/machinery/atmospherics/components/tank/air,
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "dgC" = (
@@ -28204,16 +31488,40 @@
 /area/station/service/chapel)
 "die" = (
 /obj/machinery/holopad,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"dje" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"djz" = (
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/chair/sofa/bench{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "djH" = (
 /obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "djU" = (
 /obj/machinery/atmospherics/components/binary/pump/off{
 	dir = 8;
 	name = "N2O To Pure"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -28232,6 +31540,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"dkG" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/light/directional/east,
+/obj/machinery/status_display/evac/directional/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "dkW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28241,11 +31561,24 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"dlc" = (
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/random/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "dlo" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"dlr" = (
+/obj/structure/grille/broken,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "dls" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "lawyer_blast";
@@ -28276,6 +31609,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
+"dom" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/turf/open/floor/iron,
+/area/station/security/prison)
 "doE" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
@@ -28283,12 +31621,20 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"doW" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "dpY" = (
 /obj/machinery/computer/crew{
 	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "dqd" = (
 /obj/structure/chair/comfy/teal{
@@ -28310,6 +31656,7 @@
 /obj/item/book/manual/wiki/barman_recipes{
 	pixel_y = 5
 	},
+/obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "dre" = (
@@ -28317,7 +31664,7 @@
 /obj/effect/landmark/start/scientist,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "drM" = (
 /obj/machinery/holopad,
@@ -28330,6 +31677,10 @@
 	name = "Stage Right"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/theatre,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/service/theater)
 "dsS" = (
@@ -28353,6 +31704,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
+"duK" = (
+/obj/machinery/computer/security/telescreen/research{
+	pixel_y = 30
+	},
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/rd)
+"dxd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "dxF" = (
 /obj/machinery/door/airlock/external{
 	name = "Port Docking Bay 1"
@@ -28363,6 +31729,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"dyV" = (
+/obj/effect/spawner/random/entertainment/arcade,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
 "dyY" = (
 /obj/machinery/atmospherics/components/binary/valve/digital/on{
 	dir = 4;
@@ -28383,7 +31756,13 @@
 /area/station/service/bar)
 "dAF" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "dAW" = (
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -28394,6 +31773,11 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"dCI" = (
+/obj/machinery/vending/boozeomat,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "dDo" = (
 /obj/structure/transit_tube/curved/flipped{
 	dir = 4
@@ -28405,6 +31789,7 @@
 /obj/item/wrench,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "dFl" = (
@@ -28422,12 +31807,30 @@
 /obj/effect/landmark/navigate_destination/chapel,
 /turf/open/floor/carpet,
 /area/station/service/chapel)
+"dGC" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "dGU" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "dHf" = (
 /obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"dHh" = (
+/obj/machinery/status_display/evac/directional/west,
+/obj/structure/transit_tube/station/dispenser{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/dark_blue/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "dHk" = (
@@ -28441,6 +31844,9 @@
 /obj/machinery/computer/security/telescreen/interrogation{
 	pixel_y = 32
 	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/security/brig)
 "dIB" = (
@@ -28448,6 +31854,15 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"dIV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "dIW" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4
@@ -28459,6 +31874,9 @@
 "dKs" = (
 /obj/structure/sign/departments/court/directional/north,
 /obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "dKw" = (
@@ -28469,6 +31887,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/emergency/port)
+"dKZ" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/engineering/break_room)
 "dLy" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
@@ -28482,14 +31906,46 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"dMW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "dNc" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "dPa" = (
 /obj/structure/transit_tube/station/dispenser,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"dPn" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
+"dPo" = (
+/obj/structure/sign/poster/contraband/random/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
+"dPN" = (
+/obj/structure/table,
+/obj/machinery/power/apc/auto_name/directional/east,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
+"dPO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/closet/gmcloset,
+/turf/open/floor/iron,
+/area/station/service/theater)
 "dQe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -28504,13 +31960,11 @@
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
 "dRm" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/light/directional/west,
 /obj/structure/chair{
 	dir = 4
 	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "dRs" = (
@@ -28518,8 +31972,25 @@
 /area/station/ai_monitored/command/nuke_storage)
 "dRD" = (
 /obj/machinery/vending/medical,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"dSd" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
+"dTF" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "dUp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -28529,8 +32000,18 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"dVF" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "dWi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -28538,11 +32019,32 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"dWk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/station/command/gateway)
 "dWU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/landmark/navigate_destination/janitor,
 /turf/open/floor/iron,
 /area/station/service/janitor)
+"dXb" = (
+/obj/structure/closet/firecloset,
+/obj/structure/sign/poster/official/state_laws{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"dXA" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "dYP" = (
 /obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/iron,
@@ -28557,6 +32059,9 @@
 /area/station/science/ordnance/bomb)
 "dZL" = (
 /obj/effect/landmark/start/station_engineer,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "eae" = (
@@ -28567,17 +32072,45 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "ecr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
+"ect" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/gravity_generator)
+"ecD" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"ecX" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "edn" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/brown/filled/arrow_cw,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "eej" = (
@@ -28589,7 +32122,7 @@
 /area/station/maintenance/department/medical)
 "ees" = (
 /obj/effect/landmark/start/paramedic,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "efJ" = (
 /obj/structure/cable,
@@ -28613,8 +32146,27 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"egY" = (
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"ehK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/security/execution/transfer)
 "eiQ" = (
 /obj/structure/cable,
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "eji" = (
@@ -28622,6 +32174,12 @@
 	dir = 5
 	},
 /area/station/service/chapel)
+"ejO" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "eks" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -28649,9 +32207,25 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"elh" = (
+/obj/machinery/button/door{
+	id = "Skynet_launch";
+	name = "Mech Bay Shutters";
+	pixel_y = 26;
+	req_access = list("robotics")
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "eli" = (
 /obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "elu" = (
 /turf/open/floor/iron/goonplaque,
@@ -28671,14 +32245,30 @@
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
+"elW" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "emb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter/room)
+"emo" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "emu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"emD" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
 "enH" = (
 /obj/structure/transit_tube/diagonal/topleft,
 /turf/open/floor/plating/airless,
@@ -28700,6 +32290,19 @@
 /obj/item/cigbutt/roach,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
+"eob" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
+"eoj" = (
+/obj/effect/turf_decal/trimline/dark_blue/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "eow" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
 	dir = 5
@@ -28713,16 +32316,28 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"epz" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "epG" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "eqo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "eqN" = (
@@ -28731,6 +32346,7 @@
 	pixel_y = 5
 	},
 /obj/effect/spawner/random/entertainment/lighter,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "eri" = (
@@ -28744,6 +32360,7 @@
 "erz" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "etX" = (
@@ -28754,13 +32371,27 @@
 /area/space/nearstation)
 "euw" = (
 /obj/machinery/restaurant_portal/bar,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
+"euC" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/station/service/bar)
+/area/station/hallway/primary/central)
 "eva" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
+"evl" = (
+/obj/machinery/smartfridge,
+/turf/closed/wall,
+/area/station/service/hydroponics)
 "ewn" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
@@ -28780,6 +32411,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/brown/opposingcorners,
 /turf/open/floor/iron,
 /area/station/maintenance/central)
 "exY" = (
@@ -28788,6 +32420,13 @@
 /obj/item/razor,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"eyh" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "eyj" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28819,7 +32458,8 @@
 	pixel_y = -3
 	},
 /obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/storage)
 "eAq" = (
 /obj/structure/cable,
@@ -28830,7 +32470,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "eBz" = (
 /obj/structure/cable,
@@ -28843,8 +32484,26 @@
 /area/station/hallway/primary/port)
 "eCe" = (
 /obj/effect/landmark/secequipment,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/security)
+"eCL" = (
+/obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"eCQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "eDG" = (
 /obj/structure/transit_tube/crossing/horizontal,
 /turf/open/floor/plating/airless,
@@ -28855,10 +32514,32 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"eDZ" = (
+/obj/effect/turf_decal/trimline/purple/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/research)
+"eEb" = (
+/obj/structure/marker_beacon/burgundy,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
+"eEA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/engine_smes)
 "eED" = (
 /obj/structure/marker_beacon/purple,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"eEG" = (
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/security/prison)
 "eFp" = (
 /obj/machinery/door/airlock/external{
 	name = "External Docking Port"
@@ -28870,6 +32551,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "eFv" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "eGu" = (
@@ -28886,11 +32570,14 @@
 "eHq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/science/lab)
 "eHB" = (
 /obj/machinery/portable_atmospherics/pump,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
 "eHX" = (
 /obj/machinery/door/airlock/maintenance,
@@ -28907,6 +32594,8 @@
 /area/station/engineering/supermatter/room)
 "eJc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "eJz" = (
@@ -28936,6 +32625,19 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"eMG" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
+"eMJ" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "eMM" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron,
@@ -28947,12 +32649,26 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"eNA" = (
+/obj/machinery/camera/autoname/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "eNO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"eOn" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/ai_monitored/command/storage/eva)
 "eOW" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/grimy,
@@ -28960,6 +32676,9 @@
 "ePD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "eQi" = (
@@ -28982,7 +32701,7 @@
 /area/station/maintenance/department/science)
 "eQI" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "eRh" = (
 /obj/machinery/door/firedoor/heavy,
@@ -29007,7 +32726,14 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/trimline/purple/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/science/lab)
 "eTd" = (
 /obj/effect/landmark/event_spawn,
@@ -29033,18 +32759,44 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/holopad,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"eUz" = (
+/obj/structure/table,
+/obj/item/storage/medkit/regular,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "eUD" = (
 /obj/effect/landmark/start/scientist,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/lab)
+"eUR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "eUT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/turf/open/floor/iron/white,
 /area/station/medical/psychology)
+"eVa" = (
+/obj/structure/transit_tube/curved/flipped,
+/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "eVd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -29058,15 +32810,46 @@
 /obj/machinery/light_switch/directional/west{
 	pixel_x = -21
 	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
+"eWH" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "eWN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"eXf" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/commons/fitness/recreation)
+"eXq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/sign/poster/contraband/random/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
+"eXD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/iron/dark,
+/area/station/tcommsat/computer)
 "eXQ" = (
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "eXV" = (
@@ -29077,6 +32860,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/service/theatre,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/service/theater)
 "eYe" = (
@@ -29097,7 +32884,13 @@
 /area/station/hallway/primary/port)
 "eZf" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/purple/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "eZE" = (
 /obj/structure/chair{
@@ -29105,6 +32898,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/security)
 "fah" = (
@@ -29115,20 +32911,31 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/holopad,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "faD" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/security/warden)
 "faU" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
+	},
 /obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white/corner,
 /area/station/medical/medbay/lobby)
 "fbm" = (
 /obj/machinery/vending/coffee,
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/service/library)
+"fbp" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/station/engineering/break_room)
 "fbO" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
@@ -29153,11 +32960,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/service/janitor)
+"fdn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/station/command/heads_quarters/hop)
 "fdB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "fdC" = (
@@ -29167,6 +32985,9 @@
 "fdF" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "fdQ" = (
@@ -29181,10 +33002,30 @@
 	},
 /turf/closed/wall,
 /area/station/maintenance/port/fore)
+"fet" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
+"ffu" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/ai_monitored/security/armory)
 "fgk" = (
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
+"fgT" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "fhE" = (
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/chapel{
@@ -29196,6 +33037,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"fhV" = (
+/obj/structure/cable,
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "fix" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/tank_holder/extinguisher,
@@ -29205,8 +33054,14 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/courtroom)
+"fjq" = (
+/obj/structure/chair/stool/bar/directional/east,
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "fkZ" = (
 /obj/machinery/door/airlock/mining{
 	name = "Mining Office"
@@ -29215,6 +33070,16 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
+"fld" = (
+/obj/machinery/door/window/brigdoor{
+	dir = 8;
+	name = "Test Range"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/science/auxlab)
 "fma" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -29232,7 +33097,7 @@
 	dir = 8
 	},
 /obj/machinery/holopad,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "fmG" = (
 /obj/structure/chair/comfy/brown{
@@ -29254,7 +33119,8 @@
 /area/station/maintenance/department/science)
 "fmW" = (
 /obj/machinery/holopad,
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "fni" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
@@ -29278,7 +33144,8 @@
 	pixel_y = 2
 	},
 /obj/item/storage/box/syringes,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/storage)
 "foq" = (
 /obj/structure/table,
@@ -29298,24 +33165,60 @@
 	dir = 4;
 	pixel_x = 25
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/office)
 "foH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "foL" = (
 /obj/structure/window{
 	dir = 1
 	},
 /obj/structure/sign/poster/official/random/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"foX" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"fpH" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"frc" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security/brig)
+"frQ" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "frV" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"fsv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
+/area/station/medical/morgue)
 "fsF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -29339,6 +33242,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
+"ftR" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/commons/fitness/recreation)
 "fux" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
@@ -29369,15 +33278,30 @@
 /obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
-"fyk" = (
-/obj/effect/spawner/random/maintenance,
-/obj/structure/cable,
+"fws" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/service/theater)
+"fxt" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron,
+/area/station/engineering/engine_smes)
+"fyk" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "fzd" = (
-/obj/machinery/vending/wallmed/directional/south,
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "fzf" = (
@@ -29391,6 +33315,9 @@
 /obj/item/storage/secure/safe/caps_spare/directional/west{
 	pixel_x = -24
 	},
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "fAG" = (
@@ -29398,6 +33325,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"fAN" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "fCf" = (
 /obj/structure/transit_tube/curved{
 	dir = 8
@@ -29410,18 +33346,35 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"fDP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/warning,
+/turf/open/floor/iron,
+/area/station/security/execution/transfer)
 "fEG" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"fFF" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/turf/open/floor/iron,
+/area/station/security)
 "fGe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"fHg" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "fHr" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -29435,17 +33388,21 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "fIj" = (
 /obj/machinery/holopad,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "fJy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security)
 "fJW" = (
 /obj/effect/landmark/event_spawn,
@@ -29463,8 +33420,17 @@
 /area/station/command/gateway)
 "fKX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/lab)
+"fLg" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "fMD" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -29475,6 +33441,16 @@
 /area/station/maintenance/port/central)
 "fNZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/table/reinforced,
+/obj/item/crowbar,
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
+/obj/item/wirecutters,
+/obj/item/radio/off,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security/warden)
 "fOb" = (
@@ -29484,6 +33460,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"fOq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"fOD" = (
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/commons/fitness/recreation)
 "fPz" = (
 /obj/machinery/door/airlock/science{
 	name = "Medical Research"
@@ -29521,11 +33511,20 @@
 /obj/item/pen,
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
+"fRp" = (
+/obj/effect/landmark/start/station_engineer,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/station/engineering/main)
+"fRH" = (
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/cmo)
 "fRM" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "fSx" = (
@@ -29535,6 +33534,9 @@
 /area/station/engineering/atmos)
 "fST" = (
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "fUB" = (
@@ -29548,6 +33550,11 @@
 /obj/effect/mapping_helpers/iannewyear,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
+"fWp" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "fWt" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
@@ -29565,6 +33572,9 @@
 /area/station/service/janitor)
 "fXy" = (
 /obj/structure/sign/poster/official/random/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "fXV" = (
@@ -29585,7 +33595,8 @@
 /area/station/maintenance/solars/port/aft)
 "gas" = (
 /obj/machinery/recharge_station,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "gaP" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
@@ -29598,6 +33609,28 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"gbr" = (
+/obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"gbx" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/bed/roller,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
+"gbz" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "gbQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -29620,18 +33653,22 @@
 /area/station/engineering/supermatter/room)
 "gdr" = (
 /obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "gdv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "gdS" = (
 /obj/structure/sign/directions/science{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "gej" = (
@@ -29643,11 +33680,23 @@
 /area/station/engineering/supermatter/room)
 "gev" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "gff" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/hop)
+"gfH" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "gfV" = (
 /obj/structure/window,
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted,
@@ -29656,6 +33705,25 @@
 "ggT" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos/office)
+"ghp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
+"ghq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "ghA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/bridge_pipe/supply/hidden/layer4{
@@ -29686,6 +33754,12 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
+"gjy" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security/brig)
 "gjC" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Library Maintenance"
@@ -29717,11 +33791,28 @@
 	id = "Cell 1";
 	name = "Cell 1 Locker"
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron,
 /area/station/security/brig)
+"gml" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
+"gmm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "gmW" = (
 /obj/machinery/announcement_system,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "gnB" = (
 /obj/machinery/door/airlock/mining/glass{
@@ -29747,8 +33838,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron,
 /area/station/security/warden)
+"gpM" = (
+/obj/machinery/washing_machine,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "gqk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -29758,6 +33855,15 @@
 	},
 /turf/open/floor/plating,
 /area/station/command/bridge)
+"gql" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "gqP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -29774,20 +33880,28 @@
 "grp" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "gsS" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"gtj" = (
+/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted,
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/cmo)
 "gtw" = (
 /obj/machinery/computer/security/telescreen/interrogation{
 	pixel_y = 32
 	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/security)
 "gtN" = (
-/obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "gui" = (
@@ -29838,19 +33952,26 @@
 /area/station/maintenance/central)
 "gwH" = (
 /obj/effect/spawner/random/vending/snackvend,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "gwR" = (
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/central)
 "gxO" = (
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "gyK" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
 /area/station/science/genetics)
 "gyL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -29869,12 +33990,36 @@
 	name = "Gateway Shutter Control";
 	req_access = list("command")
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"gzX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/service/theater)
 "gAq" = (
 /obj/structure/closet/secure_closet/medical2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
+"gAV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "gBg" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -29891,10 +34036,13 @@
 /obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security)
 "gCD" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/brown/filled/arrow_ccw,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "gCT" = (
@@ -29906,6 +34054,12 @@
 /obj/effect/spawner/random/entertainment/wallet_lighter,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"gDh" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "gEj" = (
 /obj/structure/cable,
 /obj/effect/landmark/event_spawn,
@@ -29937,8 +34091,17 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/pumproom)
+"gFI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "gFQ" = (
-/obj/effect/turf_decal/loading_area{
+/obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -29951,12 +34114,16 @@
 "gHx" = (
 /obj/structure/cable,
 /obj/structure/sign/departments/restroom/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "gIQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "gJI" = (
@@ -29968,7 +34135,7 @@
 	dir = 4
 	},
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
 "gLd" = (
 /obj/machinery/atmospherics/components/binary/pump/off{
@@ -29990,6 +34157,13 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/ordnance/burnchamber)
+"gOq" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
 "gOs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -30017,7 +34191,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/firealarm/directional/east,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/security/processing)
 "gQH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -30026,17 +34201,30 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
+"gQP" = (
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "gRd" = (
 /obj/machinery/computer/secure_data{
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "gRN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"gRO" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/engine_smes)
 "gRT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30064,6 +34252,20 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"gSN" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"gSY" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/pharmacy)
 "gTq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -30083,6 +34285,13 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"gUM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "gUX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30090,6 +34299,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"gVt" = (
+/obj/structure/sign/poster/official/random/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
 "gVA" = (
 /obj/machinery/door/airlock/hatch,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -30106,6 +34322,22 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"gXc" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"gXi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "gXj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -30113,8 +34345,36 @@
 /area/station/command/heads_quarters/hop)
 "gYL" = (
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
+"gZg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
+"gZk" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
+"hab" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "hat" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
@@ -30124,8 +34384,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/explab)
+"hcr" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "hcT" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/table/wood,
@@ -30135,6 +34402,11 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
+"hdN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "hdY" = (
 /obj/structure/sign/painting/library{
 	pixel_y = 32
@@ -30146,8 +34418,16 @@
 /obj/machinery/vending/medical,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"hep" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/plating,
+/area/station/medical/abandoned)
 "heW" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 4
@@ -30155,18 +34435,25 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "hff" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 8
 	},
+/obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/hallway/secondary/exit/departure_lounge)
 "hfh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
+"hft" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/electrical)
 "hfK" = (
 /obj/machinery/gulag_teleporter,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/security/processing)
 "hgI" = (
 /turf/closed/wall/r_wall,
@@ -30187,19 +34474,44 @@
 /obj/machinery/holopad/secure,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"hih" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
+"his" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
 "hjc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"hju" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "hjB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "hjK" = (
 /obj/structure/cable,
@@ -30211,8 +34523,22 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
+"hkS" = (
+/obj/structure/sign/poster/contraband/random/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
+"hld" = (
+/obj/effect/spawner/random/vending/snackvend,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "hlq" = (
 /obj/machinery/bluespace_vendor/directional/west,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "hlU" = (
@@ -30221,6 +34547,17 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"hmG" = (
+/obj/item/clothing/head/cone,
+/obj/item/clothing/head/cone,
+/obj/item/clothing/head/cone,
+/obj/item/clothing/head/cone,
+/obj/item/clothing/head/cone,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/storage)
 "hnO" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -30244,6 +34581,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "hqK" = (
@@ -30273,9 +34611,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"hwg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/ai_monitored/security/armory)
 "hwh" = (
 /obj/machinery/light/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "hwC" = (
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
@@ -30309,6 +34659,9 @@
 "hyR" = (
 /obj/machinery/light/directional/south,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "hAm" = (
@@ -30318,21 +34671,55 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"hCC" = (
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron/cafeteria,
+/area/station/security/prison)
 "hDb" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/security/checkpoint/medical)
+"hDE" = (
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "hDM" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/station/commons/lounge)
+"hDO" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/station/service/theater)
+"hEo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "hFm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30351,6 +34738,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"hHb" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/mirror/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/freezer,
+/area/station/commons/toilet/locker)
 "hHE" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -30358,7 +34755,10 @@
 "hJe" = (
 /obj/structure/chair,
 /obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "hKi" = (
 /obj/effect/turf_decal/plaque{
@@ -30369,8 +34769,16 @@
 "hLl" = (
 /obj/structure/kitchenspike,
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
+"hMO" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/security/brig)
 "hMP" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
@@ -30381,6 +34789,9 @@
 /area/station/maintenance/port/aft)
 "hNR" = (
 /obj/structure/sign/departments/medbay/alt/directional/west,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "hOm" = (
@@ -30388,6 +34799,9 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"hOC" = (
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "hOM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -30399,6 +34813,19 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"hPa" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
+"hPB" = (
+/obj/structure/chair{
+	dir = 8;
+	name = "Defense"
+	},
+/obj/effect/turf_decal/tile/green/anticorner/contrasted,
+/turf/open/floor/iron,
+/area/station/security/courtroom)
 "hPP" = (
 /obj/structure/table,
 /obj/item/storage/medkit/fire{
@@ -30410,7 +34837,8 @@
 	pixel_x = -3;
 	pixel_y = -3
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/storage)
 "hPR" = (
 /obj/structure/cable,
@@ -30419,11 +34847,23 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"hQg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
+"hSu" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "hSD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/turf/open/floor/iron/white,
 /area/station/medical/psychology)
 "hSL" = (
 /turf/closed/wall,
@@ -30432,6 +34872,9 @@
 /obj/machinery/atmospherics/components/binary/pump/off{
 	name = "Pure to Port";
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -30453,7 +34896,7 @@
 /obj/effect/landmark/event_spawn,
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "hUD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
@@ -30472,13 +34915,38 @@
 "hWd" = (
 /obj/structure/closet/firecloset,
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "hWD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
+"hWG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/commons/dorms)
+"hXd" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron,
+/area/station/engineering/break_room)
+"hXy" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet,
+/area/station/service/theater)
 "hXB" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -30499,11 +34967,14 @@
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/station/commons/lounge)
 "iac" = (
 /obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "iaj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -30514,6 +34985,15 @@
 /obj/structure/transit_tube/crossing/horizontal,
 /turf/open/space/basic,
 /area/space/nearstation)
+"ibN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos/office)
 "ibO" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
@@ -30526,6 +35006,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/pumproom)
+"iev" = (
+/obj/structure/sign/warning/pods/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "iew" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
@@ -30540,11 +35027,17 @@
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "ihv" = (
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
 /turf/open/floor/carpet,
 /area/station/command/meeting_room)
 "ihA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "iit" = (
 /obj/structure/window/reinforced{
@@ -30564,6 +35057,7 @@
 "ijy" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "ijN" = (
@@ -30600,10 +35094,16 @@
 /area/space/nearstation)
 "ikZ" = (
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "ilB" = (
 /obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "ilR" = (
@@ -30613,6 +35113,19 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
+"imJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet,
+/area/station/service/library)
+"imP" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "inn" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8
@@ -30637,6 +35150,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
+"iot" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/light/directional/west,
+/obj/machinery/status_display/evac/directional/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "ioA" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -30644,6 +35169,7 @@
 	name = "Containment Control";
 	req_access = list("xenobiology")
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "ipf" = (
@@ -30668,6 +35194,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"irU" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security)
 "isn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30675,10 +35207,29 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
+"isq" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/engineering/gravity_generator)
+"iuz" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "ivL" = (
 /obj/structure/transit_tube/curved{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -30687,10 +35238,27 @@
 /obj/structure/transit_tube/horizontal,
 /turf/open/space/basic,
 /area/space/nearstation)
+"ixi" = (
+/obj/structure/chair{
+	dir = 4;
+	name = "Prosecution"
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/security/courtroom)
 "iyu" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/emergency/port)
+"izD" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet,
+/area/station/service/theater)
 "iAl" = (
 /obj/machinery/door/airlock/medical{
 	name = "Morgue"
@@ -30700,7 +35268,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "iAx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -30716,8 +35284,14 @@
 /area/station/ai_monitored/command/storage/eva)
 "iCh" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
+"iCx" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "iCJ" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -30725,6 +35299,20 @@
 /obj/structure/window/reinforced,
 /turf/open/space/basic,
 /area/space/nearstation)
+"iCY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/station/science/auxlab)
+"iDw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "iDC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -30734,6 +35322,7 @@
 "iFt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "iFR" = (
@@ -30742,12 +35331,12 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
-/turf/open/floor/iron,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "tcomms-passthrough"
+	},
+/turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "iGi" = (
 /obj/machinery/computer/security/mining{
@@ -30761,6 +35350,9 @@
 /obj/structure/chair/office,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security)
 "iGF" = (
@@ -30778,6 +35370,9 @@
 /area/station/hallway/primary/central)
 "iHF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain)
 "iIa" = (
@@ -30786,8 +35381,13 @@
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/cryo)
+"iIo" = (
+/obj/structure/sign/poster/official/random/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/commons/storage/primary)
 "iIH" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -30813,6 +35413,29 @@
 /obj/structure/fluff/beach_umbrella,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
+"iKA" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/security/courtroom)
+"iMB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/commons/dorms)
+"iMU" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/station/commons/lounge)
+"iMV" = (
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "iNb" = (
 /obj/machinery/door/airlock/glass{
 	name = "Service Hall"
@@ -30824,6 +35447,23 @@
 /obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
+"iNh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
+"iNl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "iOF" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -30835,7 +35475,7 @@
 /area/station/command/heads_quarters/captain)
 "iOI" = (
 /obj/machinery/atmospherics/components/binary/tank_compressor,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "iOT" = (
 /obj/machinery/door/airlock/maintenance,
@@ -30850,12 +35490,33 @@
 /obj/structure/cable,
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/command/nuke_storage)
+"iQj" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/commons/fitness/recreation)
 "iQn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"iQq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/security/brig)
+"iSU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "iTm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -30874,6 +35535,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"iUX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "iWo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -30904,7 +35574,10 @@
 /obj/machinery/computer/department_orders/science{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "iYa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
@@ -30920,14 +35593,32 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
+"iZC" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "iZG" = (
 /obj/machinery/holopad,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
+"iZV" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron,
+/area/station/security)
 "jad" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/commons/storage/emergency/port)
+"jaB" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "jaX" = (
 /obj/structure/cable,
 /turf/open/floor/carpet,
@@ -30938,6 +35629,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"jbs" = (
+/obj/structure/chair/stool/bar/directional/east,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "jbU" = (
 /obj/effect/spawner/random/structure/crate_abandoned,
 /obj/effect/decal/cleanable/cobweb,
@@ -30951,9 +35647,8 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/science)
 "jcM" = (
-/obj/machinery/computer/mechpad,
-/turf/open/floor/iron,
-/area/station/science/robotics/mechbay)
+/turf/open/floor/iron/dark,
+/area/station/security/courtroom)
 "jcU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -30976,6 +35671,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "jfc" = (
@@ -30985,15 +35683,25 @@
 /area/station/engineering/supermatter/room)
 "jfW" = (
 /obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"jgc" = (
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "jgf" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/spawner/random/engineering/tracking_beacon,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/genetics)
 "jgu" = (
 /obj/effect/landmark/event_spawn,
@@ -31011,12 +35719,14 @@
 /obj/machinery/airalarm/directional/north{
 	locked = 0
 	},
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "jiK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "jiT" = (
@@ -31024,6 +35734,29 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/pumproom)
+"jkp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/cmo)
+"jks" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
+"jlY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "jmx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31045,13 +35778,21 @@
 /area/station/engineering/supermatter/room)
 "jpU" = (
 /obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/chair/sofa/bench,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "jpY" = (
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/white,
 /area/station/security/medical)
 "jqM" = (
 /turf/closed/wall/r_wall,
@@ -31062,6 +35803,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
+"jrE" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"jsu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
 "jtH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31083,6 +35837,20 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"jut" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/turf/open/floor/iron,
+/area/station/security/courtroom)
+"juB" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/security/prison/safe)
+"jvn" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/security/prison)
 "jvu" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/directions/engineering{
@@ -31113,6 +35881,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
+"jyt" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/commons/fitness/recreation)
 "jyv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -31125,8 +35900,28 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
+"jAi" = (
+/obj/structure/sign/poster/official/random/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/chair/sofa/bench{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"jAD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "jBq" = (
 /obj/machinery/vending/wardrobe/engi_wardrobe,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "jCg" = (
@@ -31135,8 +35930,18 @@
 /area/station/cargo/miningdock)
 "jEm" = (
 /obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
+"jEF" = (
+/obj/structure/sign/directions/vault/directional/west,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "jEN" = (
 /obj/machinery/door/airlock/external{
 	name = "Security Escape Airlock"
@@ -31153,14 +35958,38 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
+"jFJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
+"jGw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/iron,
+/area/station/commons/storage/primary)
+"jGJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "jGM" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "jHW" = (
-/obj/machinery/camera/autoname/directional/north,
-/turf/open/floor/iron,
+/obj/structure/sign/warning/radiation/rad_area{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "jId" = (
 /obj/structure/transit_tube/curved/flipped{
@@ -31169,10 +35998,23 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/hallway/primary/starboard)
+"jIx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/fluff/broken_flooring{
+	dir = 4;
+	icon_state = "singular"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
 "jIX" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 1
+	},
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
@@ -31203,14 +36045,33 @@
 /area/station/construction)
 "jLv" = (
 /obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"jMU" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "jNl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"jNT" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "jOa" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -31230,6 +36091,9 @@
 	tag = "icon-direction_med";
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "jOp" = (
@@ -31243,6 +36107,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"jQf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "jRv" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -31254,10 +36122,14 @@
 /area/station/commons/fitness/recreation/entertainment)
 "jVQ" = (
 /obj/machinery/light_switch/directional/south,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "jVZ" = (
 /obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "jWm" = (
@@ -31274,7 +36146,7 @@
 	name = "Crematorium"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/crematorium,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "jWC" = (
 /obj/structure/cable,
@@ -31286,7 +36158,12 @@
 /area/station/service/library/lounge)
 "jXj" = (
 /obj/effect/mapping_helpers/dead_body_placer,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/neutral/end{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
 /area/station/medical/morgue)
 "jXm" = (
 /obj/structure/disposalpipe/segment{
@@ -31303,8 +36180,13 @@
 /area/station/maintenance/port/fore)
 "jXO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"jXT" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "jYl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -31314,13 +36196,34 @@
 /obj/structure/cable/layer3,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"jYo" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"jYG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "jZk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"jZz" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/commons/lounge)
 "kaG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -31344,35 +36247,99 @@
 	name = "Counter Shutters Control";
 	req_access = list("kitchen")
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
+"kcF" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
+"kcL" = (
+/obj/structure/sign/poster/contraband/random/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
+"kdb" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
+"kdE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "kdW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/holopad,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
+"keE" = (
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "keV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
+"kfq" = (
+/turf/open/floor/iron/white,
+/area/station/science/lab)
+"kfz" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "kfT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/camera/autoname/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"kfX" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"kgo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "kgY" = (
 /obj/structure/table,
 /obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "khb" = (
 /obj/structure/rack,
@@ -31389,20 +36356,33 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"khs" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/turf/open/floor/iron,
+/area/station/security/execution/transfer)
 "khu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "kie" = (
 /obj/machinery/flasher/directional/west{
 	id = "Cell 2"
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "kis" = (
 /obj/machinery/photocopier,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/security)
 "kit" = (
@@ -31412,6 +36392,12 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"kiX" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security/brig)
 "kjL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31422,8 +36408,18 @@
 	network = list("tcomms");
 	pixel_x = 26
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
+"kkk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "kkp" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/plaque{
@@ -31431,20 +36427,56 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"kle" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"klj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "klw" = (
 /obj/machinery/suit_storage_unit/industrial/loader,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
+"klY" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
+"kmn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/ai_monitored/command/storage/eva)
 "kmo" = (
 /obj/machinery/computer/warrant{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "kmH" = (
 /obj/machinery/flasher/directional/west{
 	id = "Cell 1"
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "knH" = (
@@ -31454,6 +36486,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"knW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "koo" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -31467,11 +36508,26 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"kpB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/science/auxlab)
 "kpJ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/status_display/evac/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"kpK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/gravity_generator)
 "kpM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
@@ -31502,7 +36558,10 @@
 	pixel_x = 25
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/burnchamber)
 "kqF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31515,23 +36574,54 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
+"krx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/station/engineering/storage)
 "krU" = (
 /turf/open/floor/iron/recharge_floor,
 /area/station/science/robotics/mechbay)
 "krX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "ksH" = (
 /obj/structure/chair,
 /obj/structure/sign/poster/official/random/directional/north,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "ksV" = (
 /obj/machinery/camera/autoname/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/closet/firecloset,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"ksZ" = (
+/obj/structure/sign/poster/contraband/random/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/central)
+"ktp" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"ktI" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "ktU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -31554,22 +36644,51 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
+"kvW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron,
+/area/station/commons/fitness/recreation)
 "kvZ" = (
 /obj/machinery/shower{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "kwX" = (
 /obj/structure/cable,
 /obj/machinery/holopad,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
+"kza" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security/execution/transfer)
 "kzf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "kzm" = (
 /obj/structure/transit_tube/junction{
@@ -31577,6 +36696,16 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"kzs" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"kzw" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "kzH" = (
 /obj/structure/chair{
 	dir = 1
@@ -31589,21 +36718,68 @@
 /obj/effect/landmark/start/depsec/engineering,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)
+"kAe" = (
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
+/turf/open/floor/iron,
+/area/station/engineering/break_room)
 "kAu" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/courtroom)
+"kAJ" = (
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "kAQ" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/engine,
 /area/station/science/explab)
+"kBa" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
+"kBy" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/engine_smes)
 "kBH" = (
 /obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
+"kBO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/cafeteria,
+/area/station/service/kitchen)
+"kCa" = (
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/iron/white,
+/area/station/science/research)
+"kCn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "kCt" = (
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31611,8 +36787,19 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"kCA" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
+"kCF" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "kDj" = (
 /obj/machinery/light/built/directional/east,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/maintenance/department/security)
 "kDy" = (
@@ -31625,18 +36812,42 @@
 "kDF" = (
 /obj/structure/closet/bombcloset,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"kEj" = (
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/rd)
 "kEo" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/carpet,
 /area/station/service/theater)
+"kEy" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "kET" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/courtroom)
+"kFz" = (
+/obj/machinery/chem_master/condimaster{
+	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
+	name = "HoochMaster Deluxe"
+	},
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "kFB" = (
 /obj/structure/window/reinforced/plasma{
 	dir = 4
@@ -31647,26 +36858,50 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "kGP" = (
-/obj/machinery/holopad,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/gateway)
+"kHf" = (
+/turf/open/floor/iron/white,
+/area/station/security/medical)
+"kHr" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "kHJ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
 	name = "Dome"
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "kIv" = (
 /obj/effect/spawner/random/maintenance,
-/obj/effect/spawner/random/maintenance,
-/obj/structure/rack,
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "kIz" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"kJg" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron,
+/area/station/engineering/break_room)
+"kJh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "kJy" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31674,22 +36909,55 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Vault - Exterior"
 	},
+/obj/effect/turf_decal/tile/brown/opposingcorners,
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron,
 /area/station/maintenance/central)
+"kJX" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/turf/open/floor/carpet,
+/area/station/command/meeting_room)
+"kKb" = (
+/obj/structure/dresser,
+/turf/open/floor/iron/checker,
+/area/station/service/theater)
 "kKi" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/vending/wallmed/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/medical/morgue)
+"kKS" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/commons/lounge)
+"kLt" = (
+/obj/effect/turf_decal/bot_white/left,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/command/gateway)
+"kLW" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security)
 "kMe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "kMM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "kNb" = (
 /obj/structure/cable,
@@ -31702,16 +36970,37 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison)
+"kOO" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "kPC" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"kPT" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron,
+/area/station/security/brig)
 "kRv" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"kRP" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/airless,
+/area/station/maintenance/port/aft)
+"kTR" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "kUa" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31720,13 +37009,25 @@
 /area/station/cargo/office)
 "kUB" = (
 /obj/item/storage/secure/safe/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "kVa" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
+"kVb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "kVe" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -31734,6 +37035,12 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"kVE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/engine_smes)
 "kVL" = (
 /obj/structure/transit_tube/curved/flipped{
 	dir = 8
@@ -31755,13 +37062,47 @@
 "kXR" = (
 /obj/structure/sign/poster/official/random/directional/north,
 /obj/machinery/camera/autoname/directional/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"kXW" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/ai_monitored/security/armory)
 "kYr" = (
 /obj/machinery/newscaster/directional/west,
 /obj/item/kirbyplants/random,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/genetics)
+"kYx" = (
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/carpet,
+/area/station/commons/dorms)
+"kYQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "kZo" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -31772,20 +37113,46 @@
 /obj/structure/displaycase/forsale/kitchen{
 	pixel_y = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
+"kZN" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/random/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"laH" = (
+/obj/effect/landmark/navigate_destination/hydro,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "lbF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security)
+"ldu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "lfD" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Atmospherics N2 Tank"
 	},
 /turf/open/floor/engine/n2,
 /area/station/engineering/atmos)
+"lfK" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "lga" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
@@ -31793,6 +37160,7 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/vault,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "lgJ" = (
@@ -31802,6 +37170,13 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/library/lounge)
+"lhp" = (
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/office)
 "liM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31815,19 +37190,40 @@
 "liO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "liT" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/entertainment/lighter,
 /turf/open/floor/carpet,
 /area/station/hallway/secondary/entry)
+"ljE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
+"lkp" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "lkE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/secequipment,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/security)
 "lkT" = (
@@ -31835,6 +37231,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"lkW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "lkY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
@@ -31842,16 +37245,22 @@
 "llF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "llK" = (
 /obj/structure/cable,
 /obj/machinery/camera/autoname/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "llT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "lme" = (
@@ -31877,7 +37286,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "lpc" = (
 /obj/structure/lattice,
@@ -31895,6 +37304,12 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plating,
 /area/station/construction)
+"lpg" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security/brig)
 "lrC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -31905,7 +37320,8 @@
 /area/station/engineering/supermatter/room)
 "lso" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "ltG" = (
 /obj/structure/disposalpipe/segment{
@@ -31928,8 +37344,35 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /obj/effect/mapping_helpers/airlock/access/any/science/genetics,
 /obj/effect/mapping_helpers/airlock/access/any/medical/general,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"lwD" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
+"lwF" = (
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/station/engineering/main)
+"lxj" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "lzC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31946,6 +37389,16 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
+"lAf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "lAC" = (
 /obj/structure/chair/stool/directional/east,
 /turf/open/floor/plating,
@@ -31955,6 +37408,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"lAV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/pharmacy)
 "lBw" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
@@ -31962,7 +37421,10 @@
 "lBR" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "lCe" = (
 /obj/structure/disposalpipe/segment{
@@ -31976,7 +37438,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "lDn" = (
 /obj/structure/bed/double{
@@ -31988,20 +37450,28 @@
 	},
 /turf/open/floor/wood,
 /area/station/commons/dorms)
+"lDt" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "lDI" = (
 /obj/structure/table,
 /obj/item/surgical_drapes,
 /obj/item/razor,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "lFy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "lFz" = (
-/obj/machinery/light/small/directional/south,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "lHb" = (
@@ -32015,12 +37485,20 @@
 "lHD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/holopad,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/cryo)
+"lHM" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 8
+	},
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "lIC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "lIG" = (
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
@@ -32036,22 +37514,38 @@
 "lJL" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
 "lKn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/security)
+"lLh" = (
+/obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "lNe" = (
 /obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/purple/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "lPi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "lPy" = (
 /obj/structure/cable,
@@ -32067,6 +37561,9 @@
 "lPC" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "lPM" = (
@@ -32085,17 +37582,32 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white,
 /area/station/medical/storage)
+"lRP" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "lSc" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"lSH" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "lTU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "lUl" = (
@@ -32117,37 +37629,65 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
+"lVR" = (
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "lWs" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
 	name = "engineering security door"
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"lWw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/station/command/gateway)
 "lWL" = (
 /turf/open/space/basic,
 /area/space)
+"lXd" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/carpet,
+/area/station/command/meeting_room)
 "lXv" = (
 /obj/machinery/requests_console{
 	department = "Medbay";
 	name = "Medbay RC";
 	pixel_y = -30
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/storage)
 "lYn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "lYC" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
+"lYK" = (
+/obj/effect/turf_decal/tile/purple/opposingcorners{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "lYT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32172,18 +37712,52 @@
 	},
 /obj/machinery/light/small/directional/west,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/diagonal_centre,
+/obj/effect/turf_decal/tile/blue/diagonal_edge,
+/turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
+"mcV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"mdG" = (
+/obj/structure/table,
+/obj/item/storage/dice,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
+"meE" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "meR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"meU" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "mfp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "mfA" = (
@@ -32192,9 +37766,16 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"mfG" = (
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "mgf" = (
 /obj/machinery/gulag_item_reclaimer{
 	pixel_y = 24
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
@@ -32238,13 +37819,16 @@
 /obj/item/stack/package_wrap{
 	pixel_y = 5
 	},
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "mhe" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
 "mhI" = (
 /obj/effect/landmark/start/hangover,
@@ -32253,8 +37837,20 @@
 "mhW" = (
 /obj/effect/landmark/start/prisoner,
 /obj/machinery/airalarm/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/toilet/greyscale{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
+"miD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "mjZ" = (
 /obj/machinery/atmospherics/components/binary/pump/off{
 	name = "Port to Air";
@@ -32267,6 +37863,9 @@
 	announcementConsole = 1;
 	department = "Bridge";
 	name = "Bridge Requests Console"
+	},
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
@@ -32282,18 +37881,24 @@
 	cycle_id = "medbay-passthrough"
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white,
 /area/station/medical/psychology)
 "mmE" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 2";
 	name = "Cell 2 Locker"
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "mna" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "mnk" = (
@@ -32302,16 +37907,38 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"mnz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/ai_monitored/security/armory)
 "mnO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter)
+"moH" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/commons/storage/primary)
 "moZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
 /area/station/science/robotics/lab)
+"mpf" = (
+/obj/machinery/bluespace_vendor/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
 "mpA" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -32322,22 +37949,55 @@
 /obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
+"mqT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_blue/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/science/research)
+"mrb" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "mrA" = (
 /obj/machinery/computer/prisoner/gulag_teleporter_computer{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/security/processing)
 "mrV" = (
 /obj/machinery/door/firedoor,
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "msY" = (
 /obj/machinery/light_switch/directional/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
+"mtO" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/security/brig)
+"mtV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "muT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32345,6 +38005,7 @@
 /area/station/command/heads_quarters/captain/private)
 "mvk" = (
 /obj/machinery/holopad,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "mvx" = (
@@ -32358,19 +38019,38 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "mwp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter)
+"mww" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security/execution/transfer)
 "mwG" = (
 /obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
+"mwP" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "mxi" = (
 /obj/machinery/light/directional/west,
 /obj/structure/sign/departments/medbay/alt/directional/west,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "mxz" = (
@@ -32381,6 +38061,9 @@
 /area/station/command/bridge)
 "mxO" = (
 /obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "mxV" = (
@@ -32394,12 +38077,42 @@
 	pixel_x = -3;
 	pixel_y = -3
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/storage)
-"myP" = (
-/obj/machinery/modular_computer/console/preset/cargochat/engineering{
-	dir = 1
+"myb" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
+/turf/open/floor/iron,
+/area/station/security/checkpoint/escape)
+"myt" = (
+/obj/structure/sign/poster/contraband/random/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
+"myF" = (
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
+"myL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
+"myP" = (
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "mAh" = (
@@ -32410,6 +38123,50 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"mBd" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/sign/poster/official/high_class_martini{
+	pixel_y = -32
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"mCv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"mCw" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
+"mDr" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"mDO" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
+"mDX" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "mEi" = (
 /obj/effect/landmark/start/roboticist,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32419,12 +38176,19 @@
 /area/station/science/robotics/mechbay)
 "mEJ" = (
 /obj/machinery/holopad,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security)
 "mGm" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter)
+"mGN" = (
+/obj/structure/sink/kitchen{
+	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
+	name = "old sink"
+	},
+/turf/open/floor/iron,
+/area/station/security/prison)
 "mHj" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32439,6 +38203,10 @@
 	dir = 1
 	},
 /area/station/service/chapel)
+"mHV" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "mIl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32455,6 +38223,20 @@
 "mIV" = (
 /turf/closed/wall,
 /area/station/medical/medbay/central)
+"mJz" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/filled/corner,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
+"mMb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "mMC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -32472,6 +38254,9 @@
 /area/station/service/cafeteria)
 "mMH" = (
 /obj/structure/sign/departments/court/directional/north,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "mNG" = (
@@ -32486,8 +38271,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"mOC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "mQw" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
@@ -32496,16 +38294,69 @@
 "mRP" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/brown/half/contrasted,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"mTy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/station/engineering/main)
+"mTI" = (
+/obj/machinery/button/door{
+	id = "Skynet_launch";
+	name = "Mech Bay Shutters";
+	pixel_y = -26;
+	req_access = list("robotics")
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron,
+/area/station/science/robotics/mechbay)
+"mUp" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/sign/directions/science/directional/east{
+	dir = 2
+	},
+/obj/structure/sign/directions/supply/directional/east{
+	dir = 2;
+	pixel_y = 8
+	},
+/obj/structure/sign/directions/vault/directional/east{
+	pixel_y = -8;
+	dir = 2
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "mUJ" = (
 /obj/structure/window/fulltile,
 /turf/open/floor/plating,
 /area/station/service/library/lounge)
 "mVS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"mWc" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/commons/fitness/recreation)
+"mWo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "mWC" = (
 /obj/structure/table,
 /obj/item/pipe_dispenser{
@@ -32513,7 +38364,8 @@
 	pixel_y = 7
 	},
 /obj/item/pipe_dispenser,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/office)
 "mWE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32530,18 +38382,29 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/effect/mapping_helpers/airlock/access/any/supply/vault,
+/obj/effect/turf_decal/tile/brown/opposingcorners,
+/turf/open/floor/iron,
 /area/station/maintenance/central)
 "mXu" = (
 /obj/item/wrench,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"mXU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/chair/stool/bar/directional/south,
+/turf/open/floor/iron,
+/area/station/commons/lounge)
 "mYJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "mYR" = (
 /obj/structure/safe,
@@ -32563,7 +38426,11 @@
 /obj/item/stack/spacecash/c500,
 /obj/item/stack/spacecash/c500,
 /obj/item/gun/ballistic/automatic/pistol/deagle,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot_white/left,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "mYZ" = (
 /obj/structure/disposalpipe/segment{
@@ -32574,6 +38441,28 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"nab" = (
+/obj/structure/closet/crate,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet,
+/area/station/commons/dorms)
+"naE" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"naS" = (
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "naU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32589,7 +38478,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /obj/machinery/door/firedoor/heavy,
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/ordnance)
 "ncu" = (
 /obj/machinery/door/airlock/medical{
@@ -32598,13 +38487,26 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "ncA" = (
 /obj/machinery/light/directional/south,
 /obj/structure/sign/poster/official/random/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"ncE" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "ncQ" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/cargo_gauntlet{
@@ -32614,11 +38516,15 @@
 /obj/item/clothing/gloves/cargo_gauntlet{
 	pixel_y = 3
 	},
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "ncU" = (
 /obj/machinery/suit_storage_unit/standard_unit,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "ndz" = (
 /obj/machinery/door/firedoor,
@@ -32645,6 +38551,10 @@
 /area/station/service/hydroponics/garden)
 "neN" = (
 /obj/structure/sign/poster/official/random/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "neY" = (
@@ -32681,16 +38591,30 @@
 /area/station/medical/psychology)
 "ngx" = (
 /obj/machinery/holopad,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
+"ngT" = (
+/obj/machinery/camera/autoname/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/engineering/gravity_generator)
 "ngV" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "nhn" = (
 /mob/living/carbon/human/species/monkey/punpun,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/bar)
+"nhS" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "nig" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -32701,6 +38625,9 @@
 "nil" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
@@ -32713,6 +38640,19 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
+"njz" = (
+/obj/structure/cable,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/chair/stool{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/end{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security/warden)
 "nko" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -32724,6 +38664,13 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"nlW" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/chair/sofa/bench/right,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "nmh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -32731,6 +38678,12 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"nnB" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "nnI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32741,7 +38694,16 @@
 /obj/machinery/camera/autoname/directional/west{
 	network = list("ss13","medbay")
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/genetics)
 "nnT" = (
 /obj/structure/cable,
@@ -32753,6 +38715,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"nol" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "noN" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
@@ -32776,6 +38745,10 @@
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
+"nqM" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/cafeteria,
+/area/station/service/kitchen)
 "nrc" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -32798,7 +38771,7 @@
 /area/station/maintenance/central)
 "nsh" = (
 /obj/structure/chair/office,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/escape)
 "nsH" = (
 /obj/machinery/door/firedoor,
@@ -32819,6 +38792,18 @@
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
+"nsW" = (
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/rd)
+"ntR" = (
+/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "ntU" = (
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Antechamber"
@@ -32829,10 +38814,29 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"nui" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "num" = (
 /obj/effect/landmark/start/station_engineer,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"nuJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/iron,
+/area/station/security/brig)
 "nuY" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -32849,26 +38853,59 @@
 /area/space/nearstation)
 "nwT" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/genetics)
+"nxj" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/button/flasher{
+	id = "secentranceflasher";
+	name = "Brig Entrance Flasher";
+	req_access = list("security");
+	pixel_x = 26;
+	pixel_y = 26
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security/warden)
 "nxx" = (
 /obj/machinery/computer/bank_machine,
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "nxU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "nxY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"nym" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "nyw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -32882,6 +38919,15 @@
 /obj/structure/statue/sandstone/assistant,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
+"nBj" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "nCg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32911,6 +38957,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"nDx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/command)
 "nDQ" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/transit_tube/diagonal,
@@ -32918,8 +38973,22 @@
 /area/space/nearstation)
 "nEK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"nFV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"nGK" = (
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron,
+/area/station/engineering/gravity_generator)
 "nHa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/machinery/meter,
@@ -32927,23 +38996,48 @@
 /area/station/engineering/supermatter/room)
 "nHr" = (
 /obj/machinery/modular_computer/console/preset/cargochat/medical,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"nHF" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/green/half/contrasted,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "nIy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"nJf" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
+"nJE" = (
+/obj/machinery/holopad,
+/turf/open/floor/iron,
+/area/station/service/theater)
 "nKs" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/holopad,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
+"nKS" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/station/service/library)
 "nLx" = (
 /obj/structure/chair{
 	dir = 8
@@ -32951,12 +39045,24 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
+"nLG" = (
+/obj/effect/landmark/start/hangover,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "nLR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
+"nMj" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security)
 "nMm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32965,11 +39071,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/chair/stool/bar/directional/south,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/station/service/bar)
+/area/station/commons/lounge)
+"nMp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/turf/open/floor/iron,
+/area/station/security/brig)
 "nMq" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance,
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "nMD" = (
@@ -32996,16 +39110,40 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/holopad,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/teleporter)
 "nMM" = (
 /obj/machinery/holopad/secure,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain)
+"nMR" = (
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "nNJ" = (
 /obj/effect/landmark/start/depsec/engineering,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)
+"nNK" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"nOm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "nOZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -33017,13 +39155,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "nQf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/explab)
 "nRa" = (
 /obj/structure/cable,
@@ -33046,9 +39188,31 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"nTl" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "nTF" = (
 /turf/open/floor/plating,
 /area/station/security/execution/transfer)
+"nTG" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/station/ai_monitored/security/armory)
+"nUg" = (
+/obj/machinery/modular_computer/console/preset/cargochat/security{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/red/filled/warning{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/station/security/brig)
 "nUx" = (
 /obj/structure/bed,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -33073,6 +39237,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
+"nVv" = (
+/obj/machinery/airalarm/directional/north,
+/obj/effect/spawner/random/structure/closet_private,
+/obj/item/clothing/head/wig/natural{
+	hairstyle = "Mohawk (Unshaven)";
+	icon_state = "hair_unshaven_mohawk";
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/station/commons/dorms)
 "nWr" = (
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -33082,12 +39256,33 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
+"nXo" = (
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "nYi" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 10
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/dark_blue/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/research)
+"oas" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"oaR" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple/full,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/science/xenobiology)
 "oaU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33095,7 +39290,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "oaZ" = (
 /obj/machinery/door/airlock/external{
@@ -33113,8 +39308,21 @@
 	name = "Chief Engineer's Requests Console"
 	},
 /obj/machinery/pdapainter/engineering,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
+"obq" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/carpet,
+/area/station/commons/dorms)
+"ocD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "ocE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33122,6 +39330,13 @@
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"ocF" = (
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/rd)
 "ocI" = (
 /obj/machinery/power/emitter/welded{
 	dir = 8
@@ -33129,6 +39344,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"odJ" = (
+/obj/machinery/vending/wallmed/directional/south,
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "odN" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/camera/emp_proof/directional/south{
@@ -33143,8 +39363,9 @@
 /area/station/engineering/supermatter/room)
 "oeb" = (
 /obj/machinery/holopad,
-/turf/open/floor/iron,
-/area/station/service/bar)
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "oed" = (
 /obj/machinery/door/airlock/external,
 /obj/structure/cable,
@@ -33156,10 +39377,21 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"oey" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/engineering/gravity_generator)
 "oeA" = (
 /obj/structure/flora/bush/flowers_yw/style_3,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
+"oeQ" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "ofb" = (
 /obj/machinery/camera/emp_proof{
 	c_tag = "Engineering - Emitter Room East";
@@ -33169,6 +39401,9 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"ofl" = (
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "ohc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33179,8 +39414,19 @@
 	req_access = list("theatre");
 	pixel_x = -24
 	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/service/theater)
+"oir" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/tcommsat/computer)
 "oiG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall,
@@ -33191,10 +39437,23 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"ojV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/security)
+"okT" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "olh" = (
 /obj/item/kirbyplants/random,
 /obj/structure/sign/departments/medbay/alt/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "olv" = (
 /obj/structure/cable,
@@ -33204,7 +39463,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "olW" = (
 /obj/structure/cable,
@@ -33227,9 +39486,24 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"oni" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security/warden)
 "onE" = (
 /obj/structure/cable,
 /obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/security/prison)
 "onH" = (
@@ -33238,10 +39512,41 @@
 	},
 /turf/open/floor/carpet,
 /area/station/service/chapel)
+"ooJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/computer/security/telescreen/entertainment,
+/turf/closed/wall,
+/area/station/commons/lounge)
+"opp" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/chair/sofa/bench/left,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"opr" = (
+/obj/structure/window{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
 "oqG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/courtroom)
+"org" = (
+/obj/effect/turf_decal/bot_white/left,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/engineering/gravity_generator)
 "oty" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 1
@@ -33268,16 +39573,23 @@
 "ouh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "ouR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
+"ouX" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "oxs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33287,8 +39599,15 @@
 	req_access = list("theatre");
 	pixel_x = 24
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/checker,
 /area/station/service/theater)
+"ozo" = (
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "ozp" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
@@ -33301,6 +39620,13 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"oAq" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "oBj" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -33314,6 +39640,18 @@
 /obj/machinery/holopad,
 /turf/open/floor/carpet/red,
 /area/station/cargo/qm)
+"oBv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/station/science/robotics/lab)
+"oBD" = (
+/obj/effect/spawner/random/maintenance,
+/obj/effect/spawner/random/structure/table_or_rack,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "oCl" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron,
@@ -33322,7 +39660,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
 "oDn" = (
 /obj/machinery/door/poddoor/shutters{
@@ -33344,12 +39682,18 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "oFn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "oFp" = (
@@ -33362,7 +39706,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "oFB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33381,6 +39725,23 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"oHd" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"oIx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
+"oIJ" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "oIK" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
@@ -33389,6 +39750,13 @@
 /obj/structure/table,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
+"oJj" = (
+/obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "oJW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -33410,7 +39778,7 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "oLC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33428,6 +39796,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
+"oMO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
 "oMQ" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge"
@@ -33447,28 +39824,70 @@
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"oNK" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/gravity_generator)
+"oOf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
+"oOx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/science/auxlab)
+"oPs" = (
+/obj/machinery/flasher/portable,
+/obj/machinery/flasher/portable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/ai_monitored/security/armory)
 "oPF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/service/bar)
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "oPW" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/white,
 /area/station/security/medical)
 "oQb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/explab)
+"oRI" = (
+/obj/structure/sign/poster/official/wtf_is_co2,
+/turf/closed/wall,
+/area/station/hallway/primary/central)
 "oRU" = (
 /obj/structure/cable,
 /obj/machinery/holopad,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/server)
 "oSj" = (
 /obj/structure/table/reinforced,
@@ -33487,6 +39906,9 @@
 /area/station/service/hydroponics)
 "oSH" = (
 /obj/structure/sign/departments/lawyer/directional/north,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "oSJ" = (
@@ -33499,6 +39921,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "oTK" = (
@@ -33510,6 +39935,9 @@
 /area/station/medical/abandoned)
 "oTZ" = (
 /obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "oUZ" = (
@@ -33531,12 +39959,27 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"oWh" = (
+/obj/effect/turf_decal/tile/neutral/diagonal_centre,
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "oXJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/turf/open/floor/iron/white,
 /area/station/medical/psychology)
+"oXV" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security/brig)
 "oYp" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/carpet/red,
@@ -33553,6 +39996,7 @@
 "oZR" = (
 /obj/structure/grille/broken,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "pac" = (
@@ -33571,12 +40015,13 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "paW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/maintenance/department/security)
 "paY" = (
@@ -33604,8 +40049,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/chair/stool/bar/directional/south,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/station/service/bar)
+/area/station/commons/lounge)
 "pcn" = (
 /obj/structure/window/reinforced/plasma{
 	dir = 8
@@ -33641,28 +40088,84 @@
 /obj/structure/sign/directions/science{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"peu" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "pfz" = (
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "pgc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
+"pgm" = (
+/obj/machinery/computer/mechpad{
+	dir = 1
+	},
+/turf/open/floor/circuit/green,
+/area/station/science/robotics/mechbay)
 "pgx" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
+"pgM" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "pgS" = (
 /obj/machinery/holopad,
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
+"phj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"pig" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"piN" = (
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "piS" = (
 /obj/machinery/light/small/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/turf/open/floor/iron/white,
 /area/station/medical/psychology)
 "pjI" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
@@ -33671,12 +40174,44 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"pkp" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
+"pkC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/chair/stool/bar/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/commons/lounge)
 "pkW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/construction)
+"plS" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security/brig)
+"pmc" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "pmF" = (
 /obj/structure/transit_tube/curved{
 	dir = 4
@@ -33687,22 +40222,35 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/turf/open/floor/iron/white,
 /area/station/medical/psychology)
 "pnt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/genetics)
 "ppM" = (
 /obj/structure/cable/multilayer/connected,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
+"ppY" = (
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 4
+	},
+/obj/machinery/smartfridge/organ,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "pqm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white/corner{
+	dir = 8
+	},
 /area/station/medical/medbay/lobby)
 "pqA" = (
 /obj/machinery/atmospherics/components/binary/pump/off{
@@ -33716,6 +40264,7 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "pqV" = (
@@ -33725,6 +40274,15 @@
 	},
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
+"prz" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "prW" = (
 /obj/structure/transit_tube/crossing,
 /obj/structure/cable,
@@ -33749,20 +40307,27 @@
 /obj/structure/transit_tube/station/dispenser{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "pwd" = (
 /obj/structure/bed/roller,
 /obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "pyB" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "pzm" = (
 /obj/machinery/camera/autoname/directional/east,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "pAo" = (
@@ -33780,10 +40345,26 @@
 "pCv" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/bot,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"pCP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "pDY" = (
 /obj/machinery/rnd/production/techfab/department/security,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/security)
 "pEm" = (
@@ -33797,6 +40378,11 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"pFs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron/white,
+/area/station/science/auxlab)
 "pFL" = (
 /obj/machinery/holopad/secure,
 /turf/open/floor/iron/dark,
@@ -33819,7 +40405,10 @@
 "pHv" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/science/lab)
 "pIf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33829,12 +40418,26 @@
 /area/station/security/brig)
 "pIx" = (
 /obj/machinery/holopad,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "pKr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"pKx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/iron,
+/area/station/commons/storage/primary)
+"pLN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "pLR" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -33847,25 +40450,75 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
+"pMl" = (
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
+"pMu" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
+"pNh" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/turf/open/floor/iron,
+/area/station/security/brig)
+"pNn" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"pNI" = (
+/obj/effect/turf_decal/siding/purple/corner,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/rd)
 "pON" = (
 /obj/structure/grille,
 /obj/structure/window/fulltile,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/storage)
+"pOS" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/commons/dorms)
+"pPs" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "pPt" = (
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/grass,
-/area/station/medical/virology)
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "pPD" = (
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/escape)
 "pQd" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "pQE" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer2{
@@ -33901,10 +40554,23 @@
 /obj/structure/cable,
 /obj/item/radio/intercom/directional/south,
 /obj/machinery/camera/autoname/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"pSa" = (
+/obj/structure/chair{
+	name = "Judge"
+	},
+/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security/courtroom)
 "pSe" = (
 /obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "pSA" = (
@@ -33916,19 +40582,40 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
+"pSF" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "pTN" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/chemistry{
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "pTO" = (
 /obj/effect/landmark/start/cook,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
+"pUe" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/obey{
+	pixel_y = -32
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "pUk" = (
 /obj/effect/landmark/start/lawyer,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33936,12 +40623,51 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
+"pUG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
+"pUU" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/sign/directions/supply/directional/west{
+	pixel_y = 12;
+	dir = 1
+	},
+/obj/structure/sign/directions/science/directional/west{
+	pixel_y = 5;
+	dir = 1
+	},
+/obj/structure/sign/directions/security/directional/west{
+	pixel_y = -2
+	},
+/obj/structure/sign/directions/vault/directional/west{
+	dir = 1;
+	pixel_y = -9
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "pVW" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/meter,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"pXx" = (
+/obj/structure/sign/poster/official/safety_eye_protection{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "pXJ" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/box/white{
@@ -33957,6 +40683,7 @@
 	dir = 4
 	},
 /obj/machinery/defibrillator_mount/directional/west,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "pYa" = (
@@ -33967,7 +40694,8 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "pYG" = (
 /obj/structure/girder,
@@ -33977,40 +40705,96 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
 /area/station/engineering/storage/tcomms)
+"pZe" = (
+/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "pZj" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"pZJ" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"qaw" = (
+/obj/machinery/chem_heater{
+	pixel_x = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/pharmacy)
 "qaU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
+"qbz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
+"qbN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white/textured,
+/area/station/science/research)
+"qbO" = (
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "qce" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/floor,
+/obj/effect/turf_decal/tile/brown/opposingcorners,
 /turf/open/floor/iron,
 /area/station/maintenance/central)
 "qcS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "qdz" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
 "qeB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "qeX" = (
 /obj/structure/cable,
@@ -34019,8 +40803,42 @@
 /area/station/service/library/lounge)
 "qfq" = (
 /obj/structure/closet/l3closet/scientist,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/command/gateway)
+"qfE" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/commons/storage/primary)
+"qfK" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/station/science/auxlab)
+"qgj" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
+"qgE" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/left/directional/west{
+	name = "Genetics Desk";
+	req_access = list("genetics");
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
 "qhw" = (
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 4
@@ -34033,14 +40851,24 @@
 /obj/structure/cable/layer3,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"qiU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "qjk" = (
 /obj/machinery/atmospherics/components/binary/valve/digital,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "qjl" = (
 /obj/machinery/restaurant_portal/restaurant,
-/turf/open/floor/iron,
-/area/station/service/bar)
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "qkc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -34061,10 +40889,25 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"qli" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/newscaster/directional/north,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "qlC" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"qnG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "qoh" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
@@ -34085,6 +40928,16 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"qpc" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/service/bar)
+"qpp" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "qpq" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -34094,6 +40947,13 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"qpv" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "qqK" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
@@ -34113,16 +40973,38 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
+"qts" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/power/apc/auto_name/directional/west,
+/turf/open/floor/wood,
+/area/station/service/bar)
+"qtK" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/turf/open/floor/iron,
+/area/station/security/execution/transfer)
 "qtV" = (
 /obj/structure/transit_tube/diagonal,
 /turf/open/space/basic,
 /area/space/nearstation)
+"qvN" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "qvO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/spawner/random/engineering/tracking_beacon,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
+"qwi" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "qwj" = (
 /obj/machinery/door/airlock/engineering/glass{
@@ -34148,6 +41030,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"qxa" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security/brig)
 "qxg" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
@@ -34184,13 +41073,26 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security)
+"qyM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "qzm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "qzx" = (
 /obj/structure/disposalpipe/segment,
@@ -34198,6 +41100,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "qzy" = (
@@ -34216,28 +41121,47 @@
 "qBy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "qBT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"qCa" = (
+/turf/open/floor/iron/dark,
+/area/station/security)
 "qCf" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/station/construction)
 "qCk" = (
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "qCy" = (
 /obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "qCT" = (
 /obj/machinery/light/directional/south,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "qCX" = (
@@ -34246,6 +41170,22 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"qDj" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
+"qDO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "qEo" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -34275,10 +41215,24 @@
 /obj/effect/landmark/navigate_destination/dockescpod1,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"qHe" = (
+/obj/effect/landmark/start/hangover,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "qHy" = (
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/teleporter)
+"qHB" = (
+/obj/effect/turf_decal/siding/purple,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/rd)
 "qHQ" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -34286,8 +41240,22 @@
 /area/station/solars/port/aft)
 "qIs" = (
 /obj/structure/closet/secure_closet/security/sec,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
 /area/station/security/lockers)
+"qIO" = (
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
+"qJa" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "qJk" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron,
@@ -34305,6 +41273,9 @@
 /area/station/hallway/primary/port)
 "qJU" = (
 /obj/machinery/light/directional/west,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "qKi" = (
@@ -34324,10 +41295,25 @@
 /obj/machinery/skill_station,
 /turf/open/floor/wood,
 /area/station/service/library/lounge)
+"qKP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/security)
 "qLF" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"qLL" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/ai_monitored/command/storage/eva)
 "qMe" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -34335,7 +41321,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/navigate_destination,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "qNt" = (
@@ -34346,7 +41332,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "qPO" = (
 /obj/structure/chair/stool/directional/east,
@@ -34354,6 +41340,9 @@
 /area/station/maintenance/aft)
 "qQJ" = (
 /obj/machinery/camera/autoname/directional/west,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "qQK" = (
@@ -34363,25 +41352,56 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"qRE" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "qTH" = (
 /obj/structure/sign/departments/psychology/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "qUP" = (
 /obj/structure/cable,
 /obj/structure/fireaxecabinet/directional/south,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"qWP" = (
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
 "qWR" = (
 /obj/structure/disposalpipe/segment,
 /obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"qXh" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/chair/sofa/bench/left{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "qXt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /mob/living/simple_animal/pet/dog/pug/mcgriff,
 /obj/structure/bed/dogbed/mcgriff,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security/warden)
 "qXH" = (
@@ -34394,18 +41414,46 @@
 	},
 /turf/open/floor/plating,
 /area/station/cargo/storage)
+"qYg" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
+"qYs" = (
+/obj/machinery/dna_scannernew,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
 "qYD" = (
 /obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "qZf" = (
 /obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
+"raE" = (
+/obj/effect/decal/cleanable/oil,
+/obj/structure/sign/poster/contraband/random/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
 "raH" = (
 /obj/machinery/atmospherics/components/binary/pump/off{
 	name = "Air to Port";
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -34420,11 +41468,28 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/security/processing)
+"rbo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "rcw" = (
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
+"rcB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "rcW" = (
 /obj/machinery/holopad,
 /turf/open/floor/wood,
@@ -34435,13 +41500,33 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"rdw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
+"rdC" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/security/execution/transfer)
 "rdQ" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/structure/sign/poster/official/wtf_is_co2{
 	pixel_y = -32
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
+"rfG" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "rfL" = (
 /obj/machinery/door/airlock/external{
 	name = "Auxiliary Dock"
@@ -34450,11 +41535,21 @@
 /obj/effect/landmark/navigate_destination/dockaux,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"rga" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/ce)
 "rgL" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"rgN" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "rgR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34465,19 +41560,45 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"rjj" = (
-/obj/machinery/door/airlock/external{
-	name = "Mining Dock Airlock"
+"rhJ" = (
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
+"rjj" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"rjm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/cargo/miningdock)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security/execution/transfer)
 "rjn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"rjN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "rkD" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/maintenance,
@@ -34492,6 +41613,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
+"rkP" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "rme" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
@@ -34500,15 +41628,30 @@
 /obj/vehicle/ridden/secway,
 /obj/item/key/security,
 /obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security)
+"rmQ" = (
+/obj/effect/turf_decal/trimline/dark_blue/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "rnx" = (
 /obj/machinery/rnd/production/techfab/department/cargo,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "rnQ" = (
 /obj/item/kirbyplants/random,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "rpI" = (
 /obj/structure/cable,
@@ -34521,13 +41664,31 @@
 /area/station/service/hydroponics)
 "rpT" = (
 /obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"rqu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "rra" = (
 /obj/effect/landmark/start/scientist,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/explab)
+"rrh" = (
+/obj/structure/sign/poster/contraband/random/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "rro" = (
 /obj/effect/mapping_helpers/ianbirthday,
 /turf/open/floor/wood,
@@ -34545,6 +41706,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
+"rsF" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"rtl" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "rum" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
 	dir = 8
@@ -34560,6 +41732,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"ruZ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/storage)
+"rvb" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/surgery/theatre)
 "rvo" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L12"
@@ -34575,6 +41759,13 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/cargo/qm)
+"rxw" = (
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/commons/fitness/recreation)
 "rxM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -34644,8 +41835,20 @@
 "rBl" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"rBK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security/brig)
 "rBM" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
@@ -34664,6 +41867,11 @@
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/wood,
 /area/station/service/library)
+"rEp" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "rEL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34675,6 +41883,14 @@
 /obj/item/canvas/twentythree_twentythree,
 /turf/open/floor/wood,
 /area/station/service/library/lounge)
+"rFq" = (
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
+/area/station/science/explab)
+"rFO" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/turf/open/floor/iron,
+/area/station/security/brig)
 "rFV" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -34682,8 +41898,25 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
+"rGq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/break_room)
+"rGz" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "rGN" = (
-/obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
 "rHE" = (
@@ -34695,6 +41928,12 @@
 /area/space/nearstation)
 "rIp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "rIM" = (
@@ -34709,14 +41948,29 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"rJj" = (
+/obj/machinery/chem_dispenser,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/pharmacy)
 "rJk" = (
 /obj/machinery/vending/wardrobe/hydro_wardrobe,
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "rKT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "rLd" = (
 /obj/machinery/disposal/bin,
@@ -34725,6 +41979,21 @@
 	},
 /turf/open/floor/wood,
 /area/station/cargo/qm)
+"rLo" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
+"rML" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/commons/fitness/recreation)
 "rNb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -34736,6 +42005,10 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"rNh" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/grass,
+/area/station/medical/virology)
 "rOb" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
 	dir = 8
@@ -34745,6 +42018,12 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"rOf" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "rOi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34754,10 +42033,29 @@
 /obj/effect/spawner/random/bureaucracy/pen,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
+"rON" = (
+/obj/machinery/light/directional/east,
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "rPf" = (
 /obj/structure/chair/stool/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
+"rPh" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "rSm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/structure/cable,
@@ -34767,14 +42065,35 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/circuit/green,
 /area/station/science/robotics/mechbay)
+"rUc" = (
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "rUA" = (
-/obj/structure/closet/firecloset/full,
+/obj/structure/closet/firecloset,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "rUO" = (
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/bar)
+"rVw" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"rVK" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "rVS" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -34785,6 +42104,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
+"rXp" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/iron/white,
+/area/station/science/research)
+"rXt" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "rXU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34816,7 +42144,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "sap" = (
 /obj/item/radio/intercom/directional/north,
@@ -34826,8 +42154,29 @@
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/white,
 /area/station/security/medical)
+"sby" = (
+/obj/structure/cable,
+/obj/effect/landmark/navigate_destination,
+/obj/effect/turf_decal/tile/green/half/contrasted,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
+"sbC" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
+"sdj" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/iron/dark,
+/area/station/tcommsat/computer)
 "seT" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Atmospherics CO2 Tank"
@@ -34848,13 +42197,28 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
+"sfB" = (
+/obj/machinery/chem_master{
+	pixel_x = -2
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/pharmacy)
+"sfL" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "sgf" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation)
 "sgQ" = (
 /obj/machinery/camera/autoname/directional/west,
@@ -34876,7 +42240,9 @@
 /area/station/hallway/primary/central)
 "siK" = (
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/diagonal_centre,
+/obj/effect/turf_decal/tile/blue/diagonal_edge,
+/turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "siP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34889,13 +42255,22 @@
 /area/station/commons/dorms)
 "sjk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/auxlab)
 "sjn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/iv_drip,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"sjM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/command/gateway)
 "sjP" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark/telecomms,
@@ -34928,8 +42303,27 @@
 /area/station/hallway/primary/central)
 "slb" = (
 /obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
+"slu" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron,
+/area/station/ai_monitored/security/armory)
+"slJ" = (
+/obj/machinery/iv_drip,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
+"slM" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "slQ" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
@@ -34939,6 +42333,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"smz" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/station/command/heads_quarters/captain)
 "smC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /turf/open/floor/iron,
@@ -34950,6 +42350,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
 /turf/open/floor/carpet,
 /area/station/command/meeting_room)
 "spB" = (
@@ -34967,6 +42370,18 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/security/brig)
+"srK" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
+"srV" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "ssi" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -34974,7 +42389,20 @@
 	name = "research lab shutters"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/trimline/purple/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/lab)
+"ste" = (
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/science/lab)
 "stp" = (
 /turf/open/floor/carpet,
@@ -34984,6 +42412,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"suc" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "svt" = (
 /obj/structure/chair{
 	dir = 1
@@ -34995,6 +42429,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "svB" = (
@@ -35024,6 +42461,9 @@
 "swt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/security/prison)
 "swx" = (
@@ -35043,12 +42483,25 @@
 "sxD" = (
 /obj/structure/chair,
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "sxX" = (
 /obj/effect/landmark/navigate_destination/dockesc,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"syA" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "syC" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -35069,6 +42522,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"szo" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/structure/sign/directions/vault/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "sAj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -35082,16 +42543,42 @@
 /area/station/science/robotics/mechbay)
 "sAV" = (
 /obj/machinery/oven,
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "sBq" = (
 /obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
+"sBQ" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"sCP" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "sCV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/service/chapel/funeral)
+"sDv" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "sDI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35124,10 +42611,25 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"sGn" = (
+/obj/item/grenade/barrier,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/ai_monitored/security/armory)
 "sGt" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"sGV" = (
+/obj/effect/turf_decal/trimline/neutral/end{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
+/area/station/medical/morgue)
 "sGW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35135,6 +42637,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
+"sHy" = (
+/obj/structure/lattice,
+/obj/structure/sign/warning/docking/directional/east,
+/turf/open/space/basic,
+/area/space/nearstation)
 "sHI" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office"
@@ -35143,12 +42650,30 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
+"sHX" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/fluff/broken_flooring{
+	dir = 4;
+	icon_state = "singular"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
 "sIA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
+"sJb" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "sJL" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall,
@@ -35184,6 +42709,7 @@
 "sLt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "sLu" = (
@@ -35192,13 +42718,24 @@
 /area/station/ai_monitored/turret_protected/ai_upload)
 "sMp" = (
 /obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/station/service/bar)
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "sMu" = (
 /obj/structure/cable,
 /obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
+"sNi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron,
+/area/station/ai_monitored/security/armory)
 "sPr" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -35212,6 +42749,17 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
+"sPO" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/service/theater)
+"sRx" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/structure/window/spawner/north,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "sSE" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical,
@@ -35229,6 +42777,13 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
+"sUp" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "sUF" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -35236,6 +42791,9 @@
 /area/station/maintenance/port/fore)
 "sUS" = (
 /obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "sVc" = (
@@ -35252,6 +42810,23 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
+"sVA" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
+"sWm" = (
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/turf_decal/trimline/purple/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "sXM" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -35260,19 +42835,37 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
+"sYb" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "sYH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "sZd" = (
 /obj/structure/window/reinforced,
 /turf/open/space/basic,
 /area/space/nearstation)
+"sZl" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "tam" = (
 /obj/machinery/light/directional/west,
 /obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "taD" = (
@@ -35284,12 +42877,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"tbv" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "tcb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /turf/open/floor/plating,
 /area/station/service/hydroponics/garden)
 "tch" = (
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
 "tcj" = (
@@ -35307,6 +42907,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"tdf" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/commons/lounge)
+"tdv" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "tdF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -35319,8 +42929,21 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "tgt" = (
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/white,
 /area/station/security/medical)
+"tgJ" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
+"thy" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/engineering/gravity_generator)
 "thO" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/west{
@@ -35334,6 +42957,13 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/station/service/hydroponics/garden)
+"tiW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/warning,
+/turf/open/floor/iron,
+/area/station/security/execution/transfer)
 "tiY" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/machinery/door/window/right/directional/south{
@@ -35343,11 +42973,28 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/science/ordnance/freezerchamber)
+"tjz" = (
+/obj/machinery/modular_computer/console/preset/cargochat/engineering{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "tjB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/teleporter)
+"tjO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/break_room)
 "tjY" = (
 /obj/structure/chair/stool/directional/east,
 /turf/open/floor/plating,
@@ -35379,6 +43026,10 @@
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
+"tlO" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/station/science/robotics/lab)
 "tlV" = (
 /obj/structure/cable,
 /obj/machinery/door_timer{
@@ -35386,8 +43037,31 @@
 	name = "Cell 2";
 	pixel_x = -32
 	},
+/obj/effect/turf_decal/trimline/red/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/security/brig)
+"tmK" = (
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/love_ian{
+	pixel_y = 32
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"tmM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "tmS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -35409,6 +43083,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
+"tof" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron,
+/area/station/engineering/engine_smes)
 "tpv" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35421,8 +43102,21 @@
 /area/station/cargo/qm)
 "tpP" = (
 /obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/courtroom)
+"tpX" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/chair/sofa/bench{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"tqv" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "tqz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35435,9 +43129,15 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/library/lounge)
+"trO" = (
+/obj/structure/disposalpipe/junction/flip,
+/obj/structure/fluff/broken_flooring,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
 "trV" = (
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "tsL" = (
 /obj/structure/cable,
@@ -35446,8 +43146,17 @@
 "tsT" = (
 /obj/item/kirbyplants/random,
 /obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
+"tux" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/teleporter)
 "tva" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
@@ -35462,9 +43171,19 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"tvs" = (
+/obj/machinery/camera/autoname/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "tvx" = (
-/obj/effect/spawner/random/vending/colavend,
-/obj/machinery/light/directional/north,
+/obj/effect/spawner/random/vending/snackvend,
+/obj/structure/sign/poster/official/random/directional/north,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "txN" = (
@@ -35490,7 +43209,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "tzn" = (
 /turf/open/floor/iron/chapel{
@@ -35505,6 +43224,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/central)
+"tAs" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "tAZ" = (
 /obj/structure/chair{
 	dir = 1
@@ -35512,8 +43237,36 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/courtroom)
+"tCr" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
+"tDu" = (
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
+"tDT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
+"tEG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/command/gateway)
+"tEZ" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "tGp" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -35522,9 +43275,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"tHc" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "tHi" = (
 /obj/structure/closet/l3closet,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/storage)
 "tHD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35539,20 +43302,36 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "tJR" = (
-/obj/machinery/button/door{
-	id = "EscapeBarShutters";
-	name = "Escape Bar Shutter Control";
-	pixel_x = 24;
-	req_access = list("bar")
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/area/station/hallway/secondary/entry)
+"tKg" = (
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/research)
+"tKJ" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "tLg" = (
 /obj/structure/table,
 /obj/machinery/microwave{
 	pixel_y = 6
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "tLJ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -35561,11 +43340,73 @@
 	},
 /turf/open/floor/plating,
 /area/station/medical/treatment_center)
+"tMo" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
+"tNf" = (
+/obj/effect/landmark/start/station_engineer,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
+"tNk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/line,
+/turf/open/floor/iron/white,
+/area/station/science/research)
+"tNo" = (
+/obj/effect/spawner/random/trash/hobo_squat,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
+"tNA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
+"tND" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "tOg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
+"tOx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/chair/stool/bar/directional/south,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/floor/iron,
+/area/station/commons/lounge)
+"tOA" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "tPz" = (
 /obj/structure/reflector/single/anchored{
 	dir = 9
@@ -35593,8 +43434,18 @@
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "tQt" = (
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/line,
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/security/lockers)
+"tRr" = (
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "tRI" = (
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
@@ -35607,7 +43458,13 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/security/medical)
 "tTx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35615,10 +43472,41 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
+"tVj" = (
+/obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"tVB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/commons/dorms)
+"tWk" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/science/lab)
 "tWm" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/machinery/shower{
+	name = "emergency shower";
+	pixel_y = 16
+	},
+/obj/effect/turf_decal/trimline/blue/end,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "tYz" = (
 /obj/structure/filingcabinet/filingcabinet,
@@ -35645,6 +43533,10 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"ubi" = (
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "ubu" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -35673,6 +43565,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/end,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "ubL" = (
@@ -35683,8 +43576,27 @@
 	dir = 4;
 	pixel_x = 24
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"uci" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
+"udZ" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "ues" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
@@ -35702,10 +43614,20 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"ugC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/iron,
+/area/station/commons/storage/primary)
 "uik" = (
 /obj/machinery/holopad,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/explab)
+"uiF" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/station/solars/starboard/fore)
 "ujh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35718,6 +43640,18 @@
 /obj/machinery/holopad/secure,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"ujA" = (
+/turf/open/floor/iron/white,
+/area/station/science/research)
+"ujQ" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "ukw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -35726,8 +43660,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/research)
+"uml" = (
+/obj/structure/sign/poster/contraband/random/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "unt" = (
 /obj/machinery/button/door{
 	id = "permacell2";
@@ -35736,10 +43674,21 @@
 	pixel_y = 25;
 	req_access = list("security")
 	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
+"unY" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "uou" = (
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "upm" = (
@@ -35750,7 +43699,10 @@
 	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "upw" = (
 /obj/structure/table/glass,
@@ -35764,6 +43716,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"upO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/camera/autoname/directional/west,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "uqn" = (
 /obj/machinery/door/airlock/external{
 	name = "External Docking Port"
@@ -35783,6 +43744,19 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
+"usT" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"usY" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "usZ" = (
 /obj/structure/bed,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -35800,15 +43774,30 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/grass,
 /area/station/science/genetics)
+"utS" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/chair/sofa/bench/right{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "uuH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security)
+"uuM" = (
+/obj/structure/bodycontainer/morgue,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "uuU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/brown/opposingcorners,
 /turf/open/floor/iron,
 /area/station/maintenance/central)
 "uvG" = (
@@ -35826,26 +43815,49 @@
 "uxh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/meter/monitored/waste_loop,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"uxX" = (
+"uxR" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"uxX" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"uyj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "uyN" = (
 /obj/structure/cable,
 /obj/structure/chair/stool/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
+"uyO" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white/side{
+	dir = 8
+	},
+/area/station/medical/medbay/lobby)
 "uzS" = (
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/station/maintenance/port/aft)
 "uAm" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
+/turf/closed/wall/r_wall,
+/area/station/maintenance/department/electrical)
 "uAO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35860,6 +43872,25 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"uBw" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/random/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
+"uCm" = (
+/obj/machinery/door/window{
+	dir = 4;
+	req_access = list("bar");
+	name = "Escape Bar"
+	},
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "uCw" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
 	dir = 8
@@ -35873,12 +43904,28 @@
 /area/station/service/hydroponics/garden)
 "uDp" = (
 /obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "uDS" = (
 /obj/effect/turf_decal/trimline/white/filled/shrink_cw,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"uEf" = (
+/obj/effect/turf_decal/trimline/purple/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
+"uEk" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/freezer,
+/area/station/commons/toilet/locker)
 "uEw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35911,6 +43958,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"uFU" = (
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "uGp" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Interrogation room";
@@ -35918,6 +43971,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
+"uGL" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security)
+"uGZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "uHh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35930,8 +43996,24 @@
 /area/station/maintenance/starboard/aft)
 "uHX" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/gateway)
+"uIi" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
+"uID" = (
+/obj/machinery/camera/autoname/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "uJy" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35948,17 +44030,39 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"uKm" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/checker,
+/area/station/service/theater)
 "uKM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/station/engineering/storage/tcomms)
+"uKR" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/wood,
+/area/station/service/library)
+"uLN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/courtroom)
+"uMw" = (
+/obj/item/stack/tile/iron,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
+/area/station/maintenance/port/aft)
 "uME" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "uMJ" = (
@@ -35980,6 +44084,24 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
+"uNa" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/security/medical)
+"uNE" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/iron/white,
+/area/station/medical/abandoned)
+"uNZ" = (
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
 "uOc" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Monkey Pen"
@@ -35987,6 +44109,14 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/genetics,
 /turf/open/floor/iron,
 /area/station/science/genetics)
+"uOl" = (
+/obj/vehicle/ridden/secway,
+/obj/item/key/security,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security)
 "uOM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -35996,6 +44126,10 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"uQs" = (
+/obj/effect/turf_decal/tile/brown/opposingcorners,
+/turf/open/floor/iron,
+/area/station/maintenance/central)
 "uQA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -36005,20 +44139,62 @@
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/service/theater)
+"uRq" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/engineering/break_room)
 "uRM" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
+"uRR" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/turf/open/floor/carpet,
+/area/station/command/meeting_room)
+"uSo" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/random/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"uSL" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
+"uSR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "uWn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "uWA" = (
 /obj/structure/sign/poster/official/science{
 	pixel_x = 32
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"uWO" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
@@ -36026,6 +44202,25 @@
 /obj/effect/landmark/navigate_destination/library,
 /turf/open/floor/carpet,
 /area/station/service/library)
+"uXy" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/station/engineering/break_room)
+"uXV" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/chair/sofa/bench/left{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "uXX" = (
 /obj/machinery/door/airlock/external{
 	name = "Engineering External Access"
@@ -36071,11 +44266,31 @@
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/service/library)
+"uZT" = (
+/obj/structure/window{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"vaw" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "vaF" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
+"vaN" = (
+/obj/effect/turf_decal/bot_white/right,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/command/gateway)
 "vbW" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge"
@@ -36085,11 +44300,17 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "bridge"
 	},
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "vdi" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security/brig)
 "vff" = (
@@ -36102,8 +44323,30 @@
 /obj/machinery/flasher/directional/west{
 	id = "Cell 3"
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron,
 /area/station/security/brig)
+"vfY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"vfZ" = (
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/rd)
+"vii" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/station/ai_monitored/command/storage/eva)
 "vjd" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -36115,6 +44358,30 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/station/medical/abandoned)
+"vlo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/science/lab)
+"vlx" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"vly" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"vma" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
 "vmc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36129,6 +44396,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
+"vnw" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "vnK" = (
 /obj/structure/transit_tube/diagonal/topleft,
 /turf/open/space/basic,
@@ -36143,18 +44414,31 @@
 	dir = 1
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "voD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "voG" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
+"voI" = (
+/obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"voV" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/iron,
+/area/station/commons/storage/primary)
 "vpY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -36162,6 +44446,9 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"vqE" = (
+/turf/open/floor/iron,
+/area/station/commons/lounge)
 "vqG" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance"
@@ -36170,6 +44457,13 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
+"vsl" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "vsu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -36178,6 +44472,27 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security)
+"vsM" = (
+/obj/machinery/camera/autoname/directional/south,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"vtY" = (
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/cargo/office)
+"vul" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "vvc" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
@@ -36192,16 +44507,47 @@
 /obj/structure/girder,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"vzb" = (
-/obj/effect/spawner/random/maintenance,
+"vya" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/ai_monitored/security/armory)
+"vyr" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/area/station/maintenance/port/fore)
+"vyA" = (
+/turf/open/floor/iron/white,
+/area/station/science/auxlab)
+"vyT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"vzb" = (
+/turf/closed/wall,
+/area/station/commons/lounge)
 "vzz" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/cryo)
+"vzU" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron,
+/area/station/science/ordnance)
 "vzY" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -36220,6 +44566,9 @@
 /obj/machinery/recharger{
 	pixel_x = 6
 	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/security/warden)
 "vAl" = (
@@ -36227,6 +44576,25 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/pumproom)
+"vAu" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/science/auxlab)
+"vBg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security/prison)
+"vDp" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/break_room)
 "vDt" = (
 /obj/structure/cable,
 /turf/open/floor/carpet/red,
@@ -36242,36 +44610,79 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
+"vEG" = (
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "vEU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "vFo" = (
 /obj/effect/spawner/random/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
+"vFr" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "vFD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"vGd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "vGx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
+"vGA" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/execution/education)
 "vHd" = (
 /obj/structure/chair/stool/directional/east,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "vHg" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/trimline/brown/filled/arrow_ccw{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -36306,6 +44717,9 @@
 /area/space)
 "vKA" = (
 /obj/effect/landmark/start/prisoner,
+/obj/structure/toilet/greyscale{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
 "vKS" = (
@@ -36313,8 +44727,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
+"vKU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/iron,
+/area/station/commons/storage/primary)
 "vLc" = (
 /obj/effect/landmark/start/lawyer,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36330,10 +44754,56 @@
 /obj/item/stack/cable_coil,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"vLs" = (
+/obj/structure/chair/stool/directional/west,
+/obj/machinery/light/small/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/security/prison/safe)
+"vMh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
+"vMn" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "vMJ" = (
 /obj/structure/closet/l3closet/virology,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
+"vPs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/commons/fitness/recreation)
+"vPW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
+"vQx" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "vQX" = (
 /obj/structure/transit_tube/curved{
 	dir = 8
@@ -36349,8 +44819,24 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"vRH" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security/execution/transfer)
+"vRN" = (
+/obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "vSh" = (
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "vSn" = (
@@ -36359,13 +44845,26 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
+"vSq" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "vSw" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"vSB" = (
+/obj/machinery/mechpad,
+/turf/open/floor/circuit/green,
+/area/station/science/robotics/mechbay)
 "vSS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/open/floor/iron,
@@ -36376,6 +44875,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/service/hydroponics/garden)
+"vVu" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "vVP" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -36399,6 +44904,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
+"vXQ" = (
+/obj/effect/spawner/random/trash/garbage,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
 "vYD" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube/junction/flipped{
@@ -36406,17 +44916,36 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"vZC" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "vZE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/hallway/primary/starboard)
+"vZH" = (
+/obj/machinery/camera/directional/east{
+	c_tag = "Escape Bar";
+	pixel_y = -22
+	},
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "vZV" = (
 /obj/machinery/camera/autoname/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "vZW" = (
 /obj/machinery/camera/autoname/directional/south,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "waD" = (
@@ -36428,21 +44957,50 @@
 	},
 /turf/open/floor/engine/airless,
 /area/station/science/ordnance/freezerchamber)
+"wba" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "wbU" = (
 /obj/structure/sign/departments/chemistry/pharmacy/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "wcm" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"wdk" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "wfu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"wgq" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/floor/iron,
+/area/station/service/bar)
+"wgZ" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "whV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
@@ -36453,11 +45011,18 @@
 	dir = 4;
 	pixel_x = 24
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
 "wim" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "wjH" = (
@@ -36469,6 +45034,7 @@
 "wjQ" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/engineering_construction,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "wjS" = (
@@ -36476,12 +45042,22 @@
 	dir = 1
 	},
 /obj/machinery/status_display/evac/directional/west,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "wkS" = (
 /obj/machinery/bluespace_vendor/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"wld" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/iron/dark/textured,
+/area/station/engineering/break_room)
 "wlf" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
@@ -36497,20 +45073,62 @@
 "wpf" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/auxlab)
+"wqw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/explab)
+"wqy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "wqY" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
+"wrb" = (
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/science/research)
+"wrB" = (
+/turf/open/floor/iron/dark/textured,
+/area/station/engineering/break_room)
+"wrI" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
 "wrO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
 /area/station/medical/medbay/lobby)
 "wrZ" = (
 /obj/machinery/door/airlock/engineering/glass{
@@ -36520,6 +45138,36 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"wsf" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/engineering/storage)
+"wsm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/command)
+"wsN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"wsU" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security)
 "wtj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36532,8 +45180,16 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
 "wtp" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
+"wtO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/security/prison/safe)
 "wuA" = (
 /obj/machinery/atmospherics/components/binary/pump/off{
 	dir = 8;
@@ -36545,12 +45201,27 @@
 /obj/machinery/atmospherics/components/binary/valve/digital{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"wvo" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "wvs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
+"wvB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "wwm" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance"
@@ -36570,7 +45241,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/office)
 "wxb" = (
 /obj/structure/cable,
@@ -36580,11 +45252,17 @@
 "wxE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "wzk" = (
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "wzV" = (
@@ -36602,12 +45280,46 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"wAC" = (
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
+"wBw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "wBU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/secequipment,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/security)
+"wBZ" = (
+/obj/machinery/light/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
+"wCu" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/cleanliness{
+	pixel_y = -32
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "wCN" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -36623,17 +45335,49 @@
 /area/station/service/lawoffice)
 "wDE" = (
 /obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"wEN" = (
+/obj/item/kirbyplants/photosynthetic,
+/obj/effect/turf_decal/trimline/dark_red/corner,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "wGd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "wHk" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/construction)
+"wHL" = (
+/obj/effect/turf_decal/siding/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/rd)
+"wIs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
+"wIF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/command)
 "wJI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -36647,6 +45391,15 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/primary/starboard)
+"wKp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos/office)
 "wKv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
@@ -36655,6 +45408,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"wKZ" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
+"wLe" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security/prison)
 "wLl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -36662,12 +45427,47 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
+"wLn" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
+"wLp" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
+"wLC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "wPv" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
+"wQT" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
+"wRj" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
 "wRV" = (
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai_upload)
@@ -36677,20 +45477,37 @@
 	network = list("ss13","medbay")
 	},
 /obj/machinery/requests_console/auto_name/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "wSW" = (
 /turf/closed/wall,
 /area/station/security/prison/safe)
 "wTz" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
+"wTC" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "wTS" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/medical/cryo)
+"wUB" = (
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
+"wUP" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "wVr" = (
 /obj/structure/window/reinforced/plasma{
 	dir = 8
@@ -36700,7 +45517,28 @@
 /obj/machinery/power/energy_accumulator/tesla_coil/anchored,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
+"wWF" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"wWQ" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "wXd" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /obj/structure/sign/poster/official/random/directional/east,
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
@@ -36711,6 +45549,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
+"wZo" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/science/ordnance)
 "wZD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36723,8 +45567,30 @@
 /obj/structure/cable/layer3,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"xae" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
+"xcp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "xcq" = (
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain)
 "xcs" = (
@@ -36739,11 +45605,24 @@
 /area/station/hallway/primary/port)
 "xdA" = (
 /obj/machinery/research/anomaly_refinery,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"xdF" = (
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "xdK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "xej" = (
@@ -36752,8 +45631,18 @@
 /area/station/engineering/supermatter/room)
 "xeL" = (
 /obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
+"xfD" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/ai_monitored/command/storage/eva)
 "xfS" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -36765,6 +45654,25 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/closed/wall/r_wall,
 /area/station/maintenance/port/fore)
+"xhb" = (
+/obj/machinery/computer/department_orders/engineering{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/station/engineering/main)
+"xhe" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/ai_monitored/command/storage/eva)
+"xhq" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/security)
 "xhD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36776,11 +45684,15 @@
 /area/station/service/hydroponics/garden)
 "xiO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security)
 "xjH" = (
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/turf/open/floor/iron/white,
 /area/station/medical/psychology)
 "xjM" = (
 /obj/structure/cable,
@@ -36793,8 +45705,20 @@
 /obj/machinery/recharger,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/security/checkpoint/escape)
+"xkf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/security/courtroom)
 "xld" = (
 /obj/structure/table,
 /obj/item/paper,
@@ -36805,7 +45729,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "xmC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36827,9 +45754,22 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/central)
+"xoI" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "xpm" = (
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
+"xpY" = (
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "xqJ" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
@@ -36844,10 +45784,16 @@
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/box/red,
 /obj/structure/sign/warning/fire/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "xqX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "xri" = (
@@ -36866,12 +45812,16 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/supermatter)
+"xtR" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "xuT" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "xvx" = (
 /obj/effect/turf_decal/stripes/line{
@@ -36894,7 +45844,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "xxF" = (
 /obj/machinery/camera/directional/west{
@@ -36907,7 +45858,7 @@
 "xzf" = (
 /obj/structure/table,
 /obj/item/food/mint,
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "xzj" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
@@ -36925,6 +45876,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
+"xAv" = (
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
+"xAH" = (
+/obj/effect/turf_decal/trimline/red/end{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/lockers)
 "xBJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -36935,6 +45898,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/prison)
+"xCJ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "xDp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -36973,8 +45945,14 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 5
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/turf/open/floor/iron/white,
 /area/station/science/research)
+"xGB" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "xHu" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/camera/directional/west{
@@ -36982,6 +45960,19 @@
 	},
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
+"xJl" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"xJT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/structure/sign/poster/contraband/random/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "xKi" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -36997,14 +45988,22 @@
 /area/station/maintenance/department/medical)
 "xLJ" = (
 /obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/security)
 "xMx" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"xNL" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "xPa" = (
 /obj/machinery/ticket_machine/directional/north,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "xPb" = (
@@ -37012,8 +46011,15 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
+"xPT" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/ai_monitored/security/armory)
 "xRg" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37030,50 +46036,81 @@
 /area/station/service/chapel)
 "xSs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/neutral/end{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
 /area/station/medical/morgue)
 "xSz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/prison)
-"xTf" = (
-/obj/effect/turf_decal/loading_area{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 1
 	},
+/turf/open/floor/iron,
+/area/station/security/prison)
+"xSF" = (
+/obj/machinery/portable_atmospherics/pump,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"xTf" = (
 /obj/structure/transit_tube/curved{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
 	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "xTx" = (
-/obj/structure/table,
-/obj/item/storage/belt/medical{
-	pixel_y = 2
-	},
-/obj/item/storage/belt/medical{
-	pixel_y = 2
-	},
-/obj/item/storage/belt/medical{
-	pixel_y = 2
-	},
-/obj/item/clothing/neck/stethoscope,
 /obj/machinery/light/directional/east,
-/turf/open/floor/iron,
+/obj/machinery/rnd/production/techfab/department/medical,
+/turf/open/floor/iron/white,
 /area/station/medical/storage)
 "xTS" = (
 /obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "tcomms-passthrough"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"xUA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/security/prison/safe)
+"xUH" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
+"xVr" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "xWC" = (
 /obj/machinery/holopad,
 /turf/open/floor/carpet,
@@ -37111,15 +46148,21 @@
 /obj/machinery/modular_computer/console/preset/id{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted,
 /turf/open/floor/iron,
 /area/station/security)
 "xYV" = (
 /obj/machinery/computer/department_orders/medical,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "xZs" = (
 /obj/structure/table,
 /obj/item/clothing/glasses/meson,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "xZv" = (
@@ -37128,6 +46171,18 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
+"yab" = (
+/obj/machinery/computer/department_orders/security{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/red/filled/warning{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/security/brig)
 "yaz" = (
 /obj/machinery/rnd/server/master,
 /turf/open/floor/circuit/telecomms/server,
@@ -37163,6 +46218,17 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
+"yeI" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/security/brig)
+"yeR" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/commons/lounge)
 "yfr" = (
 /turf/closed/wall,
 /area/station/hallway/secondary/service)
@@ -37172,15 +46238,37 @@
 	},
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
+"yiO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/newscaster/directional/south,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "yjd" = (
 /obj/structure/cable,
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"ykt" = (
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
 "ykY" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
+"ylh" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "ylm" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "MiniSat Exterior - Aft Port";
@@ -45024,7 +54112,7 @@ lWL
 lWL
 lWL
 lWL
-lWL
+abN
 lWL
 lWL
 lWL
@@ -46309,7 +55397,7 @@ lWL
 lWL
 lWL
 lWL
-abN
+lWL
 lWL
 lWL
 lWL
@@ -46882,14 +55970,14 @@ cAS
 cha
 cil
 cAa
-cAa
+wUP
 cYi
 cAa
 cAa
 cAa
 cAa
 cxw
-cAa
+wUP
 cAa
 cwc
 cAa
@@ -47135,8 +56223,8 @@ bWP
 cAS
 cAS
 cAS
-cfQ
-cfQ
+ceo
+ceo
 cAa
 cAa
 cAa
@@ -47373,16 +56461,16 @@ acc
 bEB
 bEB
 dRm
-bEE
-bEE
-bEE
-bEE
-bEE
+kCF
+kCF
+kCF
+kCF
+kCF
 aNJ
 bEB
 bEB
 auz
-bEE
+kCF
 bWP
 uvG
 bDm
@@ -47390,9 +56478,9 @@ bEx
 bHc
 ban
 cAS
-cfQ
+crV
 ceo
-cfQ
+crV
 cAa
 cAa
 cjC
@@ -47405,7 +56493,7 @@ lWL
 cAS
 cAS
 cAa
-cAa
+wUP
 cAa
 cAS
 cAS
@@ -47628,17 +56716,17 @@ byu
 bAg
 acc
 kXR
-bKT
-bKT
-bKT
-bKT
-bKT
+pUG
+pUG
+pUG
+pUG
+pUG
 cgv
-bKT
+pUG
 sxX
-bKT
-bKT
-bKT
+pUG
+pUG
+pUG
 bSG
 bUf
 bUe
@@ -47884,19 +56972,19 @@ aKj
 byv
 bBD
 acc
-bKT
-bKT
-cjH
+anw
+kAJ
+cxK
 anw
 bKT
 bKT
-bWO
-bLw
-bNd
-bLw
-bWO
 bKT
 bKT
+bKT
+bKT
+bKT
+bKT
+dPn
 bWP
 bSH
 jFy
@@ -47905,7 +56993,7 @@ bHe
 aKM
 cAS
 cAa
-cAa
+wUP
 cAa
 chb
 cim
@@ -48146,18 +57234,18 @@ fzd
 cjH
 tvx
 tvb
-bKT
-cjH
-dQm
-bNe
-dQm
-cjH
-cgv
+qpp
+dkG
+aZy
+mdG
+aZy
+dkG
+frQ
 aRG
 bUf
-bSH
+myb
 aQD
-bSH
+aED
 pPD
 xjO
 cAS
@@ -48398,18 +57486,18 @@ acc
 acc
 acc
 acc
-bKT
-bKT
+anw
+odJ
 cjH
 aKJ
 gRN
-bKT
-bRA
 bLY
-bIt
-bLY
-bRA
-bKT
+cjH
+dQm
+bNe
+dQm
+cjH
+nXo
 bLZ
 bUf
 eri
@@ -48655,30 +57743,30 @@ byw
 bAj
 bBE
 bkB
-bKT
-bKT
-gwR
-bKT
+anw
+fzd
+cjH
+chQ
 gRN
-bKT
-bKT
-bKT
-bKT
-bKT
-bKT
-bKT
-bLZ
+xoI
+iot
+gZk
+eUz
+gZk
+iot
+lRP
+aCn
 clc
-iTL
-bKT
-bKT
+asr
+bEE
+bEE
 qQJ
 jfW
 cAS
 aZj
 aZj
 aZj
-aZj
+eXq
 raS
 aZj
 aZj
@@ -48896,7 +57984,7 @@ lWL
 lWL
 bvH
 bjn
-bsV
+dAv
 jWB
 eji
 xnz
@@ -48912,27 +58000,27 @@ bDh
 bDh
 bpF
 bVu
-bKT
-bKT
-bHg
-bKT
+anw
+srK
+bcI
+pMu
 gRN
-caz
-bEA
-bDl
-bEA
-bEA
-bDl
-bEA
-bDl
-caz
+bKT
+bKT
+bKT
+bKT
+bKT
+bKT
+bKT
+bKT
+bKT
 iTL
 bKT
-bHg
 bKT
 bKT
+srK
 cAS
-aZj
+wvB
 cAS
 cAS
 cAS
@@ -49116,7 +58204,7 @@ auU
 auU
 ary
 azY
-amb
+alb
 auU
 auU
 pYa
@@ -49152,8 +58240,8 @@ lWL
 lWL
 lWL
 bvH
-bsV
-bsV
+dAv
+dAv
 bvH
 bvH
 oYp
@@ -49169,25 +58257,25 @@ bDh
 bDh
 dqO
 bvH
+anw
 bKT
-aKy
-oeA
-bUd
+bHg
+bKT
 aiS
-cjH
-bKK
-bKK
-bKK
-bOL
-bKK
-gCT
-bKK
-cjH
+wKZ
+jbs
+fjq
+jbs
+jbs
+jbs
+jbs
+jbs
+wKZ
 aoK
-aKy
-bHh
-bUd
 bKT
+bHg
+bKT
+srK
 cAS
 aZj
 cdp
@@ -49206,7 +58294,7 @@ cAa
 cus
 cAS
 aZj
-cAa
+wUP
 cdk
 cAS
 cAS
@@ -49400,7 +58488,7 @@ bDP
 iIH
 aqN
 aqN
-aqN
+cCZ
 aqN
 aqN
 aqN
@@ -49426,23 +58514,23 @@ onH
 bDh
 bgy
 bVu
-cgv
+myF
 aKy
-bKe
+oeA
 bUd
-aMu
+yiO
+cjH
 bKK
-bKT
-bKT
-bKT
-bKT
-bKT
-bKT
-bKT
 bKK
-aRH
+bKK
+bOL
+bKK
+gCT
+bKK
+cjH
+qli
 aKy
-bJp
+bHh
 bUd
 jLv
 cAS
@@ -49465,7 +58553,7 @@ cbT
 aZj
 aZj
 cAa
-cAa
+bvJ
 cAa
 cAS
 cAS
@@ -49627,7 +58715,7 @@ aCI
 lWL
 lWL
 auU
-atu
+kcL
 azo
 aAa
 aAK
@@ -49662,7 +58750,7 @@ bar
 oIX
 bcG
 bDP
-aqN
+nMq
 aqN
 nMq
 bDP
@@ -49685,21 +58773,21 @@ xDp
 bvH
 uDp
 aKy
-bGe
+bKe
 bUd
 aMu
 bKK
-bKT
-tJR
-bKT
-bKT
-bKT
-bKT
-bKT
+bNi
+bNi
+bNi
+bNi
+bNi
+bNi
+bNi
 bKK
 aRH
 aKy
-nAW
+bJp
 bUd
 bKg
 cAS
@@ -49920,7 +59008,7 @@ bDP
 bDP
 bDP
 aqN
-aqN
+cCZ
 aqN
 bDP
 bDP
@@ -49940,23 +59028,23 @@ bvH
 bAm
 dGB
 bvH
-bKT
+anw
 aKy
-bJp
+bGe
 bUd
-gRN
-cjH
-bKT
-cjH
-bDt
-bEH
-aAd
-ciN
+aMu
+bKK
 bNi
-cjH
-iTL
+bxh
+bNi
+bNi
+bNi
+bNi
+bNi
+bKK
+aRH
 aKy
-bKe
+nAW
 bUd
 rBl
 cAS
@@ -50166,7 +59254,7 @@ rZi
 tYz
 cNW
 bDP
-aqN
+cCZ
 aqN
 bnV
 oZR
@@ -50179,7 +59267,7 @@ aqN
 aqN
 fJW
 aqN
-ycT
+cZy
 vff
 vff
 vff
@@ -50191,29 +59279,29 @@ vff
 vff
 vff
 awM
-fQi
-fQi
-fQi
-fQi
+oMO
+oMO
+oMO
+oMO
 aJt
 cbS
 bHm
 aKy
-bHh
+bJp
 bUd
 gRN
 cjH
-bDr
+bNi
 cjH
-cjH
-cjH
-cjH
-cjH
-cjH
+dCI
+vZH
+rON
+hff
+kFz
 cjH
 iTL
 aKy
-oeA
+bKe
 bUd
 ikZ
 cAS
@@ -50425,7 +59513,7 @@ bDP
 bDP
 bDP
 bDP
-fyk
+hjK
 aWz
 aWz
 hjK
@@ -50435,7 +59523,7 @@ ycT
 bdP
 ycT
 ycT
-ycT
+cZy
 ycT
 aqN
 bDP
@@ -50449,30 +59537,30 @@ bDP
 bDP
 bDP
 cbS
-bVy
+nJf
 bVy
 fQi
 bIB
 cbS
-bVy
-bVy
-aRI
-bVy
-bIx
-bVt
-bVy
-aMq
-bVy
-bVy
-bMa
-bVy
-bVy
-bVy
-aZW
-bVy
-aRI
-bVy
-qEo
+anw
+aKy
+bHh
+bUd
+gRN
+cjH
+uCm
+cjH
+cjH
+cjH
+cjH
+cjH
+cjH
+cjH
+iTL
+aKy
+oeA
+bUd
+ikZ
 cAS
 aZj
 cdp
@@ -50664,7 +59752,7 @@ atu
 atu
 aDv
 atu
-atu
+dXA
 atu
 atu
 atu
@@ -50683,7 +59771,7 @@ aRK
 aST
 aqN
 hjK
-aqN
+nMq
 voG
 bDP
 bDP
@@ -50693,10 +59781,10 @@ bDP
 bDP
 bfx
 bgz
-vzb
+nMq
 ahO
 bDP
-blB
+uuM
 blB
 bnN
 blB
@@ -50706,30 +59794,30 @@ blB
 blB
 aQU
 bkF
-bVy
+nJf
 bVy
 fQi
 bIB
-bVy
-bVy
-bVy
-bVy
-bVy
-bIx
-bVy
-bVy
-bVy
-bVy
 rGN
-bVy
-bVy
-bVy
-bVy
+rGN
+rGN
+opr
+rGN
+bIx
+ykt
+rGN
+emD
+rGN
+rGN
+mpf
+gVt
+rGN
+rGN
 aZW
-bVy
-bVy
-bVy
-qEo
+rGN
+opr
+rGN
+wrI
 cAS
 aZj
 cdp
@@ -50955,15 +60043,15 @@ bDP
 bDP
 blC
 xSs
-xSs
+fsv
 xSs
 bpJ
 jXj
 aZr
-aib
-aib
+sGV
+tDu
 bkH
-bVy
+wRj
 cvn
 fQi
 bBL
@@ -50977,6 +60065,7 @@ fQi
 fQi
 fQi
 fQi
+wIs
 fQi
 fQi
 fQi
@@ -50985,8 +60074,7 @@ fQi
 fQi
 fQi
 fQi
-fQi
-fQi
+oMO
 iOT
 aZj
 cdp
@@ -51203,29 +60291,29 @@ bDP
 bax
 bhT
 iIa
-bdQ
-bfy
+agr
+klY
 bfy
 wTS
-bhS
-cFT
+vEG
+kgo
 iAl
 nxU
 bmI
 bnO
-aib
+tDu
 kKi
 iac
 aib
-aib
-aib
+kBa
+ppY
 bkF
 bxk
 bVy
 bVy
 bVy
 bBM
-bVy
+nJf
 bVy
 bVy
 cis
@@ -51243,7 +60331,7 @@ bVz
 bVy
 bVy
 qEo
-bVy
+rGN
 cAS
 cdp
 cdp
@@ -51254,7 +60342,7 @@ cjJ
 ckZ
 mgf
 loa
-loa
+rdC
 cpV
 cpV
 crZ
@@ -51266,11 +60354,11 @@ cpV
 aCI
 cbR
 cAU
-cAa
+wUP
 cAa
 cbT
 aZj
-cAa
+wAC
 cAS
 cAS
 aCI
@@ -51457,14 +60545,14 @@ aQJ
 aRL
 bbN
 bbC
-bbM
-bdQ
+ntR
+jQf
 uWn
 lHD
-bdQ
+jQf
 bdQ
 bbk
-aNh
+mDO
 bjw
 bkI
 bkI
@@ -51479,12 +60567,12 @@ buy
 bkF
 bxl
 bxl
-bxl
+uBw
 bxl
 bBN
 jEm
-bVy
-bVy
+nJf
+nJf
 cis
 bVy
 bjv
@@ -51500,8 +60588,8 @@ bVy
 bVy
 bVy
 qEo
-bVy
-cbV
+rGN
+dyV
 bBN
 cev
 cfX
@@ -51509,13 +60597,13 @@ chh
 gPM
 rbk
 ckZ
-loa
+bbK
 cmh
 cmh
 cpU
 xmc
 cHB
-cqP
+vGA
 ihA
 cwf
 cxD
@@ -51670,14 +60758,14 @@ lWL
 auU
 auU
 amM
+vyr
 amM
-amM
-apP
-apP
+alb
+alb
 akb
 atu
 crI
-atu
+dXA
 auX
 avK
 beQ
@@ -51703,7 +60791,7 @@ aLN
 aOH
 aMY
 aNT
-bgJ
+rbo
 qTH
 mIV
 aQK
@@ -51721,7 +60809,7 @@ bdS
 vzz
 bfA
 wTS
-aNh
+mDO
 bjw
 bkJ
 blE
@@ -51741,7 +60829,7 @@ bGg
 bGg
 bGg
 bGg
-bVy
+nJf
 cis
 bVy
 bjv
@@ -51768,7 +60856,7 @@ cjL
 ckZ
 xqX
 chf
-loa
+khs
 cpV
 cqQ
 csb
@@ -51937,31 +61025,31 @@ ijO
 auY
 auY
 auY
-awC
+uAm
 axk
-bbx
+mtV
 aya
 awD
 axk
-bbx
+mtV
 aya
 awD
 axk
-bbx
+mtV
 aya
 aFa
 aFR
 aGM
 cpM
 aIs
-aKT
+fRH
 aJA
 aLN
-aNj
+kOO
 aNj
 aNj
 bgJ
-aNj
+gml
 mIV
 bgI
 ncu
@@ -51982,9 +61070,9 @@ wDE
 bjx
 bkJ
 cHr
-bmM
-bmM
-bmM
+gSY
+gSY
+gSY
 bpL
 bqO
 kvZ
@@ -51994,15 +61082,15 @@ bGg
 tWm
 byB
 bRD
-bDv
-bDv
+kCA
+kCA
 bDv
 bGg
-axE
+bIt
 bJr
 axE
 cjE
-axE
+bYF
 hAm
 hAm
 hAm
@@ -52021,9 +61109,9 @@ auS
 auS
 auS
 auS
-cmh
-chf
-chf
+kza
+ehK
+rjm
 hpk
 coQ
 coQ
@@ -52042,7 +61130,7 @@ aCI
 cAS
 cAS
 aZj
-cAa
+myt
 cAS
 cbR
 cbR
@@ -52194,7 +61282,7 @@ aso
 dmv
 auZ
 avM
-awC
+uAm
 ayF
 axX
 ayF
@@ -52208,11 +61296,11 @@ aDy
 ayF
 aFa
 aFS
-aKT
+fRH
 aCr
 kdW
 bau
-bau
+jkp
 aLM
 awQ
 aNj
@@ -52220,22 +61308,22 @@ aNU
 bgJ
 aOI
 agu
-aNh
-bts
+mwP
+uyj
 aSW
 aJH
-aNh
-aPv
-aNh
+epz
+wqy
+epz
 pwd
-cFT
+uci
 aNh
 bhS
 bdT
 pQd
 dgu
-aNh
-aNh
+epz
+oIJ
 aYe
 bkK
 ckW
@@ -52243,23 +61331,23 @@ blG
 blG
 blG
 bpM
-axR
-axR
+lAV
+lAV
 btl
 axR
 bvP
 gev
-bDv
-bDv
-bDv
-bDv
-bDv
+bWO
+bYG
+bYG
+jaB
+bWO
 bGg
 fXy
 bJr
 qJM
 fGe
-fGe
+kkk
 bMd
 bZB
 bZB
@@ -52275,13 +61363,13 @@ cbW
 cbW
 sKi
 cex
-tgt
+uNa
 chk
 auS
-loa
+bbK
 chf
 loa
-loa
+qtK
 coQ
 cpW
 cqR
@@ -52299,9 +61387,9 @@ aCI
 aCI
 cAS
 aZj
-cdk
+crV
 cAS
-smQ
+kRP
 smQ
 cGy
 cAS
@@ -52445,17 +61533,17 @@ aCI
 aCI
 auY
 auc
-auc
+hft
 aso
+hft
 auc
 auc
 auc
-auc
-awC
+uAm
 axm
 bbx
 bbx
-bbx
+upO
 bbx
 bbx
 bbx
@@ -52469,14 +61557,15 @@ aKT
 aHy
 aIt
 aKT
-aKT
+gtj
 aLN
-oaU
+kCn
 bgJ
 bgJ
 bgJ
 aIq
 lvR
+jks
 cFT
 cFT
 cFT
@@ -52484,16 +61573,15 @@ cFT
 cFT
 cFT
 cFT
+uSR
+ocD
+knW
 cFT
 cFT
-cFT
-cFT
-cFT
-cFT
-cFT
-cFT
-cFT
-ckT
+uSR
+ocD
+knW
+myL
 bkL
 blH
 bmM
@@ -52506,13 +61594,13 @@ bmM
 axR
 bvP
 bxm
-bDv
-bDv
-bDv
-bDv
-bDv
+gQP
+bDl
+bDl
+csD
+bWO
 bGg
-axE
+bIt
 bJr
 axE
 siP
@@ -52532,18 +61620,18 @@ hAm
 hAm
 sKi
 cey
-tgt
+kHf
 oPW
 auS
 cjO
 chf
 chf
-chf
+fDP
 coP
-tTx
-nsP
+wtO
+juB
 csc
-cny
+wLe
 clj
 cwh
 clj
@@ -52706,9 +61794,9 @@ fgk
 aso
 auc
 ues
-auc
+hft
 avO
-awC
+uAm
 axn
 sIA
 aEn
@@ -52728,52 +61816,52 @@ aFa
 aJD
 cHp
 aFa
-oaU
-aNj
-aNj
-aNj
-aIq
+qbz
+cUQ
+kfz
+kfz
+ljE
 agu
-aNh
-aNh
+rGz
+rVK
 khu
-aNh
-aNh
-aNh
-aNh
-dUt
+rVK
+rVK
+rVK
+rVK
+cNu
 baD
 bgI
 cPL
-bfC
-bfC
+xpY
+xpY
 wim
 bgI
 baC
-ckT
+myL
 bkM
 blI
 bmM
 bmM
 bmM
 bpN
-blH
+qaw
 bmM
 bmN
 axR
 bvQ
 nIy
-bDv
-bDv
-bDv
-bDv
-bDv
+bWO
+kCA
+kCA
+vVu
+bWO
 bGg
 bWN
 bJr
 axE
 siP
-cpR
+bHT
 bKW
 bNj
 bOQ
@@ -52795,17 +61883,17 @@ auS
 cjP
 chf
 loa
-loa
+qtK
 coQ
 cqe
 cqS
 wSW
-cny
-clj
-vHd
-clj
+acw
 cyr
-clj
+vHd
+mGN
+cyr
+cyr
 czo
 cAW
 lWL
@@ -52813,12 +61901,12 @@ lWL
 lWL
 cAS
 aZj
-cdk
+crV
 cAS
 cFW
 cFY
 cGA
-cFY
+cPx
 cGR
 cAS
 cAS
@@ -52965,7 +62053,7 @@ atr
 aue
 dmv
 avP
-awC
+uAm
 axo
 ayE
 aEn
@@ -52978,7 +62066,7 @@ aEn
 azs
 aEp
 awC
-aFU
+kcF
 aGO
 aFU
 awC
@@ -53001,16 +62089,16 @@ aRU
 aNl
 baD
 bbG
-bfC
+oeQ
 bfC
 wKv
 bfB
 pXR
 baC
-ckT
+myL
 bkN
-blJ
-bmN
+rJj
+sfB
 pTN
 boH
 brY
@@ -53019,18 +62107,18 @@ brZ
 blJ
 buB
 bvP
-bDv
+pXx
 byC
 hwh
-bDv
-bDv
+bYG
+bYG
 amu
 bKj
-axE
+meE
 bJr
 xda
 siP
-cpR
+bHT
 dsS
 iyu
 bOR
@@ -53049,10 +62137,10 @@ ceA
 cgb
 bLX
 cix
-chf
+mww
 mgh
 swH
-loa
+qtK
 coQ
 wSW
 wSW
@@ -53062,7 +62150,7 @@ cuA
 cwj
 vsu
 pRz
-czo
+eEG
 cAe
 cAW
 lWL
@@ -53073,10 +62161,10 @@ aZj
 chb
 cbR
 cFX
-cFY
+cPx
 cGB
 cFY
-cFY
+cPx
 smQ
 cGZ
 lWL
@@ -53210,7 +62298,7 @@ ajj
 akc
 akY
 ahR
-amM
+vyr
 ahR
 aCI
 ahR
@@ -53222,27 +62310,27 @@ ats
 auf
 avd
 auY
-awC
+uAm
 axp
-aCb
-aCb
-aCb
-aCb
+akq
+akq
+akq
+akq
 uyN
-aCb
-aCb
+akq
+akq
 aAU
-aCb
-aCb
+akq
+nHF
 aFb
 aCb
-aCb
-aCb
+akq
+sby
 aIu
-dAF
-aNU
+qpv
+prz
 aLO
-oaU
+hEo
 aNi
 aNZ
 aOM
@@ -53255,13 +62343,13 @@ mcQ
 aVk
 aWD
 aYa
-dUt
+qDj
 baD
 bbI
-bfC
+qRE
 rAy
 lBw
-bfC
+wQT
 bbI
 baC
 cHq
@@ -53283,11 +62371,11 @@ bGg
 bGg
 bGg
 bGg
-axE
+srV
 bJr
 axE
 siP
-cpR
+bHT
 dKw
 iyu
 bOS
@@ -53306,19 +62394,19 @@ ceB
 cgc
 jpY
 auS
-loa
+vRH
 chf
 loa
-loa
+qtK
 coQ
 cpZ
 vKA
 wSW
-cny
+acw
 cuB
 cwk
 vsu
-clj
+cyr
 czp
 cAf
 cAW
@@ -53331,10 +62419,10 @@ csG
 cFJ
 uzS
 cFY
-cGC
+uMw
 cFY
 cGS
-cFY
+cPx
 cHa
 lWL
 lWL
@@ -53472,16 +62560,16 @@ ahR
 aCI
 ahR
 atu
-atu
+dXA
 auY
 atn
 auY
 auY
 auY
 auY
-awC
+uAm
 axq
-aCb
+xUH
 ayK
 aOQ
 aAh
@@ -53493,7 +62581,7 @@ aDA
 aEr
 awC
 aFW
-aEn
+ayK
 aHB
 awC
 dAF
@@ -53525,11 +62613,11 @@ ckT
 aNg
 olh
 wbU
-aYg
-aYg
-aYg
-aYg
-aYg
+apK
+apK
+apK
+apK
+apK
 bid
 aet
 bvR
@@ -53540,11 +62628,11 @@ bBO
 bDx
 bEI
 aet
-axE
+bIt
 bJr
 axE
 siP
-axE
+sZl
 bKW
 bNm
 bNn
@@ -53566,18 +62654,18 @@ auS
 cfW
 chf
 chf
-chf
+fDP
 coR
 tTx
-iny
+xUA
 csd
 xSz
 coe
 coe
 kOL
 cny
-cny
-cny
+jvn
+dom
 cAW
 lWL
 lWL
@@ -53591,7 +62679,7 @@ cFY
 cFY
 cFY
 cGT
-cFY
+cPx
 cbR
 lWL
 lWL
@@ -53739,8 +62827,8 @@ avQ
 beQ
 awC
 ayd
-awC
-awC
+axt
+axt
 awC
 aAi
 aAi
@@ -53771,8 +62859,8 @@ aTb
 aRU
 aVm
 baD
-bbI
-bfC
+slJ
+wLp
 bfC
 pKr
 mVS
@@ -53789,15 +62877,15 @@ pqm
 aOR
 pgx
 aet
-xpm
+xfD
 rIp
-tmS
+blo
 bAr
-xpm
-xpm
+xhe
+xhe
 bEJ
 aet
-axE
+ylh
 bJr
 axE
 siP
@@ -53823,7 +62911,7 @@ bYA
 cjU
 chf
 nWx
-loa
+qtK
 coQ
 cqb
 cqS
@@ -53844,9 +62932,9 @@ eQi
 cAS
 cAS
 cGa
+cPx
 cFY
-cFY
-cFY
+cPx
 cFY
 cAS
 cAS
@@ -53998,7 +63086,7 @@ aye
 ayf
 ayf
 aye
-aye
+rNh
 aAi
 nnR
 aCd
@@ -54006,7 +63094,7 @@ aCz
 aDB
 kYr
 aFc
-aFX
+qYs
 aGQ
 aYf
 aAi
@@ -54026,39 +63114,39 @@ gAq
 aVn
 aWE
 fWt
-aPv
+rdw
 baD
 aLb
-bfC
+oeQ
 upw
 beP
-bfC
+hPa
 aNf
 baC
 bKl
 bkQ
-aYg
-aYg
-aYg
+qwi
+qwi
+arb
 fai
 ajJ
 faU
-aYg
+ofl
 cHs
 aet
 biD
-xpm
+qLL
 tmS
 bAr
 xpm
 xpm
-tmS
+bSZ
 tQl
-axE
+fOq
 bJr
 axE
 siP
-axE
+pUe
 bKW
 bKW
 bKW
@@ -54255,9 +63343,9 @@ axs
 ayf
 ayf
 ayf
-pPt
+aye
 aAi
-aGT
+dSd
 aCA
 aGT
 aDC
@@ -54265,9 +63353,9 @@ aGT
 bgC
 aGT
 aCA
-aGT
-aWO
-aNj
+hih
+qgE
+sYb
 bgJ
 aNj
 bIM
@@ -54279,7 +63367,7 @@ aQi
 hPP
 aRU
 aTd
-aZs
+cRr
 aVo
 aQn
 bbO
@@ -54291,7 +63379,7 @@ bcP
 bbO
 bgI
 bgI
-aNh
+sRx
 bjE
 aNg
 blM
@@ -54300,7 +63388,7 @@ aYg
 qvO
 bpP
 bqS
-aYg
+ofl
 btn
 aet
 biD
@@ -54309,13 +63397,13 @@ byX
 bAs
 iBy
 bEL
-bEL
+kmn
 bGi
-siP
+vGd
 qkd
 siP
 siP
-axE
+sZl
 bMi
 bNn
 tYN
@@ -54323,21 +63411,21 @@ bNn
 bRI
 bYA
 bUl
-bWW
+nuJ
 caC
 bYB
 bZG
-bWW
+nuJ
 caC
 bYB
 ceD
-bWW
+nuJ
 caC
 bYB
 cjV
 chf
 loa
-loa
+qtK
 coQ
 cqc
 mhW
@@ -54355,10 +63443,10 @@ aCI
 aCI
 cCh
 bcL
-cuN
+ubi
 cCh
-smQ
-smQ
+kRP
+kRP
 cGD
 cAS
 cAS
@@ -54514,14 +63602,14 @@ axt
 axt
 axt
 aAi
-aGT
+dSd
 aGT
 aGT
 aDD
 aEs
 jgf
-aFe
-aFe
+his
+his
 aFe
 aIv
 aJI
@@ -54536,7 +63624,7 @@ aQk
 fof
 aRU
 aTe
-aZs
+cRr
 aVp
 xPb
 bbO
@@ -54551,14 +63639,14 @@ dGU
 dGU
 aua
 aNn
-aYg
+aAd
 bmQ
 aYg
 aQN
 bpP
 sxD
-aYg
-aYg
+ofl
+kzw
 aet
 bvT
 vSh
@@ -54594,17 +63682,17 @@ bYB
 cjW
 chf
 cmh
-cmh
+tiW
 coS
 iny
 nsP
 cse
-cny
+wLe
 cny
 cwo
-vsu
+vBg
 cys
-clj
+bWp
 cAj
 cAW
 aCI
@@ -54771,7 +63859,7 @@ azv
 azv
 azv
 uOc
-aGT
+dSd
 aCB
 aGT
 aGT
@@ -54779,21 +63867,21 @@ nwT
 pnt
 aGT
 aGT
-aGT
+hih
 aWO
-aNj
+sYb
 aLa
 aNj
 aNj
-aNj
+gml
 aNZ
-aQl
-aQl
-aQl
+wLn
+iCx
+iCx
 lXv
 aRU
 aTf
-aZs
+rvb
 aVq
 vGx
 bbO
@@ -54804,7 +63892,7 @@ bez
 beR
 sHI
 dUt
-dUt
+rLo
 olA
 bKl
 aNg
@@ -54814,7 +63902,7 @@ aYg
 aQN
 bpP
 bqS
-aYg
+ofl
 eli
 aet
 bvU
@@ -54822,10 +63910,10 @@ vSh
 xpm
 bAr
 bBS
-xpm
+vii
 bEN
 aet
-axE
+bIt
 bJr
 xda
 siP
@@ -54836,24 +63924,24 @@ bYA
 bYA
 bYA
 bSJ
-clT
+yeI
 cip
-clT
+yeI
 tlV
-clT
+yeI
 cip
-clT
+yeI
 cdt
-clT
+yeI
 cip
-clT
+yeI
 bYA
 cjK
 clh
 cjK
 cjK
 coQ
-cqe
+vLs
 xld
 wSW
 ubL
@@ -54861,8 +63949,8 @@ cuG
 ubL
 cxN
 rPf
-clj
-clj
+hCC
+hCC
 cAW
 aCI
 aCI
@@ -55014,7 +64102,7 @@ qkc
 auU
 aCI
 auU
-atu
+dXA
 atu
 crI
 atu
@@ -55027,19 +64115,19 @@ axu
 axu
 utp
 lFz
-aAi
+aWO
 aBB
 aCg
 aFX
 aDF
 gyK
-aGT
+gOq
 aFf
 aSw
 aHG
 aAi
 ayL
-aLa
+xae
 tLg
 gwH
 aNk
@@ -55060,7 +64148,7 @@ bea
 bcS
 bVI
 bcP
-bfF
+gbx
 bfF
 rnQ
 bjs
@@ -55068,14 +64156,14 @@ aNg
 blO
 bmS
 aYg
-aQN
+ldu
 cKB
 hJe
-aYg
-aYg
+vaw
+kzw
 aet
 msY
-vSh
+eOn
 byG
 bAr
 bBT
@@ -55086,10 +64174,10 @@ bqy
 bJr
 bJv
 eBz
-clU
+rOf
 bMk
 bNq
-bdu
+hMO
 bQn
 bRJ
 bdu
@@ -55105,9 +64193,9 @@ bWW
 bWW
 pIf
 ciz
+iQq
 pIf
-pIf
-bUr
+mtO
 bYA
 coQ
 wSW
@@ -55267,7 +64355,7 @@ aCI
 lWL
 lWL
 auU
-qkc
+xJT
 auU
 aCI
 auU
@@ -55328,8 +64416,8 @@ bnR
 aZq
 aNg
 aNg
-bnR
-bnR
+uyO
+uyO
 aet
 aet
 bxs
@@ -55339,32 +64427,32 @@ aet
 aet
 aet
 bGj
-axz
+qJa
 wCN
 anB
 bIE
-hOm
+suc
 bRK
-bUr
+gjy
 bNr
-bUr
+kPT
 bRK
-bUr
+lpg
 bUr
 naU
-bUr
-clT
+gtN
+oXV
 bZK
-bUr
-bUr
-bUr
-bUr
-bUr
+plS
+plS
+plS
+plS
+frc
 bUr
 ciA
 bUr
 xzG
-clT
+pNh
 coT
 coT
 coT
@@ -55380,7 +64468,7 @@ ciy
 ciy
 aCI
 cCh
-bcL
+oOf
 bcL
 cEV
 cCh
@@ -55534,97 +64622,97 @@ crI
 aEm
 atu
 auU
-axE
-axE
-axE
-axE
-axE
-axE
-axE
-axE
-axE
+gfH
+bGS
+bGS
+bGS
+bGS
+bGS
+uSo
+bGS
+bGS
 ape
 aCD
 aDG
 aEu
 aDG
 aGa
-axE
-axE
+bGS
+gbz
 ape
-axE
-chd
-axE
-axE
-axE
-axE
-ape
-axE
-axE
-axE
-axE
+bGS
+pCP
+bGS
+bGS
+bGS
+qXh
+djz
+utS
+bGS
+bGS
+bGS
 cQM
-axE
+bGS
 aVs
 aWH
-axE
-axE
-axE
-axE
-axE
-axE
-axE
-axE
-axE
-axE
-aLf
-axE
-axE
+bGS
+bGS
+bGS
+bGS
+bGS
+qXh
+bsV
+utS
+bGS
+bGS
+pSF
+bGS
+bGS
 hNR
-axE
-fGe
-axE
-axE
-axE
-axE
+bGS
+gql
+bGS
+bGS
+bGS
+bGS
 mxi
-axE
-cpR
-axE
-axE
+bGS
+bHT
+bYF
+bYF
 aGU
-axE
-axE
-axE
+bYF
+bYF
+bYF
 axE
 bJr
 avm
 rrv
-rXU
+qDO
 bMm
 bNs
-pIf
+rBK
 bQp
 bRL
 pIf
 bWW
 naU
-bUr
+bVL
 bXc
 gpu
 bXc
 bXc
 bXc
 bXc
-bUr
-bUr
+kiX
+plS
 ciB
 cka
 clk
-xzG
+nMp
 coT
 coT
-cnH
+kXW
 cqW
 csf
 ctd
@@ -55863,12 +64951,12 @@ bYA
 bYA
 bYA
 bYA
-clT
+qxa
 bUr
 bUr
-bXc
-bXc
-bZM
+pNh
+njz
+nxj
 caI
 ccc
 cdv
@@ -55882,10 +64970,10 @@ cmj
 coT
 coT
 kBH
-cqT
+cYn
 csg
-cnH
-cnH
+tqv
+tqv
 coT
 lWL
 cCh
@@ -55895,7 +64983,7 @@ cCh
 csj
 cCh
 bcL
-cuN
+ubi
 cCh
 cCh
 aCI
@@ -56048,7 +65136,7 @@ crI
 aWB
 atu
 jtP
-siP
+wsN
 cjE
 axE
 ayg
@@ -56096,7 +65184,7 @@ xda
 axE
 axE
 axE
-cpR
+qKi
 ukw
 axE
 axE
@@ -56114,7 +65202,7 @@ axE
 ubu
 bkm
 rrv
-axE
+sZl
 bvX
 bMj
 tRI
@@ -56123,9 +65211,9 @@ bYB
 dHA
 bUr
 gtN
+rFO
 bXd
-bYF
-bZM
+oni
 caJ
 ccd
 cdw
@@ -56135,12 +65223,12 @@ cht
 bXc
 ckc
 cll
-wYn
+hwg
 cnG
 coT
 cqh
 cqT
-cnH
+nTG
 cte
 cuJ
 coT
@@ -56149,10 +65237,10 @@ cCh
 czr
 cAl
 cCh
-cuN
+pPt
 bcL
 bcL
-cuN
+cAl
 cCh
 lWL
 aCI
@@ -56295,17 +65383,17 @@ aCI
 lWL
 auU
 auU
-amM
+vyr
 auU
 aCI
 ahR
-crI
+cSW
 crI
 crI
 aWB
 atu
 auU
-axE
+bIt
 cjE
 cpR
 cpR
@@ -56377,11 +65465,11 @@ bNu
 bNu
 hXB
 bRM
-clT
+qxa
 bUr
 bVL
+nUg
 bXd
-bYG
 bZM
 caK
 cdy
@@ -56390,12 +65478,12 @@ cdy
 cdy
 chu
 bXc
-ckd
+sGn
 ckd
 wYn
-wYn
+sNi
 coU
-wYn
+mnz
 wYn
 csh
 lYC
@@ -56408,7 +65496,7 @@ cAm
 cwt
 bcL
 bcL
-cuN
+dPo
 cCh
 cCh
 lWL
@@ -56562,73 +65650,73 @@ auU
 auU
 auU
 auU
-axE
+bIt
 cjE
 cpR
-axE
-axE
+bIt
+bIt
 avo
-axE
+bIt
 aBa
 afn
-axE
+bIt
 aCG
 aDG
 aEu
 aDG
 foL
 qCy
-axE
-pzm
-axE
+eyh
+eNA
+bIt
 aLh
 aLX
 aMD
-aNm
-axE
-axE
-axE
-axE
+lkp
+sCP
+sCP
+sCP
+sCP
 pzm
 avo
-qCy
-axE
-iUw
-axE
-axE
-axE
-axE
+voI
+tAs
+akp
+tAs
+tAs
+bIt
+bIt
 avo
 afn
-axE
-pzm
-axE
-kMe
-axE
-axE
-avo
+bIt
+uID
+cNe
+miD
+uxR
+cNe
+gSN
 neN
-qCy
-pzm
-axE
-iUw
+gbr
+uID
+cNe
+eUR
 bqU
-axE
+fpH
 jNl
-axE
-axE
-aLh
+eWH
+fpH
+ecX
 byI
 aNm
-avo
-axE
-axE
-axE
+sBQ
+kZN
+fpH
+fpH
 axE
 cpR
 bJz
 rrv
-axD
+vsM
 bvX
 bNv
 bPa
@@ -56637,7 +65725,7 @@ bYB
 vdi
 clT
 bVM
-bXd
+yab
 bYH
 bZO
 fNZ
@@ -56647,14 +65735,14 @@ ceF
 cgk
 chv
 ciD
+xPT
 cnH
 cnH
-cnH
-cnH
+slu
 coT
 cqj
 cnH
-cnH
+nTG
 ctg
 cuL
 coT
@@ -56664,7 +65752,7 @@ cCh
 cCh
 cCh
 bcL
-cuN
+pPt
 cCh
 cCh
 lWL
@@ -56819,9 +65907,9 @@ asx
 aty
 auo
 atx
-axz
+qJa
 xRg
-hOm
+pmc
 ayi
 ayi
 ayi
@@ -56842,7 +65930,7 @@ ayi
 ayi
 ayi
 ayi
-axE
+oWh
 aOS
 aPy
 aQm
@@ -56852,12 +65940,12 @@ ayi
 aTi
 iFR
 aTi
-aTi
 ayi
 ayi
 ayi
 ayi
-beb
+ayi
+ayi
 beb
 bfG
 lUl
@@ -56881,7 +65969,7 @@ hVo
 hVo
 hVo
 bGk
-axz
+tHc
 hOm
 anB
 huX
@@ -56894,7 +65982,7 @@ bRO
 bRO
 bUs
 bRO
-bXd
+bYB
 bXd
 bZP
 caM
@@ -56905,19 +65993,19 @@ bXd
 bXd
 ciC
 ckf
-cnH
+vya
 cmn
 cnJ
 coT
 cqY
-cqY
-cnH
-cnH
-cnH
+oPs
+ffu
+tqv
+tqv
 coT
 lWL
 cCh
-bcL
+oOf
 bcL
 bcL
 bcL
@@ -57076,9 +66164,9 @@ asy
 bpB
 aup
 avj
-axE
+bIt
 cjE
-cpR
+bHT
 ayi
 ayP
 bcU
@@ -57138,7 +66226,7 @@ jde
 bAv
 bEP
 hVo
-bHL
+rsF
 hGr
 bJB
 egK
@@ -57151,14 +66239,14 @@ bRO
 gtw
 cns
 bVN
-chz
-chz
+xhq
+xhq
 bZQ
 cch
 cch
 cch
 bWU
-chz
+xhq
 eCe
 cjF
 ckg
@@ -57175,7 +66263,7 @@ coT
 lWL
 cCh
 bcL
-cuN
+pPt
 cBa
 cCh
 cCh
@@ -57333,7 +66421,7 @@ mvU
 atA
 ouR
 bMg
-siP
+wsN
 cjE
 hyR
 ayi
@@ -57364,14 +66452,14 @@ aFZ
 aUx
 aTj
 aYh
-aSa
-aNo
+eXD
+sdj
 xTS
 bcU
 bcU
+elW
 bcU
-bcU
-beb
+ayi
 beU
 bfH
 bjH
@@ -57395,19 +66483,19 @@ bBV
 bDC
 mMC
 bGm
-bJD
+bDt
 xMx
 bJC
 lCe
-bJD
+ouX
 bvX
 brC
 lHi
 brC
 bRO
-chz
+kLW
 cns
-cns
+iZV
 bXe
 bXe
 qyx
@@ -57590,7 +66678,7 @@ asA
 fob
 aur
 avj
-cpR
+foX
 rXU
 abX
 nfs
@@ -57621,14 +66709,14 @@ bcU
 bcU
 ayi
 aUv
-aSa
+eXD
 aUv
 ayi
 aFh
 baE
 bcU
 bcU
-beb
+ayi
 beV
 bfI
 bgQ
@@ -57652,7 +66740,7 @@ bBW
 cir
 bEQ
 bGn
-bTw
+pLN
 bTw
 aiP
 lCe
@@ -57664,15 +66752,15 @@ bQs
 bRO
 pDY
 bUu
-chz
+fFF
 bXf
 bYI
 fJy
-chz
+qCa
 ccj
 cdA
 ceI
-chz
+kLW
 wBU
 kXe
 cki
@@ -57689,7 +66777,7 @@ aCI
 lWL
 cCh
 bcL
-cuN
+ubi
 cCh
 lWL
 lWL
@@ -57835,7 +66923,7 @@ atu
 dxF
 gEj
 alf
-amM
+vyr
 amM
 amM
 amM
@@ -57847,9 +66935,9 @@ jgL
 bOT
 aus
 atx
-cpR
+foX
 cjE
-axD
+tvs
 ayi
 ayS
 bcU
@@ -57880,12 +66968,12 @@ aLY
 aMH
 aVy
 aMH
-aMH
+aLY
 aLY
 aLY
 aLY
 bcV
-bed
+aLY
 bed
 bfJ
 bgR
@@ -57909,28 +66997,28 @@ bBX
 bDD
 bER
 bGm
-bJD
+bDt
 xMx
 bJD
 lCe
 bLf
 bNF
 bNz
-chz
-chz
-chz
-chz
+wsU
+xhq
+xhq
+irU
 uuH
-chz
+fFF
 bXg
 bYJ
 mEJ
-chz
+qCa
 cck
 cdB
 ceJ
-chz
-lKn
+kLW
+qKP
 ciG
 cnD
 coJ
@@ -57946,7 +67034,7 @@ cCh
 cCh
 cCh
 bcL
-cAp
+cAl
 cCh
 lWL
 lWL
@@ -58092,8 +67180,8 @@ atu
 auU
 adP
 aWB
-atu
-atu
+adP
+alb
 auU
 auU
 auU
@@ -58104,9 +67192,9 @@ atx
 atx
 atx
 atx
-qKi
+fhV
 cjE
-axE
+bYF
 ayi
 ayT
 bcU
@@ -58137,15 +67225,15 @@ aTl
 aUw
 aSa
 aNo
-aMH
+bKw
 aZx
 baF
 cqz
 aba
 khb
-bed
-bed
-bed
+bKw
+bKw
+bKw
 bik
 bfI
 bkT
@@ -58166,7 +67254,7 @@ hVo
 hVo
 hVo
 hVo
-bJD
+bDt
 xMx
 bJD
 dIW
@@ -58181,13 +67269,13 @@ uYm
 lKn
 eZE
 bXh
-chz
-chz
+xhq
+xhq
 ccl
 bXh
 ceK
-chz
-chz
+irU
+cGp
 kXe
 ckk
 xhD
@@ -58203,7 +67291,7 @@ cwp
 cCh
 bcL
 bcL
-cAp
+oBD
 cCh
 aCI
 aCI
@@ -58353,12 +67441,12 @@ auU
 auU
 auU
 aol
-ape
-fGe
+aRp
+kkk
 aqG
 arC
-iUw
-cpR
+iDw
+bHT
 bal
 aBd
 cpR
@@ -58402,7 +67490,7 @@ aba
 khb
 beW
 bfK
-bed
+bKw
 bil
 bjH
 bjH
@@ -58423,7 +67511,7 @@ bCb
 bEc
 bFD
 bGo
-sGt
+xdF
 xMx
 bJD
 lCe
@@ -58432,8 +67520,8 @@ bNF
 bNB
 bPe
 xiO
-chz
-chz
+nMj
+uGL
 chz
 chz
 vsw
@@ -58455,11 +67543,11 @@ ckm
 aCI
 csj
 ctj
-cuN
-cAp
+pPt
+cAl
 cCh
 bcL
-cAp
+cAl
 cCh
 cCh
 lWL
@@ -58647,19 +67735,19 @@ aPC
 aQo
 aQV
 aSa
-aYh
+oir
 aUy
-aYh
+oir
 aNo
-aMH
+bKw
 aZz
 pYH
 iWo
 uKM
-aba
+bXk
 aba
 bfL
-bed
+bKw
 bim
 bjH
 bjH
@@ -58690,14 +67778,14 @@ bNC
 bPf
 bNC
 cqU
-bST
+uOl
 bST
 rmn
 vsw
 bYL
 bZT
-chz
-chz
+nMj
+nMj
 cdC
 ceM
 iGo
@@ -58872,12 +67960,12 @@ rzW
 axE
 aKU
 kMe
-xda
+dlc
 auv
 avo
-axE
-axE
-axE
+bIt
+iev
+dje
 ayi
 bcU
 bcU
@@ -58908,7 +67996,7 @@ aTo
 aMH
 aMH
 aMH
-aMH
+bKw
 bKw
 aba
 tsL
@@ -58916,7 +68004,7 @@ aba
 aba
 beX
 bfM
-bed
+bKw
 bin
 bjI
 bkU
@@ -58932,7 +68020,7 @@ afE
 afB
 kzm
 pYa
-pYa
+bEA
 bBY
 bDG
 erz
@@ -58955,10 +68043,10 @@ bRO
 bRO
 bRO
 ccm
-bNF
+ceR
 ceN
-bNF
-bNF
+ceR
+ceR
 bNF
 lWL
 lWL
@@ -58972,7 +68060,7 @@ cuN
 bcL
 bcL
 bcL
-bcL
+jGJ
 czx
 cAq
 cBb
@@ -59125,7 +68213,7 @@ lWL
 anB
 aoo
 pdu
-axE
+uFU
 aqH
 anB
 anB
@@ -59173,7 +68261,7 @@ bcZ
 bef
 beY
 bKw
-bed
+bKw
 bio
 bio
 bio
@@ -59207,14 +68295,14 @@ cqU
 bSU
 bUw
 bVP
-vsw
+ojV
 bYM
 bRO
 caQ
 bYN
-bNF
+ceR
 ceO
-cwx
+tgJ
 cCh
 lWL
 lWL
@@ -59225,7 +68313,7 @@ cCh
 cCh
 cCh
 cCh
-cuN
+ubi
 bcL
 cCh
 cCh
@@ -59451,33 +68539,33 @@ siq
 bEd
 bEW
 gfV
-bJD
+bDt
 xMx
 bJD
 lCe
 bLk
 bGl
 qIs
-tQt
+xAH
 gas
 cqU
 bSV
-vsw
-vsw
-vsw
+ojV
+ojV
+ojV
 bYN
 bRO
 caR
 ccn
-bNF
+ceR
 ceO
-cuN
+cAl
 cCh
 cCh
 cCh
 cCh
 cmt
-cuN
+pPt
 cuN
 cuN
 cuN
@@ -59708,11 +68796,11 @@ bGt
 bGt
 bGt
 bGt
-bJD
+bDt
 xMx
 bJD
 lCe
-bJD
+kzs
 bGl
 bNE
 bPg
@@ -59726,7 +68814,7 @@ bYO
 bRO
 caQ
 xLJ
-bNF
+ceR
 ceQ
 ctn
 ctn
@@ -59738,11 +68826,11 @@ ctn
 coZ
 cql
 cra
-ctn
+tMo
 ctn
 cuS
 cwt
-cxP
+xGB
 cyB
 cxP
 ceR
@@ -59887,7 +68975,7 @@ lWL
 aCI
 aCI
 ahR
-akh
+hdN
 akh
 auU
 aCI
@@ -59965,11 +69053,11 @@ bLv
 bLv
 bLv
 pcv
-vKb
+fAN
 vKb
 bNI
 lCe
-bLl
+dGC
 bGl
 bGl
 bGl
@@ -59983,7 +69071,7 @@ ggT
 bNF
 bNF
 bNF
-bNF
+ceR
 ceR
 ceR
 ceR
@@ -60222,12 +69310,12 @@ bGt
 bGt
 bGt
 bGt
-bJD
+bDt
 xMx
 bJD
 jXm
-bJD
-bHL
+kzs
+ecD
 bNG
 bNG
 bQx
@@ -60469,9 +69557,9 @@ bGt
 bLv
 bGt
 bGt
-bqZ
-bqZ
-bqZ
+bGt
+bGt
+bGt
 bxD
 byQ
 bAD
@@ -60488,7 +69576,7 @@ hGr
 xMx
 bJD
 bJD
-sAj
+jYG
 bSY
 eFv
 bVS
@@ -60510,7 +69598,7 @@ bUO
 bUO
 aCI
 ceR
-cuN
+ubi
 ceO
 hHE
 hHE
@@ -60728,7 +69816,7 @@ bGt
 bwb
 btB
 btB
-bsf
+jcM
 bxD
 byR
 bAE
@@ -60736,13 +69824,13 @@ bCe
 bDJ
 bEY
 bGv
-bJD
+bDt
 fhR
 bJF
 bKs
-bJD
-bHL
-xMx
+emo
+jrE
+oAq
 bJD
 bJD
 bRR
@@ -60769,9 +69857,9 @@ aCI
 ceR
 cHo
 ceO
+pPt
 cuN
-cuN
-cuN
+pPt
 cuN
 cuN
 cBd
@@ -60993,18 +70081,18 @@ bAF
 mqF
 bDJ
 bGw
-bJD
+bDt
 fhR
 bJG
 bKs
-bJD
-bJB
-xMx
+meU
+oRI
+rPh
 bXo
 xMx
-cTs
+mWo
 bTa
-che
+ibN
 teu
 bRy
 ggT
@@ -61177,14 +70265,14 @@ aCI
 auU
 auU
 auU
-atu
+dXA
 khd
 pYa
 eDG
 pYa
 aHp
 arG
-atu
+dXA
 atD
 aiD
 aCI
@@ -61239,7 +70327,7 @@ boP
 btA
 bLv
 bGt
-bsf
+jcM
 buI
 buI
 kET
@@ -61250,13 +70338,13 @@ bCg
 bDJ
 bDJ
 dls
-bJD
+bDt
 fhR
 bJH
 bKs
-bJD
-bHL
-bJD
+gDh
+boX
+ktp
 bJD
 bJD
 dEN
@@ -61288,7 +70376,7 @@ cCh
 cAp
 cuN
 cuN
-cuN
+pPt
 cuN
 cCh
 lWL
@@ -61497,9 +70585,9 @@ boP
 bqd
 bGt
 oqG
-bAL
+uLN
 oFA
-bAL
+uLN
 bxE
 bJd
 bAH
@@ -61516,7 +70604,7 @@ bMq
 bNI
 bNI
 bNI
-bNI
+jlY
 ggT
 bUE
 bVW
@@ -61768,15 +70856,15 @@ dKs
 xMx
 bJD
 lCe
-bJD
-bHL
+mfG
+lDt
 bNJ
 bNJ
-fRM
+xSF
 fRM
 ggT
 bUF
-che
+wKp
 jVQ
 ggT
 aEk
@@ -61799,11 +70887,11 @@ ceR
 cuX
 ceR
 ceR
-cuN
+pPt
 czA
 cAt
 cBe
-cuN
+dPo
 cCh
 cCh
 lWL
@@ -62016,12 +71104,12 @@ buG
 bsf
 bsf
 byV
-bsf
+jcM
 tpP
-buG
+iKA
 kmo
 bGx
-bJD
+bDt
 xMx
 bJD
 lCe
@@ -62056,7 +71144,7 @@ ctr
 cvj
 cwz
 ceR
-cuN
+cAl
 cuN
 cAu
 cAu
@@ -62271,25 +71359,25 @@ bsl
 bAL
 bAL
 bwe
-bwe
+ixi
 bGx
 bCi
 bCi
 bCi
-bsf
+jcM
 bGx
-bJD
+bDt
 xMx
 bJD
 lCe
-bJD
+wCu
 bMy
 bNK
 bPi
 bQz
 bMz
 bTb
-bXu
+vMh
 oFn
 uxh
 bYP
@@ -62311,7 +71399,7 @@ crb
 csk
 cwB
 svB
-cwB
+hXd
 ceR
 ceR
 ceR
@@ -62526,20 +71614,20 @@ bqf
 bGt
 bsm
 btI
-bAL
+xkf
 bwf
 bxG
 bGx
 bCi
 bCi
 bCi
-bsf
+jcM
 bGx
-sGt
+xdF
 xMx
 bJD
 lCe
-bJD
+nnB
 bMy
 bNL
 bPj
@@ -62568,14 +71656,14 @@ crc
 csk
 cwB
 svB
-cwB
-cwB
+fbp
+dKZ
 cyC
-cyC
+apP
 ceR
 cAp
 wlf
-cuN
+pPt
 cCh
 lWL
 lWL
@@ -62785,14 +71873,14 @@ bsn
 btJ
 pUk
 bsf
-bsf
+jut
 bGx
 bCi
 bCi
 bCi
-bsf
+jcM
 bGx
-bJD
+bDt
 xMx
 xMx
 bzh
@@ -62821,17 +71909,17 @@ cdH
 cpg
 cpg
 bXw
-cpg
+mCw
 ske
 gYL
 svB
-cwC
-cwB
+uXy
+wrB
 cyC
 cyC
 ceR
 cBg
-cuN
+pPt
 cuN
 cCh
 cCh
@@ -63044,16 +72132,16 @@ buN
 bwg
 bxI
 byY
-bAL
+uLN
 llF
 fiS
-bsf
+jcM
 bGy
-bJD
+bDt
 xMx
 bJD
 lCe
-bJD
+nnB
 bMy
 bNN
 dWU
@@ -63083,7 +72171,7 @@ csk
 ctv
 svB
 cwD
-cwB
+wrB
 cyD
 cyD
 ceR
@@ -63295,18 +72383,18 @@ blS
 btA
 bLv
 bGt
-bsn
+pSa
 btL
 vLc
 bsf
-bsf
+jut
 bGx
 tAZ
 log
 kAu
 bFd
 bGx
-bJD
+bDt
 xMx
 bJD
 lCe
@@ -63339,14 +72427,14 @@ crf
 csk
 ctw
 svB
-cwB
-cwB
-cyE
+fbp
+uRq
+wld
 cyE
 ceR
 cBi
 cCl
-cuN
+pPt
 cHo
 cCh
 lWL
@@ -63561,9 +72649,9 @@ bGx
 tAZ
 bCi
 bCi
-bsf
+jcM
 bGx
-bJD
+bDt
 xMx
 bJD
 lCe
@@ -63573,13 +72661,13 @@ bNP
 fde
 bQE
 bMz
-bTg
-bXu
-paY
-cpg
-caU
-caU
-caU
+cAE
+gUM
+jFJ
+fHg
+qiU
+qiU
+vPW
 caU
 cpg
 bcM
@@ -63813,18 +72901,18 @@ bsq
 btN
 eyC
 bwi
-bwi
+hPB
 bGx
 tAZ
 bCi
 bCi
-bsf
+jcM
 bGx
-bJD
+bDt
 xMx
 sGt
 lCe
-bLl
+vul
 bMy
 bNQ
 fWD
@@ -63853,7 +72941,7 @@ crh
 csm
 cty
 cve
-cwB
+kJg
 csp
 cyF
 czE
@@ -64066,22 +73154,22 @@ lWL
 bGt
 bLv
 bGt
-bsf
+jcM
 btO
 nuY
 bsf
 bxL
 bGx
-bAL
+uLN
 bCl
 bAO
 bwb
 bGx
-bJD
+bDt
 xMx
 bJD
 lCe
-bJD
+qvN
 bMz
 bMz
 bMz
@@ -64093,7 +73181,7 @@ aOC
 buR
 bjr
 gFj
-chE
+rcB
 chE
 chE
 mXu
@@ -64110,7 +73198,7 @@ cri
 csk
 ctz
 svB
-cwB
+vDp
 csp
 cyF
 cHP
@@ -64338,7 +73426,7 @@ mMH
 xMx
 bJD
 lCe
-bJD
+nnB
 ayX
 bQH
 bQH
@@ -64367,7 +73455,7 @@ jXO
 csk
 ctA
 cwK
-cwB
+vDp
 csp
 cyG
 cHP
@@ -64591,13 +73679,13 @@ bCm
 bCm
 bCm
 bGz
-nig
+euC
 nig
 czM
 bKt
-bJD
+nnB
 ayX
-bQH
+vQx
 tyB
 tyB
 bMB
@@ -64607,7 +73695,7 @@ xWK
 iYa
 iYa
 jiT
-cdH
+uGZ
 cdH
 cdH
 cdH
@@ -64624,7 +73712,7 @@ cId
 cmx
 vKS
 ltG
-cwB
+vDp
 csp
 cyG
 cHP
@@ -64848,11 +73936,11 @@ btQ
 btQ
 btQ
 btQ
-bJD
+egY
 xMx
 bJD
 lCe
-bNI
+vyT
 mgP
 aot
 tyB
@@ -64864,7 +73952,7 @@ cvZ
 iYa
 cUk
 kpM
-uFd
+naS
 bXw
 cdL
 bXw
@@ -64881,7 +73969,7 @@ bXq
 csk
 ctL
 ltG
-cwB
+vDp
 csp
 cyG
 cHP
@@ -65109,10 +74197,10 @@ xPa
 xMx
 bJD
 lCe
-bJD
+nnB
 ayX
 bQH
-rpI
+slM
 crn
 ayX
 kVa
@@ -65134,11 +74222,11 @@ cmD
 bXw
 cph
 cqs
-cpg
+kEy
 csk
 cwB
 ltG
-cwB
+vDp
 csp
 cyH
 czG
@@ -65146,7 +74234,7 @@ cyH
 cBj
 cCq
 wGd
-cDc
+rga
 cEy
 cBj
 lWL
@@ -65362,7 +74450,7 @@ bCo
 bDQ
 pCv
 dfK
-xMx
+gXc
 xMx
 bJD
 lCe
@@ -65395,7 +74483,7 @@ csk
 csk
 ctE
 ltG
-cwB
+vDp
 csp
 pAo
 cHP
@@ -65614,7 +74702,7 @@ btA
 btQ
 bxO
 bzg
-rrS
+fdn
 bCp
 gff
 bFh
@@ -65652,7 +74740,7 @@ aCI
 csp
 ctF
 ltG
-cwB
+vDp
 csp
 cyI
 cyI
@@ -65822,7 +74910,7 @@ pYa
 pYa
 pYa
 pYa
-pYa
+bEA
 lWL
 aCI
 lWL
@@ -65876,7 +74964,7 @@ bCq
 gff
 bFi
 bGC
-bJD
+egY
 xMx
 bJK
 adr
@@ -65909,14 +74997,14 @@ aCI
 csp
 ctG
 ltG
-cwB
+vDp
 cvy
-cAB
-cAB
-cAB
+daK
+uSL
+uSL
 cBl
 cCt
-chH
+qnG
 cDK
 cvy
 cvy
@@ -66075,7 +75163,7 @@ lWL
 lWL
 lWL
 pYa
-pYa
+bEA
 vxE
 aAn
 pYa
@@ -66133,11 +75221,11 @@ bCr
 gff
 bFj
 bGC
-bJD
+egY
 uac
 tky
 dIW
-bLg
+nNK
 ayX
 bQH
 bQH
@@ -66168,7 +75256,7 @@ ctH
 cvi
 qzx
 cxR
-fux
+peu
 fux
 cBm
 cBm
@@ -66390,14 +75478,14 @@ bCs
 bDQ
 bFk
 bGC
-sGt
+nMR
 xMx
 bJD
 lCe
 bLo
 ayX
 bQH
-bQH
+vQx
 bQK
 ayX
 aCI
@@ -66425,13 +75513,13 @@ ctH
 vmF
 cwI
 cvy
-cAB
-jZk
+jNT
+mOC
 emu
 bZU
 bZU
 cCv
-cAB
+ccx
 cEA
 cHP
 bZV
@@ -66592,7 +75680,7 @@ pYa
 pYa
 pYa
 pYa
-pYa
+bEA
 pYa
 lWL
 aCI
@@ -66623,9 +75711,9 @@ lWL
 lWL
 lWL
 baK
-bwn
+rhJ
 bfd
-bff
+klj
 bxS
 bir
 bjP
@@ -66647,7 +75735,7 @@ bCt
 bDQ
 pCv
 bGC
-xMx
+gXc
 xMx
 xMx
 bzh
@@ -66680,11 +75768,11 @@ aCI
 csp
 ctJ
 vmF
-cwB
+vDp
 csp
 cFj
-jZk
-cAB
+lAf
+myP
 pqR
 wjQ
 jBq
@@ -66880,14 +75968,14 @@ aRb
 baK
 baK
 baK
-bwn
+qIO
 aVJ
-bff
+klj
 bxS
 bis
 xcq
 iHF
-blY
+smz
 bnd
 bpa
 wvs
@@ -66904,11 +75992,11 @@ bCu
 bDT
 bFl
 bGD
-bJD
+egY
 xMx
 bJD
 lCe
-djH
+vRN
 ayX
 bQH
 cdO
@@ -66940,7 +76028,7 @@ lAb
 cwC
 csp
 cyN
-jZk
+kVb
 num
 cFi
 cFi
@@ -67139,7 +76227,7 @@ fAw
 mkl
 bwn
 bwn
-bff
+klj
 bxS
 blY
 blb
@@ -67161,17 +76249,17 @@ bCB
 gff
 gff
 gff
-bJD
+tmK
 xMx
 bJD
 lCe
-bLl
+vul
 ayX
 bQH
 bQH
 bQH
 ayX
-nWr
+aCI
 aCI
 aCI
 aCI
@@ -67197,7 +76285,7 @@ cvl
 cwL
 csp
 cBp
-jZk
+mTy
 xZs
 cFi
 bQU
@@ -67396,7 +76484,7 @@ bwn
 bde
 bel
 bwn
-bff
+klj
 bxS
 biu
 bjS
@@ -67418,13 +76506,13 @@ eVe
 nqr
 bFm
 gff
-bJD
+egY
 xMx
 bJD
 lCe
-bJD
+nnB
 ayX
-bQH
+vQx
 bQH
 bQH
 ayX
@@ -67454,7 +76542,7 @@ cvl
 cwM
 csp
 cBq
-jZk
+mTy
 cCx
 cFi
 rya
@@ -67653,7 +76741,7 @@ bwn
 bdf
 bem
 bwn
-bff
+klj
 bxS
 biv
 iOF
@@ -67675,16 +76763,16 @@ bDX
 oLa
 bFn
 gff
-bHL
+tEZ
 hGr
 bJB
 liM
-bHL
+pZJ
 ayX
 bQH
 bQH
 bQH
-bQH
+vQx
 bQH
 bUP
 bQH
@@ -67695,23 +76783,23 @@ bQH
 bQH
 cdO
 bQH
+vQx
 bQH
 bQH
 bQH
-bQH
-bQH
+vQx
 bQH
 cnZ
-bNZ
+wWQ
 qJU
-bNZ
+tRr
 csq
-cwB
+bfc
 cvl
 cwN
 csp
 cyP
-jZk
+mTy
 cCy
 cFi
 adW
@@ -67932,11 +77020,11 @@ bCy
 bDV
 bFo
 gff
-bJD
+egY
 ueW
 jPX
 lCe
-bJD
+nnB
 ayX
 bNX
 cdO
@@ -67948,10 +77036,10 @@ ayX
 ayX
 ayX
 ayX
-bQH
+vQx
 bQH
 bUP
-bQH
+tNo
 ayX
 ayX
 ayX
@@ -67959,17 +77047,17 @@ ayX
 bQH
 bQH
 coa
+iMV
 bNZ
-bNZ
-gIQ
+qyM
 csr
-vmF
-vmF
-cwB
+tjO
+rGq
+kAe
 csp
 cyQ
-jZk
-ctP
+mTy
+hDE
 cFi
 sSE
 wZL
@@ -68167,7 +77255,7 @@ bwn
 bwn
 dlY
 bwn
-bff
+klj
 bxS
 bxS
 bRm
@@ -68193,7 +77281,7 @@ bHH
 cdP
 iHC
 lCe
-bJD
+nnB
 bMC
 ayX
 ayX
@@ -68216,7 +77304,7 @@ ayX
 ayX
 ayX
 cnZ
-bNZ
+rgN
 bNZ
 gIQ
 csp
@@ -68225,7 +77313,7 @@ csp
 csp
 csp
 uou
-jZk
+ghp
 bXB
 cFi
 qzy
@@ -68427,7 +77515,7 @@ bwn
 bff
 jIX
 bix
-ipf
+nDx
 bri
 bri
 bri
@@ -68440,50 +77528,50 @@ bri
 bri
 bri
 bgY
-sfu
+wIF
 bBe
 bCz
 bBe
-bHL
-bJD
+dVF
+cHU
 bJD
 gbe
 bJN
 lCe
-bNI
+vyT
 bME
-rjn
-rjn
-rjn
+ail
+ail
+ail
 bRZ
-rjn
-rjn
-rjn
-rjn
-rjn
-rjn
-rjn
+ail
+ail
+ail
+ail
+ail
+ail
+tNA
 bRZ
 mOA
 cfa
-rjn
-rjn
-rjn
-rjn
-rjn
-bRZ
+ail
+ail
+ail
+ail
+wBw
+wBZ
 svz
-rjn
+kdE
 rjn
 bWh
 cxe
 ctP
-cBl
+sUp
 cwP
 cxT
-cAB
+iSU
 jZk
-cAB
+tbv
 cHb
 oJW
 wZL
@@ -68732,15 +77820,15 @@ hPR
 aJv
 gvh
 gvh
-gvh
+bIX
 coH
 xKi
-xKi
+rEp
 lWs
 cst
-xKi
+lfK
 oua
-cku
+dTF
 qwj
 cCB
 qil
@@ -68943,7 +78031,7 @@ doa
 fST
 fST
 fST
-sfu
+wsm
 bxV
 fST
 fST
@@ -68958,9 +78046,9 @@ bzt
 vbW
 wqY
 vbW
-hGr
-xMx
-xMx
+rVw
+gXc
+gXc
 qwq
 bJP
 bKz
@@ -68969,33 +78057,33 @@ bMF
 qWR
 bOa
 oSL
-bNZ
+rfG
 bTm
-sUS
-bNZ
+lLh
+rfG
 hAJ
-bNZ
-bNZ
-bNZ
-bNZ
+rfG
+rfG
+rfG
+rfG
 sUS
-bNZ
-bNZ
-bNZ
+hSu
+hSu
+hSu
 aAw
-bNZ
+hSu
 ubO
 cmH
-hAJ
-bNZ
+iNh
+wgZ
 cqx
 cxE
 cxe
 ctR
-xKi
+rEp
 cwQ
 cvy
-cAB
+iSU
 cBv
 sLt
 cBt
@@ -69193,7 +78281,7 @@ bwn
 baO
 bwn
 bwn
-cid
+fet
 baK
 gqk
 bhb
@@ -69221,7 +78309,7 @@ bHK
 knH
 rvo
 lCe
-bJD
+oHd
 bMG
 bMH
 bMI
@@ -69474,21 +78562,21 @@ bCC
 bDW
 bFr
 bwt
-bJD
+egY
 kkp
 hKi
 lCe
-bJD
+vFr
 bMH
 bOb
-bZe
+jgc
 bQR
-bZe
+jgc
 bTn
 bUR
 bWq
-rdb
-bZe
+rjN
+jgc
 aEH
 cbd
 bMH
@@ -69497,7 +78585,7 @@ cgJ
 cgJ
 cgM
 lAL
-cky
+nab
 clD
 cmJ
 uEw
@@ -69509,7 +78597,7 @@ ctS
 bKQ
 cwS
 cxV
-cAB
+iSU
 chH
 csu
 cFi
@@ -69731,13 +78819,13 @@ bzi
 bzi
 bFs
 bwt
-bHL
+tEZ
 hGr
 bJB
 bjc
-bHL
+nym
 bMH
-bZe
+jgc
 bZe
 bZe
 bZe
@@ -69754,7 +78842,7 @@ cfc
 cgJ
 cgM
 lAL
-cgJ
+kYx
 clD
 cmK
 uEw
@@ -69766,7 +78854,7 @@ kzT
 apu
 cwT
 puW
-num
+tNf
 chH
 cpe
 cFi
@@ -69964,7 +79052,7 @@ cid
 cid
 cid
 cid
-cid
+fet
 baK
 ncU
 bhd
@@ -69982,19 +79070,19 @@ bzi
 bvd
 bww
 bxX
-bCw
+lXd
 bzi
 bDU
-bCw
+uRR
 bFt
 bwt
-bJD
+egY
 xMx
 bJD
 lCe
-bJD
+oHd
 bMI
-bZe
+jgc
 bZe
 bXL
 bZe
@@ -70023,9 +79111,9 @@ gix
 apu
 cwU
 cxV
-cAB
+iSU
 chH
-xKi
+rEp
 cFi
 ybE
 gvk
@@ -70241,7 +79329,7 @@ bwx
 bxY
 bzx
 bzi
-bwy
+kJX
 bCw
 bFu
 bwt
@@ -70249,9 +79337,9 @@ ksH
 uac
 bJD
 lCe
-bJD
+oHd
 bMI
-bZe
+jgc
 bZe
 bXL
 bSd
@@ -70280,9 +79368,9 @@ nNJ
 cvs
 cwV
 cxV
-cAB
-chH
-xKi
+jNT
+dxd
+rEp
 cFi
 cCF
 gbT
@@ -70488,9 +79576,9 @@ lWL
 aZQ
 vSn
 bmi
-bpg
-bpg
-bpg
+tux
+tux
+tux
 bwt
 bzi
 ihv
@@ -70506,7 +79594,7 @@ bHZ
 xMx
 bJS
 lCe
-bJD
+oHd
 bMI
 bOd
 bZe
@@ -70538,8 +79626,8 @@ cvt
 cwW
 csv
 cyU
-chH
-xKi
+eCQ
+rEp
 cFi
 cFi
 wrZ
@@ -70775,7 +79863,7 @@ vIh
 rdb
 bZb
 bZe
-bZe
+jgc
 ccC
 cgJ
 cgJ
@@ -70795,11 +79883,11 @@ csv
 csv
 csv
 cyV
-chH
-xKi
-cAB
+eCQ
+sJb
+uSL
 cxY
-xKi
+vZC
 cDX
 cxe
 cxe
@@ -70810,7 +79898,7 @@ lWL
 lWL
 lWL
 lWL
-lWL
+lVR
 lWL
 lWL
 lWL
@@ -71016,13 +80104,13 @@ bwt
 bwt
 bwt
 bwt
-bJD
+egY
 xMx
 sGt
 lCe
-bJD
+oHd
 bMI
-bZe
+jgc
 bZe
 bXL
 bZe
@@ -71052,12 +80140,12 @@ aCI
 aCI
 cxW
 cyM
-chH
+eCQ
 xKi
 chH
 chH
 vpY
-cAB
+myP
 uXX
 cHP
 cxU
@@ -71268,16 +80356,16 @@ aZQ
 bhm
 aZQ
 bzA
-bBk
+qfE
 boi
 bBk
 bFv
 bGI
-bJD
+rjj
 xMx
 bJD
 lCe
-bJD
+oHd
 bMI
 bOf
 bZe
@@ -71292,7 +80380,7 @@ bZe
 cbi
 bMH
 cdX
-cgM
+cUT
 exY
 chS
 ciW
@@ -71309,12 +80397,12 @@ lWL
 lWL
 cxW
 cEM
-chH
+gZg
 cku
-cku
+pkp
 cAB
 xKi
-cEJ
+lwF
 cxe
 cFk
 cvy
@@ -71524,17 +80612,17 @@ aZQ
 aZQ
 aIL
 aZQ
-bBk
-bBk
+iIo
+moH
 bCG
-bBk
-bBk
+moH
+qfE
 bGK
-bJD
+rjj
 xMx
 bJD
 lCe
-bJD
+oHd
 bMI
 bOg
 bZe
@@ -71549,7 +80637,7 @@ bZe
 cbj
 bMH
 cdY
-kPC
+qHe
 cgE
 cgM
 lAL
@@ -71568,7 +80656,7 @@ bbD
 bby
 bby
 bby
-cku
+qgj
 cAB
 xKi
 cEa
@@ -71782,30 +80870,30 @@ vSn
 aIL
 aZQ
 bzC
-bBk
+moH
 bCH
-bBk
+voV
 bFw
 bGI
-bJD
+rjj
 xMx
 bJD
 lCe
-bJD
+oHd
 bMI
 bOh
 bZe
 bXL
 bZe
-bZe
+jgc
 bUT
 bWs
-ngV
-ngV
-ngV
+hju
+hju
+hju
 cbk
 bMH
-cdX
+gpM
 cgM
 cgD
 cgM
@@ -71828,7 +80916,7 @@ bby
 vFD
 cAB
 xKi
-cAB
+myP
 cEH
 cvy
 lWL
@@ -72039,18 +81127,18 @@ vSn
 bhm
 aZQ
 bzD
-bBk
+moH
 bCI
-bBk
+voV
 bFx
 byb
-bHK
+bYj
 xMx
 bJD
 lCe
 djH
 bMH
-bZe
+jgc
 bZe
 bZe
 bZe
@@ -72078,14 +81166,14 @@ czk
 clQ
 cvz
 cwY
-eXQ
+krx
 dZL
 czP
 bby
 cBA
 cAB
 xKi
-cAB
+myP
 cEI
 cvy
 lWL
@@ -72279,7 +81367,7 @@ lWL
 lWL
 aZQ
 aZQ
-aIL
+ksZ
 aIL
 tZz
 aZQ
@@ -72305,11 +81393,11 @@ aJj
 dlo
 bJD
 lCe
-bJD
-bSZ
+oHd
+eks
+jgc
 bZe
-bZe
-bZe
+laH
 bZe
 bTu
 bMI
@@ -72335,14 +81423,14 @@ czk
 cFE
 cvz
 cyT
-eXQ
+ruZ
 eXQ
 czQ
 pON
-cku
+qgj
 cAB
 xKi
-num
+fRp
 cEJ
 cvy
 lWL
@@ -72553,28 +81641,28 @@ vSn
 aIL
 aZQ
 bzF
-bCL
+pKx
 bCK
-eJc
+jGw
 bFz
 byb
-bJD
+rjj
 xMx
 bJD
 jXm
-bJD
+oHd
 eks
-bZe
-bZe
-bZe
-bZe
+jgc
+jgc
+jgc
+jgc
 bTv
 bMH
 bWu
 eQI
 bZl
 cac
-cac
+nqM
 ccE
 bUV
 cfh
@@ -72583,7 +81671,7 @@ cgM
 lAL
 cgJ
 csw
-cmQ
+nVv
 wLl
 csw
 cmQ
@@ -72594,12 +81682,12 @@ cvv
 bWi
 qBy
 cyY
-eXQ
+hmG
 pON
-cku
+qgj
 cAB
 lHb
-cAB
+myP
 cEK
 cvy
 lWL
@@ -72815,13 +81903,13 @@ bCH
 eJc
 bBk
 bGI
-bJD
+rjj
 xMx
 bJD
 lCe
-bLl
+wba
 bMH
-bMH
+evl
 bPA
 oSj
 bPA
@@ -72850,13 +81938,13 @@ bZW
 cvz
 cxb
 csy
-ubB
+bQc
 ubB
 cAJ
-cku
+qgj
 cAB
 xKi
-cAB
+myP
 cEL
 cvy
 lWL
@@ -73067,16 +82155,16 @@ vSn
 wtj
 lZG
 bwC
-bwC
+vKU
 cbF
-krX
+ugC
 krX
 qMe
-aiP
+rqu
 fdQ
 fdQ
 bKy
-gul
+aTu
 hZP
 bqm
 bqm
@@ -73110,10 +82198,10 @@ fdB
 fIj
 ilB
 pON
-cku
+qgj
 cAB
 xKi
-cAB
+myP
 cEM
 cvy
 lWL
@@ -73326,23 +82414,23 @@ aZQ
 bzI
 tHI
 bCN
-bBk
+qfE
 bFC
 bGL
-bHG
+kle
 aeW
 bHG
 bKx
 bJD
-bHL
-bJD
-bJD
-bJD
-bJD
-bTw
+tdf
+vqE
+vqE
+vqE
+vqE
+pkC
 paS
 bWx
-gdv
+kBO
 bZi
 sAV
 cac
@@ -73360,17 +82448,17 @@ oLC
 oLC
 oLC
 czk
-dkW
+sVA
 cvz
 cxd
-pfz
+cJn
 eXQ
 czS
 pON
-cku
+qgj
 cAB
 xKi
-cAB
+myP
 cBy
 cvy
 lWL
@@ -73586,17 +82674,17 @@ byb
 byb
 byb
 byb
-bJD
+rjj
 xMx
 bJD
 lCe
 bJD
-bHL
-bJD
-bJD
-sGt
-bJD
-bTw
+tdf
+vqE
+kKS
+iMU
+vqE
+mXU
 bUW
 cac
 gdv
@@ -73627,7 +82715,7 @@ bby
 cBC
 cAB
 xKi
-cAB
+myP
 cvy
 cvy
 lWL
@@ -73843,20 +82931,20 @@ bCb
 bEc
 bFD
 bGo
-sAj
+lkW
 kqh
 bJE
 bKz
-bHG
+oas
 bML
-bHG
-bHG
-bHG
-bHG
+yeR
+yeR
+yeR
+jZz
 boO
 bUX
 cac
-cac
+nqM
 bZl
 cag
 nPb
@@ -73865,7 +82953,7 @@ bUV
 cfm
 cgJ
 cgM
-lAL
+bVn
 iXM
 cgM
 cgM
@@ -73873,7 +82961,7 @@ cgM
 cgM
 cgM
 crB
-csw
+czk
 ctZ
 cvz
 cxf
@@ -73881,12 +82969,12 @@ cyb
 eXQ
 czU
 pON
-chH
+eCQ
 cAB
 xKi
 myP
+tjz
 cvy
-lWL
 lWL
 aCI
 lWL
@@ -74100,16 +83188,16 @@ bBY
 bDF
 bJD
 bGp
-sAj
+lkW
 fhR
 bJF
 bKs
-bJD
+nol
 bMM
 qjl
-bOi
-bOi
-bOi
+syA
+syA
+uIi
 bTy
 kZo
 cac
@@ -74122,28 +83210,28 @@ bUV
 cfn
 cgJ
 cgM
-bVn
+lAL
 jaX
 cgJ
 cmW
 cky
 cgJ
 cqF
-cgJ
+obq
 czk
 bZW
 cvz
 cxg
+wsf
 pfz
-pfz
-czU
+czT
 pON
-chH
+gZg
 cku
 cDq
 ccx
+xhb
 cvy
-aCI
 aCI
 aCI
 lWL
@@ -74289,13 +83377,13 @@ lWL
 qoT
 lWL
 lWL
-aCI
+eEb
 lWL
 lWL
 lWL
 lWL
 lWL
-aCI
+eEb
 lWL
 vnK
 lWL
@@ -74357,17 +83445,17 @@ bBY
 bDG
 erz
 gdS
-bJD
+rjj
 fhR
 bJG
 bKs
-bJD
-bMN
+nol
+vzb
 bOj
 bOk
-sMp
-bOi
-bTy
+nLG
+qYg
+ooJ
 bUV
 bWz
 bUV
@@ -74400,7 +83488,7 @@ cCK
 cyd
 cyd
 cyd
-lWL
+cyd
 aCI
 lWL
 lWL
@@ -74614,19 +83702,19 @@ bBY
 vRv
 bJD
 bGr
-ajC
+dMW
 fhR
 bJH
 bKs
-bJD
-bMN
+jYo
+vzb
 bOk
 bOi
 bQW
 sMp
-nMm
+tOx
 bUY
-bOi
+wgq
 bXR
 cep
 cai
@@ -74634,8 +83722,8 @@ cbr
 oCu
 cdZ
 cfo
-cgM
-cgM
+tCr
+lxj
 lAL
 cGl
 clF
@@ -74649,9 +83737,9 @@ cuc
 cvA
 cFE
 cvz
-tch
+fxt
 czW
-czi
+tof
 cBG
 mIl
 cDr
@@ -74802,7 +83890,7 @@ lWL
 lWL
 api
 lWL
-pYa
+bEA
 pYa
 lWL
 lWL
@@ -74871,11 +83959,11 @@ siq
 bEd
 bEW
 gfV
-ajC
+dMW
 wJI
 kpO
 lCe
-bJD
+nol
 bMO
 bOk
 bPC
@@ -74883,7 +83971,7 @@ bOk
 bSf
 nMm
 eqN
-bOi
+qpc
 bXS
 cep
 caj
@@ -75128,19 +84216,19 @@ pAU
 pAU
 pAU
 pAU
-bJD
+rjj
 xMx
 bJD
 lCe
-bLl
-bMN
+wWF
+vzb
 bOl
 bOi
 bQX
-bOi
+qYg
 bTA
 dqV
-bOi
+wgq
 bXT
 cep
 cak
@@ -75148,8 +84236,8 @@ cbt
 aeH
 ceb
 cfp
-cgM
-cgM
+tCr
+lxj
 lAL
 jaX
 clF
@@ -75164,7 +84252,7 @@ cvC
 cFE
 cvz
 dgf
-czi
+bLw
 rCr
 cBI
 tdF
@@ -75299,7 +84387,7 @@ lWL
 aCI
 aCI
 lWL
-pYa
+bEA
 pYa
 abT
 oVB
@@ -75323,7 +84411,7 @@ lWL
 lWL
 lWL
 lWL
-aCI
+sHy
 lWL
 lWL
 lWL
@@ -75385,19 +84473,19 @@ bCO
 bCO
 bFF
 pAU
-bJD
+rjj
 xMx
 bJD
 lCe
-bJD
-bMN
+mBd
+vzb
 bOj
 bOk
-sMp
+rtl
 oeb
 bTA
 bVa
-bOi
+wgq
 bXU
 cep
 cal
@@ -75423,7 +84511,7 @@ cvz
 tch
 czX
 cAN
-czi
+kVE
 tdF
 cDu
 cyd
@@ -75621,7 +84709,7 @@ lWL
 aCI
 lWL
 lWL
-pYa
+bEA
 pYa
 pYa
 lWL
@@ -75632,7 +84720,7 @@ lWL
 bqr
 bru
 bsz
-bsA
+uKR
 bvj
 bwE
 bvj
@@ -75642,12 +84730,12 @@ bCP
 bEe
 bFG
 pAU
-bJD
+nlW
 xMx
 bJD
 lCe
-bJD
-bMN
+nol
+vzb
 bOk
 bOi
 bQW
@@ -75663,14 +84751,14 @@ aeH
 ced
 cfr
 cgK
-gbQ
-wfu
-iXM
+hWG
+tVB
+pPs
 clF
 cna
 cos
 cos
-cos
+hHb
 crE
 czk
 sDI
@@ -75678,7 +84766,7 @@ seW
 cxi
 cvz
 tch
-czi
+bLw
 rCr
 ngx
 cCO
@@ -75903,15 +84991,15 @@ jpU
 xMx
 bJD
 lCe
-bJD
+nol
 bMO
 bOk
 bPC
 bOk
-bOi
+kHr
 pbE
 cAL
-bOi
+wgq
 bXW
 cep
 cep
@@ -75922,12 +85010,12 @@ csw
 csw
 csw
 cjf
-iXM
+pPs
 clF
 cnb
 cot
 crE
-crE
+uEk
 crF
 czk
 sDI
@@ -75937,7 +85025,7 @@ cvz
 tch
 czX
 cAN
-czi
+kVE
 czi
 cyd
 aCI
@@ -76156,45 +85244,45 @@ try
 lgJ
 qeX
 pAU
-bJD
+opp
 xMx
 bJD
 lCe
-bJD
-bMN
+nol
+vzb
 bOk
 bOi
 bQX
 sMp
-pbE
+caz
 bUZ
 nhn
 eqo
 bZn
 dAE
-sKu
+qts
 can
 csw
 cfs
 cgL
 csw
-lAL
-wfu
+iNl
+iMB
 clH
 cnc
 cou
 cqL
 cqL
-cqL
+cSA
 czk
 sDI
 uHh
 cFE
 cvz
 tch
-czi
+bLw
 rCr
-czi
+kVE
 cCP
 cyd
 lWL
@@ -76328,9 +85416,9 @@ pYa
 pYa
 pYa
 vZE
+tdv
 apx
-apx
-apx
+usY
 adQ
 pYa
 pYa
@@ -76418,12 +85506,12 @@ xMx
 bJD
 lCe
 bGN
-bMN
+vzb
 bOj
 bOk
 bOi
 bSi
-pbE
+caz
 bUZ
 txN
 bXY
@@ -76435,7 +85523,7 @@ csw
 cft
 con
 chZ
-lAL
+iNl
 gHx
 clF
 cnd
@@ -76451,7 +85539,7 @@ cvz
 tch
 czX
 cAN
-czi
+kVE
 cyd
 cyd
 lWL
@@ -76579,13 +85667,13 @@ lWL
 aCI
 aCI
 lWL
-pYa
+bEA
 pYa
 pYa
 pYa
 pYa
 vZE
-cfu
+doW
 yjd
 vZW
 adQ
@@ -76670,19 +85758,19 @@ bCR
 enV
 mUJ
 pAU
-bJD
+rjj
 xMx
 bJD
 lCe
-bJD
-bMN
+nol
+vzb
 bOl
-sMp
+rtl
 bQW
-sMp
+keE
 oPF
-oPF
-oPF
+bdR
+imP
 bXZ
 bMN
 cap
@@ -76692,8 +85780,8 @@ csw
 lny
 cgN
 csw
-lAL
-iXM
+iNl
+pPs
 clF
 cne
 clF
@@ -76705,10 +85793,10 @@ cug
 bZW
 cug
 cvz
-czi
+kBy
 czZ
-czi
-czi
+eEA
+gRO
 cyd
 lWL
 lWL
@@ -76842,9 +85930,9 @@ pYa
 pYa
 pYa
 adQ
-aeY
+dXb
 aeZ
-cfu
+unY
 adQ
 ajB
 ajB
@@ -76887,9 +85975,9 @@ aKm
 fEG
 aRj
 aRj
-agO
-agO
-agO
+ayn
+isq
+ayn
 ayn
 aRj
 aRj
@@ -76916,7 +86004,7 @@ adj
 adj
 aZQ
 brx
-bsA
+uKR
 bud
 bsA
 bwI
@@ -76927,18 +86015,18 @@ bsA
 gBg
 fbm
 bBn
-bJD
+rjj
 xMx
 bJD
 lCe
-bJD
+nol
 bMO
 bOk
 bPC
 bOk
+mHV
 bOi
-bOi
-bOi
+mHV
 bTC
 bbs
 bMN
@@ -76949,13 +86037,13 @@ csw
 lDn
 mhI
 csw
-lAL
-iXM
+iNl
+pPs
 clF
 clF
-csw
-csw
-csw
+clF
+clF
+clF
 czk
 czk
 czk
@@ -77144,9 +86232,9 @@ aKm
 fEG
 aRj
 aRj
+bHM
 agO
-agO
-agO
+org
 aPI
 aQu
 aRe
@@ -77182,15 +86270,15 @@ aVK
 aVK
 aVK
 qFe
-qFe
+imJ
 bGO
-cTs
+jAD
 vKb
 bNI
 adr
-bLl
-bMN
-bOk
+wWF
+vzb
+dPN
 bPD
 bQX
 bSj
@@ -77357,8 +86445,8 @@ lWL
 lWL
 lWL
 adQ
-apx
-cfu
+vsl
+naE
 agl
 jOh
 apx
@@ -77380,7 +86468,7 @@ lWL
 lWL
 lWL
 ajB
-awL
+bDr
 awL
 ayo
 lWL
@@ -77402,9 +86490,9 @@ fEG
 aRj
 aRj
 jHW
-agO
+ayn
 aPb
-ane
+oey
 aQt
 ane
 axF
@@ -77426,11 +86514,11 @@ biS
 dRs
 aCI
 buf
-aIL
+gwR
 adj
 aZQ
 brz
-bsA
+nKS
 bsA
 bsA
 bwH
@@ -77439,9 +86527,9 @@ bzK
 bBo
 bBo
 bBo
-bBo
+clV
 bGP
-bHG
+kle
 nCD
 bHG
 bKx
@@ -77463,7 +86551,7 @@ csw
 cmP
 cgO
 csw
-lAL
+iNl
 jWC
 cgJ
 oLC
@@ -77614,12 +86702,12 @@ lWL
 lWL
 adT
 aew
-apx
+ciN
 yjd
 olW
 cfu
 cfu
-apx
+bVt
 jId
 pYa
 pYa
@@ -77637,7 +86725,7 @@ atG
 lWL
 lWL
 ajB
-apx
+ciN
 aYN
 ayo
 ayo
@@ -77658,9 +86746,9 @@ rVS
 lWL
 aRj
 aRj
+org
 agO
-agO
-agO
+bHM
 tyO
 aQu
 aRf
@@ -77669,7 +86757,7 @@ aTE
 aVS
 jbU
 bdr
-bdr
+uNE
 bdr
 aYC
 bhN
@@ -77698,11 +86786,11 @@ bCS
 bEg
 bFI
 bBn
-bJD
+rjj
 xMx
 bJD
 lCe
-bJD
+nnB
 bMP
 bOm
 bPE
@@ -77712,7 +86800,7 @@ bTG
 bVf
 bWD
 bYa
-bZt
+kKb
 bMP
 cbB
 kEo
@@ -77872,11 +86960,11 @@ lWL
 lWL
 adQ
 afb
-mxO
-ani
-apx
+oJj
+iuz
+ciN
 cfu
-apx
+bVt
 fCf
 ajB
 ajB
@@ -77894,8 +86982,8 @@ atH
 ajB
 lWL
 ajB
-apx
-apx
+ciN
+bVt
 ayo
 ayY
 ayY
@@ -77915,12 +87003,12 @@ lWL
 lWL
 aRj
 aRj
-agO
-agO
-agO
-agO
+ayn
+thy
+ngT
+ayn
 aQu
-agO
+kpK
 bVq
 aTF
 aVS
@@ -77965,11 +87053,11 @@ bOn
 bRc
 bLB
 cee
-bLB
+aGy
 oxs
 bWE
-bRc
-bRc
+uKm
+awd
 bTI
 cbC
 cdb
@@ -77977,7 +87065,7 @@ csw
 cfv
 gQH
 csw
-cgM
+pOS
 iXM
 lAL
 cnh
@@ -78131,19 +87219,19 @@ acD
 acD
 acD
 acD
-apx
+wdk
 cfu
-apx
-alD
+bVt
+vlx
 anP
 puZ
 ivL
-alD
-alD
-anP
-puZ
+vlx
+uWO
+eVa
+dHh
 xTf
-alD
+uWO
 abT
 abT
 ajB
@@ -78151,8 +87239,8 @@ atI
 ajB
 abT
 abT
-apx
-apx
+ciN
+bVt
 ayo
 ayo
 wHk
@@ -78177,7 +87265,7 @@ aRj
 aRj
 aRj
 aRj
-agO
+kpK
 aSv
 aTG
 aVS
@@ -78206,7 +87294,7 @@ byh
 bvm
 bwI
 aVK
-bsA
+nKS
 bBr
 bsA
 bsA
@@ -78219,7 +87307,7 @@ tlb
 bLD
 bMP
 bOo
-bRc
+sPO
 bRa
 bMP
 bTI
@@ -78381,14 +87469,14 @@ lWL
 aCI
 acp
 acD
+vaN
 afd
-afd
-afd
+kLt
 aex
 afc
 afL
 wzV
-apx
+mrb
 cfu
 apx
 apx
@@ -78408,8 +87496,8 @@ atJ
 ajB
 aeY
 abT
-apx
-apx
+ciN
+bVt
 abT
 ayo
 ayY
@@ -78455,7 +87543,7 @@ dRs
 aCI
 buf
 aIL
-adj
+cZk
 aZQ
 hdY
 bsA
@@ -78488,8 +87576,8 @@ cas
 cbD
 aLd
 cOu
-bRc
-bRc
+aXD
+aXD
 bMP
 cji
 iXM
@@ -78636,7 +87724,7 @@ lWL
 lWL
 lWL
 aCI
-acp
+uiF
 acD
 acU
 ads
@@ -78645,7 +87733,7 @@ uHX
 aez
 mfp
 agn
-apx
+mrb
 gjY
 gjY
 oFB
@@ -78657,16 +87745,16 @@ shq
 gjY
 gjY
 gjY
-gjY
+bMa
 aqO
+bMa
+bMa
+bMa
+bMa
+bMa
+bMa
 gjY
-gjY
-gjY
-gjY
-gjY
-gjY
-gjY
-gjY
+bMa
 abT
 ayo
 ayo
@@ -78696,7 +87784,7 @@ aSx
 aRj
 aVS
 aVW
-aYC
+hep
 ayu
 aYC
 aYC
@@ -78733,7 +87821,7 @@ skL
 bLD
 bMP
 bOq
-bRc
+sPO
 bLB
 bSl
 bTJ
@@ -78741,12 +87829,12 @@ bVi
 oLS
 bYc
 bFE
-cat
+izD
 cbE
 svt
 cef
 cfw
-bRc
+hDO
 bMP
 cjj
 ckL
@@ -78895,14 +87983,14 @@ lWL
 aCI
 acp
 acD
+kLt
 afd
-afd
-afd
+vaN
 kGP
 acT
-acT
+dWk
 fKB
-akG
+wLC
 gjY
 apx
 bDn
@@ -78949,8 +88037,8 @@ lWL
 lWL
 aRj
 aRk
-fHu
-agO
+oNK
+aRI
 aVS
 aVX
 uOM
@@ -78983,15 +88071,15 @@ bCU
 rFV
 aoW
 yfr
-bJD
+rjj
 xMx
 bJK
 adr
-bLk
+uZT
 bMP
 bOr
 bRc
-bLB
+gzX
 bMP
 bTJ
 bTJ
@@ -79000,14 +88088,14 @@ bYc
 bFE
 cat
 cbE
-svt
+hXy
 cef
 cfx
-bRc
+aXD
 bMP
 cjk
 iXM
-lAL
+kYQ
 csw
 csw
 csw
@@ -79168,19 +88256,19 @@ apx
 alD
 amv
 cpf
-ani
-apx
+iuz
+ciN
 wkS
-apx
-axL
-arQ
-mxO
-cfd
-apx
-agS
-apx
+ciN
+avT
+tVj
+oJj
+vfY
+ktI
+mUp
+vSq
 lAa
-gjY
+bMa
 ayp
 cHn
 azC
@@ -79206,8 +88294,8 @@ aCI
 aCI
 aRj
 aRl
-fHu
-agO
+ect
+nGK
 aVS
 aYC
 aZL
@@ -79240,14 +88328,14 @@ iXa
 lzC
 bEi
 iNb
-vKb
+nui
 vKb
 bNI
 vmc
-bJD
+nnB
 bMP
 bOs
-bRc
+nJE
 bRe
 bMP
 bTK
@@ -79415,14 +88503,14 @@ adZ
 aey
 afe
 acD
-apx
+eMJ
 apx
 gjY
 apx
 aiV
 apx
 apx
-alD
+kfX
 amx
 amx
 amx
@@ -79435,9 +88523,9 @@ adQ
 atL
 adQ
 adQ
+vSq
 apx
-apx
-gjY
+bMa
 abT
 abT
 abT
@@ -79497,7 +88585,7 @@ eTk
 bEj
 aPq
 yfr
-bJD
+rjj
 xMx
 bJD
 lCe
@@ -79505,7 +88593,7 @@ ncA
 bMP
 bOt
 bPI
-bLB
+dPO
 bMP
 bTJ
 bTJ
@@ -79514,14 +88602,14 @@ bYc
 bFE
 kzH
 cbE
-svt
+hXy
 cef
 cfz
-bRc
+hDO
 bMP
 cgJ
 iXM
-lAL
+kYQ
 cnk
 cgM
 cgM
@@ -79667,12 +88755,12 @@ lWL
 acp
 acD
 acY
-afd
-afd
+lWw
+sjM
 uME
 aUk
 acD
-apx
+ciN
 apx
 gjY
 apx
@@ -79692,50 +88780,50 @@ uZn
 tbk
 hVl
 adQ
+vSq
 apx
-apx
-gjY
+bMa
 ayq
 azb
 azD
 aAq
 cli
-apx
-apx
-anO
-apx
+bVt
+mDr
+fLg
+mDr
 aNL
 bwM
-bYf
-apx
+cPR
+bVt
 dHf
-apx
-bwP
+bVt
+hld
 aLr
-brJ
-apx
-apx
-apx
+gFI
+bVt
+uXV
+tpX
 bYf
-apx
+bVt
 aNL
-apx
-bAC
-apx
+mDr
+xVr
+mDr
 dHf
-apx
-apx
-cfd
+bVt
+bVt
+gAV
 aZQ
 baV
 aIL
 aIL
 aIL
-aIL
+gwR
 aIL
 biY
 exz
-biY
+uQs
 aIL
 aIL
 aIL
@@ -79754,11 +88842,11 @@ aZQ
 aZQ
 aZQ
 aZQ
-bJD
+rjj
 xMx
 bJD
 lCe
-bJD
+nnB
 bMP
 bOu
 bRc
@@ -79774,11 +88862,11 @@ cbE
 svt
 cef
 cfA
-bRc
+aXD
 bMP
 aVg
 iXM
-lAL
+kYQ
 cnk
 cgM
 cgM
@@ -79926,15 +89014,15 @@ acD
 acZ
 adw
 cjG
-bYl
+tEG
 bYl
 afN
-gjY
+nFV
 gjY
 oFB
 apx
-mxO
-ani
+oJj
+iuz
 akH
 alG
 amx
@@ -79949,7 +89037,7 @@ apx
 atM
 atM
 adQ
-apx
+vSq
 apx
 gjY
 akG
@@ -79982,7 +89070,7 @@ gjY
 gjY
 gjY
 gjY
-cfd
+gAV
 bya
 bdl
 bdl
@@ -80011,14 +89099,14 @@ aIL
 aIL
 aIL
 lga
-bJD
+rjj
 xMx
 bJU
 lCe
-bJD
+nnB
 bMP
 bOv
-bRc
+sPO
 bRf
 bMP
 bTJ
@@ -80031,11 +89119,11 @@ ekQ
 aLd
 cOu
 cfB
-bRc
+aXD
 bMP
 nUz
 iXM
-lAL
+kYQ
 cnk
 cgM
 cgM
@@ -80186,10 +89274,10 @@ aec
 aeB
 qfq
 acD
-apx
+ciN
 vZV
-bAC
-agS
+bKP
+vMn
 aiY
 aiY
 aiY
@@ -80239,7 +89327,7 @@ bug
 bug
 brJ
 gjY
-aYN
+szo
 aZQ
 baX
 aIL
@@ -80250,7 +89338,7 @@ aIL
 bkl
 exz
 bkl
-aIL
+gwR
 aIL
 aIL
 bpl
@@ -80268,14 +89356,14 @@ baV
 bmh
 bok
 aZQ
-bHL
+kTR
 hGr
 bJB
 egK
-bHL
+pZJ
 bMP
 bOw
-bRc
+sPO
 bRg
 bMP
 drS
@@ -80463,7 +89551,7 @@ abT
 abT
 abT
 adQ
-aWh
+vly
 cfu
 gjY
 cfu
@@ -80496,7 +89584,7 @@ apx
 apx
 kit
 gjY
-vZW
+czJ
 abT
 abT
 abT
@@ -80524,22 +89612,22 @@ aZQ
 aZQ
 aZQ
 aZQ
-bGS
-bmp
+aZQ
+sDv
 lSc
 abT
 ahZ
-bmp
+jMU
 bMP
 bOx
 gJI
 bTM
 eXV
-bTM
+fws
 ohc
 bWF
-bTM
-bTM
+fws
+fws
 bTL
 uQA
 iAx
@@ -80695,7 +89783,7 @@ lWL
 aFr
 aeG
 adb
-agv
+rrh
 agv
 aik
 afh
@@ -80720,73 +89808,73 @@ asS
 atN
 awV
 asO
-aWh
+vly
 cfu
 akG
-apx
+vSq
 mxO
-apx
+vSq
 uWA
-apx
-aWh
-agS
-apx
-apx
-apx
-apx
-apx
-apx
+vSq
+gmm
+rkP
+vSq
+vSq
+vSq
+vSq
+vSq
+vSq
 arQ
-apx
-apx
-aWh
-agS
-apx
-apx
-apx
-apx
-apx
-apx
-apx
-agS
-apx
-apx
+vSq
+vSq
+vly
+rkP
+vSq
+vSq
+vSq
+vSq
+vSq
+vSq
+vSq
+rkP
+vSq
+vSq
 aWh
 gjY
-apx
-bwM
-apx
+aMq
+cOi
+aMq
 crA
 bdv
 bey
-apx
-apx
-apx
-anO
-bYf
-apx
+aMq
+aMq
+jEF
+usT
+piN
+aMq
 hlq
-apx
-apx
-aNL
-apx
+bVt
+uXV
+jAi
+cyO
 dam
-bYf
-apx
+cPR
+bVt
 bvp
 bwM
 byj
-apx
+bVt
 aNL
-apx
-apx
+bVt
+bVt
 tam
-apx
+pUU
 apx
 cfu
 bnt
 jmx
-bug
+xJl
 jKq
 bOy
 bPK
@@ -80801,14 +89889,14 @@ bMP
 cbI
 cdc
 ceh
-cdd
+jyt
 isn
 coC
 qJk
 eKd
 wxE
 cnn
-coC
+ftR
 cpD
 czk
 crJ
@@ -80952,7 +90040,7 @@ lWL
 aFr
 aeG
 agv
-agv
+xNL
 agv
 aik
 agv
@@ -80987,9 +90075,9 @@ aCm
 aCm
 aBG
 aCm
-apx
-apx
-apx
+lYK
+lYK
+lYK
 adQ
 azu
 azu
@@ -81006,8 +90094,8 @@ aNy
 aNy
 aNy
 aNy
-apx
-apx
+aNy
+vSq
 gSF
 gjY
 gjY
@@ -81043,7 +90131,7 @@ gjY
 gjY
 xDK
 bKC
-akG
+tmM
 bMR
 bMP
 bPL
@@ -81225,10 +90313,10 @@ amq
 amy
 bJw
 anX
-xxh
+abx
 cKb
 aDc
-awV
+tWk
 awV
 asU
 atO
@@ -81239,9 +90327,9 @@ cfu
 axM
 aCm
 azd
-aBl
+pNI
 aAr
-aBl
+vfZ
 aBH
 aCm
 atd
@@ -81261,10 +90349,10 @@ aOp
 gjr
 aPM
 aOs
+aOs
 aRo
 aNy
-apx
-apx
+vSq
 jcU
 bug
 bug
@@ -81300,22 +90388,22 @@ bug
 hnO
 hnO
 bYi
-cfd
-cfd
+mCv
+mCv
 bOz
-cfd
-cfd
-cfd
-cfd
-cfd
-cfd
+mCv
+mCv
+mCv
+mcV
+mCv
+mCv
 vSw
-cfd
+mCv
 caw
-wjH
-wjH
-wjH
-wjH
+kvW
+vPs
+vPs
+vPs
 hgQ
 rOi
 cjp
@@ -81469,7 +90557,7 @@ asm
 asm
 asm
 asm
-agv
+adD
 afO
 aEG
 nSv
@@ -81483,7 +90571,7 @@ ajO
 nYi
 xGr
 bDg
-agK
+ujA
 aDc
 aqS
 arV
@@ -81491,14 +90579,14 @@ pHv
 arV
 auD
 asO
-apx
+vSq
 cfu
 axH
 aCm
 aze
-aBl
+qHB
 aAs
-aBl
+kEj
 aBI
 bqa
 aCY
@@ -81507,7 +90595,7 @@ aEz
 hqK
 aGs
 aHb
-aHc
+tlO
 aHc
 aHc
 aHc
@@ -81519,9 +90607,9 @@ aPf
 aPN
 aPf
 iog
-aNB
+iog
 bAC
-gjY
+gXi
 cfd
 apx
 apx
@@ -81576,8 +90664,8 @@ nUO
 cgS
 skt
 cjq
-fMD
-coC
+fOD
+mWc
 cnq
 wjH
 cpG
@@ -81731,7 +90819,7 @@ aEG
 agv
 agU
 ahz
-ail
+adD
 aiY
 ajN
 akN
@@ -81740,22 +90828,22 @@ ajO
 hWd
 aQF
 xxh
-agK
+ujA
 aDc
 aqT
-awV
-awV
-awV
+kfq
+kfq
+kfq
 auE
 avu
-apx
+vSq
 cfu
 bnq
 aCm
 azf
 aBl
-aBl
-aBl
+wHL
+ocF
 blF
 bqa
 asP
@@ -81768,73 +90856,73 @@ moZ
 xeL
 mvk
 lTU
-lYn
-lYn
+xcp
+xcp
 ewn
 iog
 mEi
 sAv
 iog
-aRp
+iog
+mTI
 aNy
-aTL
-apx
+elh
 cfd
 apx
-apx
-agS
-apx
-apx
-apx
+sfL
+fgT
+sfL
+sfL
+sfL
 auw
-apx
-apx
-arQ
-apx
-aWh
-apx
-anO
-apx
-apx
-apx
+sfL
+sfL
+eCL
+sfL
+pig
+sfL
+ncE
+sfL
+sfL
+sfL
 auw
-aWh
+pig
 bBx
 dcJ
 ani
 bwP
 bym
-agS
-apx
-apx
-gjY
+fgT
+sfL
+sfL
+iUX
 apx
 bGT
-apx
-apx
-apx
+ciN
+ciN
+ciN
 bKE
-apx
+ciN
 cfu
 kpJ
-apx
-apx
-mxO
-arQ
+ciN
+ciN
+oJj
+tVj
 vZV
-apx
-apx
-apx
+ciN
+ciN
+ciN
 kHJ
-coC
+eXf
 iaj
 coC
 cfH
 qJk
 sEf
 cjq
-coC
-fMD
+mWc
+fOD
 cnq
 wjH
 cpH
@@ -81997,7 +91085,7 @@ ajO
 hqK
 oLs
 xxh
-agK
+ujA
 aDc
 aqU
 arX
@@ -82006,7 +91094,7 @@ apE
 auF
 avv
 bTT
-gjY
+gXi
 aer
 aCm
 azg
@@ -82021,21 +91109,21 @@ aEB
 hqK
 aGu
 lYn
-lYn
+oBv
 voD
 voD
 voD
-lYn
+xcp
 agN
 aNC
 aHT
+bho
 aPg
 aPO
 aPg
 aos
 aSE
-hff
-apx
+phj
 cfd
 aXx
 abT
@@ -82071,7 +91159,7 @@ bIe
 bIe
 bIe
 bGU
-bEm
+tKJ
 lPC
 bGU
 bOD
@@ -82083,7 +91171,7 @@ bOD
 bOD
 bOD
 bOD
-coC
+eXf
 iaj
 coC
 coC
@@ -82252,12 +91340,12 @@ aUZ
 akS
 amz
 aMe
-aQF
+xCJ
 xxh
 aEF
 aDc
 aqV
-atV
+vlo
 eUD
 fKX
 auG
@@ -82266,19 +91354,19 @@ atd
 atw
 atd
 bqa
-aBl
-aBl
+duK
+nsW
 azI
 aBj
 aBL
 bqa
 aDb
-xxh
+qbN
 aEC
 hqK
 aGv
 lYn
-aHc
+tlO
 aIZ
 aHc
 keV
@@ -82286,13 +91374,13 @@ aMk
 aMO
 aNC
 aOt
+vSB
 krU
 rTc
 krU
 aos
 aSE
-hff
-apx
+phj
 cfd
 aXx
 aYQ
@@ -82309,8 +91397,8 @@ brL
 apx
 anO
 bnt
-apx
-apx
+vnw
+pNn
 bqz
 brE
 bsE
@@ -82321,14 +91409,14 @@ bvt
 bvt
 bBt
 bqz
-bJW
-bEu
+tJR
+tOA
 bGU
 bIf
 bJg
 bIf
 bGU
-bEu
+aTL
 akA
 bGU
 bPN
@@ -82496,7 +91584,7 @@ aik
 agv
 agv
 agv
-agv
+xNL
 agv
 aEG
 agv
@@ -82514,8 +91602,8 @@ xxh
 bES
 aDc
 aqW
-atV
-awV
+vlo
+kfq
 fKX
 auH
 asO
@@ -82542,14 +91630,14 @@ uqO
 aiK
 aMP
 aNC
-bxh
+aOs
+pgm
 aPi
 bho
 aPi
 aos
 aSE
-hff
-apx
+phj
 cfd
 aXx
 aYQ
@@ -82559,33 +91647,33 @@ bcs
 bdz
 aYQ
 bdt
-apx
-ani
-ani
-aWh
+bRA
+nBj
+nBj
+mMb
 bll
-anO
-anO
-apx
+mDX
+mDX
+bRA
 bpo
 bqz
 brF
+uNZ
 bsI
 bsI
 bsI
 bsI
-bsI
-bsI
+vXQ
 bBu
 bqz
-bJW
-bEu
+tJR
+tOA
 bGU
 bGU
 bGU
 bGU
 bGU
-bEu
+aTL
 akA
 bGU
 bPT
@@ -82599,16 +91687,16 @@ bPT
 bOD
 qZf
 coC
-coC
+eXf
 cfI
 cgU
 cgU
-coC
+eXf
 cgU
 cgU
-coC
+eXf
 cgU
-cgU
+rML
 czk
 crQ
 efJ
@@ -82766,19 +91854,19 @@ akQ
 aBA
 lFy
 ajc
-agK
+bEH
 xxh
-agK
+ujA
 aDc
 aqX
 atV
-awV
+ste
 eHq
 auI
 asO
 avw
 xxh
-ano
+rXp
 aCm
 azj
 azK
@@ -82787,8 +91875,8 @@ nLR
 aBN
 bqa
 ano
-xxh
-xxh
+abx
+tNk
 aFu
 aGx
 lYn
@@ -82799,13 +91887,13 @@ aLy
 aMm
 aMQ
 aNC
-jcM
+aOs
 aOu
 aPQ
 mHO
+aOs
 aRr
 aNy
-aTN
 wXd
 cfd
 aXy
@@ -82827,7 +91915,7 @@ bjd
 bpp
 bqz
 brG
-bsI
+oIx
 bsI
 bsI
 bsI
@@ -82835,14 +91923,14 @@ bsI
 bsI
 bBt
 bqz
-bJW
-bEu
+tJR
+tOA
 bKF
 bIg
 gyL
 bKa
 bKF
-bEu
+aTL
 qCT
 bGU
 bPT
@@ -82854,8 +91942,8 @@ bPT
 bPT
 bPT
 bOD
-coC
-coC
+eXf
+ftR
 bWL
 bWL
 cgV
@@ -83013,7 +92101,7 @@ agv
 aeF
 aeE
 aEG
-agv
+uml
 acE
 ahB
 aXp
@@ -83023,9 +92111,9 @@ xuT
 bRB
 amC
 aMe
-agK
+ujA
 xxh
-agK
+ujA
 aDc
 aqY
 ssi
@@ -83043,9 +92131,9 @@ azk
 aBm
 bqa
 bqa
-agK
+ujA
 xxh
-agK
+aTN
 hqK
 cGM
 cGM
@@ -83073,7 +92161,7 @@ bcu
 bjj
 aZY
 gdr
-bny
+vtY
 bhG
 bIu
 bks
@@ -83093,13 +92181,13 @@ bvu
 bBv
 bqz
 kfT
-bEu
+tOA
 bGW
 bIh
 nyw
 bJZ
 bKG
-bEu
+aTL
 llK
 bGU
 bPQ
@@ -83111,8 +92199,8 @@ bOD
 bOD
 bOD
 bOD
-coC
-coC
+eXf
+ftR
 bWL
 cfJ
 cfJ
@@ -83280,27 +92368,27 @@ hUu
 lFy
 amD
 aMe
-agK
+ujA
 xxh
 ulF
 aqm
-agK
+aTN
 cgR
-agK
+wrb
 rKT
-agK
-avw
-agK
-xxh
-agK
+bEH
+kCa
+aTN
+abx
+bEH
 amG
 iXP
 aNO
-agK
-kzf
-agK
+eoj
+mqT
+rmQ
 sYH
-agK
+ujA
 bDg
 aEE
 hqK
@@ -83319,7 +92407,7 @@ aRt
 aRt
 aRt
 aEQ
-afV
+jIx
 blZ
 jcF
 jRv
@@ -83341,7 +92429,7 @@ pRR
 bpr
 bqz
 brI
-bsI
+oIx
 bsI
 eoI
 bsI
@@ -83349,14 +92437,14 @@ bsI
 bzT
 bBt
 bqz
-bJW
-bEu
+tJR
+tOA
 bKF
 gRT
 bJi
 bEu
 bKF
-bEu
+aTL
 akA
 bGU
 bPR
@@ -83365,11 +92453,11 @@ bPT
 bTP
 tiP
 bOD
+iQj
+ftR
+ftR
 coC
-coC
-coC
-coC
-coC
+ftR
 bWL
 cfJ
 cfJ
@@ -83562,7 +92650,7 @@ xxh
 aEF
 hqK
 aEI
-aEI
+xtR
 aIc
 aJf
 aFE
@@ -83598,7 +92686,7 @@ bny
 pSA
 bqB
 nnT
-iFt
+jsu
 iFt
 iFt
 aLs
@@ -83607,13 +92695,13 @@ bzU
 bSp
 bqz
 bEo
-bEu
+tOA
 bGU
 bIj
 bJj
 bKb
 bGU
-bEu
+aTL
 akA
 bOF
 gGH
@@ -83622,10 +92710,10 @@ bTP
 bTP
 taD
 bOD
-coC
-coC
-fMD
-coC
+eXf
+eXf
+rxw
+eXf
 cdg
 bWL
 cfJ
@@ -83794,29 +92882,29 @@ akR
 bOK
 amF
 aMe
-avw
+kCa
 agK
-xxh
-agK
-agK
-agK
-agK
-agK
+dIV
+eDZ
+ujA
+ujA
+ujA
+ujA
 auJ
-avw
-kzf
-agK
+wEN
+ajQ
+tKg
 agK
 aAX
 lNe
 agK
 kzf
-agK
-agK
+eDZ
+ujA
 ahh
 agK
-xxh
-bES
+dIV
+sWm
 hqK
 aGA
 die
@@ -83844,7 +92932,7 @@ aYQ
 aZY
 aYQ
 bny
-bny
+lhp
 rnx
 bje
 bkv
@@ -83863,14 +92951,14 @@ bwQ
 bzV
 bBw
 bqz
-bJW
-bEu
+tJR
+tOA
 bGU
 bIk
 bGU
 bGU
 bGU
-bEu
+aTL
 akA
 bGU
 tcb
@@ -84076,7 +93164,7 @@ aEb
 aDg
 aFv
 aEI
-aEI
+xtR
 aIb
 sER
 aKx
@@ -84086,7 +93174,7 @@ aIk
 jqM
 aWk
 aPl
-aPl
+trO
 aRt
 aRt
 aRt
@@ -84095,7 +93183,7 @@ aUV
 gnI
 aXC
 ddZ
-aZZ
+bjk
 bbr
 bcx
 bdF
@@ -84120,10 +93208,10 @@ bqz
 bqz
 bqz
 bqz
-bJW
-gRT
-gRT
-gRT
+tJR
+ghq
+ghq
+ghq
 elu
 bKc
 fdF
@@ -84328,12 +93416,12 @@ hcg
 rra
 aBP
 aBO
-aEI
+ejO
 lCD
-aQG
+wUB
 aFw
 aQG
-aQG
+okT
 xjM
 aJf
 aFE
@@ -84355,19 +93443,19 @@ aYS
 bIZ
 aTO
 bbg
-bbg
+nhS
 beF
-bbg
-bbg
+xAv
+ozo
 oTZ
 bjf
 bkx
 ncQ
 aHw
-aqP
+tND
 bav
 aNF
-hrZ
+hQg
 oDn
 eYe
 gEp
@@ -84569,7 +93657,7 @@ aUZ
 aUZ
 lFy
 bUc
-aUZ
+lwD
 ase
 asZ
 atW
@@ -84578,17 +93666,17 @@ avz
 aww
 axa
 axc
-ayw
+iCY
 aBO
 azO
 aoV
 aBs
 aBQ
 aBO
-aEI
+ejO
 liO
-aEI
-aEI
+hOC
+fWp
 aEI
 ioA
 boN
@@ -84605,16 +93693,16 @@ aQy
 gOs
 def
 def
-def
+sHX
 def
 afV
 ddZ
-bbg
+pZe
 aLU
-aqP
-aqP
-aqP
-aqP
+fyk
+fyk
+fyk
+bNd
 aqP
 aqP
 aqP
@@ -84624,7 +93712,7 @@ ciY
 aqM
 awK
 byN
-byN
+kJh
 brN
 jiK
 bum
@@ -84823,7 +93911,7 @@ alR
 bIs
 anv
 aoh
-aUZ
+pMl
 lFy
 qBT
 bgw
@@ -84844,7 +93932,7 @@ aBR
 aBO
 aDi
 liO
-aEI
+hOC
 aFy
 aFv
 aFv
@@ -85080,7 +94168,7 @@ alS
 alW
 alS
 alW
-aUZ
+qbO
 apJ
 aqr
 aUZ
@@ -85123,19 +94211,19 @@ ddZ
 aWp
 aXF
 aYT
-bag
+ujQ
 vEk
 bcz
 bdG
 aUX
+rUc
 bbg
-bbg
-bbg
+hcr
 bbg
 pSe
 eMM
 pSe
-bbg
+hcr
 bJf
 bbg
 mRP
@@ -85337,7 +94425,7 @@ waD
 amJ
 eow
 alW
-aUZ
+qbO
 apJ
 aUZ
 arf
@@ -85347,7 +94435,7 @@ atX
 auP
 sjk
 awy
-sjk
+pFs
 axS
 ayx
 azU
@@ -85373,19 +94461,19 @@ aHl
 aIk
 aIk
 jqM
-bgx
+bhM
 ddZ
 ddZ
 ddZ
 aWq
 jOp
-eva
+nOm
 eva
 bbj
-bag
-bag
+aXR
+wvo
 beG
-bbg
+rUc
 bbg
 bbg
 bbg
@@ -85601,21 +94689,21 @@ arg
 iOI
 aQE
 atX
-auQ
+vyA
 avB
 awz
 axe
-auQ
+vyA
 ayy
 aBO
 azS
 aAB
 aAB
-aAB
+rFq
 azU
 aDl
 cHC
-aEI
+hOC
 aFB
 aFv
 aHl
@@ -85635,7 +94723,7 @@ aoH
 aTU
 ddZ
 aWr
-bag
+aXR
 bag
 bag
 aXR
@@ -85644,21 +94732,21 @@ bdI
 aUX
 bfs
 bbg
+hcr
 bbg
-bbg
-bbg
-uAm
-bbg
-hrZ
-bbg
+jXT
+gFQ
+iZC
+tDT
+nTl
 gFQ
 bqH
 csx
 ckS
 bsP
 csx
-bEu
-bEu
+lHM
+tOA
 bAb
 bEu
 bDb
@@ -85670,7 +94758,7 @@ bEu
 bEu
 bEu
 bEu
-bEu
+tOA
 aul
 bPY
 neu
@@ -85858,21 +94946,21 @@ bwV
 aZb
 bwV
 atX
-auQ
+vyA
 avC
 atX
 axf
-auQ
-atX
+fld
+qfK
 azU
-bNg
+wqw
 bNg
 bNg
 aBV
 azU
 aDm
 cHC
-aEI
+hOC
 aFC
 aFv
 aHm
@@ -85892,14 +94980,14 @@ aoH
 aTV
 ddZ
 aWs
-bag
+aXR
 jCg
 ifK
 wTz
 bag
 bdJ
 aUX
-bbg
+rUc
 bHx
 dYP
 iYV
@@ -85917,17 +95005,17 @@ csx
 ksV
 bEu
 bEu
-bEu
-bEu
-bEu
-bEu
+aTL
+aTL
+aTL
+aTL
 cjv
-bEu
-bEu
-bEu
-bEu
-bEu
-bEu
+aTL
+aTL
+aTL
+aTL
+aTL
+tOA
 bGU
 bUx
 bPY
@@ -86098,7 +95186,7 @@ aik
 aik
 aik
 ahz
-agv
+xNL
 agv
 aiv
 agv
@@ -86108,19 +95196,19 @@ alU
 amL
 any
 bFY
-aUZ
+uEf
 apJ
 wwK
 aVf
 bBC
 mWC
 atX
-auQ
-auQ
+vyA
+vyA
 atX
-axg
+kpB
 auQ
-auQ
+amb
 azU
 azT
 aAE
@@ -86149,9 +95237,9 @@ ddZ
 ddZ
 ddZ
 aWt
+aXR
 bag
-bag
-bag
+aXR
 aXR
 bag
 bdK
@@ -86173,7 +95261,7 @@ csx
 csx
 bGU
 bju
-bEu
+tOA
 bwU
 bwU
 bwU
@@ -86183,7 +95271,7 @@ bwU
 bwU
 bwU
 bwU
-bEu
+aTL
 uDS
 bwU
 bPZ
@@ -86352,12 +95440,12 @@ lWL
 lWL
 aik
 aik
-afp
-afp
+adD
+adD
 afp
 agv
 agv
-aiv
+dlr
 agv
 ajY
 acE
@@ -86375,9 +95463,9 @@ atX
 avE
 avD
 atX
-auQ
+kpB
 axT
-auQ
+amb
 azU
 kAQ
 aAF
@@ -86387,18 +95475,18 @@ azU
 aDo
 aEf
 liO
-aEI
+hOC
 aGD
-aQG
-aEI
-aEI
+mJz
+lSH
+pgM
 aKz
-aQG
-aEI
-aEI
+mJz
+lSH
+pgM
 aNG
-aQG
-aEI
+mJz
+lSH
 aPU
 jqM
 gFc
@@ -86408,8 +95496,8 @@ ddZ
 aWu
 aXI
 aYV
-bag
-aXR
+hab
+aNB
 bcA
 bdL
 aUX
@@ -86440,7 +95528,7 @@ lWL
 lWL
 lWL
 bwU
-aJc
+eMG
 bDe
 bwU
 bPZ
@@ -86630,11 +95718,11 @@ jqM
 jqM
 jqM
 auR
-auQ
+vyA
 atX
 axg
-auQ
-auQ
+vAu
+oOx
 azU
 azT
 azT
@@ -86642,20 +95730,20 @@ azT
 nQf
 azU
 aDp
-aEI
+hOC
 eTp
-aQG
+wUB
 mrV
-aQG
-aQG
-aQG
-aQG
-aQG
-aQG
-aQG
-aQG
-aQG
-aQG
+rXt
+oaR
+wTC
+wUB
+rXt
+oaR
+wTC
+wUB
+rXt
+oaR
 aPV
 aQz
 aRw
@@ -86666,7 +95754,7 @@ ddZ
 aUX
 aUX
 aYW
-rjj
+bbo
 aYW
 aUX
 aUX
@@ -86879,15 +95967,15 @@ lWL
 lWL
 lWL
 aik
-aUZ
-apJ
+wZo
+vzU
 ddZ
-blZ
-blZ
+qWP
+vma
 qLF
 atY
 wpf
-auQ
+vyA
 jqM
 jqM
 jqM
@@ -86903,16 +95991,16 @@ aEg
 lCD
 wcm
 aGE
-aQG
-aEI
-aEI
+sbC
+kdb
+udZ
 aKA
-aQG
-aEI
-aEI
+sbC
+kdb
+udZ
 aNH
-aQG
-aEI
+sbC
+kdb
 aPW
 jqM
 bgx
@@ -86923,7 +96011,7 @@ ddZ
 pYa
 aYW
 bah
-aXR
+bag
 bcB
 aYW
 pYa
@@ -87136,8 +96224,8 @@ aeG
 aeG
 aeG
 aik
-aUZ
-apJ
+wZo
+vzU
 aoi
 aqb
 aqb
@@ -87150,7 +96238,7 @@ gaP
 ayW
 blZ
 blZ
-blZ
+qWP
 aoH
 aBv
 aBW
@@ -87394,7 +96482,7 @@ aEG
 aEG
 ozp
 aoZ
-apJ
+vzU
 ddZ
 ark
 blZ
@@ -87412,7 +96500,7 @@ aAH
 aqb
 aqb
 tpv
-aqb
+eob
 aqb
 aqb
 eWN
@@ -87649,12 +96737,12 @@ aeG
 aeG
 aeG
 aeG
-awE
+aik
 awE
 apL
-awE
-awE
-awE
+ddZ
+ddZ
+ddZ
 ddZ
 ddZ
 ddZ
@@ -87911,7 +96999,7 @@ apa
 bMS
 vnW
 arl
-awE
+ddZ
 atg
 byL
 blZ
@@ -87923,7 +97011,7 @@ ayC
 ddZ
 btv
 ddZ
-blZ
+qWP
 blZ
 aoH
 ayW
@@ -88168,7 +97256,7 @@ apb
 bSB
 aqu
 arm
-awE
+ddZ
 ath
 blZ
 blZ
@@ -88176,14 +97264,14 @@ blZ
 awA
 blZ
 lAC
-blZ
+vma
 ddZ
 nWr
 ddZ
 ddZ
 blZ
 aoH
-blZ
+vma
 aEh
 aoH
 eWN
@@ -88425,9 +97513,9 @@ apc
 apO
 aqv
 apM
-awE
+ddZ
 ati
-blZ
+vma
 auT
 byL
 ddZ
@@ -88458,7 +97546,7 @@ jqM
 jqM
 jqM
 bgx
-ayW
+raE
 ddZ
 aVb
 ddZ
@@ -88682,7 +97770,7 @@ afH
 afH
 afH
 aro
-awE
+ddZ
 atj
 blZ
 blZ
@@ -88943,7 +98031,7 @@ ddZ
 atk
 byL
 blZ
-blZ
+akl
 ddZ
 aCI
 ddZ
@@ -88951,24 +98039,24 @@ ddZ
 blZ
 blZ
 blZ
+vma
 blZ
+hkS
 blZ
-blZ
-blZ
 ddZ
 ddZ
 ddZ
 ddZ
 ddZ
 ddZ
-blZ
+vma
 aKC
 anu
 ddZ
 ddZ
 ddZ
 ddZ
-blZ
+qWP
 blZ
 blZ
 bao
@@ -89218,14 +98306,14 @@ lWL
 lWL
 lWL
 ddZ
-blZ
+qWP
 aKD
 blZ
-blZ
+qWP
 aOB
 aNI
 blZ
-blZ
+vma
 blZ
 blZ
 bao
@@ -89239,7 +98327,7 @@ pYa
 pYa
 pYa
 pYa
-pYa
+bEA
 lWL
 lWL
 lWL
@@ -89738,7 +98826,7 @@ aEV
 aEV
 lWL
 ddZ
-blZ
+qWP
 ddZ
 lWL
 ddZ
@@ -90773,7 +99861,7 @@ ddZ
 aRA
 ddZ
 ddZ
-pYa
+bEA
 aCI
 lWL
 lWL
@@ -92309,7 +101397,7 @@ lWL
 lWL
 lWL
 lWL
-pYa
+bEA
 ddZ
 bWj
 aRE


### PR DESCRIPTION
## Changelog
+First decal pass (probably subject to change)
+Gives the HoS and detective their respective lockers
-Removed Xmas trees
+Improved some external airlocks
+Added air tanks to some maintenance domes to mitigate air problems
+Minor gateway changes, added the Gateway Console
+Fixed janitor's closet access
+Preloaded the pharmacy smartfridges
+Minor tweaks to Genetics. Added a box of disks
*Fixed the Tank Compressor in Ordnance facing the wrong direction
*Fixed all instances of req_access_txt. Buttons and windoors should now be functional
+Attempted to make the chapel look better
*Moved some wires to make maint grilles no longer electrified
+Replaced icon_states with broken_floor mapping helpers
+Amended certain requests consoles to include the announcement flag (bridge, CMO, CE, RD, Captain, HOS, QM, tcomms admin.)
*Fixed the messaging server not working at roundstart
*Fixed a door's access being set to maintenance instead of Engine Equipment
+Cargo adjustments
-Removes depreciated bitflag "departmentType" on requests consoles (depot map more modern than main?)
-Sanitized other unused or unnecessary variables
+Geneticists now have more medbay access besides the side entrance (medsci ftw)
*APC fixes
+Added lights to central maintenance (catwalks with a full view of space being completely dark looked odd)
+Added some fancy marker beacons around transit tubes. Colored by destination!
*Replaced an Atmospherics Monitoring Console with a Station Atmospherics Monitoring Console. This clears the 'Test Atmos Controls' errors.
*Replaced many loot spawners with locker/crate spawners, and added more crates overall
+Added a ton of broken floor helpers to maint
+Added a shower to engineering
+Added the DiscStation Commission Plaque. "Sleep Tight", it says.
+Split an area into two (Bar & Lounge)
*Moved some navigate_destination points around (please use them!!)
*Moved the Dorms APC out of maintenance
+More signs and posters
+Fixed the Engine Waste loop not having a space exhaust. Whoops!
+Added dirt to a lot of usually dirty areas.
+Added some goodies to the theater.
+Added some benches to hopefully make the hallways feel less massive
+Added a Smartfridge to Morgue
+Added some variables to the Chapel's Crematorium
*Maintenance areas have annexed the ownership of some neighboring walls
*Adjustments to Security and Warden's Office. Created more space for their Cargo Consoles
*Fixed some issues with the HoS Office
*Armsky
+The Nanotrasen Human Rights Accord has installed Perma Prison Cell toiletries and more fire extinguishers.
*Upgraded tcomms passthrough cycle helper
+Ensured that those with Vault access can get into the leading maintenance corridor
+Mech bay is now 1 tile taller
+Extra goodies for miners
+Added PDA painter to RD office
*Replaced like 3 or 4 partmarts in the primary halls with snack machines.
*Some miniscule changes not worth documenting
*Neglected the inevitable re-do of the atmospherics room (please help)
## To-do:
-Find a solution to fix the escape shuttle crashing into the chaplain's funeral room.
-Revisit the piping in Atmospherics
-Cameras need to be checked
-Check the operational status of ordnance (again)
-Unchecked report of problems in engineering maintenance.
-Decals and general decoration (in progress!)
-Maint rooms could probably use more grime & dust
-AI Satellite definitely needs some work
-The Chapel could be better
-The carpet in the dorms is absolutely ugly
-Probably some unlisted/undiscovered things