### PR TITLE
Makes Discstation pass Linters

### DIFF
--- a/StationMaps/DiscStation/DiscStation.dmm
+++ b/StationMaps/DiscStation/DiscStation.dmm
@@ -17006,10 +17006,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/shower{
-	dir = 4;
-	tag = null
-	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "byJ" = (

--- a/StationMaps/DiscStation/DiscStation.dmm
+++ b/StationMaps/DiscStation/DiscStation.dmm
@@ -44,7 +44,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
-	name = "brig shutters"
+	name = "Brig Shutters"
 	},
 /turf/open/floor/plating,
 /area/station/security/execution/transfer)
@@ -1028,7 +1028,7 @@
 /area/station/maintenance/starboard/fore)
 "agB" = (
 /obj/machinery/door/airlock/maintenance_hatch{
-	name = "turret maintenance hatch"
+	name = "Turret Maintenance Hatch"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
 /turf/open/floor/iron,
@@ -1154,8 +1154,8 @@
 "ahB" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/camera/autoname/directional/north{
-	network = list("ss13","rd");
-	c_tag = "Ordnance Lab North"
+	c_tag = "Ordnance Lab North";
+	network = list("ss13","rd")
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
@@ -1463,8 +1463,8 @@
 /obj/machinery/turretid{
 	control_area = "/area/station/ai_monitored/turret_protected/aisat_interior";
 	name = "Antechamber Turret Control";
-	req_access = list("minisat");
-	pixel_y = 30
+	pixel_y = 30;
+	req_access = list("minisat")
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
@@ -1580,9 +1580,9 @@
 /area/station/maintenance/solars/port/fore)
 "ake" = (
 /obj/machinery/power/solar_control{
+	dir = 8;
 	id = "foreport";
-	name = "Fore Port Solar Control";
-	dir = 8
+	name = "Fore Port Solar Control"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
@@ -1746,9 +1746,9 @@
 /area/station/science/xenobiology)
 "alc" = (
 /obj/structure/mirror{
+	broken = 1;
 	icon_state = "mirror_broke";
-	pixel_y = 28;
-	broken = 1
+	pixel_y = 28
 	},
 /obj/effect/decal/cleanable/cobweb,
 /obj/item/stack/rods/ten,
@@ -1930,14 +1930,10 @@
 /area/space/nearstation)
 "amm" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the bridge is.";
-	icon_state = "direction_bridge";
-	name = "bridge";
-	tag = "icon-direction_bridge (EAST)";
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+/obj/structure/sign/directions/command{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -2898,7 +2894,7 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-07";
 	name = "Photosynthetic Potted plant";
-	tag = "icon-plant-07"
+	tag = null
 	},
 /obj/effect/turf_decal/trimline/purple/corner,
 /obj/effect/turf_decal/tile/purple{
@@ -3310,7 +3306,7 @@
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "rnd2";
-	name = "research lab shutters"
+	name = "Research Lab Shutters"
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/trimline/purple/filled/warning{
@@ -3418,8 +3414,8 @@
 "atj" = (
 /obj/structure/table/wood,
 /obj/item/toy/plush/abductor/agent{
-	name = "Agent Incognito";
-	desc = "He's always watching."
+	desc = "He's always watching.";
+	name = "Agent Incognito"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
@@ -3856,9 +3852,9 @@
 /area/station/maintenance/department/electrical)
 "ave" = (
 /obj/structure/mirror{
+	broken = 1;
 	icon_state = "mirror_broke";
-	pixel_y = 28;
-	broken = 1
+	pixel_y = 28
 	},
 /obj/machinery/iv_drip,
 /obj/item/retractor,
@@ -3904,7 +3900,7 @@
 /obj/structure/grille,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "rnd";
-	name = "research lab shutters"
+	name = "Research Lab Shutters"
 	},
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/disposalpipe/segment,
@@ -3914,7 +3910,7 @@
 /obj/structure/grille,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "rnd";
-	name = "research lab shutters"
+	name = "Research Lab Shutters"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -3928,7 +3924,7 @@
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "rnd";
-	name = "research lab shutters"
+	name = "Research Lab Shutters"
 	},
 /obj/structure/desk_bell,
 /turf/open/floor/plating,
@@ -4011,8 +4007,8 @@
 /area/station/maintenance/department/electrical)
 "avP" = (
 /obj/machinery/computer/monitor{
-	name = "backup power monitoring console";
-	dir = 1
+	dir = 1;
+	name = "backup power monitoring console"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -4625,7 +4621,7 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-07";
 	name = "Photosynthetic Potted plant";
-	tag = "icon-plant-07"
+	tag = null
 	},
 /turf/open/floor/grass,
 /area/station/hallway/primary/starboard)
@@ -5060,8 +5056,8 @@
 /area/station/hallway/primary/port)
 "aBa" = (
 /obj/machinery/camera/autoname{
-	tag = "icon-camera (NORTHWEST)";
-	dir = 6
+	dir = 6;
+	tag = null
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -6265,8 +6261,8 @@
 /area/space/nearstation)
 "aFJ" = (
 /obj/machinery/conveyor{
-	id = "garbage";
-	dir = 1
+	dir = 1;
+	id = "garbage"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
@@ -6572,8 +6568,8 @@
 /area/station/maintenance/department/science)
 "aGG" = (
 /obj/machinery/conveyor{
-	id = "garbage";
-	dir = 1
+	dir = 1;
+	id = "garbage"
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "Disposal Exit";
@@ -6656,8 +6652,8 @@
 /area/station/science/genetics)
 "aGU" = (
 /obj/machinery/camera/autoname{
-	tag = "icon-camera (NORTHEAST)";
-	dir = 10
+	dir = 10;
+	tag = null
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -6761,7 +6757,7 @@
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio6";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/cable,
@@ -6963,8 +6959,8 @@
 	id = "robotics";
 	name = "Robotics Privacy Control";
 	pixel_x = -24;
-	req_access = list("robotics");
-	pixel_y = -6
+	pixel_y = -6;
+	req_access = list("robotics")
 	},
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
@@ -7008,7 +7004,7 @@
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio3";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -7045,7 +7041,7 @@
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio8";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -7288,7 +7284,7 @@
 /obj/structure/grille,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "robotics";
-	name = "robotics lab shutters"
+	name = "Research Lab Shutters"
 	},
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/iron,
@@ -7323,7 +7319,7 @@
 "aJd" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "misclab";
-	name = "test chamber blast door"
+	name = "Test Chamber Blast Door"
 	},
 /obj/structure/cable,
 /obj/machinery/door/window/brigdoor{
@@ -7337,7 +7333,7 @@
 /obj/structure/grille,
 /obj/machinery/door/poddoor/preopen{
 	id = "misclab";
-	name = "test chamber blast door"
+	name = "Test Chamber Blast Door"
 	},
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/cable,
@@ -7636,7 +7632,7 @@
 /obj/item/pen,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "robotics";
-	name = "robotics lab shutters"
+	name = "Research Lab Shutters"
 	},
 /obj/structure/desk_bell,
 /turf/open/floor/plating,
@@ -7938,7 +7934,7 @@
 /obj/structure/grille,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "robotics";
-	name = "robotics lab shutters"
+	name = "Research Lab Shutters"
 	},
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/disposalpipe/segment{
@@ -8174,7 +8170,7 @@
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio2";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -8187,7 +8183,7 @@
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio7";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -8305,16 +8301,16 @@
 /area/station/science/robotics/lab)
 "aMQ" = (
 /obj/machinery/computer/operating{
-	name = "Robotics Operating Computer";
-	dir = 8
+	dir = 8;
+	name = "Robotics Operating Computer"
 	},
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "aMR" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Xenobiology - Secure Cell";
-	network = list("ss13","xeno","rd");
-	name = "xenobiology camera"
+	name = "xenobiology camera";
+	network = list("ss13","xeno","rd")
 	},
 /obj/machinery/light/directional/south,
 /turf/open/floor/engine,
@@ -8886,7 +8882,7 @@
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio1";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -8899,7 +8895,7 @@
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio6";
-	name = "containment blast door"
+	name = "Containment Blast Door"
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -8934,8 +8930,8 @@
 /area/station/hallway/primary/port)
 "aPA" = (
 /obj/machinery/computer/telecomms/server{
-	network = "tcommsat";
-	dir = 4
+	dir = 4;
+	network = "tcommsat"
 	},
 /obj/machinery/requests_console/directional/south{
 	announcementConsole = 1;
@@ -9352,7 +9348,7 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
 	layer = 2.9;
-	name = "bridge blast door"
+	name = "Bridge Blast Door"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -9570,8 +9566,8 @@
 /area/station/medical/medbay/central)
 "aRY" = (
 /obj/machinery/computer/telecomms/monitor{
-	network = "tcommsat";
-	dir = 4
+	dir = 4;
+	network = "tcommsat"
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -9728,7 +9724,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters{
 	id = "Skynet_launch";
-	name = "mech bay"
+	name = "Mech Bay"
 	},
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
@@ -10019,9 +10015,9 @@
 /obj/machinery/airalarm/directional/north,
 /obj/effect/spawner/random/structure/closet_private,
 /obj/item/clothing/head/wig/natural{
+	dir = 4;
 	hairstyle = "Mohawk (Unshaven)";
-	icon_state = "hair_unshaven_mohawk";
-	dir = 4
+	icon_state = "hair_unshaven_mohawk"
 	},
 /turf/open/floor/wood,
 /area/station/commons/dorms)
@@ -11101,8 +11097,8 @@
 /area/station/command/bridge)
 "aYt" = (
 /obj/structure/chair/comfy/black{
-	dir = 1;
-	color = "#EFB341"
+	color = "#EFB341";
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/dark,
@@ -12856,8 +12852,8 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/left/directional/east{
-	name = "Ore Redemtion Window";
-	dir = 8
+	dir = 8;
+	name = "Ore Redemtion Window"
 	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
@@ -13025,8 +13021,8 @@
 /area/station/ai_monitored/command/nuke_storage)
 "bhu" = (
 /obj/machinery/camera/motion/directional/north{
-	network = list("vault");
-	c_tag = "Vault"
+	c_tag = "Vault";
+	network = list("vault")
 	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
@@ -13446,7 +13442,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "lawyer_blast";
-	name = "privacy shutters"
+	name = "Privacy Shutters"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
@@ -13649,8 +13645,8 @@
 /area/station/cargo/storage)
 "bky" = (
 /obj/machinery/conveyor_switch/oneway{
-	id = "QMLoad";
-	dir = 8
+	dir = 8;
+	id = "QMLoad"
 	},
 /obj/structure/railing{
 	dir = 1
@@ -13881,7 +13877,7 @@
 	},
 /obj/machinery/door/poddoor{
 	id = "QMLoaddoor2";
-	name = "supply dock loading door"
+	name = "Supply Dock Loading Door"
 	},
 /turf/open/floor/plating,
 /area/station/cargo/storage)
@@ -13892,7 +13888,7 @@
 	},
 /obj/machinery/door/poddoor{
 	id = "QMLoaddoor2";
-	name = "supply dock loading door"
+	name = "Supply Dock Loading Door"
 	},
 /obj/structure/plasticflaps,
 /turf/open/floor/plating,
@@ -14281,11 +14277,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
-"bmX" = (
-/obj/item/stack/sheet/mineral/wood,
-/turf/open/floor/plating,
-/turf/open/floor/plating,
-/area/station/maintenance/port)
 "bmY" = (
 /obj/structure/table,
 /turf/open/floor/wood,
@@ -14375,17 +14366,17 @@
 	id = "QMLoaddoor";
 	layer = 4;
 	name = "Loading Doors";
+	pixel_x = 24;
 	pixel_y = -8;
-	req_access = list("cargo");
-	pixel_x = 24
+	req_access = list("cargo")
 	},
 /obj/machinery/button/door/directional/west{
 	id = "QMLoaddoor2";
 	layer = 4;
 	name = "Loading Doors";
+	pixel_x = 24;
 	pixel_y = 8;
-	req_access = list("cargo");
-	pixel_x = 24
+	req_access = list("cargo")
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
@@ -14563,8 +14554,8 @@
 /area/station/service/hydroponics/garden)
 "bor" = (
 /obj/machinery/conveyor_switch/oneway{
-	id = "QMDeliver";
-	dir = 1
+	dir = 1;
+	id = "QMDeliver"
 	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
@@ -14831,7 +14822,7 @@
 	},
 /obj/machinery/door/poddoor{
 	id = "QMLoaddoor";
-	name = "supply dock loading door"
+	name = "Supply Dock Loading Door"
 	},
 /turf/open/floor/plating,
 /area/station/cargo/storage)
@@ -14842,7 +14833,7 @@
 	},
 /obj/machinery/door/poddoor{
 	id = "QMLoaddoor";
-	name = "supply dock loading door"
+	name = "Supply Dock Loading Door"
 	},
 /obj/structure/plasticflaps,
 /turf/open/floor/plating,
@@ -14989,7 +14980,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/maintenance{
-	name = "Courtroom maintenance"
+	name = "Courtroom Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/mapping_helpers/airlock/unres{
@@ -15446,7 +15437,7 @@
 "brN" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "qm_warehouse";
-	name = "warehouse shutters"
+	name = "Warehouse Shutters"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -16317,7 +16308,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "fumehood";
-	name = "fume hood shutter"
+	name = "Fume Hood Shutter"
 	},
 /turf/open/floor/plating,
 /area/station/medical/chemistry)
@@ -16426,8 +16417,8 @@
 	},
 /obj/item/clothing/mask/cigarette/cigar,
 /obj/item/reagent_containers/food/drinks/flask/gold{
-	pixel_y = 6;
-	pixel_x = 9
+	pixel_x = 9;
+	pixel_y = 6
 	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain/private)
@@ -17015,6 +17006,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/shower{
+	dir = 4;
+	tag = null
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "byJ" = (
@@ -17548,9 +17543,9 @@
 "bAI" = (
 /obj/structure/lattice,
 /obj/machinery/camera/directional/west{
+	active_power_usage = 0;
 	c_tag = "MiniSat Exterior - Fore Starboard";
-	network = list("minisat");
-	active_power_usage = 0
+	network = list("minisat")
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -17982,15 +17977,15 @@
 /obj/machinery/button/door{
 	id = "hop";
 	name = "Privacy Shutters";
-	pixel_y = 8;
 	pixel_x = 24;
+	pixel_y = 8;
 	req_access = list("hop")
 	},
 /obj/machinery/button/door{
 	id = "hopqueue";
 	name = "Queue Shutters";
-	pixel_y = -2;
 	pixel_x = 24;
+	pixel_y = -2;
 	req_access = list("hop")
 	},
 /obj/machinery/button/flasher{
@@ -18312,7 +18307,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "hop";
-	name = "privacy shutters"
+	name = "Privacy Shutters"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -18333,7 +18328,7 @@
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "hop";
-	name = "privacy shutters"
+	name = "Privacy Shutters"
 	},
 /obj/structure/desk_bell,
 /turf/open/floor/iron,
@@ -18936,8 +18931,8 @@
 /area/station/ai_monitored/command/storage/eva)
 "bGj" = (
 /obj/structure/sign/directions/evac{
-	tag = "icon-direction_evac (NORTH)";
-	dir = 1
+	dir = 1;
+	tag = null
 	},
 /obj/structure/sign/directions/security{
 	pixel_y = -8
@@ -18945,27 +18940,25 @@
 /obj/structure/sign/directions/medical{
 	dir = 1;
 	pixel_y = 8;
-	tag = "icon-direction_med (NORTH)"
+	tag = null
 	},
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/command/storage/eva)
 "bGk" = (
-/obj/structure/sign/directions{
-	tag = "icon-direction_bridge (EAST)";
-	icon_state = "direction_bridge";
-	dir = 4
-	},
 /obj/structure/sign/directions/science{
 	desc = "A direction sign, pointing out which way the research department is.";
 	dir = 4;
 	name = "research department";
 	pixel_y = -8;
-	tag = "icon-direction_sci (EAST)"
+	tag = null
 	},
 /obj/structure/sign/directions/engineering{
 	dir = 4;
 	pixel_y = 8;
-	tag = "icon-direction_eng (EAST)"
+	tag = null
+	},
+/obj/structure/sign/directions/command{
+	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/station/security/detectives_office)
@@ -19027,7 +19020,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "lawyer_blast";
-	name = "privacy shutters"
+	name = "Privacy Shutters"
 	},
 /turf/open/floor/plating,
 /area/station/service/lawoffice)
@@ -19079,11 +19072,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bGE" = (
-/obj/structure/sign/directions{
-	dir = 1;
-	icon_state = "direction_bridge";
-	pixel_y = -8;
-	tag = "icon-direction_bridge (NORTH)"
+/obj/structure/sign/directions/command{
+	dir = 1
 	},
 /turf/closed/wall/r_wall,
 /area/station/command/meeting_room)
@@ -19164,8 +19154,8 @@
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/south{
-	req_access = list("security");
-	name = "Arrivals Security Checkpoint"
+	name = "Arrivals Security Checkpoint";
+	req_access = list("security")
 	},
 /obj/machinery/door/poddoor/shutters{
 	id = "secpost1"
@@ -19432,10 +19422,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"bII" = (
-/obj/structure/lattice,
-/turf/closed/wall,
-/area/station/maintenance/starboard/aft)
 "bIM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -19887,7 +19873,7 @@
 "bLi" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-08";
-	tag = "icon-plant-08"
+	tag = null
 	},
 /turf/open/floor/grass,
 /area/station/hallway/primary/central)
@@ -19970,14 +19956,14 @@
 "bLC" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21";
-	tag = "icon-plant-21"
+	tag = null
 	},
 /turf/open/floor/grass,
 /area/station/hallway/primary/central)
 "bLD" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-18";
-	tag = "icon-plant-18"
+	tag = null
 	},
 /turf/open/floor/grass,
 /area/station/hallway/primary/central)
@@ -20147,18 +20133,18 @@
 /area/station/engineering/atmos/pumproom)
 "bMC" = (
 /obj/structure/sign/directions/security{
-	tag = "icon-direction_sec (WEST)";
-	dir = 8
+	dir = 8;
+	tag = null
 	},
 /obj/structure/sign/directions/medical{
 	dir = 8;
 	pixel_y = -8;
-	tag = "icon-direction_med (WEST)"
+	tag = null
 	},
 /obj/structure/sign/directions/evac{
 	dir = 1;
 	pixel_y = 8;
-	tag = "icon-direction_evac (NORTH)"
+	tag = null
 	},
 /turf/closed/wall,
 /area/station/maintenance/department/engine/atmos)
@@ -20184,16 +20170,14 @@
 	desc = "A direction sign, pointing out which way the research department is.";
 	dir = 4;
 	name = "research department";
-	tag = "icon-direction_sci (EAST)"
+	tag = null
 	},
 /obj/structure/sign/directions/engineering{
 	pixel_y = -8
 	},
-/obj/structure/sign/directions{
+/obj/structure/sign/directions/supply{
 	dir = 4;
-	icon_state = "direction_supply";
-	pixel_y = 8;
-	tag = "icon-direction_supply (EAST)"
+	pixel_y = 8
 	},
 /turf/closed/wall,
 /area/station/service/hydroponics)
@@ -20248,16 +20232,15 @@
 /obj/structure/sign/directions/evac{
 	dir = 1;
 	pixel_y = -8;
-	tag = "icon-direction_evac (NORTH)"
-	},
-/obj/structure/sign/directions/engineering{
-	tag = "icon-direction_eng (WEST)";
-	dir = 8
+	tag = null
 	},
 /obj/structure/sign/directions/medical{
 	dir = 8;
 	pixel_y = 8;
-	tag = "icon-direction_med (WEST)"
+	tag = null
+	},
+/obj/structure/sign/directions/engineering{
+	dir = 8
 	},
 /turf/closed/wall,
 /area/station/service/theater)
@@ -21420,7 +21403,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
-	name = "brig shutters"
+	name = "Brig Shutters"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -21655,8 +21638,8 @@
 "bSY" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/north{
-	name = "Atmospherics Desk";
 	dir = 2;
+	name = "Atmospherics Desk";
 	req_access = list("atmospherics")
 	},
 /obj/item/folder/yellow,
@@ -22270,8 +22253,8 @@
 /obj/machinery/button/curtain{
 	id = "theater_curtains";
 	name = "curtain control";
-	req_access = list("theatre");
-	pixel_x = -24
+	pixel_x = -24;
+	req_access = list("theatre")
 	},
 /turf/open/floor/wood,
 /area/station/service/theater)
@@ -22284,8 +22267,8 @@
 /obj/machinery/button/curtain{
 	id = "theater_curtains";
 	name = "curtain control";
-	req_access = list("theatre");
-	pixel_x = 24
+	pixel_x = 24;
+	req_access = list("theatre")
 	},
 /turf/open/floor/wood,
 /area/station/service/theater)
@@ -22406,9 +22389,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/window/brigdoor/security/cell{
+	dir = 8;
 	id = "Cell 1";
-	name = "Cell 1";
-	dir = 8
+	name = "Cell 1"
 	},
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron,
@@ -23329,9 +23312,9 @@
 /obj/machinery/button/flasher{
 	id = "secentranceflasher";
 	name = "Brig Entrance Flasher";
-	req_access = list("security");
 	pixel_x = 26;
-	pixel_y = 26
+	pixel_y = 26;
+	req_access = list("security")
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -23430,8 +23413,8 @@
 /obj/machinery/door/window/left/directional/east{
 	dir = 8;
 	name = "Hydroponics Window";
-	req_one_access_txt = list("hydroponics");
-	req_access = list("hydroponics")
+	req_access = list("hydroponics");
+	req_one_access_txt = list("hydroponics")
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
@@ -23578,9 +23561,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/window/brigdoor/security/cell{
+	dir = 8;
 	id = "Cell 2";
-	name = "Cell 2";
-	dir = 8
+	name = "Cell 2"
 	},
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron,
@@ -25015,14 +24998,14 @@
 /obj/machinery/button/flasher{
 	id = "stageflash";
 	name = "Stage Flasher";
-	pixel_y = -1;
-	pixel_x = 5
+	pixel_x = 5;
+	pixel_y = -1
 	},
 /obj/machinery/button/curtain{
 	id = "theater_curtains";
 	name = "curtain control";
-	pixel_y = 7;
-	pixel_x = 5
+	pixel_x = 5;
+	pixel_y = 7
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -25133,9 +25116,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/window/brigdoor/security/cell{
+	dir = 8;
 	id = "Cell 3";
-	name = "Cell 3";
-	dir = 8
+	name = "Cell 3"
 	},
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron,
@@ -25408,7 +25391,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
-	name = "brig shutters"
+	name = "Brig Shutters"
 	},
 /turf/open/floor/plating,
 /area/station/security/processing)
@@ -25919,7 +25902,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
-	name = "brig shutters"
+	name = "Brig Shutters"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
@@ -26621,8 +26604,8 @@
 /area/station/commons/dorms)
 "cmX" = (
 /obj/machinery/shower{
-	tag = "icon-shower (EAST)";
-	dir = 4
+	dir = 4;
+	tag = null
 	},
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
@@ -26632,8 +26615,8 @@
 /area/station/commons/toilet/locker)
 "cmZ" = (
 /obj/machinery/shower{
-	tag = "icon-shower (WEST)";
-	dir = 8
+	dir = 8;
+	tag = null
 	},
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/freezer,
@@ -27196,8 +27179,8 @@
 /area/station/engineering/storage/tech)
 "cpu" = (
 /obj/machinery/shower{
-	tag = "icon-shower (EAST)";
-	dir = 4
+	dir = 4;
+	tag = null
 	},
 /obj/structure/mirror/directional/west,
 /turf/open/floor/iron/freezer,
@@ -27209,8 +27192,8 @@
 /area/station/commons/toilet/locker)
 "cpw" = (
 /obj/machinery/shower{
-	tag = "icon-shower (WEST)";
-	dir = 8
+	dir = 8;
+	tag = null
 	},
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
@@ -28178,8 +28161,8 @@
 	},
 /obj/item/gun/energy/disabler,
 /obj/item/gun/energy/disabler{
-	pixel_y = -3;
-	pixel_x = 2
+	pixel_x = 2;
+	pixel_y = -3
 	},
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -28553,8 +28536,8 @@
 /area/station/security/prison/toilet)
 "cuH" = (
 /obj/machinery/shower{
-	tag = "icon-shower (WEST)";
-	dir = 8
+	dir = 8;
+	tag = null
 	},
 /obj/item/soap,
 /obj/structure/cable,
@@ -29044,7 +29027,7 @@
 "cwP" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
-	name = "engineering security door"
+	name = "Engineering Security Door"
 	},
 /obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/iron,
@@ -29052,7 +29035,7 @@
 "cwQ" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
-	name = "engineering security door"
+	name = "Engineering Security Door"
 	},
 /obj/structure/sign/warning/radiation/directional/south,
 /obj/effect/turf_decal/caution/stand_clear,
@@ -29200,9 +29183,9 @@
 /area/station/maintenance/solars/starboard/aft)
 "cxq" = (
 /obj/machinery/power/solar_control{
+	dir = 1;
 	id = "aftstarboard";
-	name = "Aft Starboard Solar Control";
-	dir = 1
+	name = "Aft Starboard Solar Control"
 	},
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
@@ -29485,7 +29468,7 @@
 "cyI" = (
 /obj/machinery/door/poddoor{
 	id = "Secure Storage";
-	name = "secure storage"
+	name = "Secure Storage"
 	},
 /turf/open/floor/plating,
 /area/station/engineering/main)
@@ -29794,9 +29777,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "cAm" = (
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/effect/landmark/xeno_spawn,
+/obj/effect/gibspawner/generic,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "cAn" = (
@@ -29923,7 +29905,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
-	name = "brig shutters"
+	name = "Brig Shutters"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -30117,13 +30099,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "cCd" = (
-/obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/structure/rack,
 /obj/item/storage/medkit/regular,
 /obj/item/stack/medical/bruise_pack,
 /obj/item/stack/medical/bruise_pack,
 /obj/item/stack/medical/ointment,
 /obj/item/clothing/glasses/hud/health,
+/obj/effect/gibspawner/human,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "cCe" = (
@@ -30336,12 +30318,12 @@
 /area/station/maintenance/port/aft)
 "cCX" = (
 /mob/living/simple_animal/hostile/carp{
-	butcher_results = list(/obj/item/food/carpmeat=5);
+	butcher_results = list(/obj/item/food/fishmeat/carp=5);
 	desc = "A particularly ferocious, fang-bearing creature that resembles a fish.";
 	emote_taunt = list("glares, gnashes");
+	environment_smash = 0;
 	maxHealth = 100;
-	name = "Chompers";
-	environment_smash = 0
+	name = "Chompers"
 	},
 /turf/open/space/basic,
 /area/space)
@@ -31679,7 +31661,7 @@
 "dls" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "lawyer_blast";
-	name = "privacy shutters"
+	name = "Privacy Shutters"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -31763,8 +31745,8 @@
 /area/station/medical/medbay/central)
 "dqd" = (
 /obj/structure/chair/comfy/teal{
-	dir = 1;
-	color = "#52B4E9"
+	color = "#52B4E9";
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/dark,
@@ -31854,8 +31836,8 @@
 "duu" = (
 /obj/machinery/door/window{
 	dir = 4;
-	req_access = list("bar");
-	name = "Escape Bar"
+	name = "Escape Bar";
+	req_access = list("bar")
 	},
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
@@ -32389,9 +32371,9 @@
 "elx" = (
 /obj/structure/lattice,
 /obj/machinery/camera/directional/east{
+	active_power_usage = 0;
 	c_tag = "MiniSat Exterior - Fore Port";
-	network = list("minisat");
-	active_power_usage = 0
+	network = list("minisat")
 	},
 /turf/open/space/basic,
 /area/station/ai_monitored/command/storage/satellite)
@@ -32915,7 +32897,7 @@
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "rnd2";
-	name = "research lab shutters"
+	name = "Research Lab Shutters"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -33257,9 +33239,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/camera/directional/north{
-	network = list("minisat");
 	active_power_usage = 0;
-	c_tag = "MiniSat Exterior - Aft"
+	c_tag = "MiniSat Exterior - Aft";
+	network = list("minisat")
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -34079,7 +34061,7 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
 	layer = 2.9;
-	name = "bridge blast door"
+	name = "Bridge Blast Door"
 	},
 /turf/open/floor/plating,
 /area/station/command/bridge)
@@ -34420,7 +34402,7 @@
 /area/station/service/chapel/funeral)
 "gOQ" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "Courtroom maintenance"
+	name = "Courtroom Maintenance"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35145,8 +35127,8 @@
 /area/space/nearstation)
 "hTb" = (
 /obj/machinery/atmospherics/components/binary/pump/off{
-	name = "Pure to Port";
-	dir = 8
+	dir = 8;
+	name = "Pure to Port"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -36408,14 +36390,10 @@
 /area/station/engineering/supermatter/room)
 "jOh" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the medical department is.";
-	icon_state = "direction_med";
-	name = "medical department";
-	tag = "icon-direction_med";
+/obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
+/obj/structure/sign/directions/medical{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -37023,13 +37001,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/maintenance/department/security)
-"kDy" = (
-/obj/structure/lattice,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "kDF" = (
 /obj/structure/closet/bombcloset,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37914,8 +37885,8 @@
 	pixel_y = 8
 	},
 /obj/structure/sign/directions/vault/directional/east{
-	pixel_y = -8;
-	dir = 2
+	dir = 2;
+	pixel_y = -8
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
@@ -37966,7 +37937,7 @@
 "lWs" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
-	name = "engineering security door"
+	name = "Engineering Security Door"
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/caution/stand_clear,
@@ -38160,8 +38131,8 @@
 /area/station/security/prison/safe)
 "mjZ" = (
 /obj/machinery/atmospherics/components/binary/pump/off{
-	name = "Port to Air";
-	dir = 8
+	dir = 8;
+	name = "Port to Air"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -38357,12 +38328,12 @@
 	dir = 8
 	},
 /obj/structure/sign/directions/supply/directional/west{
-	pixel_y = 12;
-	dir = 1
+	dir = 1;
+	pixel_y = 12
 	},
 /obj/structure/sign/directions/science/directional/west{
-	pixel_y = 5;
-	dir = 1
+	dir = 1;
+	pixel_y = 5
 	},
 /obj/structure/sign/directions/security/directional/west{
 	pixel_y = -2
@@ -39549,8 +39520,8 @@
 /area/station/science/research)
 "nYo" = (
 /obj/effect/decal/cleanable/crayon{
-	name = "THIS ROOM FUCKING SUCKS.";
-	desc = "I HATE IT. I HATE IT SO MUCH. PLEASE JUST MAKE IT NOT SUCK SO MUCH."
+	desc = "I HATE IT. I HATE IT SO MUCH. PLEASE JUST MAKE IT NOT SUCK SO MUCH.";
+	name = "THIS ROOM FUCKING SUCKS."
 	},
 /turf/open/floor/iron,
 /area/station/construction)
@@ -39620,8 +39591,8 @@
 /area/station/security/execution/transfer)
 "obk" = (
 /obj/machinery/requests_console/directional/south{
-	department = "Chief Engineer's Desk";
 	announcementConsole = 1;
+	department = "Chief Engineer's Desk";
 	name = "Chief Engineer's Requests Console"
 	},
 /obj/machinery/pdapainter/engineering,
@@ -39693,8 +39664,8 @@
 /obj/machinery/button/curtain{
 	id = "theater_curtains";
 	name = "curtain control";
-	req_access = list("theatre");
-	pixel_x = -24
+	pixel_x = -24;
+	req_access = list("theatre")
 	},
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
@@ -39867,8 +39838,8 @@
 /obj/machinery/button/curtain{
 	id = "theater_curtains";
 	name = "curtain control";
-	req_access = list("theatre");
-	pixel_x = 24
+	pixel_x = 24;
+	req_access = list("theatre")
 	},
 /turf/open/floor/iron/checker,
 /area/station/service/theater)
@@ -39929,9 +39900,9 @@
 "oCq" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/west{
+	dir = 1;
 	name = "Genetics Desk";
-	req_access = list("genetics");
-	dir = 1
+	req_access = list("genetics")
 	},
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
@@ -39944,7 +39915,7 @@
 "oDn" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "qm_warehouse";
-	name = "warehouse shutters"
+	name = "Warehouse Shutters"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -40718,11 +40689,11 @@
 "pGT" = (
 /obj/docking_port/stationary{
 	dir = 8;
-	dwidth = 11;
-	height = 18;
+	dwidth = 8;
+	height = 19;
 	id = "emergency_home";
 	name = "DiscStation emergency evac bay";
-	width = 30
+	width = 16
 	},
 /turf/open/space/basic,
 /area/space)
@@ -41299,11 +41270,8 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "qxL" = (
-/obj/structure/sign/directions{
-	dir = 1;
-	icon_state = "direction_bridge";
-	pixel_y = -8;
-	tag = "icon-direction_bridge (NORTH)"
+/obj/structure/sign/directions/command{
+	dir = 1
 	},
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/hop)
@@ -41725,8 +41693,8 @@
 /area/station/commons/fitness/recreation)
 "raH" = (
 /obj/machinery/atmospherics/components/binary/pump/off{
-	name = "Air to Port";
-	dir = 4
+	dir = 4;
+	name = "Air to Port"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -41905,8 +41873,8 @@
 /area/station/medical/treatment_center)
 "roc" = (
 /mob/living/simple_animal/pet/cat{
-	name = "Katie";
-	desc = "Yoss, queen, slay."
+	desc = "Yoss, queen, slay.";
+	name = "Katie"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
@@ -42757,7 +42725,7 @@
 "sqE" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
-	name = "brig shutters"
+	name = "Brig Shutters"
 	},
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -42776,7 +42744,7 @@
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "rnd2";
-	name = "research lab shutters"
+	name = "Research Lab Shutters"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -42991,7 +42959,7 @@
 /obj/structure/grille,
 /obj/machinery/door/poddoor/preopen{
 	id = "misclab";
-	name = "test chamber blast door"
+	name = "Test Chamber Blast Door"
 	},
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/cable,
@@ -46176,9 +46144,9 @@
 /area/station/science/research)
 "xxF" = (
 /obj/machinery/camera/directional/west{
+	active_power_usage = 0;
 	c_tag = "MiniSat Exterior - Aft Starboard";
-	network = list("minisat");
-	active_power_usage = 0
+	network = list("minisat")
 	},
 /turf/open/space/basic,
 /area/station/ai_monitored/turret_protected/aisat_interior)
@@ -46368,8 +46336,8 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	tag = "icon-camera (NORTHWEST)";
-	dir = 6
+	dir = 6;
+	tag = null
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
@@ -46643,9 +46611,9 @@
 /area/station/commons/fitness/recreation/entertainment)
 "ylm" = (
 /obj/machinery/camera/directional/east{
+	active_power_usage = 0;
 	c_tag = "MiniSat Exterior - Aft Port";
-	network = list("minisat");
-	active_power_usage = 0
+	network = list("minisat")
 	},
 /turf/open/space/basic,
 /area/station/ai_monitored/turret_protected/aisat_interior)
@@ -46655,9 +46623,9 @@
 "ylN" = (
 /obj/structure/lattice,
 /obj/machinery/camera/directional/south{
-	network = list("minisat");
 	active_power_usage = 0;
-	c_tag = "MiniSat Exterior - Fore"
+	c_tag = "MiniSat Exterior - Fore";
+	network = list("minisat")
 	},
 /turf/open/space/basic,
 /area/station/ai_monitored/turret_protected/ai)
@@ -62425,7 +62393,7 @@ aji
 auU
 amM
 auU
-kDy
+aCI
 auU
 auY
 auY
@@ -70961,7 +70929,7 @@ lWL
 lWL
 bjK
 blQ
-bmX
+boL
 blS
 boP
 bqd
@@ -95421,7 +95389,7 @@ nvl
 bra
 cja
 ctY
-bII
+czk
 czk
 czk
 lWL

--- a/StationMaps/DiscStation/shuttles/arrival_disc.dmm
+++ b/StationMaps/DiscStation/shuttles/arrival_disc.dmm
@@ -1,15 +1,11 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
-/turf/closed/wall/mineral/titanium,
-/area/space)
 "e" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
-/area/space)
+/area/shuttle/arrival)
 "g" = (
-/turf/open/space/basic,
 /turf/closed/wall/mineral/titanium,
-/area/space)
+/area/shuttle/arrival)
 "k" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4
@@ -18,7 +14,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/shuttle/arrival)
 "l" = (
 /obj/structure/table,
 /obj/item/storage/medkit/regular{
@@ -27,19 +23,19 @@
 	},
 /obj/item/crowbar,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/arrival)
 "p" = (
 /obj/structure/table,
 /obj/item/storage/medkit/fire,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/arrival)
 "q" = (
 /obj/structure/closet/wardrobe/green,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/arrival)
 "s" = (
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/arrival)
 "u" = (
 /obj/structure/chair{
 	dir = 4
@@ -49,13 +45,13 @@
 	},
 /obj/effect/landmark/latejoin,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/arrival)
 "y" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/shuttle/arrival)
 "F" = (
 /obj/structure/chair{
 	dir = 8
@@ -65,73 +61,73 @@
 	},
 /obj/effect/landmark/latejoin,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/arrival)
 "L" = (
 /turf/open/space/basic,
-/area/space)
+/area/template_noop)
 "R" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/arrival)
 "W" = (
 /obj/machinery/door/airlock/shuttle{
 	name = "Emergency Shuttle Airlock"
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/arrival)
 "Y" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/shuttle,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/arrival)
 
 (1,1,1) = {"
-a
+g
 R
 W
 Y
-a
-a
+g
+g
 R
 W
 R
-a
+g
 "}
 (2,1,1) = {"
-a
+g
 l
 s
 q
-a
-a
+g
+g
 p
 s
 q
-a
+g
 "}
 (3,1,1) = {"
-a
+g
 F
 s
 F
-a
-a
+g
+g
 F
 s
 F
-a
+g
 "}
 (4,1,1) = {"
-a
+g
 u
 s
 u
-a
-a
+g
+g
 u
 s
 u
-a
+g
 "}
 (5,1,1) = {"
 e
@@ -146,40 +142,40 @@ F
 e
 "}
 (6,1,1) = {"
-a
+g
 u
 s
 u
-a
-a
+g
+g
 u
 s
 u
-a
+g
 "}
 (7,1,1) = {"
-a
+g
 F
 s
 F
-a
-a
+g
+g
 F
 s
 F
-a
+g
 "}
 (8,1,1) = {"
-a
+g
 u
 s
 u
-a
-a
+g
+g
 u
 s
 u
-a
+g
 "}
 (9,1,1) = {"
 g

--- a/StationMaps/DiscStation/shuttles/emergency_disc.dmm
+++ b/StationMaps/DiscStation/shuttles/emergency_disc.dmm
@@ -1,36 +1,36 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "b" = (
 /obj/machinery/door/poddoor/shutters{
 	name = "Escape Shuttle Cargo Shutters"
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/escape)
 "c" = (
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/escape)
 "d" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/shuttle/escape/brig)
 "e" = (
 /obj/machinery/computer/communications,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/escape)
 "f" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/escape)
 "g" = (
 /obj/structure/bed/dogbed,
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/escape)
 "i" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4
@@ -39,14 +39,10 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/shuttle/escape)
 "k" = (
 /turf/open/floor/iron,
-/area/space)
-"l" = (
-/turf/open/space/basic,
-/turf/closed/wall/mineral/titanium,
-/area/space)
+/area/shuttle/escape/brig)
 "m" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -58,40 +54,40 @@
 /obj/item/restraints/handcuffs,
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/escape/brig)
 "n" = (
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/escape)
 "p" = (
 /obj/machinery/space_heater,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/escape)
 "s" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/escape)
 "t" = (
 /obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/escape)
 "u" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "shuttlecargo";
 	name = "Escape Shuttle Cargo Shutters"
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/escape)
 "v" = (
 /obj/structure/rack,
 /obj/item/storage/medkit/regular,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/escape)
 "w" = (
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/escape)
 "x" = (
 /obj/structure/chair{
 	dir = 4
@@ -100,27 +96,27 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/escape)
 "y" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/shuttle/escape)
 "z" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/escape)
 "A" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/escape)
 "B" = (
 /turf/closed/wall/mineral/titanium,
-/area/space)
+/area/shuttle/escape)
 "C" = (
 /obj/structure/table,
 /obj/item/storage/medkit/fire,
@@ -129,14 +125,14 @@
 	pixel_y = 3
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/escape)
 "D" = (
 /obj/machinery/sleeper{
-	icon_state = "sleeper-open";
-	dir = 4
+	dir = 4;
+	icon_state = "sleeper-open"
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/escape)
 "E" = (
 /obj/structure/reagent_dispensers/wall/peppertank{
 	pixel_x = -29
@@ -144,14 +140,14 @@
 /obj/structure/closet/bombcloset,
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
-/area/space)
+/area/shuttle/escape/brig)
 "F" = (
 /obj/structure/sign/departments/medbay/alt{
 	pixel_x = -32
 	},
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
-/area/space)
+/area/shuttle/escape)
 "G" = (
 /obj/machinery/button/door{
 	id = "shuttlecargo";
@@ -159,52 +155,52 @@
 	pixel_y = -26
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/escape)
 "H" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/escape)
 "I" = (
 /obj/machinery/door/airlock/shuttle{
 	name = "Emergency Shuttle Airlock"
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/escape)
 "J" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Cockpit";
 	req_access_txt = "19"
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/escape)
 "K" = (
 /obj/structure/table,
 /obj/item/defibrillator/loaded,
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/escape)
 "L" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/shuttle/escape/brig)
 "M" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/emergency{
 	pixel_y = 3
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/escape)
 "N" = (
 /obj/structure/sign/departments/medbay/alt{
 	pixel_x = 32
 	},
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
-/area/space)
+/area/shuttle/escape)
 "O" = (
 /mob/living/simple_animal/bot/medbot{
 	name = "\improper emergency medibot";
@@ -212,7 +208,7 @@
 	pixel_y = 2
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/escape)
 "P" = (
 /obj/machinery/button/door{
 	id = "shuttlecargo";
@@ -221,7 +217,7 @@
 	req_access_txt = "50"
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/escape)
 "Q" = (
 /obj/structure/table,
 /obj/item/storage/medkit/toxin,
@@ -230,26 +226,20 @@
 	pixel_y = 3
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/escape)
 "R" = (
 /obj/machinery/door/airlock/shuttle{
 	name = "Emergency Shuttle Airlock"
 	},
 /obj/docking_port/mobile/emergency{
 	dir = 8;
-	height = 20;
-	width = 18
-	},
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 9;
-	height = 20;
-	id = "emergency_home";
-	name = "Escape Home";
-	width = 18
+	dwidth = 8;
+	height = 19;
+	name = "Disc emergency shuttle";
+	width = 16
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/escape)
 "S" = (
 /obj/structure/table,
 /obj/item/scalpel{
@@ -266,55 +256,55 @@
 /obj/item/clothing/mask/surgical,
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/escape)
 "T" = (
 /obj/machinery/computer/crew,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/escape)
 "U" = (
 /turf/open/floor/circuit,
-/area/space)
+/area/shuttle/escape)
 "V" = (
 /obj/machinery/computer/emergency_shuttle,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/escape)
 "W" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
-/area/space)
+/area/shuttle/escape)
 "X" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Escape Shuttle Infirmary"
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/escape)
 "Y" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Brig"
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/shuttle/escape)
 "Z" = (
 /obj/machinery/recharge_station,
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/circuit,
-/area/space)
+/area/shuttle/escape)
 
 (1,1,1) = {"
 a
 a
-l
+B
 W
 W
 W
 B
 a
 a
-l
+B
 W
 W
 W
-l
+B
 a
 a
 "}
@@ -428,7 +418,7 @@ a
 "}
 (8,1,1) = {"
 a
-l
+B
 B
 H
 H
@@ -441,7 +431,7 @@ A
 D
 C
 B
-l
+B
 a
 "}
 (9,1,1) = {"
@@ -499,7 +489,7 @@ B
 a
 "}
 (12,1,1) = {"
-l
+B
 B
 B
 B
@@ -514,7 +504,7 @@ B
 B
 B
 B
-l
+B
 "}
 (13,1,1) = {"
 B
@@ -636,7 +626,7 @@ R
 I
 B
 I
-l
+B
 y
 y
 y

--- a/StationMaps/DiscStation/shuttles/whiteship_disc.dmm
+++ b/StationMaps/DiscStation/shuttles/whiteship_disc.dmm
@@ -4,41 +4,41 @@
 	anchored = 1
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "b" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion (EAST)";
-	dir = 4
+	dir = 4;
+	tag = null
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "c" = (
 /obj/machinery/mass_driver{
 	dir = 4;
 	id = "oldship_gun"
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "d" = (
 /obj/machinery/door/airlock/shuttle,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "e" = (
 /obj/structure/chair,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "f" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/breath,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "g" = (
 /obj/machinery/door/poddoor{
 	id = "oldship_gun";
-	name = "pod bay door"
+	name = "Pod Bay Door"
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "h" = (
 /obj/machinery/door/airlock/shuttle,
 /obj/docking_port/mobile{
@@ -47,8 +47,6 @@
 	height = 22;
 	id = "whiteship";
 	name = "NT Medical Ship";
-	roundstart_move = "whiteship_away";
-	travelDir = 180;
 	width = 35
 	},
 /obj/docking_port/stationary{
@@ -60,24 +58,24 @@
 	width = 35
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "i" = (
 /obj/structure/table,
 /obj/item/tank/internals/oxygen,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "k" = (
 /obj/machinery/sleeper{
-	icon_state = "sleeper-open";
-	dir = 8
+	dir = 8;
+	icon_state = "sleeper-open"
 	},
 /obj/effect/decal/remains/human,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "l" = (
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "n" = (
 /obj/structure/rack,
 /obj/item/tank/internals/emergency_oxygen,
@@ -86,35 +84,38 @@
 /obj/item/tank/internals/emergency_oxygen,
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "p" = (
 /obj/item/shard{
 	icon_state = "medium"
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "q" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_r (EAST)";
+	dir = 4;
 	icon_state = "propulsion_r";
-	dir = 4
+	tag = null
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "r" = (
 /obj/machinery/door/airlock/shuttle,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "s" = (
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (WEST)";
-	dir = 8
+	dir = 8;
+	tag = null
 	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
+"u" = (
+/turf/closed/wall/mineral/titanium,
+/area/ruin/space/has_grav/whiteship)
 "w" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
@@ -123,48 +124,48 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "x" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "y" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_l (EAST)";
+	dir = 4;
 	icon_state = "propulsion_l";
-	dir = 4
+	tag = null
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "A" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "B" = (
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "C" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /obj/effect/decal/remains/human,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "D" = (
 /turf/closed/wall/mineral/titanium,
 /area/space)
 "F" = (
 /obj/item/multitool,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "G" = (
 /obj/machinery/computer/pod{
 	id = "oldship_gun"
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "H" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
@@ -175,41 +176,41 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "I" = (
 /obj/machinery/door/window,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "J" = (
 /turf/open/space/basic,
-/area/space)
+/area/template_noop)
 "L" = (
 /obj/machinery/door/window/right/directional/north,
 /obj/effect/decal/remains/human,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "M" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "N" = (
 /obj/structure/table,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "O" = (
 /obj/structure/table,
 /obj/item/radio/off,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "P" = (
 /obj/item/scalpel,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "Q" = (
 /obj/structure/table,
 /obj/item/screwdriver,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "R" = (
 /obj/structure/table,
 /obj/item/storage/medkit/regular{
@@ -217,38 +218,38 @@
 	pixel_y = -5
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "S" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "T" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "V" = (
 /obj/machinery/computer/shuttle/white_ship,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "W" = (
 /obj/structure/table,
 /obj/item/gun/energy/laser/retro,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "X" = (
 /obj/item/stock_parts/cell{
 	charge = 100;
 	maxcharge = 15000
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "Y" = (
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/mineral/titanium/white,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 "Z" = (
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/whiteship)
 
 (1,1,1) = {"
 J
@@ -259,11 +260,11 @@ J
 J
 J
 J
-D
-D
+u
+u
 d
-D
-D
+u
+u
 J
 J
 J
@@ -282,11 +283,11 @@ J
 J
 J
 J
-D
-D
+u
+u
 B
-D
-D
+u
+u
 J
 J
 J
@@ -305,11 +306,11 @@ J
 J
 J
 J
-D
+u
 B
 B
 B
-D
+u
 J
 J
 J
@@ -328,11 +329,11 @@ J
 J
 J
 J
-D
+u
 B
 B
 B
-D
+u
 J
 J
 J
@@ -351,11 +352,11 @@ J
 J
 J
 J
-D
+u
 B
 B
 B
-D
+u
 J
 J
 J
@@ -374,11 +375,11 @@ J
 J
 J
 J
-D
+u
 B
 B
 B
-D
+u
 J
 J
 J
@@ -397,11 +398,11 @@ J
 J
 J
 J
-D
+u
 B
 B
 B
-D
+u
 J
 J
 J
@@ -420,11 +421,11 @@ J
 J
 J
 J
-D
+u
 B
 B
 B
-D
+u
 J
 J
 J
@@ -443,11 +444,11 @@ J
 J
 J
 J
-D
+u
 B
 B
 T
-D
+u
 J
 J
 J
@@ -466,11 +467,11 @@ J
 J
 J
 J
-D
-D
+u
+u
 B
-D
-D
+u
+u
 J
 J
 J
@@ -489,11 +490,11 @@ J
 J
 J
 J
-D
-D
+u
+u
 d
-D
-D
+u
+u
 J
 J
 J
@@ -513,9 +514,9 @@ J
 J
 J
 J
-D
+u
 B
-D
+u
 J
 J
 J
@@ -536,9 +537,9 @@ J
 J
 J
 D
-D
+u
 d
-D
+u
 D
 J
 J
@@ -559,9 +560,9 @@ J
 J
 D
 D
-D
+u
 B
-D
+u
 D
 D
 J
@@ -573,7 +574,7 @@ J
 J
 "}
 (15,1,1) = {"
-D
+u
 y
 b
 b
@@ -593,62 +594,62 @@ b
 b
 b
 q
-D
+u
 "}
 (16,1,1) = {"
-D
-D
+u
+u
 s
 s
 s
-D
-D
-D
+u
+u
+u
 B
 B
 B
 B
 B
-D
-D
-D
+u
+u
+u
 s
 s
 s
-D
-D
+u
+u
 "}
 (17,1,1) = {"
 J
-D
-D
+u
+u
 Z
 Z
-D
-D
-D
+u
+u
+u
 B
 B
 B
 B
 B
-D
-D
-D
+u
+u
+u
 Z
 Z
-D
-D
+u
+u
 J
 "}
 (18,1,1) = {"
 J
 J
-D
-D
+u
+u
 Z
 Z
-D
+u
 B
 B
 B
@@ -656,11 +657,11 @@ B
 B
 B
 S
-D
+u
 Z
 Z
-D
-D
+u
+u
 J
 J
 "}
@@ -668,21 +669,21 @@ J
 J
 J
 J
-D
-D
+u
+u
 r
-D
-D
-D
+u
+u
+u
 x
 Y
 x
-D
-D
-D
+u
+u
+u
 r
-D
-D
+u
+u
 J
 J
 J
@@ -691,8 +692,8 @@ J
 J
 J
 J
-D
-D
+u
+u
 B
 B
 B
@@ -704,8 +705,8 @@ B
 B
 B
 B
-D
-D
+u
+u
 J
 J
 J
@@ -713,9 +714,9 @@ J
 (21,1,1) = {"
 J
 J
-D
-D
-D
+u
+u
+u
 X
 B
 B
@@ -727,45 +728,45 @@ B
 B
 B
 B
-D
-D
-D
+u
+u
+u
 J
 J
 "}
 (22,1,1) = {"
 J
-D
-D
-D
+u
+u
+u
 B
 B
 B
 B
-D
-D
-D
-D
-D
-D
+u
+u
+u
+u
+u
+u
 B
 B
-D
-D
-D
-D
+u
+u
+u
+u
 J
 "}
 (23,1,1) = {"
-D
-D
-D
-D
-D
-D
-D
+u
+u
+u
+u
+u
+u
+u
 B
-D
+u
 I
 B
 B
@@ -775,8 +776,8 @@ B
 B
 d
 B
-D
-D
+u
+u
 J
 "}
 (24,1,1) = {"
@@ -785,71 +786,71 @@ B
 B
 f
 f
-D
-D
+u
+u
 B
-D
+u
 w
 B
 i
 H
-D
+u
 B
 B
-D
+u
 B
 R
-D
-D
+u
+u
 "}
 (25,1,1) = {"
-D
+u
 B
 B
 B
 B
 n
-D
+u
 B
 d
 B
 B
 B
 L
-D
+u
 B
 B
-D
+u
 B
 B
-D
-D
+u
+u
 "}
 (26,1,1) = {"
-D
+u
 O
 B
 B
 B
 B
-D
+u
 B
-D
-D
-D
-D
-D
-D
+u
+u
+u
+u
+u
+u
 B
 X
 M
 P
 B
 B
-D
+u
 "}
 (27,1,1) = {"
-D
+u
 Q
 B
 B
@@ -869,17 +870,17 @@ M
 B
 B
 k
-D
+u
 "}
 (28,1,1) = {"
-D
+u
 B
 B
 B
 B
 B
-D
-D
+u
+u
 B
 B
 B
@@ -892,39 +893,39 @@ M
 B
 B
 B
-D
+u
 "}
 (29,1,1) = {"
-D
+u
 B
 B
 B
 B
-D
-D
-D
-D
+u
+u
+u
+u
 M
 Y
 M
-D
-D
-D
-D
-D
+u
+u
+u
+u
+u
 B
 B
 B
-D
+u
 "}
 (30,1,1) = {"
-D
+u
 B
 B
 B
-D
-D
-D
+u
+u
+u
 B
 B
 B
@@ -934,19 +935,19 @@ B
 N
 N
 N
-D
+u
 B
 B
-D
-D
+u
+u
 "}
 (31,1,1) = {"
 d
 B
 G
 B
-D
-D
+u
+u
 B
 B
 B
@@ -957,18 +958,18 @@ B
 B
 B
 B
-D
-D
+u
+u
 a
-D
+u
 J
 "}
 (32,1,1) = {"
-D
-D
-D
+u
+u
+u
 l
-D
+u
 a
 A
 B
@@ -981,17 +982,17 @@ B
 B
 e
 a
-D
-D
-D
+u
+u
+u
 J
 "}
 (33,1,1) = {"
 J
 J
-D
+u
 c
-D
+u
 a
 A
 B
@@ -1003,19 +1004,19 @@ B
 B
 B
 B
-D
-D
-D
+u
+u
+u
 J
 J
 "}
 (34,1,1) = {"
 J
 J
-D
+u
 g
-D
-D
+u
+u
 p
 B
 B
@@ -1025,9 +1026,9 @@ N
 B
 B
 B
-D
-D
-D
+u
+u
+u
 J
 J
 J
@@ -1037,9 +1038,9 @@ J
 J
 J
 J
-D
-D
-D
+u
+u
+u
 M
 M
 M
@@ -1047,9 +1048,9 @@ M
 M
 M
 M
-D
-D
-D
+u
+u
+u
 J
 J
 J


### PR DESCRIPTION
I wanted to run Discstation as an event on downstream but it wouldn't pass most checks, I ended up fixing most of them minus a single shuttle runtime which I couldn't be bothered to get around to debugging when parallel map testing takes half a hour to complete. This updates the station and its shuttles with these fixes:

Fixes:
-Tag vars from icon state generation (mostly on department signs and cameras)
- Doors/poddoor names not being uppercased
- Lattices in walls
- Turfs stacking
- Chompers' gib var edit not being updated to the newer meat item path
- Whiteship docking ports using depreciated variables
- Cycle helper that wasn't on an airlock but in the middle of space
- Shuttles missing areas and access helpers.

Run Linters & Compile Maps now run smoothly but I'm still encountering a runtime during parallel map testing that I couldn't quite figure out no matter how much I looked at the docking/stationary port if anyone can share the wisdom to make it work that'd be cool I think even if it might be an issue of how I compiled the map locally.

![image](https://user-images.githubusercontent.com/25415050/175280996-618a6ac7-de0d-413d-9565-68af2d8b3d03.png)
