### PR TITLE
Adds a Submodule to tgstation/tgstation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tgstation"]
+	path = tgstation
+	url = https://github.com/tgstation/tgstation.git


### PR DESCRIPTION
I had an idea a few months ago about getting submodules set up to leverage the usability of the CI Tooling we develop over there. This is just the first steps leading into a project that will probably make me wanna bash my skull in.

For future reference - Very, very old maps will definitely fail these CI checks. It should _not_ and it should _never_ be a requirement to pass the CI on the Map Depot in order to get your map merged here. Preserving history is the ultimate goal, and this should not be impeded by red X's. However, for the current maps that we currently uptain (portmanteu of Upkeep and Maintain), it's a good tool to have to support from the absolute jump so we don't have to run a bunch of .sh files and what-not.

One larger downside is that I'm pretty sure you'll need to download the tgstation repository every time you need to clone the map-depot (which might take no small bit of time), but I'm completely uncertain what a good way of avoiding this would be without manually mirroring the files.