### PR TITLE
Revert "Adds a Submodule to tgstation/tgstation"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "tgstation"]
-	path = tgstation
-	url = https://github.com/tgstation/tgstation.git


### PR DESCRIPTION
Reverts tgstation/map_depot#49

Submodules are bad.

See:
https://github.com/tgstation/tgstation/pull/28871
https://github.com/tgstation/tgstation/pull/28902
https://github.com/tgstation/tgstation/pull/29091
