### PR TITLE
Gitmodule Ignores Being Dirtied

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,4 @@
 	path = tgstation
 	url = https://github.com/tgstation/tgstation.git
 	branch = master
+	ignore = dirty


### PR DESCRIPTION
Doing this as a PR so I can reference it later as opposed to a direct commit (which I would have done anyways).

If what I read was correct, you can pretty much alter the submodule in any way you want on your branch in order to leverage it. So, instead of needing two branches checked out (one for the map_depot, one for tgstation) to do something like UpdatePaths, you can just do it in one and git should ignore any "dirtying" of the submodule. I'll try it out after this on my local.

Sidebar: I just tried to install the mapmerge2 githooks to my repository using this submodule, and it appears to have worked splendidly. The only thing I fear now is for when this "honeymoon" period ends and I'll have to throw everything away because something breaks horribly. Results are promising thus far, and I'll try to write as much down as I can because the history of people toying with submodules in stuff like this is lackluster.