### PR TITLE
DiscStation 2022 Update 3: Atmos overhaul + more

### DIFF
--- a/StationMaps/DiscStation/DiscStation.dmm
+++ b/StationMaps/DiscStation/DiscStation.dmm
@@ -301,8 +301,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/mix)
 "adh" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/obj/structure/closet/toolcloset,
+/turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "adi" = (
 /obj/effect/landmark/start/ai/secondary,
@@ -941,7 +944,9 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "afC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
@@ -1631,11 +1636,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
-"akg" = (
-/obj/structure/chair/stool/directional/north,
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/carpet/red,
-/area/station/commons/dorms)
 "akh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -1841,6 +1841,14 @@
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
+"alA" = (
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark,
+/area/station/hallway/secondary/command)
 "alC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/plating,
@@ -4555,32 +4563,25 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "ayo" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/computer/camera_advanced/base_construction/aux{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 8
 	},
-/obj/structure/sign/poster/official/random/directional/south,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
-"ayp" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
-"ayq" = (
-/obj/structure/table,
-/obj/item/stack/sheet/plasteel{
-	amount = 10
-	},
-/obj/item/stack/rods/fifty,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
-/obj/item/storage/box/lights/mixed,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
+"ayp" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
+"ayq" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "ays" = (
 /obj/machinery/computer/department_orders/security{
 	dir = 1
@@ -4656,6 +4657,12 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/medical/virology)
+"ayH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/navigate_destination/bridge,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "ayK" = (
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 4
@@ -4737,27 +4744,21 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/mix)
 "ayY" = (
-/obj/machinery/door/airlock/external{
-	name = "Construction Zone"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/aux_base,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/construction/mining/aux_base)
 "azb" = (
+/obj/structure/cable,
 /obj/effect/turf_decal/trimline/dark_blue/filled/shrink_ccw,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "azc" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 6
 	},
-/obj/machinery/status_display/evac/directional/west,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "azd" = (
 /obj/structure/rack,
 /obj/item/circuitboard/aicore{
@@ -5034,17 +5035,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
 "aAq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/engineering/hallway)
+/area/station/engineering/atmos)
 "aAr" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/siding/purple{
@@ -6280,13 +6275,20 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "aFl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/engineering/storage/tech)
+/area/station/engineering/hallway)
 "aFn" = (
-/obj/structure/chair/comfy/beige,
-/turf/open/floor/carpet,
-/area/station/hallway/secondary/entry)
+/turf/open/floor/plating,
+/area/station/construction/mining/aux_base)
 "aFq" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
@@ -6577,28 +6579,27 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "aGm" = (
-/obj/structure/chair{
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/machinery/light/directional/west,
-/obj/machinery/status_display/evac/directional/west,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/landmark/start/assistant,
+/obj/machinery/atmospherics/components/binary/pump/off{
+	dir = 8;
+	name = "Mix Out"
+	},
 /turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/area/station/engineering/atmos/mix)
 "aGn" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+/obj/effect/turf_decal/trimline/dark_blue/corner{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "aGo" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_blue/warning,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "aGp" = (
 /obj/structure/chair{
 	name = "Judge"
@@ -7043,9 +7044,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "aHN" = (
-/obj/effect/turf_decal/trimline/dark_blue/corner,
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/structure/window,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "aHO" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -7398,10 +7402,12 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "aIR" = (
-/obj/structure/chair/comfy/beige,
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/wood,
-/area/station/commons/lounge)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "aIU" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "robotics";
@@ -7705,11 +7711,11 @@
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "aKl" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-13"
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
 	},
-/turf/open/floor/glass/reinforced,
-/area/station/hallway/primary/starboard)
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "aKm" = (
 /obj/effect/turf_decal/trimline/dark_blue/corner{
 	dir = 1
@@ -7717,12 +7723,11 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "aKn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/plating,
-/area/station/hallway/primary/starboard)
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "aKr" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/right/directional/east{
@@ -8787,7 +8792,6 @@
 /area/station/engineering/atmos)
 "aOD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/holopad,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
@@ -11177,6 +11181,13 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
+"aYk" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "aYl" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Telcom Storage"
@@ -14736,8 +14747,6 @@
 /turf/open/floor/plating,
 /area/station/cargo/storage)
 "boB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
@@ -14811,9 +14820,6 @@
 /area/station/science/ordnance)
 "boV" = (
 /obj/structure/filingcabinet,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /obj/machinery/camera/directional/west{
 	c_tag = "Captain's Office"
 	},
@@ -14862,7 +14868,6 @@
 "bpf" = (
 /obj/structure/closet/crate,
 /obj/item/crowbar,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -15541,6 +15546,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "brJ" = (
@@ -15550,9 +15558,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "brK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -15958,9 +15963,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "btI" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 1
 	},
@@ -16797,10 +16800,12 @@
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "bxu" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
-/obj/machinery/camera/autoname/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/hallway/primary/starboard)
 "bxw" = (
 /obj/structure/filingcabinet,
 /obj/machinery/light/small/directional/north,
@@ -17329,6 +17334,7 @@
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "bzu" = (
@@ -17735,13 +17741,11 @@
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/captain/private)
 "bBe" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
 	dir = 4
 	},
-/obj/structure/table/wood,
-/obj/effect/spawner/random/entertainment/lighter,
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/engineering/atmos)
 "bBf" = (
 /obj/item/hand_labeler,
 /obj/item/assembly/timer,
@@ -18142,6 +18146,7 @@
 /area/station/command/heads_quarters/hop)
 "bCz" = (
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "bCA" = (
@@ -18445,11 +18450,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/hop)
-"bDR" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/atmos/mix)
 "bDT" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor{
@@ -20137,6 +20137,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"bLL" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/shrink_cw,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "bLV" = (
 /obj/effect/turf_decal/trimline/white/filled/line,
 /obj/machinery/camera/autoname/directional/south,
@@ -20836,7 +20840,6 @@
 /area/station/service/theater)
 "bOs" = (
 /obj/structure/table,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/item/radio/headset{
 	frequency = 1489;
 	name = "Theater headset"
@@ -22696,9 +22699,8 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bWf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos/mix)
+/turf/open/floor/glass/reinforced,
+/area/station/hallway/primary/starboard)
 "bWg" = (
 /obj/machinery/newscaster/directional/east,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
@@ -23050,8 +23052,8 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "bXu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 10
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -23465,14 +23467,6 @@
 /obj/structure/dresser,
 /turf/open/floor/iron/checker,
 /area/station/service/theater)
-"bZv" = (
-/obj/machinery/computer/shuttle/mining{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron,
-/area/station/construction/mining/aux_base)
 "bZx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -23883,7 +23877,7 @@
 /area/station/medical/psychology)
 "caU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
+	dir = 10
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -24238,9 +24232,6 @@
 /obj/structure/table,
 /obj/machinery/recharger{
 	pixel_y = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/security)
@@ -24611,7 +24602,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cdH" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cdI" = (
@@ -24968,7 +24961,6 @@
 /obj/structure/table,
 /obj/item/folder/red,
 /obj/item/restraints/handcuffs,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -25076,11 +25068,15 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ceZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/structure/window{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/hallway/primary/starboard)
 "cfa" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "South Central Aft Hall"
@@ -25408,7 +25404,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "cgs" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cgu" = (
@@ -25460,15 +25458,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/commons/dorms)
-"cgF" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/construction/mining/aux_base)
 "cgH" = (
 /obj/effect/spawner/random/entertainment/arcade,
 /turf/open/floor/carpet/red,
@@ -26508,15 +26497,10 @@
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "cli" = (
-/obj/machinery/computer/camera_advanced/base_construction/aux{
-	dir = 1
-	},
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/construction/mining/aux_base)
+/obj/structure/chair/comfy/beige,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "clj" = (
 /turf/open/floor/iron,
 /area/station/security/prison)
@@ -27394,12 +27378,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cph" = (
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
 	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/dark,
-/area/station/hallway/secondary/command)
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "cpn" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -27615,9 +27598,6 @@
 	c_tag = "Prison Cell 3";
 	network = list("ss13","prison")
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
 /obj/item/bedsheet/red,
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
@@ -27626,9 +27606,6 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Prison Cell 2";
 	network = list("ss13","prison")
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
 	},
 /obj/item/bedsheet/red,
 /obj/effect/decal/cleanable/dirt,
@@ -27672,13 +27649,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
-"cqi" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "cqj" = (
 /obj/machinery/flasher/portable,
 /obj/machinery/flasher/portable,
@@ -29223,14 +29193,14 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "cwj" = (
-/obj/structure/table,
-/obj/item/toy/cards/deck,
-/obj/item/toy/cards/deck,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/station/security/prison)
+/area/station/engineering/atmos)
 "cwk" = (
 /obj/structure/table,
 /obj/item/storage/dice,
@@ -29282,11 +29252,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "cwC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos/mix)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "cwD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -30761,7 +30732,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
+	dir = 9
 	},
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
@@ -31161,11 +31132,6 @@
 "cFE" = (
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"cFF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/dark_blue/warning,
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
 "cFH" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -31401,11 +31367,24 @@
 /turf/open/floor/iron/solarpanel/airless,
 /area/station/solars/port/aft)
 "cHn" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 9
+/obj/structure/rack,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/wallframe/camera,
+/obj/item/wallframe/camera,
+/obj/item/wallframe/camera,
+/obj/item/wallframe/camera,
+/obj/item/assault_pod/mining,
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/construction/mining/aux_base)
 "cHo" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating,
@@ -31544,6 +31523,12 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"cJx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "cJA" = (
 /obj/machinery/button/door{
 	id = "Skynet_launch";
@@ -31673,6 +31658,11 @@
 /obj/item/toy/figure/psychologist,
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
+"cOh" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/mix)
 "cOu" = (
 /obj/machinery/door/airlock/wood{
 	name = "Backstage"
@@ -31716,13 +31706,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"cPQ" = (
-/obj/machinery/camera/autoname/directional/east,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "cQM" = (
 /obj/structure/sign/poster/official/random/directional/west,
 /obj/effect/turf_decal/tile/blue{
@@ -31745,6 +31728,11 @@
 "cRn" = (
 /obj/item/cigbutt,
 /turf/open/floor/glass/reinforced,
+/area/station/hallway/primary/starboard)
+"cRo" = (
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "cRs" = (
 /obj/effect/turf_decal/delivery,
@@ -31769,12 +31757,6 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
-"cSN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos/mix)
 "cTq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31874,13 +31856,6 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"cZv" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/carpet,
-/area/station/service/theater)
 "cZP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/effect/spawner/structure/window/reinforced,
@@ -31948,12 +31923,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"ddV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "ddW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32030,6 +31999,13 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
+"dgP" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/carpet,
+/area/station/service/theater)
 "dhe" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
@@ -32113,17 +32089,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/service/lawoffice)
-"dlN" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "dlY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/captain)
 "dlZ" = (
 /obj/structure/chair{
 	dir = 4
@@ -32700,17 +32671,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/janitor)
-"dWW" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/turf/open/floor/plating,
-/area/station/hallway/primary/starboard)
 "dXf" = (
 /obj/machinery/ntnet_relay,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -32779,6 +32739,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
+"ebw" = (
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "ebD" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -32847,7 +32811,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
+	dir = 6
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -32869,12 +32833,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
-"eiO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "eiQ" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/west,
@@ -32903,6 +32861,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/mix)
+"eku" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "ekQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33020,6 +32986,11 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron,
 /area/station/security/prison)
+"epf" = (
+/obj/structure/chair/wood,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/wood,
+/area/station/service/cafeteria)
 "epG" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
@@ -33170,6 +33141,20 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"eyN" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/random/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
+"ezJ" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/structure/sign/directions/vault/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "ezK" = (
 /turf/closed/wall,
 /area/station/medical/psychology)
@@ -33484,9 +33469,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "eRV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible,
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/mix)
 "eSg" = (
 /obj/effect/turf_decal/tile/green/anticorner/contrasted{
 	dir = 1
@@ -33494,16 +33479,11 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "eSj" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/turf/open/floor/plating,
-/area/station/hallway/primary/starboard)
+/turf/open/floor/iron,
+/area/station/engineering/atmos/mix)
 "eSl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33527,6 +33507,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
+"eTc" = (
+/obj/effect/turf_decal/trimline/dark_blue/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "eTd" = (
 /obj/effect/landmark/event_spawn,
 /obj/item/reagent_containers/syringe,
@@ -33553,19 +33539,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
-"eTA" = (
-/obj/docking_port/stationary{
-	dheight = 4;
-	dwidth = 4;
-	height = 9;
-	id = "aux_base_zone";
-	name = "Aux Base Zone";
-	roundstart_template = /datum/map_template/shuttle/aux_base/default;
-	width = 9;
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/station/construction/mining/aux_base)
 "eUD" = (
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/white,
@@ -33607,6 +33580,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine/atmos)
+"eWp" = (
+/obj/structure/table,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/pipe_dispenser,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 4
+	},
+/obj/item/storage/toolbox/mechanical,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/iron,
+/area/station/construction/mining/aux_base)
 "eWN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33833,6 +33821,16 @@
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
+"fgu" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/light/directional/west,
+/obj/machinery/status_display/evac/directional/west,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "fgV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33860,6 +33858,11 @@
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
+"fiM" = (
+/obj/structure/chair/stool/directional/north,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/carpet/red,
+/area/station/commons/dorms)
 "fiS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -33894,6 +33897,7 @@
 	dir = 1
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "flI" = (
@@ -33957,16 +33961,6 @@
 /obj/structure/marker_beacon/cerulean,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"fnw" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/holopad,
-/turf/open/floor/iron,
-/area/station/construction/mining/aux_base)
 "fob" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -34064,12 +34058,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
-"fqX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos/mix)
 "frA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34160,9 +34148,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"fyF" = (
-/turf/open/floor/glass/reinforced,
-/area/station/hallway/primary/starboard)
 "fzd" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
@@ -34231,6 +34216,12 @@
 /obj/effect/turf_decal/tile/blue/diagonal_edge,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
+"fFQ" = (
+/obj/structure/chair/comfy/beige{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/station/hallway/secondary/entry)
 "fGe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34449,26 +34440,12 @@
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/button/door/directional/south{
-	id = "bridgedoors";
-	name = "Bridge Access Blast Doors";
-	pixel_x = 24;
-	req_access = list("command");
-	pixel_y = 0
-	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "fTf" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
-"fUk" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/obj/structure/closet/toolcloset,
-/turf/open/floor/iron,
-/area/station/construction/mining/aux_base)
 "fUB" = (
 /obj/machinery/atmospherics/components/binary/pump/off{
 	dir = 4;
@@ -34501,13 +34478,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"fWL" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/wood,
-/area/station/service/cafeteria)
 "fXy" = (
 /obj/structure/sign/poster/official/random/directional/north,
 /obj/effect/turf_decal/tile/neutral{
@@ -34531,6 +34501,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
+"fYW" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/holopad,
+/turf/open/floor/iron,
+/area/station/construction/mining/aux_base)
 "fZn" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -34564,12 +34544,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"gbp" = (
-/obj/structure/closet/firecloset,
-/obj/effect/landmark/start/hangover/closet,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "gbt" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34738,6 +34712,14 @@
 /obj/structure/sign/poster/official/random/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"gjl" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/status_display/evac/directional/west,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "gjr" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
@@ -34792,11 +34774,6 @@
 /obj/effect/spawner/random/structure/table_or_rack,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
-"gnA" = (
-/obj/structure/chair/wood,
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/wood,
-/area/station/service/cafeteria)
 "gnB" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay"
@@ -34890,6 +34867,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/command/bridge)
+"gqs" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_blue/filled/shrink_cw,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "gqP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34947,13 +34929,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"guT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
 "gvh" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -34971,6 +34946,9 @@
 "gvs" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
 "gvu" = (
@@ -35068,12 +35046,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"gAk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "gAq" = (
 /obj/structure/closet/secure_closet/medical2,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
@@ -35147,14 +35119,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
-"gFd" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/vending/cigarette,
-/obj/structure/sign/clock/directional/north,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "gFj" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -35189,6 +35153,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"gGQ" = (
+/obj/item/toy/plush/space_lizard_plushie,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "gHx" = (
 /obj/structure/cable,
 /obj/structure/sign/departments/restroom/directional/south,
@@ -35213,6 +35181,15 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
+"gJq" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/science{
+	pixel_x = 32
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "gJI" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -35435,11 +35412,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"gUs" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/dark_blue,
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
 "gUX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35458,10 +35430,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
-"gVE" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/space/nearstation)
 "gWj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35494,6 +35462,11 @@
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
+"gZV" = (
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/machinery/camera/autoname/directional/west,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "hat" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35548,12 +35521,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
-"hdU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "hdY" = (
 /obj/structure/sign/painting/library{
 	pixel_y = 32
@@ -35588,12 +35555,6 @@
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
-"hfO" = (
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
 "hgf" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -35638,12 +35599,6 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
-"hiX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "hjc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -35659,6 +35614,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"hjx" = (
+/obj/structure/sign/warning/yes_smoking/circle/directional/south,
+/turf/open/floor/glass/reinforced,
+/area/station/hallway/primary/starboard)
 "hjB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35858,6 +35817,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"huo" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/sign/warning/vacuum/external/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "huJ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
@@ -35881,6 +35847,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"hwx" = (
+/obj/machinery/camera/autoname/directional/east,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "hwC" = (
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	id = "engsm";
@@ -35947,10 +35920,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"hBT" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "hDb" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -35989,16 +35958,13 @@
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/station/maintenance/department/bridge)
-"hFW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+"hGh" = (
+/obj/structure/chair/comfy/beige{
+	dir = 4
 	},
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "hGr" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -36049,12 +36015,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
-"hJq" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "hKi" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L14"
@@ -36074,11 +36034,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
-"hMh" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line,
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
 "hMm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
@@ -36163,6 +36118,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
+"hQY" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/wood,
+/area/station/service/cafeteria)
 "hSD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -36235,11 +36197,6 @@
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
-"hXh" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
 "hXw" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
 	dir = 1
@@ -36250,18 +36207,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
-"hYn" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/button/door/directional/west{
-	id = "construction";
-	name = "Auxiliary Construction Shutters";
-	req_access = list("aux_base");
-	pixel_x = 24
-	},
-/turf/open/floor/iron,
-/area/station/construction/mining/aux_base)
 "hYw" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
@@ -36285,6 +36230,13 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"hZI" = (
+/obj/structure/cable,
+/obj/structure/window{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "hZP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36418,11 +36370,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "iiB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ije" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37426,6 +37377,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"jyT" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_blue,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "jzi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -37438,6 +37394,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
+"jAe" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/construction/mining/aux_base)
 "jAr" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating/airless,
@@ -37525,12 +37490,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"jGQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "jHg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
@@ -37733,6 +37692,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
+"jRT" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "jTw" = (
 /obj/structure/table/reinforced,
 /obj/machinery/chem_dispenser/drinks/beer{
@@ -37897,6 +37860,12 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
+"kcs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "kcv" = (
 /obj/machinery/vending/wardrobe/chef_wardrobe,
 /obj/machinery/button/door/directional/east{
@@ -37942,15 +37911,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"kgX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
 "kgY" = (
 /obj/structure/table,
 /obj/machinery/light/small/directional/west,
@@ -38012,18 +37972,18 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"kix" = (
+"kjc" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron,
+/area/station/engineering/engine_smes)
+"kjF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
 	dir = 8
 	},
 /obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"kjc" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/iron,
-/area/station/engineering/engine_smes)
 "kjL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -38071,12 +38031,6 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"klU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/navigate_destination/bridge,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "kmj" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -38432,6 +38386,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"kFz" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/vending/cigarette,
+/obj/structure/sign/clock/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "kFB" = (
 /obj/structure/window/reinforced/plasma{
 	dir = 4
@@ -38595,11 +38557,6 @@
 /area/station/commons/dorms)
 "kPI" = (
 /obj/effect/turf_decal/caution/stand_clear,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
-"kRe" = (
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "kRv" = (
@@ -38768,12 +38725,6 @@
 /obj/structure/sign/warning/secure_area/directional/west,
 /turf/open/floor/iron,
 /area/station/maintenance/central)
-"lfk" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "lfD" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Atmospherics N2 Tank"
@@ -38912,12 +38863,12 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "lpe" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/station/hallway/primary/starboard)
 "lqc" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 8;
@@ -38952,6 +38903,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
+"lsL" = (
+/obj/structure/closet/firecloset,
+/obj/effect/landmark/start/hangover/closet,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "lsQ" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -39188,6 +39145,15 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
+"lId" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security)
 "lIk" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -39294,6 +39260,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"lOJ" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/shrink_ccw,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "lPi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39326,6 +39296,12 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"lQE" = (
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "lQP" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay Storage"
@@ -39435,6 +39411,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"lUo" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "lUy" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39538,24 +39523,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
-"mcc" = (
-/obj/structure/table,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/pipe_dispenser,
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
-	dir = 4
-	},
-/obj/item/storage/toolbox/mechanical,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/obj/machinery/light_switch/directional/east,
-/turf/open/floor/iron,
-/area/station/construction/mining/aux_base)
 "mcq" = (
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
+"mcL" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/hallway/secondary/command)
 "mcQ" = (
 /obj/structure/chair{
 	dir = 4
@@ -39573,6 +39550,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"mdC" = (
+/obj/machinery/camera/autoname/directional/west,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "meR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/delivery,
@@ -39700,10 +39684,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
-"mkQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "mlK" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/yellow{
@@ -39770,6 +39750,12 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"mov" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "moZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -39783,6 +39769,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"mqd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "mqp" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plating,
@@ -40057,14 +40049,10 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"mEZ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 6
-	},
-/turf/open/floor/iron,
+"mFE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/station/engineering/atmos)
 "mGm" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
@@ -40081,6 +40069,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/red,
 /area/station/commons/dorms)
+"mHb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "mHj" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40190,6 +40190,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"mOV" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "mPo" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -40215,18 +40222,6 @@
 /obj/item/stack/sheet/iron/fifty,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
-"mQL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
 "mRl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40261,6 +40256,12 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
+"mUE" = (
+/obj/docking_port/stationary/public_mining_dock{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/construction/mining/aux_base)
 "mUJ" = (
 /obj/structure/window/fulltile,
 /turf/open/floor/plating,
@@ -40451,8 +40452,6 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "ndz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
 /turf/open/floor/iron/dark,
@@ -40599,6 +40598,11 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"nkS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/dark_blue/warning,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "nlX" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -40642,12 +40646,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
-"nnZ" = (
-/obj/effect/turf_decal/trimline/dark_blue/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
 "nov" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40736,6 +40734,9 @@
 /area/station/service/chapel)
 "nsP" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
 "nsS" = (
@@ -40790,6 +40791,12 @@
 /obj/structure/sign/poster/contraband/random/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"nua" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/sign/warning/engine_safety/directional/south,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "num" = (
 /obj/effect/landmark/start/station_engineer,
 /obj/effect/turf_decal/stripes/line,
@@ -40817,10 +40824,30 @@
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"nvF" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "nwq" = (
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
+"nwt" = (
+/obj/structure/table,
+/obj/item/stack/sheet/plasteel{
+	amount = 10
+	},
+/obj/item/stack/rods/fifty,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/obj/item/storage/box/lights/mixed,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/construction/mining/aux_base)
 "nwC" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/red{
@@ -40832,13 +40859,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
-"nxm" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/sign/warning/vacuum/external/directional/west,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "nxu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -40875,6 +40895,21 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"nyo" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/button/door/directional/south{
+	id = "bridgedoors";
+	name = "Bridge Access Blast Doors";
+	pixel_x = 24;
+	req_access = list("command");
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark,
+/area/station/hallway/secondary/command)
 "nyw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -40907,6 +40942,10 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron/airless,
 /area/station/maintenance/port/aft)
+"nBu" = (
+/obj/effect/turf_decal/trimline/dark_blue/corner,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "nCg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41019,6 +41058,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"nID" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "nJF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -41066,13 +41109,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
-"nLY" = (
-/obj/structure/cable,
-/obj/structure/window{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "nMm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41139,12 +41175,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
-"nPs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/dark_blue/warning,
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
 "nQf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -41257,11 +41287,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "nYo" = (
-/obj/effect/spawner/random/engineering/tracking_beacon,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos/mix)
 "nYr" = (
 /obj/structure/rack{
 	dir = 8;
@@ -41335,6 +41365,19 @@
 /obj/structure/closet/secure_closet/engineering_chief,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
+"oce" = (
+/obj/docking_port/stationary{
+	dheight = 4;
+	dwidth = 4;
+	height = 9;
+	id = "aux_base_zone";
+	name = "Aux Base Zone";
+	roundstart_template = /datum/map_template/shuttle/aux_base/default;
+	width = 9;
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/construction/mining/aux_base)
 "ocE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41466,12 +41509,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
-"omK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "omO" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Laser Room"
@@ -41488,6 +41525,9 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security/prison)
 "onH" = (
@@ -41503,11 +41543,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "ood" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "ooE" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
@@ -41676,6 +41715,10 @@
 /obj/machinery/holopad,
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/qm)
+"oBT" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "oCc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41690,12 +41733,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine/atmos)
-"oCd" = (
-/obj/structure/chair/comfy/beige{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/station/hallway/secondary/entry)
 "oCl" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron,
@@ -41754,13 +41791,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
-"oEf" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/dark_blue/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
 "oEP" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/south,
@@ -41908,10 +41938,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "oMQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/closed/wall/r_wall,
-/area/station/hallway/secondary/command)
+/obj/effect/turf_decal/trimline/dark_blue/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "oNl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42088,13 +42119,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"oYi" = (
-/obj/machinery/camera/autoname/directional/west,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "oYp" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/carpet/red,
@@ -42104,16 +42128,14 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
-"oYJ" = (
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
 "oYN" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"oZn" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "oZK" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -42185,13 +42207,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/commons/lounge)
-"pbU" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
-	dir = 4
+"pbQ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 6
 	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "pcn" = (
 /obj/structure/window/reinforced/plasma{
 	dir = 8
@@ -42263,6 +42285,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
+"pfU" = (
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/glass/reinforced,
+/area/station/hallway/primary/starboard)
 "pgc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -42363,8 +42389,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
-"poU" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/line,
+"pnM" = (
+/obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "ppM" = (
@@ -42541,6 +42569,10 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"pDK" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/storage/tech)
 "pDY" = (
 /obj/machinery/rnd/production/techfab/department/security,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -42865,6 +42897,10 @@
 "pYa" = (
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"pYm" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "pYn" = (
 /obj/machinery/computer/med_data{
 	dir = 1
@@ -42905,15 +42941,6 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
-"qbd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "qbm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42979,10 +43006,6 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/wood,
 /area/station/service/library/lounge)
-"qfj" = (
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/glass/reinforced,
-/area/station/hallway/primary/starboard)
 "qfq" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/effect/turf_decal/bot{
@@ -43034,6 +43057,12 @@
 /obj/machinery/restaurant_portal/restaurant,
 /turf/open/floor/iron,
 /area/station/commons/lounge)
+"qjW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "qkc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -43141,6 +43170,17 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"qqq" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
+/turf/open/floor/plating,
+/area/station/hallway/primary/starboard)
 "qqK" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
@@ -43322,11 +43362,29 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"qzZ" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
+/turf/open/floor/plating,
+/area/station/hallway/primary/starboard)
 "qAo" = (
 /obj/structure/marker_beacon/burgundy,
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"qAJ" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_blue/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "qBy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43350,7 +43408,12 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "qCf" = (
-/turf/open/floor/plating,
+/obj/machinery/computer/shuttle/mining{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "qCk" = (
 /obj/structure/extinguisher_cabinet/directional/west,
@@ -43457,6 +43520,7 @@
 "qHy" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
 "qHQ" = (
@@ -43653,6 +43717,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"qXa" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/station/security)
 "qXt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -43673,12 +43741,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/cargo/storage)
-"qXQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "qYD" = (
 /turf/closed/wall,
 /area/station/engineering/atmos)
@@ -43796,15 +43858,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"riL" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "rjj" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -43907,17 +43960,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"rnV" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump/off{
-	dir = 8;
-	name = "Mix Out"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos/mix)
 "roc" = (
 /mob/living/simple_animal/pet/cat{
 	desc = "Yoss, queen, slay.";
@@ -43954,23 +43996,15 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
-"rpD" = (
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+"rpI" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 9
 	},
-/obj/structure/window{
-	dir = 1
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
-"rpI" = (
-/obj/structure/chair/comfy/beige{
-	dir = 4
-	},
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/wood,
-/area/station/commons/lounge)
+/area/station/engineering/atmos)
 "rpQ" = (
 /obj/machinery/hydroponics/constructable,
 /obj/structure/cable,
@@ -44050,12 +44084,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"rvP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "rvQ" = (
 /obj/effect/turf_decal/tile/dark_blue{
 	dir = 4
@@ -44188,9 +44216,8 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "rAA" = (
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/turf/closed/wall/r_wall,
+/area/station/hallway/secondary/command)
 "rBb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44249,18 +44276,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
+"rCQ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "rCX" = (
 /obj/machinery/computer/mechpad{
 	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
-"rDE" = (
-/obj/docking_port/stationary/public_mining_dock{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/station/construction/mining/aux_base)
 "rDR" = (
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/wood,
@@ -44305,6 +44332,7 @@
 /area/station/hallway/secondary/service)
 "rGk" = (
 /obj/machinery/holopad,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/station/service/theater)
 "rGt" = (
@@ -44468,6 +44496,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
 /area/station/engineering/atmos/mix)
+"rRg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "rRA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44482,6 +44520,16 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"rSL" = (
+/obj/machinery/door/airlock/external{
+	name = "Construction Zone"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/aux_base,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/construction/mining/aux_base)
 "rST" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
@@ -44562,8 +44610,8 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "rYs" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 9
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -44583,18 +44631,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
-"sao" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/station/engineering/hallway)
 "sap" = (
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/wood,
@@ -44706,12 +44742,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"sgz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
 "sgL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44896,13 +44926,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
-"sqw" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/structure/window,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "sqE" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
@@ -44912,11 +44935,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/security/brig)
-"srg" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/dark_blue/warning,
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
+"srw" = (
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "ssg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45029,10 +45051,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"sxs" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/shrink_cw,
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
 "sxw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45070,13 +45088,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"syu" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 6
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "syC" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -45230,13 +45241,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"sHx" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/structure/sign/directions/vault/directional/west,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "sHI" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office"
@@ -45298,6 +45302,14 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"sMb" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/effect/spawner/random/entertainment/lighter,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "sMp" = (
 /obj/effect/landmark/start/hangover,
 /obj/effect/turf_decal/siding/wood/corner{
@@ -45373,6 +45385,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
+"sTs" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "sTD" = (
 /obj/structure/sign/poster/contraband/random/directional/west,
 /turf/open/floor/plating,
@@ -45406,6 +45424,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/bridge)
+"sVB" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-13"
+	},
+/turf/open/floor/glass/reinforced,
+/area/station/hallway/primary/starboard)
 "sVO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral{
@@ -45542,13 +45566,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
-"thg" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+"tgW" = (
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+	dir = 9
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/engineering/atmos)
 "thO" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/west{
@@ -45712,6 +45735,7 @@
 "trV" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "tsw" = (
@@ -45954,12 +45978,19 @@
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "tJc" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
+"tJd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "tJr" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Fuel Pipe to Incinerator";
@@ -46014,6 +46045,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
+"tMy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "tMI" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
@@ -46148,6 +46186,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
+"tUC" = (
+/obj/structure/chair/comfy/beige{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/station/hallway/secondary/entry)
 "tVJ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
@@ -46249,6 +46293,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
+"uaO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/hallway)
 "ubu" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -46421,6 +46477,7 @@
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "uns" = (
@@ -46444,6 +46501,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
+"unQ" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_blue/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "uou" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/stripes/line{
@@ -46456,10 +46520,6 @@
 /obj/structure/sign/warning/docking/directional/east,
 /turf/open/space/basic,
 /area/space/nearstation)
-"uoO" = (
-/obj/structure/sign/warning/yes_smoking/circle/directional/south,
-/turf/open/floor/glass/reinforced,
-/area/station/hallway/primary/starboard)
 "upm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -46585,11 +46645,11 @@
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
 "uxh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 9
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 6
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -46875,6 +46935,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"uTk" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/button/door/directional/west{
+	id = "construction";
+	name = "Auxiliary Construction Shutters";
+	req_access = list("aux_base");
+	pixel_x = 24
+	},
+/turf/open/floor/iron,
+/area/station/construction/mining/aux_base)
 "uTS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46888,15 +46960,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
-"uUO" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/construction/mining/aux_base)
 "uUU" = (
 /obj/effect/landmark/start/hangover,
 /obj/effect/turf_decal/tile/neutral{
@@ -47020,6 +47083,7 @@
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "vcA" = (
@@ -47072,15 +47136,6 @@
 /obj/machinery/door/poddoor/incinerator_atmos_main,
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
-"vkI" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/structure/sign/poster/official/science{
-	pixel_x = 32
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "vkP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -47265,13 +47320,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/bridge)
-"vAh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
 "vAj" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -47430,6 +47478,9 @@
 /obj/structure/toilet/greyscale{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
 "vKH" = (
@@ -47508,12 +47559,12 @@
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"vPL" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
-	dir = 9
+"vOS" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/turf/open/space/basic,
+/area/space)
 "vQy" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -47701,7 +47752,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
-"wbJ" = (
+"wbi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/violet/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/mix)
@@ -47730,10 +47781,14 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "wdw" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/dark_blue/filled/shrink_cw,
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "wew" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -47871,6 +47926,7 @@
 "wqY" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "wrn" = (
@@ -47951,9 +48007,10 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "wvs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/captain)
+/obj/machinery/holopad,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "wwm" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance"
@@ -48058,6 +48115,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"wBd" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/line,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "wBn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -48065,6 +48126,15 @@
 /obj/structure/sign/poster/contraband/random/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"wBz" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "wBU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -48075,6 +48145,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/security)
+"wCe" = (
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos/mix)
 "wCN" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -48121,11 +48197,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "wHk" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/structure/chair/comfy/beige,
+/turf/open/floor/carpet,
+/area/station/hallway/secondary/entry)
 "wIu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
@@ -48140,13 +48214,6 @@
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
-"wJz" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
 "wJI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -48375,11 +48442,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/courtroom)
-"xeb" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/dark_blue/filled/shrink_ccw,
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
 "xej" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
@@ -48504,6 +48566,15 @@
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain)
+"xmH" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/construction/mining/aux_base)
 "xnz" = (
 /turf/open/floor/iron/chapel{
 	dir = 6
@@ -48579,12 +48650,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"xqW" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/sign/warning/engine_safety/directional/south,
-/turf/open/floor/iron,
-/area/station/engineering/main)
 "xqX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -48705,12 +48770,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
-"xAg" = (
-/obj/structure/chair/comfy/beige{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/station/hallway/secondary/entry)
 "xAq" = (
 /obj/machinery/holopad/secure,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -48974,15 +49033,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
-"xSC" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "xTf" = (
 /obj/structure/transit_tube/curved{
 	dir = 1
@@ -48997,25 +49047,6 @@
 /obj/machinery/rnd/production/techfab/department/medical,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
-"xTF" = (
-/obj/structure/rack,
-/obj/item/electronics/airlock,
-/obj/item/electronics/airlock,
-/obj/item/electronics/airlock,
-/obj/item/electronics/airlock,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/wallframe/camera,
-/obj/item/wallframe/camera,
-/obj/item/wallframe/camera,
-/obj/item/wallframe/camera,
-/obj/item/assault_pod/mining,
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/construction/mining/aux_base)
 "xTJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49056,6 +49087,12 @@
 /obj/item/flashlight/lantern,
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
+"xVt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_blue/warning,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "xWs" = (
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 4
@@ -49158,12 +49195,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
-"yak" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "yaz" = (
 /obj/machinery/rnd/server/master,
 /turf/open/floor/circuit/telecomms/server,
@@ -49234,10 +49265,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
-"yfg" = (
-/obj/item/toy/plush/space_lizard_plushie,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "yfr" = (
 /turf/closed/wall,
 /area/station/hallway/secondary/service)
@@ -49293,6 +49320,10 @@
 "ylB" = (
 /turf/open/floor/iron/white,
 /area/station/security/medical)
+"ylM" = (
+/obj/item/stack/cable_coil/five,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "ylN" = (
 /obj/structure/lattice,
 /obj/machinery/camera/directional/south{
@@ -60771,7 +60802,7 @@ cjH
 vbC
 gRN
 cgv
-aGm
+fgu
 dmF
 wpd
 dmF
@@ -65169,7 +65200,7 @@ wSW
 wSW
 onE
 cuA
-cwj
+cuB
 vsu
 pRz
 qLt
@@ -68158,7 +68189,7 @@ crI
 aWB
 atu
 jtP
-wWY
+bIt
 cjE
 axE
 ayg
@@ -68413,7 +68444,7 @@ fgf
 crI
 crI
 aWB
-atu
+ylM
 auU
 bIt
 cjE
@@ -69741,14 +69772,14 @@ bcU
 ayi
 beV
 bfI
-fWL
+hQY
 bjH
 bjH
 rcW
 ptb
 bjH
 bjH
-gnA
+epf
 bfI
 bgQ
 bGt
@@ -70296,7 +70327,7 @@ kyb
 ccl
 bXh
 ceK
-rQe
+lId
 sGl
 kXe
 ckk
@@ -70551,7 +70582,7 @@ chz
 chz
 chz
 chz
-chz
+qXa
 ceL
 chz
 kis
@@ -74147,16 +74178,16 @@ qst
 kaG
 ggT
 fSx
-syu
+azc
 cEv
 bUN
 cgu
-iiB
-afC
+pbQ
+mFE
 bUN
 anh
-iiB
-afC
+pbQ
+mFE
 bUN
 anh
 bUN
@@ -74401,9 +74432,9 @@ bMz
 bTb
 lki
 oFn
-mEZ
-bYP
 uxh
+bYP
+rpI
 ceV
 apY
 cdG
@@ -74420,7 +74451,7 @@ mDD
 crb
 csk
 jJX
-cDy
+uaO
 dSy
 hKW
 vxm
@@ -74657,8 +74688,8 @@ bQA
 bMz
 bTc
 mEL
-xSC
-bXu
+efU
+kcs
 bKo
 bXw
 xqJ
@@ -74673,11 +74704,11 @@ xqJ
 uCw
 bXw
 cHV
-lfk
+ayq
 crc
 csk
 mXT
-cDy
+uaO
 kIN
 pkd
 dmL
@@ -74914,27 +74945,27 @@ bQB
 bMz
 bTd
 dFJ
-efU
-omK
+cwj
+aKn
+jRT
+jRT
 cgs
-cgs
-hJq
-hdU
 cdH
+ayp
 ceW
 ceW
-yak
-cdH
-cdH
+bBe
+ayp
+ayp
 ceW
-yak
-cdH
-hiX
-aGn
+bBe
+ayp
+mov
+aKl
 sgv
 ske
 gYL
-sao
+cDy
 kIN
 pCp
 dmL
@@ -75171,23 +75202,23 @@ bQC
 bMz
 bTf
 iTr
-efU
-caU
+cwj
+iiB
 cpg
 cpg
 cpg
 cpg
 cpg
-cPQ
+hwx
 xRQ
+jRT
+jRT
+jRT
 cgs
-cgs
-cgs
-hJq
 cpg
 cpg
-rYs
-aGn
+cph
+aKl
 cre
 csk
 ctv
@@ -75428,12 +75459,12 @@ bQD
 bMz
 nyY
 dFJ
-qbd
+wdw
 gbN
 jUy
-eRV
+pYm
 lUm
-dlY
+ebw
 uqV
 qYD
 sHg
@@ -75443,8 +75474,8 @@ cpg
 cpg
 cpg
 qJx
-rYs
-aGn
+cph
+aKl
 crf
 csk
 ctw
@@ -75686,12 +75717,12 @@ afy
 bTg
 bMe
 bSm
-caU
-ddV
+iiB
+bXu
 spA
-kix
+kjF
 dck
-ceZ
+aAq
 dck
 cpg
 cpg
@@ -75700,8 +75731,8 @@ cpg
 cpg
 cpg
 cpg
-rYs
-aGn
+cph
+aKl
 crg
 csk
 ctx
@@ -75943,12 +75974,12 @@ bNQ
 cAs
 cAs
 cDC
-caU
+iiB
 lUT
 jUQ
 pGz
 dck
-ceZ
+aAq
 dck
 cpg
 cpg
@@ -75957,8 +75988,8 @@ cpg
 cpg
 cpg
 cpg
-rYs
-aGn
+cph
+aKl
 crh
 csm
 cty
@@ -76200,7 +76231,7 @@ mIR
 hZn
 hMm
 aOC
-caU
+iiB
 bWc
 bXx
 kWX
@@ -76214,8 +76245,8 @@ cpg
 cpg
 cpg
 cpg
-rYs
-aGn
+cph
+aKl
 cri
 csk
 ctz
@@ -76457,12 +76488,12 @@ cdJ
 pxi
 iYt
 xXy
-caU
+iiB
 cpg
 bXy
-jGQ
+lQE
 oyI
-ceZ
+aAq
 hXw
 cpg
 cpg
@@ -76471,8 +76502,8 @@ cpg
 cpg
 cpg
 cpg
-rYs
-aGn
+cph
+aKl
 jXO
 csk
 ctA
@@ -76714,7 +76745,7 @@ bMB
 adf
 cZP
 xWK
-mkQ
+nID
 cpg
 cpg
 nDU
@@ -76728,8 +76759,8 @@ cpg
 cpg
 cpg
 pqA
-rYs
-aGn
+cph
+aKl
 cId
 cmx
 vKS
@@ -76971,16 +77002,16 @@ krK
 lFw
 csr
 tOg
-wHk
+caU
 kkC
-dlY
-gAk
-rvP
+ebw
+mqd
+cJx
 cDz
-bxu
-dlY
-dlY
-rvP
+gZV
+ebw
+ebw
+cJx
 mww
 oYN
 oYN
@@ -76990,7 +77021,7 @@ bPq
 bXq
 jHH
 pqo
-aAq
+aFl
 cwB
 csp
 cyG
@@ -77232,12 +77263,12 @@ cql
 cql
 cql
 lzO
-vPL
+tgW
 jaE
 cpg
 cpg
 cpg
-qXQ
+rCQ
 cKp
 cJV
 cJV
@@ -77480,27 +77511,27 @@ aMv
 cAs
 iue
 krK
-fqX
-cwC
+wCe
+eSj
 tDs
-bDR
+cOh
 ntK
-cdH
-cdH
-cdH
-ood
-cdH
-yak
-cdH
-ood
-cdH
-cdH
-cdH
-cdH
-cdH
-cdH
-cHn
-aGn
+ayp
+ayp
+ayp
+tJd
+ayp
+bBe
+ayp
+tJd
+ayp
+ayp
+ayp
+ayp
+ayp
+ayp
+sTs
+aKl
 wiv
 csk
 ctE
@@ -77736,9 +77767,9 @@ lCe
 bLs
 cAs
 kpM
-bWf
-wbJ
-cSN
+eRV
+wbi
+nYo
 cAt
 ubG
 xDt
@@ -77757,7 +77788,7 @@ bXw
 bXw
 bXw
 bXw
-eiO
+rYs
 wiv
 csk
 ctF
@@ -77994,7 +78025,7 @@ bLt
 cAs
 jxP
 bQL
-rnV
+aGm
 ayX
 ibE
 csr
@@ -78259,11 +78290,11 @@ cDK
 aLD
 bTj
 bUN
-aGo
+afC
 bUN
 anh
 bUN
-aGo
+afC
 bUN
 anh
 bUN
@@ -78735,7 +78766,7 @@ lWL
 baK
 fDb
 bfd
-guT
+tMy
 bxS
 bir
 bjP
@@ -78991,8 +79022,8 @@ baK
 baK
 baK
 uxX
-hXh
-guT
+wvs
+tMy
 bxS
 bis
 xcq
@@ -79000,8 +79031,8 @@ iHF
 lLL
 bnd
 bpa
-wvs
 bpa
+dlY
 bAZ
 bst
 btS
@@ -79243,13 +79274,13 @@ aRb
 aRb
 aRb
 aYr
-xeb
+azb
 baL
 fAw
 mkl
-kgX
-kgX
-mQL
+lUo
+lUo
+mHb
 bxS
 blY
 blb
@@ -79500,13 +79531,13 @@ aRb
 ufJ
 aWT
 bwn
-srg
+aGo
 cXe
-aHN
-hfO
-hfO
-nnZ
-vAh
+nBu
+oMQ
+oMQ
+aGn
+cwC
 bxS
 biu
 bjS
@@ -79757,13 +79788,13 @@ iGi
 ufJ
 aWU
 omr
-wdw
+gqs
 baO
 aZG
 bde
 bel
-oYJ
-vAh
+eTc
+cwC
 bxS
 biv
 iOF
@@ -80014,12 +80045,12 @@ aUE
 bLE
 aWV
 aYt
-hMh
+ood
 baO
 aZG
 bdf
 bem
-oYJ
+eTc
 bgb
 bxS
 biw
@@ -80271,13 +80302,13 @@ ufJ
 bwn
 aWW
 mxz
-xeb
+azb
 baO
 aZG
 bdg
 ben
-oYJ
-vAh
+eTc
+cwC
 bxS
 bxS
 bRm
@@ -80528,11 +80559,11 @@ ele
 aVI
 slV
 slV
-nPs
+xVt
 slV
-oEf
-wJz
-wJz
+unQ
+qAJ
+qAJ
 aKm
 tyB
 jIX
@@ -80546,10 +80577,10 @@ bgY
 bri
 bri
 bsv
-cph
+mcL
 bri
 bri
-bgY
+alA
 uad
 umz
 bCz
@@ -80786,9 +80817,9 @@ aVJ
 aWY
 aYv
 aZG
-nYo
+pnM
 ije
-sgz
+qjW
 aDP
 ije
 bff
@@ -80808,11 +80839,11 @@ bue
 bue
 bue
 sfu
-oMQ
+rAA
 ndz
 boB
-oMQ
-klU
+rAA
+ayH
 xri
 uJy
 rgR
@@ -81042,34 +81073,34 @@ aUJ
 mNG
 bps
 whV
-cFF
+nkS
 whV
 bwn
 bwn
-gUs
-ayp
-ayp
+jyT
+nvF
+nvF
 doa
-bzt
-bzt
-bzt
+fST
+fST
+fST
 tCv
 bxV
-bzt
-bzt
-bzt
+fST
+fST
+fST
 mna
 sMu
-bzt
-bzt
-wzk
 fST
+fST
+wzk
+nyo
 bzt
 vbW
 wqY
 wqY
 vbW
-pbU
+eku
 geH
 qwq
 bJP
@@ -81299,7 +81330,7 @@ ojf
 bwn
 aXa
 heW
-sxs
+bLL
 baO
 bwn
 bwn
@@ -81556,7 +81587,7 @@ aUK
 mpA
 aXb
 dqd
-poU
+wBd
 baO
 bwn
 bwn
@@ -81813,7 +81844,7 @@ wlQ
 ojf
 aXc
 oty
-azb
+lOJ
 baO
 bwn
 bwn
@@ -82070,7 +82101,7 @@ aRb
 ojf
 aXd
 bwn
-srg
+aGo
 lMh
 cid
 cid
@@ -82135,7 +82166,7 @@ cwU
 cxV
 oKr
 chH
-xqW
+nua
 cFi
 ybE
 gvk
@@ -82327,7 +82358,7 @@ aRb
 aRb
 aRb
 aYy
-wdw
+gqs
 baL
 bcb
 bdj
@@ -83152,7 +83183,7 @@ lAL
 csw
 aCI
 cmO
-aFl
+pDK
 cps
 coj
 cmO
@@ -84688,7 +84719,7 @@ jJr
 ccE
 bUV
 cfh
-akg
+fiM
 asJ
 lAL
 rnn
@@ -86988,7 +87019,7 @@ lCe
 cSi
 bMO
 bOk
-aIR
+cli
 bOk
 bSf
 bLw
@@ -87760,7 +87791,7 @@ cSi
 nGA
 bOk
 bOi
-rpI
+hGh
 cfN
 bTB
 bVb
@@ -87965,7 +87996,7 @@ aCI
 lWL
 lWL
 lWL
-lpe
+aIR
 lWL
 lWL
 lWL
@@ -87984,7 +88015,7 @@ lWL
 lWL
 lWL
 lWL
-lWL
+vOS
 aCI
 lWL
 lWL
@@ -88222,7 +88253,7 @@ aGZ
 aGZ
 lWL
 lWL
-lpe
+aIR
 lWL
 lWL
 lWL
@@ -88467,19 +88498,19 @@ lWL
 lWL
 lWL
 aGZ
-qCf
-qCf
-qCf
-qCf
-qCf
-qCf
-qCf
-qCf
-qCf
+aFn
+aFn
+aFn
+aFn
+aFn
+aFn
+aFn
+aFn
+aFn
 aGZ
 lWL
 lWL
-lpe
+aIR
 lWL
 lWL
 aRj
@@ -88724,19 +88755,19 @@ lWL
 lWL
 lWL
 aGZ
-qCf
-qCf
-qCf
-qCf
-qCf
-qCf
-qCf
-qCf
-qCf
+aFn
+aFn
+aFn
+aFn
+aFn
+aFn
+aFn
+aFn
+aFn
 aGZ
 aCI
 aCI
-lpe
+aIR
 aCI
 aRj
 aRj
@@ -88788,7 +88819,7 @@ cSi
 nGA
 bOl
 eXz
-rpI
+hGh
 sMp
 xKR
 vFh
@@ -88976,24 +89007,24 @@ lWL
 lWL
 pYa
 hSL
-yfg
+gGQ
 lWL
 lWL
 lWL
 aGZ
-qCf
-qCf
-qCf
-qCf
-qCf
-qCf
-qCf
-qCf
-qCf
+aFn
+aFn
+aFn
+aFn
+aFn
+aFn
+aFn
+aFn
+aFn
 aGZ
 lWL
 lWL
-lpe
+aIR
 lWL
 aRj
 aRj
@@ -89238,19 +89269,19 @@ ajB
 ajB
 ajB
 aGZ
-qCf
-qCf
-qCf
-qCf
-qCf
-qCf
-qCf
-qCf
-qCf
+aFn
+aFn
+aFn
+aFn
+aFn
+aFn
+aFn
+aFn
+aFn
 aGZ
 lWL
 lWL
-lpe
+aIR
 lWL
 aRj
 aRj
@@ -89493,21 +89524,21 @@ ajB
 rlI
 awL
 awL
-aKl
+sVB
 aGZ
-qCf
-qCf
-qCf
-qCf
-eTA
-qCf
-qCf
-qCf
-qCf
+aFn
+aFn
+aFn
+aFn
+oce
+aFn
+aFn
+aFn
+aFn
 aGZ
 pkW
-lpe
-lpe
+aIR
+aIR
 aCI
 aRj
 aRj
@@ -89740,27 +89771,27 @@ pYa
 pYa
 pYa
 pmF
-gVE
+oBT
 lWL
 pYa
 atG
 lWL
 lWL
 ajB
-fyF
+bWf
 cRn
-qfj
-uoO
+pfU
+hjx
 aGZ
-qCf
-qCf
-qCf
-qCf
-qCf
-qCf
-qCf
-qCf
-qCf
+aFn
+aFn
+aFn
+aFn
+aFn
+aFn
+aFn
+aFn
+aFn
 aGZ
 pkW
 lWL
@@ -90004,20 +90035,20 @@ atH
 ajB
 lWL
 ajB
-bBe
+sMb
 apx
-hBT
-dlN
+oZn
+mOV
 aGZ
-qCf
-qCf
-qCf
-qCf
-qCf
-qCf
-qCf
-qCf
-qCf
+aFn
+aFn
+aFn
+aFn
+aFn
+aFn
+aFn
+aFn
+aFn
 aGZ
 pkW
 lWL
@@ -90261,20 +90292,20 @@ atI
 ajB
 abT
 abT
-gFd
-hBT
+kFz
+oZn
 aiV
-ayo
+eyN
 aGZ
-qCf
-qCf
-qCf
-qCf
-qCf
-qCf
-qCf
-qCf
-qCf
+aFn
+aFn
+aFn
+aFn
+aFn
+aFn
+aFn
+aFn
+aFn
 aGZ
 pkW
 aCI
@@ -90523,15 +90554,15 @@ apx
 apx
 vVh
 aGZ
-qCf
-qCf
-qCf
-qCf
-rDE
-qCf
-qCf
-qCf
-qCf
+aFn
+aFn
+aFn
+aFn
+mUE
+aFn
+aFn
+aFn
+aFn
 aGZ
 pkW
 lWL
@@ -90774,21 +90805,21 @@ aRI
 aRI
 aRI
 aRI
-hFW
+rRg
 gjY
 gjY
 apx
-cqi
+bxu
 aGZ
 aGZ
-adh
-adh
-adh
 ayY
-adh
-adh
-adh
-adh
+ayY
+ayY
+rSL
+ayY
+ayY
+ayY
+ayY
 aGZ
 pkW
 lWL
@@ -91020,7 +91051,7 @@ apx
 apx
 apx
 apx
-rAA
+srw
 apx
 apx
 lAa
@@ -91036,18 +91067,18 @@ apx
 gjY
 apx
 vVh
-gbp
+lsL
 aGZ
-xTF
+cHn
 aFq
 aFq
-cgF
-fUk
+xmH
+adh
 aFq
 aFq
-cli
+ayo
 aGZ
-eSj
+qqq
 abT
 aCI
 aCI
@@ -91108,7 +91139,7 @@ bTJ
 oLS
 bYc
 bFE
-cZv
+dgP
 cbE
 lSL
 cef
@@ -91295,16 +91326,16 @@ apx
 vVh
 azC
 aGZ
-mcc
-ayq
+eWp
+nwt
 oIK
-fnw
+fYW
 jKB
-uUO
-hYn
-bZv
+jAe
+uTk
+qCf
 aGZ
-aKn
+lpe
 abT
 lWL
 aCI
@@ -91561,7 +91592,7 @@ aCk
 aGZ
 aGZ
 aGZ
-dWW
+qzZ
 abT
 ajB
 ajB
@@ -91815,11 +91846,11 @@ uAa
 cUG
 uAa
 uAa
-oYi
+mdC
 gNn
-azc
-riL
-nxm
+gjl
+wBz
+huo
 bwP
 aLr
 nZw
@@ -92579,8 +92610,8 @@ gjY
 cfu
 cfu
 cfu
-nLY
-nLY
+hZI
+hZI
 fen
 cfu
 cfu
@@ -92588,7 +92619,7 @@ cfu
 cfu
 mgT
 cfu
-kRe
+cRo
 cfu
 cfu
 olW
@@ -92833,19 +92864,19 @@ asO
 qbm
 cfu
 akG
-vkI
+gJq
 mxO
-sqw
+aHN
 uWA
 xfI
 sxG
-rpD
+ceZ
 bsV
 bsV
 bsV
 bsV
 bsV
-thg
+aYk
 fyk
 bsV
 bsV
@@ -92871,7 +92902,7 @@ bdv
 bey
 lIk
 fem
-sHx
+ezJ
 uSP
 fpk
 fem
@@ -96746,11 +96777,11 @@ bEu
 bCX
 gRT
 bEu
-aFn
+wHk
 bIn
 bIn
 bKd
-oCd
+tUC
 bEu
 akA
 bGU
@@ -97260,11 +97291,11 @@ bEu
 bCZ
 nyw
 bEu
-aFn
+wHk
 bIp
 bIp
 bIp
-oCd
+tUC
 bEu
 pRY
 bGU
@@ -97518,9 +97549,9 @@ bEu
 nyw
 bEu
 bGZ
-xAg
+fFQ
 bIq
-xAg
+fFQ
 bGZ
 bEu
 bhi

--- a/StationMaps/DiscStation/DiscStation.dmm
+++ b/StationMaps/DiscStation/DiscStation.dmm
@@ -292,6 +292,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
+"adf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/meter,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/mix)
 "adh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -926,13 +932,10 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
 "afy" = (
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/turf/closed/wall/r_wall,
+/area/station/service/janitor)
 "afB" = (
 /obj/structure/transit_tube,
 /turf/open/space/basic,
@@ -964,6 +967,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
 /obj/structure/cable,
 /obj/effect/landmark/navigate_destination/minisat_access_ai,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "afL" = (
@@ -1041,6 +1045,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/science/genetics,
 /obj/effect/mapping_helpers/airlock/access/any/medical/general,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "agv" = (
@@ -1051,7 +1056,7 @@
 	name = "Turret Maintenance Hatch"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "agD" = (
 /obj/machinery/door/poddoor/shutters{
@@ -1077,16 +1082,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"agN" = (
-/obj/structure/closet/crate/science{
-	name = "MOD core crate"
-	},
-/obj/item/mod/core/standard,
-/obj/item/mod/core/standard,
-/obj/item/mod/core/standard,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
 "agO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -1587,6 +1582,7 @@
 	cycle_id = "medbay-passthrough"
 	},
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "ajT" = (
@@ -1876,7 +1872,6 @@
 /obj/machinery/computer/rdservercontrol{
 	dir = 1
 	},
-/obj/machinery/light_switch/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/server)
@@ -1885,6 +1880,7 @@
 /obj/item/folder/white,
 /obj/item/pen,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/science/server)
 "alP" = (
@@ -1961,7 +1957,7 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
 "amd" = (
-/obj/item/clothing/suit/fire/atmos,
+/obj/item/clothing/suit/utility/fire/atmos,
 /obj/item/stack/rods/ten,
 /obj/item/clothing/mask/breath,
 /turf/open/floor/plating,
@@ -2220,20 +2216,17 @@
 /turf/open/floor/plating,
 /area/station/hallway/primary/port)
 "anG" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
-"anK" = (
-/obj/structure/sign/warning/secure_area,
-/turf/closed/wall/r_wall,
-/area/station/ai_monitored/turret_protected/aisat/foyer)
+/obj/structure/lattice,
+/obj/structure/sign/warning/secure_area/directional/west,
+/turf/open/space/basic,
+/area/space/nearstation)
 "anL" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Teleporter Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "anM" = (
@@ -2242,6 +2235,7 @@
 	name = "AI Satellite Teleport Access"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "anO" = (
@@ -2343,19 +2337,17 @@
 /area/station/hallway/primary/port)
 "aom" = (
 /obj/structure/chair,
-/obj/machinery/airalarm/directional/north{
-	locked = 0
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/structure/sign/warning/pods/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "aoo" = (
-/obj/structure/sign/warning/pods/directional/north,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 4
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "aop" = (
@@ -2560,7 +2552,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "apg" = (
-/obj/machinery/status_display/evac/directional/east,
 /obj/structure/transit_tube/station/dispenser{
 	dir = 8
 	},
@@ -2727,6 +2718,9 @@
 /obj/machinery/atmospherics/components/binary/pump/off{
 	dir = 4;
 	name = "N2 To Pure"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -2910,6 +2904,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/structure/sign/calendar/directional/north,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "aqT" = (
@@ -2979,6 +2974,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/structure/sign/clock/directional/north,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "aqY" = (
@@ -3008,10 +3004,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "arg" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Ordnance Lab South";
-	network = list("ss13","rd")
-	},
 /obj/machinery/atmospherics/components/trinary/filter/flipped,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
@@ -3358,10 +3350,12 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "asK" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/docking,
-/turf/open/floor/plating,
-/area/station/hallway/primary/starboard)
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "asO" = (
 /turf/closed/wall/r_wall,
 /area/station/science/lab)
@@ -3973,6 +3967,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/commons/storage/tools)
+"avl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "avm" = (
 /turf/closed/wall,
 /area/station/maintenance/department/bridge)
@@ -4700,8 +4702,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "ayX" = (
-/turf/closed/wall/r_wall,
-/area/station/maintenance/department/engine/atmos)
+/obj/machinery/computer/atmos_control/mix_tank{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos/mix)
 "ayY" = (
 /turf/open/floor/iron,
 /area/station/construction)
@@ -4738,7 +4746,7 @@
 /obj/item/taperecorder{
 	pixel_x = -3
 	},
-/obj/item/paicard{
+/obj/item/pai_card{
 	pixel_x = 4
 	},
 /turf/open/floor/iron/dark,
@@ -5242,7 +5250,7 @@
 /obj/structure/bedsheetbin{
 	pixel_x = 2
 	},
-/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/jacket/straight_jacket,
 /obj/item/clothing/mask/muzzle,
 /obj/structure/table/glass,
 /obj/machinery/light/directional/east,
@@ -5586,6 +5594,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/station/construction)
 "aCW" = (
@@ -6143,6 +6152,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "aEX" = (
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "aEY" = (
@@ -6554,6 +6564,12 @@
 /area/station/security/courtroom)
 "aGr" = (
 /obj/machinery/airalarm/directional/north,
+/obj/structure/closet/crate/science{
+	name = "MOD core crate"
+	},
+/obj/item/mod/core/standard,
+/obj/item/mod/core/standard,
+/obj/item/mod/core/standard,
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "aGs" = (
@@ -7376,7 +7392,7 @@
 /obj/item/mmi,
 /obj/item/mmi,
 /obj/item/radio/intercom/directional/east,
-/obj/item/paicard,
+/obj/item/pai_card,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
@@ -7446,9 +7462,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "aJn" = (
-/obj/machinery/door/window{
-	dir = 4
-	},
+/obj/machinery/door/window/left/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "aJo" = (
@@ -7822,16 +7836,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/door/window{
-	dir = 4
-	},
+/obj/machinery/door/window/right/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "aKI" = (
-/obj/structure/disposalpipe/trunk,
-/obj/structure/disposaloutlet{
-	dir = 8
-	},
+/obj/effect/spawner/random/trash/garbage,
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "aKJ" = (
@@ -8061,11 +8071,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "aLD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/closed/wall,
-/area/station/maintenance/disposal)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/station/engineering/atmos)
 "aLE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
@@ -8097,6 +8105,7 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/navigate_destination,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "aLN" = (
@@ -8420,6 +8429,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
+/obj/structure/sign/calendar/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aNf" = (
@@ -8751,11 +8761,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "aOC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
-/obj/machinery/meter/monitored/distro_loop,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/engineering/atmos/pumproom)
+/area/station/engineering/atmos)
 "aOD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/holopad,
@@ -8768,6 +8780,8 @@
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 8
 	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "aOH" = (
@@ -8830,6 +8844,9 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
+	},
+/obj/machinery/camera/autoname/directional/south{
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
@@ -8989,6 +9006,7 @@
 	},
 /obj/effect/spawner/random/trash/caution_sign,
 /obj/effect/spawner/random/trash/garbage,
+/obj/structure/sign/calendar/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "aPv" = (
@@ -9484,7 +9502,7 @@
 /area/station/engineering/gravity_generator)
 "aRl" = (
 /obj/structure/table,
-/obj/item/clothing/suit/radiation,
+/obj/item/clothing/suit/utility/radiation,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 4
 	},
@@ -9610,6 +9628,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "aRQ" = (
@@ -9693,9 +9712,9 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "aSi" = (
-/obj/machinery/modular_computer/console/preset/engineering,
 /obj/effect/turf_decal/tile/dark_blue/fourcorners,
 /obj/structure/cable,
+/obj/machinery/computer/rdconsole,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "aSj" = (
@@ -9795,6 +9814,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
 /obj/effect/landmark/navigate_destination,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "aSE" = (
@@ -9926,6 +9946,7 @@
 /obj/item/hemostat,
 /obj/machinery/vending/wallmed/directional/north,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "aTe" = (
@@ -10493,6 +10514,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "tcomms-passthrough"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "aVC" = (
@@ -10829,10 +10851,6 @@
 "aWQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/camera/autoname/directional/east{
-	network = list("ss13","medbay")
-	},
-/obj/item/radio/intercom/directional/east,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
@@ -10857,8 +10875,7 @@
 "aWW" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
-/obj/structure/table/reinforced,
-/obj/machinery/computer/security/telescreen/ce,
+/obj/machinery/modular_computer/console/preset/engineering,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "aWY" = (
@@ -11249,7 +11266,7 @@
 /area/station/hallway/primary/starboard)
 "aYQ" = (
 /turf/closed/wall,
-/area/station/cargo/qm)
+/area/station/command/heads_quarters/qm)
 "aYR" = (
 /turf/closed/wall,
 /area/station/cargo/storage)
@@ -11406,25 +11423,25 @@
 /obj/item/paper_bin/carbon,
 /obj/item/toy/figure/qm,
 /turf/open/floor/carpet/blue,
-/area/station/cargo/qm)
+/area/station/command/heads_quarters/qm)
 "aZT" = (
 /obj/structure/closet/secure_closet/quartermaster,
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/carpet/blue,
-/area/station/cargo/qm)
+/area/station/command/heads_quarters/qm)
 "aZU" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/light/directional/north,
 /obj/machinery/modular_computer/console/preset/id,
 /turf/open/floor/carpet/blue,
-/area/station/cargo/qm)
+/area/station/command/heads_quarters/qm)
 "aZV" = (
 /obj/machinery/camera/autoname/directional/north,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/carpet/blue,
-/area/station/cargo/qm)
+/area/station/command/heads_quarters/qm)
 "aZW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -11436,7 +11453,7 @@
 "aZY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/cargo/qm)
+/area/station/command/heads_quarters/qm)
 "aZZ" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
@@ -11467,6 +11484,7 @@
 "bah" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/emcloset,
+/obj/machinery/camera/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bai" = (
@@ -11558,19 +11576,18 @@
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "bay" = (
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 4
 	},
+/obj/machinery/camera/autoname/directional/north{
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "baz" = (
-/obj/machinery/door/airlock/medical{
-	name = "Cryo Room"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -11580,6 +11597,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Cryo Room"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "baA" = (
@@ -11681,7 +11701,7 @@
 	name = "Quartermaster's Requests Console"
 	},
 /turf/open/floor/carpet/blue,
-/area/station/cargo/qm)
+/area/station/command/heads_quarters/qm)
 "bbb" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -11691,10 +11711,10 @@
 	},
 /obj/effect/landmark/start/quartermaster,
 /turf/open/floor/carpet/blue,
-/area/station/cargo/qm)
+/area/station/command/heads_quarters/qm)
 "bbe" = (
 /turf/open/floor/carpet/blue,
-/area/station/cargo/qm)
+/area/station/command/heads_quarters/qm)
 "bbf" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/supply/qm,
@@ -11706,7 +11726,7 @@
 	},
 /obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron,
-/area/station/cargo/qm)
+/area/station/command/heads_quarters/qm)
 "bbg" = (
 /turf/open/floor/iron,
 /area/station/cargo/storage)
@@ -11720,15 +11740,15 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bbk" = (
-/obj/machinery/door/airlock/medical{
-	name = "Cryo Room"
-	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Cryo Room"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "bbo" = (
@@ -11960,7 +11980,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/wood,
-/area/station/cargo/qm)
+/area/station/command/heads_quarters/qm)
 "bcs" = (
 /obj/structure/table,
 /obj/item/computer_hardware/hard_drive/portable/quartermaster{
@@ -11976,24 +11996,24 @@
 	gpstag = "QM0"
 	},
 /turf/open/floor/wood,
-/area/station/cargo/qm)
+/area/station/command/heads_quarters/qm)
 "bct" = (
 /obj/machinery/computer/security/qm{
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/station/cargo/qm)
+/area/station/command/heads_quarters/qm)
 "bcu" = (
 /obj/machinery/computer/cargo{
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/station/cargo/qm)
+/area/station/command/heads_quarters/qm)
 "bcv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
-/area/station/cargo/qm)
+/area/station/command/heads_quarters/qm)
 "bcx" = (
 /obj/machinery/vending/wardrobe/cargo_wardrobe,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
@@ -12027,9 +12047,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bcC" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Mining Dock External"
-	},
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -12063,10 +12080,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
-"bcM" = (
-/obj/machinery/atmospherics/components/unary/bluespace_sender,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "bcP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -12256,14 +12269,14 @@
 "bdz" = (
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/wood,
-/area/station/cargo/qm)
+/area/station/command/heads_quarters/qm)
 "bdA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/wood,
-/area/station/cargo/qm)
+/area/station/command/heads_quarters/qm)
 "bdC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12271,7 +12284,7 @@
 	dir = 6
 	},
 /turf/open/floor/wood,
-/area/station/cargo/qm)
+/area/station/command/heads_quarters/qm)
 "bdF" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
@@ -12553,7 +12566,7 @@
 	name = "Quartermaster's Office"
 	},
 /turf/open/floor/iron,
-/area/station/cargo/qm)
+/area/station/command/heads_quarters/qm)
 "beE" = (
 /turf/closed/wall,
 /area/station/cargo/office)
@@ -13182,13 +13195,6 @@
 "bhO" = (
 /turf/closed/wall,
 /area/station/ai_monitored/turret_protected/aisat_interior)
-"bhS" = (
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
 "bhT" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
 /turf/open/floor/iron/white,
@@ -13356,10 +13362,10 @@
 /area/station/ai_monitored/command/nuke_storage)
 "biT" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/box/red,
 /obj/machinery/nuclearbomb/selfdestruct{
 	layer = 2
 	},
-/obj/effect/turf_decal/box/red,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "biW" = (
@@ -13377,6 +13383,7 @@
 /area/station/ai_monitored/command/nuke_storage)
 "biY" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners,
+/obj/structure/sign/departments/vault/directional/west,
 /turf/open/floor/iron,
 /area/station/maintenance/central)
 "bjb" = (
@@ -13430,7 +13437,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
-/area/station/cargo/qm)
+/area/station/command/heads_quarters/qm)
 "bjn" = (
 /obj/structure/bodycontainer/morgue,
 /obj/effect/decal/cleanable/cobweb,
@@ -13450,9 +13457,12 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "bjr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
+/obj/structure/tank_holder/extinguisher,
 /turf/open/floor/iron,
-/area/station/engineering/atmos/pumproom)
+/area/station/hallway/primary/central/aft)
 "bjs" = (
 /obj/machinery/vending/medical,
 /obj/structure/disposalpipe/segment{
@@ -13503,12 +13513,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "bjA" = (
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/machinery/camera/autoname/directional/south{
+	network = list("ss13","medbay")
 	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "bjB" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
@@ -13574,11 +13584,17 @@
 	dir = 4
 	},
 /obj/effect/spawner/random/aimodule/harmful,
+/obj/item/ai_module/reset/purge{
+	pixel_y = 6
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "bjN" = (
 /obj/structure/table,
 /obj/item/ai_module/reset,
+/obj/item/ai_module/supplied/freeform{
+	pixel_y = 5
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "bjO" = (
@@ -13918,6 +13934,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/structure/sign/clock/directional/west,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "blb" = (
@@ -14277,6 +14294,7 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 4
 	},
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "bmx" = (
@@ -16207,9 +16225,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
-"buR" = (
-/turf/open/floor/iron,
-/area/station/engineering/atmos/pumproom)
 "buS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16688,6 +16703,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/service/chapel_office,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/service/chapel/office)
 "bxe" = (
@@ -17709,7 +17725,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plating,
 /area/station/maintenance/port)
 "bAS" = (
 /obj/structure/disposalpipe/segment{
@@ -17792,7 +17808,7 @@
 /area/station/service/library)
 "bBr" = (
 /obj/structure/table/wood,
-/obj/item/paicard,
+/obj/item/pai_card,
 /turf/open/floor/wood,
 /area/station/service/library)
 "bBs" = (
@@ -18145,6 +18161,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
+"bCA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Gas to Mix"
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "bCB" = (
 /turf/closed/wall,
 /area/station/command/heads_quarters/hop)
@@ -18401,7 +18428,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bDG" = (
-/obj/machinery/status_display/evac/directional/north,
 /obj/structure/transit_tube/station/dispenser/flipped{
 	dir = 1
 	},
@@ -18506,6 +18532,7 @@
 	dir = 4
 	},
 /obj/item/kirbyplants/photosynthetic,
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bEe" = (
@@ -18550,6 +18577,7 @@
 	dir = 1
 	},
 /obj/machinery/camera/autoname/directional/east,
+/obj/structure/sign/clock/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "bEm" = (
@@ -18618,8 +18646,9 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "bEC" = (
 /obj/machinery/pdapainter/supply,
+/obj/machinery/keycard_auth/directional/north,
 /turf/open/floor/wood,
-/area/station/cargo/qm)
+/area/station/command/heads_quarters/qm)
 "bEE" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -19771,6 +19800,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bKc" = (
@@ -20172,6 +20202,15 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security)
+"bMe" = (
+/obj/structure/cable,
+/obj/machinery/shower/directional/west,
+/obj/effect/turf_decal/trimline/blue/end{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos)
 "bMg" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -20251,6 +20290,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/service/janitor,
+/obj/effect/landmark/navigate_destination/janitor,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "bMy" = (
@@ -20260,14 +20301,12 @@
 /turf/closed/wall/r_wall,
 /area/station/service/janitor)
 "bMB" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics"
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Air to Distro"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/engineering/atmos/pumproom)
+/area/station/engineering/atmos/mix)
 "bMC" = (
 /obj/structure/sign/directions/security{
 	dir = 8
@@ -20281,7 +20320,7 @@
 	pixel_y = 8
 	},
 /turf/closed/wall,
-/area/station/maintenance/department/engine/atmos)
+/area/station/hallway/primary/central/aft)
 "bME" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20535,11 +20574,9 @@
 /area/station/security)
 "bNA" = (
 /obj/structure/closet/wardrobe/red,
-/obj/machinery/camera/directional/north{
-	c_tag = "Security Locker Room"
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/bot,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security)
 "bNB" = (
@@ -20567,6 +20604,7 @@
 	pixel_y = -2
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "bNF" = (
@@ -20609,6 +20647,7 @@
 "bNL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/directional/north,
+/obj/machinery/portable_atmospherics/canister/water_vapor,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "bNN" = (
@@ -20616,6 +20655,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom/directional/north,
 /obj/structure/cable,
+/obj/machinery/light/small/directional/north,
+/obj/machinery/vending/wardrobe/jani_wardrobe,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "bNO" = (
@@ -20630,16 +20671,23 @@
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "bNP" = (
-/obj/structure/closet/l3closet/janitor,
-/obj/machinery/airalarm/directional/north,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/machinery/door/window/left{
+	name = "Janitorial Delivery";
+	req_access = list("janitor")
+	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "bNQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/wardrobe/jani_wardrobe,
-/turf/open/floor/iron,
-/area/station/service/janitor)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/mix)
 "bNS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20648,9 +20696,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "bNX" = (
-/obj/effect/spawner/random/structure/crate,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/diagonal_centre,
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "bNZ" = (
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
@@ -20941,6 +20995,7 @@
 /area/station/commons/storage/emergency/port)
 "bOT" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "bOU" = (
@@ -21011,6 +21066,7 @@
 /obj/structure/table,
 /obj/item/storage/box/lights/tubes,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "bPj" = (
@@ -21263,10 +21319,10 @@
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "bQB" = (
-/obj/machinery/light/directional/south,
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/mop,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "bQC" = (
@@ -21287,36 +21343,30 @@
 /area/station/service/janitor)
 "bQE" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/canister/water_vapor,
+/obj/structure/closet/l3closet/janitor,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "bQF" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/window/left/directional/west{
-	name = "Janitorial Delivery";
-	req_access = list("janitor")
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Distro to Waste"
 	},
 /turf/open/floor/iron,
-/area/station/service/janitor)
+/area/station/engineering/atmos/mix)
 "bQG" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=8";
-	freq = 1400;
-	location = "Janitor"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/meter/monitored/waste_loop,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
-/area/station/service/janitor)
+/area/station/engineering/atmos/mix)
 "bQH" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
 /turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos)
+/area/station/engineering/atmos/mix)
 "bQJ" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -21325,14 +21375,17 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bQK" = (
-/obj/structure/chair/stool/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos)
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
+/turf/open/space/basic,
+/area/space/nearstation)
 "bQL" = (
-/obj/structure/table,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos)
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos/mix)
 "bQQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -21627,10 +21680,10 @@
 /turf/open/floor/iron,
 /area/station/service/theater)
 "bSm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -21821,18 +21874,19 @@
 /area/station/engineering/atmos/office)
 "bTb" = (
 /obj/structure/closet/secure_closet/atmospherics,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 9
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "bTc" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/machinery/light/directional/north,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "bTd" = (
 /obj/structure/closet/wardrobe/atmospherics_yellow,
@@ -21840,48 +21894,37 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/structure/cable,
+/obj/machinery/camera/autoname/directional/north,
+/turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "bTf" = (
 /obj/machinery/suit_storage_unit/atmos,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "bTg" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "bTi" = (
-/obj/machinery/airalarm/directional/north{
-	locked = 0
+/obj/effect/turf_decal/trimline/yellow/filled/shrink_cw{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron,
-/area/station/engineering/atmos/pumproom)
+/area/station/hallway/primary/central/aft)
 "bTj" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/binary/pump/off{
-	dir = 8;
-	name = "Mix to Waste"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos/pumproom)
-"bTk" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/camera/directional/north{
-	c_tag = "Atmos North East"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos/pumproom)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/turf/open/floor/plating/airless,
+/area/station/engineering/atmos)
 "bTm" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "North Central Aft Hall"
@@ -22030,6 +22073,7 @@
 	name = "Stage Left"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/theatre,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/checker,
 /area/station/service/theater)
 "bTJ" = (
@@ -22056,6 +22100,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/service/theater)
 "bTM" = (
@@ -22244,6 +22289,10 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/requests_console/directional/north{
+	name = "Atmospherics Requests Console";
+	department = "Atmospherics"
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "bUE" = (
@@ -22273,19 +22322,14 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "bUG" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "atmos"
-	},
+/obj/structure/sign/warning/vacuum/external/directional/north,
+/obj/structure/tank_holder/extinguisher,
 /turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos)
+/area/station/engineering/atmos)
 "bUL" = (
-/obj/machinery/atmospherics/components/binary/pump/off{
-	dir = 1;
-	name = "Distro to Waste"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos/pumproom)
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/station/maintenance/central)
 "bUN" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -22295,9 +22339,10 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "bUP" = (
-/obj/structure/grille/broken,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos)
+/obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/structure/sign/warning/secure_area/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "bUR" = (
 /obj/machinery/light/directional/west,
 /obj/structure/closet/secure_closet/freezer/fridge,
@@ -22476,6 +22521,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Chapel"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "bVv" = (
@@ -22626,7 +22672,9 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -22646,16 +22694,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bWf" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics"
+/obj/structure/sign/poster/official/random/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/visible{
-	dir = 4
-	},
-/obj/structure/cable,
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron,
-/area/station/engineering/atmos/pumproom)
+/area/station/hallway/primary/starboard)
 "bWg" = (
 /obj/machinery/newscaster/directional/east,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
@@ -22667,7 +22712,6 @@
 /obj/structure/sign/warning/radiation/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
@@ -22704,13 +22748,9 @@
 /turf/open/floor/engine/airless,
 /area/station/engineering/atmos)
 "bWo" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/machinery/newscaster/directional/west,
-/obj/effect/turf_decal/tile/yellow/diagonal_centre,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
+/obj/structure/sign/clock/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/security/courtroom)
 "bWq" = (
 /obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/tile/green/opposingcorners,
@@ -22884,6 +22924,7 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron,
 /area/station/security)
 "bWV" = (
@@ -22965,6 +23006,11 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/iron/dark,
 /area/station/security)
+"bXl" = (
+/obj/structure/closet/crate,
+/obj/item/storage/belt/utility,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "bXm" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -22989,6 +23035,13 @@
 "bXq" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bXr" = (
@@ -23029,11 +23082,15 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "bXD" = (
-/obj/machinery/computer/atmos_control/mix_tank{
-	dir = 8
+/obj/machinery/conveyor{
+	dir = 9;
+	id = "garbage"
 	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos/pumproom)
+/obj/effect/spawner/random/trash/garbage{
+	spawn_loot_count = 3
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/disposal)
 "bXE" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron,
@@ -23047,11 +23104,9 @@
 /turf/open/floor/engine/airless,
 /area/station/engineering/atmos)
 "bXH" = (
-/obj/machinery/vending/assist,
-/obj/machinery/status_display/evac/directional/west,
-/obj/effect/turf_decal/tile/yellow/diagonal_centre,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
+/obj/structure/sign/calendar/directional/east,
+/turf/open/floor/wood,
+/area/station/command/meeting_room)
 "bXL" = (
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/iron,
@@ -23282,6 +23337,7 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
+/obj/structure/sign/calendar/directional/east,
 /turf/open/floor/iron,
 /area/station/security)
 "bYM" = (
@@ -23313,8 +23369,10 @@
 /obj/machinery/atmospherics/components/binary/valve/digital{
 	name = "Waste Release"
 	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bYU" = (
@@ -23331,13 +23389,10 @@
 /turf/open/floor/engine/airless,
 /area/station/engineering/atmos)
 "bZa" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/machinery/computer/security/telescreen/entertainment/directional/west,
-/obj/effect/turf_decal/tile/yellow/diagonal_centre,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
+/obj/structure/table,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/wood,
+/area/station/maintenance/port)
 "bZb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -24073,10 +24128,6 @@
 	},
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
-"cbP" = (
-/obj/structure/sign/warning/docking,
-/turf/closed/wall,
-/area/station/maintenance/port/aft)
 "cbR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -24243,12 +24294,11 @@
 /turf/open/floor/engine/air,
 /area/station/engineering/atmos)
 "ccr" = (
-/obj/machinery/meter{
-	name = "Mixed Air Tank Out"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos)
+/turf/open/floor/engine,
+/area/station/maintenance/disposal/incinerator)
 "ccu" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/effect/turf_decal/tile/neutral{
@@ -24265,6 +24315,9 @@
 "ccy" = (
 /obj/machinery/computer/atmos_control/nitrous_tank{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -24548,6 +24601,9 @@
 /obj/machinery/computer/atmos_control/air_tank{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cdH" = (
@@ -24559,9 +24615,11 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/emergency/port)
 "cdJ" = (
-/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/mix)
 "cdL" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2o{
 	dir = 1
@@ -24575,9 +24633,8 @@
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
 "cdO" = (
-/obj/structure/grille,
 /turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos)
+/area/station/engineering/atmos)
 "cdP" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/plaque{
@@ -24621,7 +24678,7 @@
 /area/station/commons/dorms)
 "cdV" = (
 /obj/structure/table/wood,
-/obj/item/paicard,
+/obj/item/pai_card,
 /turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "cdX" = (
@@ -24688,6 +24745,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/service/theatre,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/checker,
 /area/station/service/theater)
 "cef" = (
@@ -24767,7 +24825,7 @@
 /area/station/security/processing)
 "cex" = (
 /obj/structure/bed,
-/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/jacket/straight_jacket,
 /obj/item/clothing/glasses/blindfold,
 /obj/item/clothing/mask/muzzle,
 /obj/machinery/camera/directional/west{
@@ -24999,6 +25057,9 @@
 "ceV" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ceW" = (
@@ -25008,24 +25069,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"ceY" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "ceZ" = (
 /obj/machinery/light/directional/east,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cfa" = (
@@ -25355,10 +25403,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "cgs" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "N2 to Airmix"
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cgu" = (
@@ -25370,10 +25418,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"cgw" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "cgy" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Atmospherics East"
@@ -25381,6 +25425,9 @@
 /obj/machinery/atmospherics/components/binary/pump/off{
 	dir = 8;
 	name = "Plasma To Pure"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -25653,9 +25700,12 @@
 /turf/open/floor/engine/n2,
 /area/station/engineering/atmos)
 "chE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/sign/departments/telecomms/directional/east,
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/hallway/primary/port)
 "chH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -25664,6 +25714,9 @@
 "chJ" = (
 /obj/machinery/computer/atmos_control/plasma_tank{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -25680,12 +25733,9 @@
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
 "chN" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
+/obj/machinery/status_display/evac,
+/turf/closed/wall,
+/area/station/hallway/primary/starboard)
 "chO" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -25878,6 +25928,9 @@
 /obj/machinery/computer/atmos_control/nitrogen_tank{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ciM" = (
@@ -25894,11 +25947,16 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "ciO" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/yellow/diagonal_centre,
+/obj/machinery/vending/assist,
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/hallway/primary/central/aft)
 "ciP" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
 	dir = 1
@@ -25912,12 +25970,9 @@
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
 "ciS" = (
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
+/obj/structure/sign/clock/directional/east,
+/turf/open/floor/wood,
+/area/station/command/meeting_room)
 "ciV" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -26429,6 +26484,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"cld" = (
+/obj/machinery/atmospherics/pipe/color_adapter{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/mix)
 "clh" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
@@ -26680,7 +26741,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -26692,6 +26752,9 @@
 "cmD" = (
 /obj/machinery/computer/atmos_control/carbon_tank{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -27024,6 +27087,9 @@
 /obj/machinery/computer/atmos_control/oxygen_tank{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cnV" = (
@@ -27042,16 +27108,14 @@
 /turf/closed/wall/r_wall,
 /area/station/hallway/primary/central/aft)
 "coa" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/effect/mapping_helpers/airlock/unres{
+/obj/effect/turf_decal/siding/purple{
 	dir = 1
 	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
+/obj/machinery/camera/autoname/directional/north{
+	network = list("ss13","rd")
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "cod" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Tech Storage"
@@ -27272,14 +27336,12 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "coZ" = (
-/obj/structure/rack,
-/obj/item/clothing/neck/stethoscope,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "cpa" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/engine/o2,
@@ -27321,6 +27383,9 @@
 "cph" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/space_heater,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cpn" = (
@@ -27613,25 +27678,23 @@
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
 "cql" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "cqn" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/service/theater)
 "cqs" = (
-/obj/machinery/space_heater,
-/obj/effect/turf_decal/trimline/yellow/filled/shrink_ccw{
-	dir = 4
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=2";
+	freq = 1400;
+	location = "Janitor"
 	},
+/obj/structure/plasticflaps,
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/service/janitor)
 "cqx" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -27710,6 +27773,7 @@
 /obj/machinery/door/airlock/glass{
 	name = "Terrarium"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
 "cqP" = (
@@ -27779,25 +27843,21 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "cra" = (
-/obj/structure/closet/crate,
-/obj/item/storage/belt/utility,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "crb" = (
-/obj/machinery/airalarm/directional/south,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
+/obj/structure/tank_holder/extinguisher,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "crc" = (
 /obj/machinery/light/directional/south,
-/obj/machinery/camera/directional/south{
-	c_tag = "Atmost South West"
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cre" = (
@@ -27813,6 +27873,7 @@
 /obj/machinery/light/directional/west,
 /obj/item/multitool,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "crf" = (
@@ -27823,6 +27884,7 @@
 /obj/item/t_scanner,
 /obj/item/t_scanner,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "crg" = (
@@ -27835,19 +27897,20 @@
 	},
 /obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "crh" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cri" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "crl" = (
@@ -27860,9 +27923,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
 "crn" = (
-/obj/machinery/pipedispenser/disposal/transit_tube,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos)
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Mix to Distro"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos/mix)
 "crp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -28174,19 +28240,15 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "csr" = (
-/obj/machinery/door/airlock/glass{
-	name = "Engineering Corridor"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow/fourcorners,
-/turf/open/floor/iron,
-/area/station/engineering/hallway)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/mix)
 "cst" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engine Room"
@@ -28302,7 +28364,7 @@
 /area/station/security/execution/education)
 "csS" = (
 /obj/structure/bed,
-/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/jacket/straight_jacket,
 /obj/item/clothing/glasses/blindfold,
 /obj/item/clothing/mask/muzzle,
 /turf/open/floor/plating,
@@ -28440,18 +28502,21 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "cto" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/effect/spawner/random/engineering/atmospherics_portable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/department/engine/atmos)
 "ctq" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/department/engine/atmos)
 "ctr" = (
-/obj/machinery/light_switch/directional/west,
 /obj/effect/turf_decal/tile/yellow/opposingcorners{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2,
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "ctv" = (
@@ -28524,6 +28589,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/structure/sign/calendar/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "ctH" = (
@@ -28825,19 +28891,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "cuU" = (
-/obj/structure/grille/broken,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/department/engine/atmos)
 "cuX" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Engineering Maintenance"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -28848,8 +28912,12 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/machinery/door/airlock/glass{
+	name = "Atmospherics Corridor"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/turf/open/floor/iron,
+/area/station/maintenance/department/engine/atmos)
 "cve" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -28888,6 +28956,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "cvl" = (
@@ -29062,12 +29131,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "cvZ" = (
-/obj/machinery/atmospherics/components/binary/pump/off{
-	name = "Mix to Pure"
+/obj/structure/chair{
+	dir = 8
 	},
-/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron,
-/area/station/engineering/atmos/pumproom)
+/area/station/hallway/primary/starboard)
 "cwb" = (
 /obj/item/stack/sheet/iron/fifty,
 /turf/open/floor/plating,
@@ -29171,6 +29243,8 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/item/wrench,
+/obj/structure/rack,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "cwB" = (
@@ -29222,6 +29296,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/sign/clock/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "cwM" = (
@@ -29489,6 +29564,7 @@
 /area/station/security/prison)
 "cxO" = (
 /obj/structure/table,
+/obj/item/clothing/neck/stethoscope,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "cxP" = (
@@ -29517,15 +29593,10 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/main)
 "cxU" = (
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/turf/open/floor/plating,
-/area/station/engineering/main)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "cxV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -29618,10 +29689,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "cyo" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/visible,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/mix)
 "cyq" = (
 /obj/machinery/seed_extractor,
 /obj/machinery/light/small/directional/west,
@@ -29707,7 +29777,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cyN" = (
-/obj/machinery/camera/autoname/directional/north,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/rnd/production/circuit_imprinter,
 /turf/open/floor/iron,
@@ -29827,9 +29896,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "czA" = (
-/obj/structure/chair/comfy/black,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/machinery/button/ignition/incinerator/atmos{
+	pixel_y = -7;
+	pixel_x = 5
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/disposal/incinerator)
 "czE" = (
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/rods/fifty,
@@ -30014,10 +30089,16 @@
 /turf/open/floor/iron/checker,
 /area/station/service/theater)
 "cAp" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/all_access{
+	pixel_y = 24;
+	dir = 1
+	},
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "cAq" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
@@ -30034,21 +30115,19 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "cAs" = (
-/obj/structure/table,
-/obj/item/paper,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/mix)
 "cAt" = (
-/obj/structure/table,
-/obj/item/newspaper,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/mix)
 "cAu" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/machinery/air_sensor/incinerator_tank,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/turf/open/floor/engine,
+/area/station/maintenance/disposal/incinerator)
 "cAv" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
 /obj/machinery/light/small/directional/west,
@@ -30143,43 +30222,50 @@
 /obj/structure/rack,
 /obj/item/wirecutters,
 /obj/item/multitool,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "cBb" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
 "cBd" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "cBe" = (
-/obj/structure/table,
-/obj/item/lighter,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/incinerator_input{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/station/maintenance/disposal/incinerator)
 "cBg" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance,
-/obj/item/clothing/head/welding,
+/obj/machinery/door/airlock/public/glass/incinerator/atmos_interior,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "incinerator"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/embedded_controller/radio/airlock_controller/incinerator_atmos{
+	pixel_x = -8;
+	pixel_y = -40
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/open/floor/plating,
-/area/station/maintenance/aft)
+/area/station/maintenance/disposal/incinerator)
 "cBh" = (
-/obj/machinery/shieldgen,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/turf/closed/wall/r_wall,
+/area/station/maintenance/department/engine/atmos)
 "cBi" = (
-/obj/structure/table,
-/obj/item/stack/cable_coil,
-/obj/item/weldingtool,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/machinery/camera/autoname/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "cBj" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/ce)
@@ -30233,6 +30319,7 @@
 /area/station/engineering/supermatter/room)
 "cBu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/meter,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "cBv" = (
@@ -30345,22 +30432,16 @@
 /turf/closed/wall,
 /area/station/maintenance/aft)
 "cCj" = (
-/obj/structure/girder/reinforced,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/turf/closed/wall/r_wall,
+/area/station/maintenance/disposal/incinerator)
 "cCl" = (
-/obj/structure/table,
-/obj/item/screwdriver,
-/obj/item/bodypart/l_arm/robot{
-	pixel_x = -7;
-	pixel_y = 3
+/obj/machinery/camera/directional/east{
+	c_tag = "Turbine Vent";
+	network = list("turbine");
+	active_power_usage = 0
 	},
-/obj/item/bodypart/chest/robot,
-/obj/item/bodypart/head/robot{
-	pixel_y = 10
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/turf/open/space/basic,
+/area/space)
 "cCm" = (
 /obj/machinery/suit_storage_unit/ce,
 /turf/open/floor/iron/dark,
@@ -30639,67 +30720,56 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "cDy" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/turf/open/floor/iron,
+/area/station/engineering/hallway)
 "cDz" = (
-/obj/machinery/power/solar_control{
-	id = "aftport";
-	name = "Aft Port Solar Control"
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "cDA" = (
-/obj/machinery/power/terminal{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port/aft)
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "cDB" = (
-/obj/machinery/power/smes,
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "cDC" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/structure/cable,
+/obj/structure/fireaxecabinet/directional/north,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "cDD" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/structure/cable,
+/obj/machinery/computer/turbine_computer{
+	mapping_id = "main_turbine";
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching the turbine vent.";
+	dir = 1;
+	name = "turbine vent monitor";
+	network = list("turbine");
+	pixel_y = -28
+	},
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "cDE" = (
 /obj/machinery/computer/apc_control{
 	dir = 4
@@ -30751,12 +30821,10 @@
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/ce)
 "cDK" = (
-/obj/machinery/camera/autoname/directional/south,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/station/engineering/main)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
+/turf/open/floor/plating/airless,
+/area/station/engineering/atmos)
 "cDN" = (
 /obj/structure/table,
 /obj/item/folder/yellow,
@@ -30788,7 +30856,6 @@
 /area/station/engineering/supermatter/room)
 "cDX" = (
 /obj/machinery/light/directional/south,
-/obj/structure/sign/warning/vacuum/external/directional/south,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -30818,22 +30885,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
 "cEu" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
+/obj/structure/lattice/catwalk,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/space/basic,
 /area/station/maintenance/solars/port/aft)
 "cEv" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/maintenance/solars/port/aft)
+/area/station/engineering/atmos)
 "cEx" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -31023,10 +31083,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cFk" = (
-/obj/machinery/light/small/directional/east,
 /obj/structure/closet/emcloset,
-/turf/open/floor/plating,
-/area/station/engineering/main)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "cFl" = (
 /obj/item/rack_parts,
 /turf/open/floor/plating,
@@ -31353,10 +31415,13 @@
 /turf/open/space/basic,
 /area/space)
 "cHw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/atmos/pumproom)
+/obj/structure/sign/poster/official/random/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/camera/autoname/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "cHx" = (
 /obj/machinery/door/airlock/hatch,
 /obj/effect/mapping_helpers/airlock/access/any/command/maintenance,
@@ -31424,9 +31489,9 @@
 "cId" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cJA" = (
@@ -31449,6 +31514,10 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"cJV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "cKb" = (
 /obj/machinery/button/door{
 	id = "rdordnance";
@@ -31469,6 +31538,12 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"cKp" = (
+/obj/machinery/atmospherics/components/binary/pump/off{
+	name = "Ports to Fuel Pipe"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "cKB" = (
 /obj/machinery/medical_kiosk,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -31527,6 +31602,16 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
+"cMQ" = (
+/obj/machinery/door/airlock/public/glass/incinerator/atmos_exterior,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "incinerator"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/turf/open/floor/engine,
+/area/station/maintenance/disposal/incinerator)
 "cND" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -31544,6 +31629,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/theatre,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/service/theater)
 "cOI" = (
@@ -31587,6 +31673,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"cRa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/station/maintenance/disposal/incinerator)
 "cRe" = (
 /obj/machinery/rnd/bepis,
 /turf/open/floor/iron,
@@ -31637,9 +31731,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "cTx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos/pumproom)
+/obj/machinery/conveyor/inverted{
+	dir = 6;
+	id = "garbage"
+	},
+/obj/effect/spawner/random/trash/garbage{
+	spawn_loot_count = 3
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/disposal)
 "cTC" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral{
@@ -31648,9 +31748,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "cUk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
+/obj/machinery/meter/monitored/distro_loop,
 /turf/open/floor/iron,
-/area/station/engineering/atmos/pumproom)
+/area/station/engineering/atmos/mix)
 "cUs" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -31676,6 +31777,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"cUV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/mix)
 "cVj" = (
 /obj/structure/chair{
 	dir = 8
@@ -31708,6 +31814,11 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"cZP" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/mix)
 "cZZ" = (
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/carpet,
@@ -31741,6 +31852,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
+"dck" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "dcl" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 4
@@ -31868,15 +31989,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "djU" = (
-/obj/machinery/atmospherics/components/binary/pump/off{
-	dir = 8;
-	name = "N2O To Pure"
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
+	dir = 9
 	},
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/mix)
 "djX" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
@@ -31906,6 +32025,11 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"dlq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/maintenance/disposal/incinerator)
 "dls" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "lawyer_blast";
@@ -32077,12 +32201,18 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/service/theater)
 "dsS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/commons/storage/emergency/port)
+"dsX" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "dtI" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/engine,
@@ -32093,7 +32223,7 @@
 	},
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
-/area/station/cargo/qm)
+/area/station/command/heads_quarters/qm)
 "dum" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32235,6 +32365,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"dFJ" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos)
 "dGk" = (
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 8
@@ -32424,6 +32558,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "dTV" = (
@@ -32473,7 +32608,6 @@
 "dWU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/effect/landmark/navigate_destination/janitor,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "dXf" = (
@@ -32607,6 +32741,13 @@
 /obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
 /area/station/maintenance/department/bridge)
+"efU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "egK" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -32616,6 +32757,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"ehv" = (
+/obj/structure/cable,
+/obj/machinery/power/smes{
+	capacity = 9e+006;
+	charge = 10000
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "eiQ" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/west,
@@ -32638,15 +32788,10 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "ekt" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/mix)
 "ekQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32704,6 +32849,16 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"emw" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "emK" = (
 /obj/machinery/chem_master/condimaster{
 	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
@@ -32784,6 +32939,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
 "erz" = (
@@ -32980,6 +33136,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"eEl" = (
+/obj/machinery/door/airlock/external{
+	name = "Atmospheric Tanks Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "eEr" = (
 /obj/machinery/flasher/portable,
 /obj/machinery/flasher/portable,
@@ -33134,6 +33300,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"eOt" = (
+/obj/structure/chair/stool/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "eOu" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -33299,6 +33470,11 @@
 	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
+"eVD" = (
+/obj/machinery/shieldgen,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/department/engine/atmos)
 "eWN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33332,6 +33508,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/service/theater)
 "eYe" = (
@@ -33440,6 +33617,8 @@
 /area/station/command/heads_quarters/rd)
 "fde" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/east,
+/mob/living/simple_animal/hostile/lizard/wags_his_tail,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "fdj" = (
@@ -33553,6 +33732,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
+"fjs" = (
+/obj/machinery/door/airlock/external{
+	name = "Atmospheric Tanks Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "fkH" = (
 /obj/effect/turf_decal/trimline/dark_red/corner{
 	dir = 4
@@ -33700,6 +33887,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/structure/sign/departments/vault/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "fpt" = (
@@ -33722,6 +33910,14 @@
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
+"fqV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning/fire/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "frA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33850,10 +34046,11 @@
 /turf/open/floor/plating,
 /area/station/hallway/primary/starboard)
 "fCL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/sign/clock/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/service/theater)
 "fDb" = (
 /obj/effect/turf_decal/tile/dark_blue{
 	dir = 8
@@ -33861,6 +34058,7 @@
 /obj/effect/turf_decal/tile/dark_blue{
 	dir = 4
 	},
+/obj/structure/sign/departments/aiupload/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "fEr" = (
@@ -33887,6 +34085,19 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"fHj" = (
+/obj/structure/table,
+/obj/item/screwdriver,
+/obj/item/bodypart/l_arm/robot{
+	pixel_x = -7;
+	pixel_y = 3
+	},
+/obj/item/bodypart/chest/robot,
+/obj/item/bodypart/head/robot{
+	pixel_y = 10
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "fHr" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -33953,6 +34164,23 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
+"fLD" = (
+/obj/machinery/button/door/incinerator_vent_atmos_aux{
+	pixel_x = 24;
+	pixel_y = 8
+	},
+/obj/machinery/button/door/incinerator_vent_atmos_main{
+	pixel_x = 36;
+	pixel_y = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/atmos_control/nocontrol/incinerator{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "fLM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
@@ -33973,6 +34201,13 @@
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"fMY" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/bluespace_sender,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "fNo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34071,6 +34306,9 @@
 	dir = 4;
 	name = "O2 To Pure"
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "fVM" = (
@@ -34092,10 +34330,9 @@
 /turf/open/floor/iron,
 /area/station/medical/surgery/theatre)
 "fWD" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/lizard/wags_his_tail,
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/iron,
-/area/station/service/janitor)
+/area/station/hallway/primary/central/aft)
 "fXy" = (
 /obj/structure/sign/poster/official/random/directional/north,
 /obj/effect/turf_decal/tile/neutral{
@@ -34119,11 +34356,28 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
+"fZn" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Ports to South Ports"
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "gas" = (
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
+"gaH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "gaP" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating,
@@ -34144,6 +34398,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"gbN" = (
+/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "gbQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34202,9 +34463,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "gea" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump/off{
+	dir = 8;
+	name = "N2O To Pure"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -34323,13 +34587,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"gll" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "gln" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 1";
@@ -34345,12 +34602,10 @@
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "gnj" = (
-/obj/structure/sign/directions/vault/directional/west,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/station/maintenance/central)
 "gnl" = (
 /obj/effect/spawner/random/maintenance,
 /obj/effect/spawner/random/structure/table_or_rack,
@@ -34396,6 +34651,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "gou" = (
@@ -34559,6 +34815,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
+/obj/structure/sign/clock/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "gwR" = (
@@ -34575,6 +34832,12 @@
 /obj/effect/turf_decal/tile/green/anticorner/contrasted,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
+"gyj" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "gyK" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -34658,6 +34921,11 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"gEo" = (
+/obj/machinery/igniter/incinerator_atmos,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/turf/open/floor/engine,
+/area/station/maintenance/disposal/incinerator)
 "gEp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -34681,9 +34949,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "gFj" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/engineering/atmos/pumproom)
+/area/station/maintenance/solars/port/aft)
 "gFQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34717,11 +34988,15 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"gHX" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "gIQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "gIU" = (
@@ -34742,14 +35017,6 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
-"gLd" = (
-/obj/machinery/atmospherics/components/binary/pump/off{
-	dir = 8;
-	name = "Mix to Distro"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/engineering/atmos/pumproom)
 "gMi" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1
@@ -34918,6 +35185,14 @@
 /obj/structure/window/spawner/north,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"gTl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/tank/plasma{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "gTq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -34934,7 +35209,7 @@
 /area/station/engineering/main)
 "gTx" = (
 /obj/structure/table/reinforced,
-/obj/item/clothing/suit/radiation,
+/obj/item/clothing/suit/utility/radiation,
 /obj/item/clothing/head/radiation,
 /obj/item/clothing/glasses/meson,
 /obj/item/clothing/glasses/meson,
@@ -35000,13 +35275,21 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "hat" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
-/turf/open/floor/plating,
-/area/station/engineering/atmos/pumproom)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/blobstart,
+/turf/open/floor/iron,
+/area/station/maintenance/department/engine/atmos)
 "hbK" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -35088,8 +35371,12 @@
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "hgI" = (
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/pumproom)
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/camera/autoname/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "hgL" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
@@ -35182,6 +35469,13 @@
 /obj/item/kirbyplants/photosynthetic,
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"hmd" = (
+/obj/machinery/atmospherics/components/trinary/filter/flipped/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "hmx" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/dark_blue{
@@ -35236,6 +35530,7 @@
 /area/station/service/bar)
 "hoj" = (
 /obj/machinery/holopad/secure,
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain/private)
 "hon" = (
@@ -35253,6 +35548,13 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
+"hpp" = (
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "hpq" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -35267,6 +35569,13 @@
 "hqK" = (
 /turf/closed/wall,
 /area/station/science/research)
+"hqM" = (
+/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "hrq" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral,
@@ -35295,6 +35604,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"hsq" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "hsP" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
@@ -35309,12 +35625,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "huJ" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "Unfiltered & Air to Mix"
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
 	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron,
-/area/station/engineering/atmos/pumproom)
+/area/station/hallway/primary/central/aft)
 "huX" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -35451,8 +35767,12 @@
 /area/station/security/execution/transfer)
 "hHE" = (
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light_switch/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "hIl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35478,6 +35798,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"hKW" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
+/turf/closed/wall/r_wall,
+/area/station/maintenance/disposal/incinerator)
 "hLl" = (
 /obj/structure/kitchenspike,
 /obj/machinery/airalarm/directional/north,
@@ -35487,6 +35811,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
+"hMm" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/mix)
 "hMP" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
@@ -35496,11 +35825,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "hMY" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "hNu" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/red{
@@ -35574,12 +35906,9 @@
 /turf/closed/wall,
 /area/space/nearstation)
 "hTb" = (
-/obj/machinery/atmospherics/components/binary/pump/off{
-	dir = 8;
-	name = "Pure to Port"
-	},
+/obj/machinery/space_heater,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -35588,6 +35917,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "hTE" = (
@@ -35596,6 +35926,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/satellite)
 "hTP" = (
@@ -35636,6 +35967,12 @@
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
+"hXw" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/heater{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "hXB" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -35647,9 +35984,16 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "hZn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Waste to Filter"
+	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/engineering/atmos/pumproom)
+/area/station/engineering/atmos/mix)
 "hZv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35688,9 +36032,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "ibE" = (
-/obj/effect/spawner/random/trash/hobo_squat,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos)
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Unfiltered to Mix"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos/mix)
 "ibO" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
@@ -35699,10 +36049,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "ich" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/atmos/pumproom)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/camera/autoname/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "idF" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -35712,6 +36062,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/auxlab)
+"ieb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "iew" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
@@ -35726,6 +36085,13 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
+"igw" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/maintenance/department/engine/atmos)
 "igA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -35760,15 +36126,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "iit" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port/aft)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/radiation,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "iiB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35887,6 +36250,7 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
 	dir = 8
 	},
+/obj/machinery/meter,
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter/room)
 "iog" = (
@@ -35905,6 +36269,17 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"ioH" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/door/airlock/atmos{
+	name = "Incinerator"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/landmark/navigate_destination/incinerator,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/maintenance/department/engine/atmos)
 "ipf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35951,6 +36326,12 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"iue" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos/mix)
 "ivL" = (
 /obj/structure/transit_tube/curved{
 	dir = 1
@@ -36082,6 +36463,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "tcomms-passthrough"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "iGi" = (
@@ -36115,6 +36497,10 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
+"iHz" = (
+/obj/machinery/atmospherics/pipe/color_adapter,
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "iHC" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L4"
@@ -36268,6 +36654,13 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"iTr" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos)
 "iTL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -36341,9 +36734,22 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "iYa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron,
-/area/station/engineering/atmos/pumproom)
+/area/station/hallway/primary/starboard)
+"iYt" = (
+/obj/effect/turf_decal/tile/yellow/fourcorners,
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Atmospherics Monitoring"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/structure/cable,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/mix)
 "iYV" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/iron,
@@ -36363,6 +36769,13 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/commons/storage/emergency/port)
+"jaE" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Pure to Ports"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "jaX" = (
 /obj/structure/cable,
 /turf/open/floor/carpet/red,
@@ -36462,11 +36875,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
+"jiL" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "jiT" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
-/turf/open/floor/plating,
-/area/station/engineering/atmos/pumproom)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "jiZ" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1
@@ -36516,6 +36933,9 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "jmt" = (
@@ -36600,6 +37020,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/structure/sign/warning/secure_area/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "jtP" = (
@@ -36692,10 +37113,16 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "jxP" = (
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos)
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	dir = 4;
+	name = "Waste Release"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos/mix)
 "jxT" = (
 /obj/effect/turf_decal/bot_white/left,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -36715,6 +37142,9 @@
 /area/station/service/cafeteria)
 "jzy" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/camera/directional/north{
+	c_tag = "Command EVA"
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
 "jAr" = (
@@ -36742,6 +37172,24 @@
 /obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
+"jCq" = (
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
+"jDk" = (
+/obj/structure/table,
+/obj/item/candle{
+	pixel_y = 7;
+	pixel_x = -5
+	},
+/obj/item/lighter{
+	pixel_x = -5;
+	pixel_y = -2
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/aft)
 "jDR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -36802,6 +37250,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"jHH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos)
 "jHW" = (
 /obj/structure/sign/warning/radiation/rad_area/directional/north,
 /obj/effect/turf_decal/bot_white,
@@ -36858,6 +37310,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"jJX" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4,
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/iron,
+/area/station/engineering/hallway)
 "jKm" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
@@ -36903,6 +37363,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"jLA" = (
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "jNl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36976,6 +37442,18 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
+"jUy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/meter,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
+"jUQ" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "jVx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -36988,6 +37466,7 @@
 "jVQ" = (
 /obj/machinery/light_switch/directional/south,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
+/obj/structure/tank_holder/extinguisher,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "jVZ" = (
@@ -37060,8 +37539,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "jXO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "jXR" = (
@@ -37172,6 +37654,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"khj" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/mix)
 "khu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -37229,6 +37716,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"kkC" = (
+/obj/machinery/atmospherics/components/binary/pump/off{
+	name = "Air to Ports"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "klw" = (
 /obj/machinery/suit_storage_unit/industrial/loader,
 /turf/open/floor/iron,
@@ -37325,10 +37818,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "kpM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/turf/open/floor/plating,
-/area/station/engineering/atmos/pumproom)
+/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/machinery/camera/autoname/directional/north,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/mix)
 "kpO" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -37376,6 +37873,9 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
+"krK" = (
+/turf/open/floor/iron,
+/area/station/engineering/atmos/mix)
 "krU" = (
 /turf/open/floor/iron/recharge_floor,
 /area/station/science/robotics/mechbay)
@@ -37464,6 +37964,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"kxC" = (
+/obj/machinery/power/turbine/core_rotor{
+	mapping_id = "main_turbine"
+	},
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/station/maintenance/disposal/incinerator)
 "kyb" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
@@ -37560,6 +38067,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"kEh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "kEo" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/carpet,
@@ -37622,9 +38136,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "kIz" = (
-/obj/machinery/holopad,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/structure/sign/warning/docking/directional/north,
+/turf/open/space/basic,
+/area/space)
 "kIN" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -37661,6 +38175,12 @@
 /obj/machinery/vending/wallmed/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
+"kKT" = (
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	name = "Mix to Atmos Stage"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos/mix)
 "kMe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral{
@@ -37752,13 +38272,15 @@
 "kUB" = (
 /obj/item/storage/secure/safe/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
-"kVa" = (
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/engineering/atmos/pumproom)
+"kUP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "kVe" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -37772,6 +38294,11 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"kWX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
+/obj/machinery/meter,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "kXa" = (
 /obj/effect/spawner/random/trash/garbage,
 /obj/effect/decal/cleanable/dirt,
@@ -37811,6 +38338,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
+"kYu" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "kYv" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -37843,6 +38375,7 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/sign/departments/aisat/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "lbF" = (
@@ -37866,6 +38399,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
+"ldo" = (
+/obj/structure/cable,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/atmospherics,
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "leb" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /obj/structure/sign/warning/secure_area/directional/west,
@@ -37924,11 +38466,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "lki" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "lkE" = (
 /obj/structure/cable,
@@ -38027,9 +38569,14 @@
 /turf/open/floor/iron,
 /area/station/science/auxlab)
 "lqW" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/mix)
 "lrC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -38075,6 +38622,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/science/genetics,
 /obj/effect/mapping_helpers/airlock/access/any/medical/general,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "lxl" = (
@@ -38093,10 +38641,9 @@
 /turf/open/floor/carpet,
 /area/station/command/meeting_room)
 "lyn" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 9
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 1
 	},
-/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "lyx" = (
@@ -38110,11 +38657,25 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"lzl" = (
+/obj/structure/cable/layer3,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Mix Bypass"
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "lzC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
+"lzO" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Mix to Ports"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "lAa" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -38204,6 +38765,13 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
+"lFw" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/heater/on{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/mix)
 "lFy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38220,6 +38788,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "lGf" = (
@@ -38432,6 +39001,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"lSB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/mix)
 "lSL" = (
 /obj/structure/chair{
 	dir = 1
@@ -38486,6 +39063,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
+"lUm" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "South Port to Filter"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "lUy" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38509,6 +39093,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
+"lUT" = (
+/obj/machinery/holopad,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "lWs" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
@@ -38650,14 +39238,12 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "mgP" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics"
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/effect/mapping_helpers/airlock/unres,
+/obj/structure/sign/clock/directional/east,
 /turf/open/floor/iron,
-/area/station/maintenance/department/engine/atmos)
+/area/station/security)
 "mgR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -38705,12 +39291,12 @@
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
 "mjZ" = (
-/obj/machinery/atmospherics/components/binary/pump/off{
-	dir = 8;
-	name = "Port to Air"
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/engineering/main)
 "mkl" = (
 /obj/machinery/requests_console/directional/west{
 	announcementConsole = 1;
@@ -38722,6 +39308,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"mkK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "mlK" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/yellow{
@@ -38742,6 +39337,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
 "mmE" = (
@@ -38832,9 +39428,6 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "msd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
@@ -38862,6 +39455,22 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"muB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/maintenance{
+	name = "Engineering Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "muS" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/purple{
@@ -38887,6 +39496,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"mvE" = (
+/obj/effect/spawner/random/maintenance,
+/obj/item/clothing/head/welding,
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron,
+/area/station/maintenance/department/engine/atmos)
 "mvU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38899,6 +39516,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter)
+"mww" = (
+/obj/machinery/atmospherics/components/binary/pump/off{
+	name = "Ports to Engine"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "mwG" = (
 /obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/iron/grimy,
@@ -38986,6 +39609,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"mBj" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "mBR" = (
 /obj/structure/dresser,
 /obj/effect/turf_decal/tile/red/opposingcorners,
@@ -39001,6 +39630,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
+"mDD" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "mDF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39028,6 +39663,13 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/station/security)
+"mEL" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos)
 "mGm" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -39048,6 +39690,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/medical/abandoned)
+"mHu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/mix)
 "mHO" = (
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
@@ -39080,12 +39730,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "mIR" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Air to Distro"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/engineering/atmos/pumproom)
+/area/station/engineering/atmos/mix)
 "mIV" = (
 /turf/closed/wall,
 /area/station/medical/medbay/central)
@@ -39249,10 +39899,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/central)
 "mXu" = (
-/obj/item/wrench,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/machinery/camera/autoname/directional/north,
+/turf/open/floor/wood,
+/area/station/service/theater)
 "mXT" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -39357,6 +40006,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "ncA" = (
@@ -39403,7 +40053,7 @@
 /area/station/engineering/engine_smes)
 "nee" = (
 /obj/structure/table/reinforced,
-/obj/item/clothing/suit/radiation,
+/obj/item/clothing/suit/utility/radiation,
 /obj/item/clothing/head/radiation,
 /obj/item/clothing/glasses/meson,
 /obj/item/geiger_counter,
@@ -39476,6 +40126,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
+"ngH" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "ngV" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -39622,6 +40281,9 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"nrd" = (
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/aft)
 "nrE" = (
 /obj/machinery/door/airlock/hatch,
 /obj/effect/mapping_helpers/airlock/access/any/command/maintenance,
@@ -39686,6 +40348,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"ntK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "ntU" = (
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Antechamber"
@@ -39788,10 +40457,12 @@
 /area/station/commons/dorms)
 "nyY" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/item/radio/intercom/directional/north,
+/obj/structure/cable,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "nzt" = (
 /obj/effect/turf_decal/stripes/line{
@@ -39851,6 +40522,13 @@
 /obj/structure/transit_tube/diagonal,
 /turf/open/space/basic,
 /area/space/nearstation)
+"nDU" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Ports to North Ports"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "nEK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /turf/open/floor/iron/dark,
@@ -40136,6 +40814,7 @@
 /obj/effect/turf_decal/trimline/dark_blue/corner{
 	dir = 1
 	},
+/obj/structure/sign/departments/rndserver/directional/north,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "nYo" = (
@@ -40328,6 +41007,7 @@
 /area/station/medical/medbay/lobby)
 "olv" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "olA" = (
@@ -40418,6 +41098,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/gateway)
+"osm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "oty" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 1
@@ -40476,6 +41162,19 @@
 	},
 /turf/open/floor/iron/checker,
 /area/station/service/theater)
+"oyv" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/thermomachine/heater{
+	dir = 4
+	},
+/obj/machinery/camera/autoname/directional/west,
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
+"oyI" = (
+/obj/item/wrench,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "oyM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/random/trash/garbage,
@@ -40526,7 +41225,19 @@
 /obj/structure/cable,
 /obj/machinery/holopad,
 /turf/open/floor/carpet/blue,
-/area/station/cargo/qm)
+/area/station/command/heads_quarters/qm)
+"oCc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/department/engine/atmos)
 "oCl" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron,
@@ -40594,10 +41305,13 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "oFn" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -40671,17 +41385,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"oKM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos/mix)
 "oKO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
-"oKY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "oLa" = (
 /obj/structure/cable,
 /turf/open/floor/carpet,
@@ -40879,6 +41594,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"oVM" = (
+/obj/structure/table,
+/obj/item/stack/cable_coil,
+/obj/item/weldingtool,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "oXJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40953,10 +41674,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/security)
 "paY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "pbj" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay"
@@ -41009,6 +41729,7 @@
 	c_tag = "Engineering - Engine Room South-East";
 	network = list("ss13","engine","engineering")
 	},
+/obj/machinery/meter,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "pdu" = (
@@ -41066,12 +41787,10 @@
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
 "piM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "piS" = (
@@ -41105,6 +41824,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/construction)
+"pmx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/department/engine/atmos)
 "pmF" = (
 /obj/structure/transit_tube/curved{
 	dir = 4
@@ -41151,10 +41882,16 @@
 	dir = 8
 	},
 /area/station/medical/medbay/lobby)
-"pqA" = (
-/obj/machinery/atmospherics/components/binary/pump/off{
-	name = "Pure to Engine"
+"pqo" = (
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/turf/open/floor/iron,
+/area/station/engineering/hallway)
+"pqA" = (
+/obj/effect/turf_decal/box/corners,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "pqG" = (
@@ -41216,7 +41953,6 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)
 "puZ" = (
-/obj/machinery/status_display/evac/directional/west,
 /obj/structure/transit_tube/station/dispenser{
 	dir = 4
 	},
@@ -41235,6 +41971,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"pxi" = (
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/mix)
 "pyl" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -41346,13 +42087,11 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "pGz" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/spawner/random/structure/crate,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "pGT" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -41558,6 +42297,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
+"pTs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/mix)
 "pTN" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/chemistry{
@@ -41717,6 +42461,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "qeX" = (
@@ -41743,6 +42488,20 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"qic" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/disposal/incinerator)
+"qik" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "N2 to Airmix"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "qil" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41799,6 +42558,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/bridge)
+"qmO" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Mix to Waste"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos/mix)
 "qnl" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -41888,11 +42654,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
-	dir = 8
-	},
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
+"qsC" = (
+/obj/machinery/power/smes,
+/obj/machinery/light/small/directional/north,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/aft)
+"qtz" = (
+/obj/structure/sign/warning/vacuum/external/directional/east,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "qtV" = (
 /obj/structure/transit_tube/diagonal,
 /turf/open/space/basic,
@@ -41944,6 +42720,10 @@
 /obj/effect/landmark/start/cyborg,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"qxG" = (
+/obj/machinery/power/turbine/turbine_outlet,
+/turf/open/floor/engine,
+/area/station/maintenance/disposal/incinerator)
 "qxL" = (
 /obj/structure/sign/directions/command{
 	dir = 1
@@ -42067,6 +42847,13 @@
 /obj/effect/turf_decal/tile/bar,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"qCM" = (
+/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "qCT" = (
 /obj/machinery/light/directional/south,
 /obj/structure/cable,
@@ -42179,18 +42966,26 @@
 /obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
 /area/station/cargo/storage)
+"qJx" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "qJM" = (
 /obj/structure/cable,
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "qJU" = (
-/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
+/area/station/engineering/atmos)
 "qKi" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
@@ -42212,6 +43007,11 @@
 /obj/machinery/skill_station,
 /turf/open/floor/wood,
 /area/station/service/library/lounge)
+"qKU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/mix)
 "qLg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -42273,9 +43073,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "qPO" = (
-/obj/structure/chair/stool/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning/hot_temp/directional/south,
+/turf/open/floor/iron,
+/area/station/maintenance/department/engine/atmos)
 "qQJ" = (
 /obj/machinery/camera/autoname/directional/west,
 /obj/effect/turf_decal/tile/red{
@@ -42354,12 +43155,8 @@
 /turf/open/floor/plating,
 /area/station/cargo/storage)
 "qYD" = (
-/obj/item/radio/intercom/directional/north,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/hallway)
+/turf/closed/wall,
+/area/station/engineering/atmos)
 "qYN" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 4
@@ -42373,6 +43170,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
+"qZy" = (
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
 "raA" = (
 /obj/structure/chair{
 	dir = 8
@@ -42381,15 +43183,13 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "raH" = (
-/obj/machinery/atmospherics/components/binary/pump/off{
-	dir = 4;
-	name = "Air to Port"
+/obj/machinery/door/airlock/glass{
+	name = "Engineering Corridor"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/yellow/fourcorners,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/engineering/hallway)
 "raS" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -42480,6 +43280,7 @@
 "rjn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "rjz" = (
@@ -42491,6 +43292,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"rke" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Mix to Gas"
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "rkD" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/maintenance,
@@ -42585,10 +43397,10 @@
 /obj/effect/turf_decal/tile/dark_blue{
 	dir = 8
 	},
+/obj/structure/sign/calendar/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "roK" = (
-/obj/machinery/status_display/evac/directional/west,
 /obj/structure/transit_tube/station/dispenser{
 	dir = 4
 	},
@@ -42603,9 +43415,16 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "rpI" = (
+/obj/machinery/atmospherics/components/binary/pump/off{
+	dir = 8;
+	name = "Mix Out"
+	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos)
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos/mix)
 "rpQ" = (
 /obj/machinery/hydroponics/constructable,
 /obj/structure/cable,
@@ -42707,7 +43526,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/station/cargo/qm)
+/area/station/command/heads_quarters/qm)
 "rxu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42726,7 +43545,7 @@
 "rxT" = (
 /obj/machinery/computer/security/telescreen/ce,
 /turf/closed/wall/r_wall,
-/area/station/maintenance/aft)
+/area/station/command/heads_quarters/ce)
 "rya" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -42738,6 +43557,15 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"rys" = (
+/obj/machinery/airlock_sensor/incinerator_atmos{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/engine,
+/area/station/maintenance/disposal/incinerator)
 "ryG" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -42879,6 +43707,13 @@
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/wood,
 /area/station/service/library)
+"rEp" = (
+/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "rEL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43005,7 +43840,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/station/cargo/qm)
+/area/station/command/heads_quarters/qm)
 "rLE" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
@@ -43050,6 +43885,7 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners{
 	dir = 8
 	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "rPf" = (
@@ -43070,6 +43906,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/security)
+"rQj" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/station/engineering/atmos/mix)
 "rRA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43089,6 +43929,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
 "rTc" = (
@@ -43186,7 +44027,7 @@
 "sap" = (
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/wood,
-/area/station/cargo/qm)
+/area/station/command/heads_quarters/qm)
 "saC" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
@@ -43286,6 +44127,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation)
+"sgv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "sgL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43375,8 +44221,9 @@
 	name = "Atmospherics"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "skl" = (
@@ -43437,10 +44284,6 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"smC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos/pumproom)
 "smQ" = (
 /turf/open/floor/iron/airless,
 /area/station/maintenance/port/aft)
@@ -43453,6 +44296,13 @@
 	},
 /turf/open/floor/carpet,
 /area/station/command/meeting_room)
+"spA" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "North Port to Filter"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "spB" = (
 /obj/item/crowbar/large,
 /obj/structure/rack,
@@ -43516,7 +44366,7 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "suC" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/shrink_ccw{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -43531,7 +44381,6 @@
 "svz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
@@ -43639,12 +44488,23 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/station/medical/abandoned)
+"syS" = (
+/obj/structure/chair/comfy/black,
+/obj/item/newspaper,
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/aft)
 "syZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"szS" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "sAj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -43760,6 +44620,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"sHg" = (
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "sHI" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office"
@@ -43768,6 +44635,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "sIh" = (
@@ -43939,13 +44807,6 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"sVX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "sWL" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/porta_turret/ai,
@@ -44017,7 +44878,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "tcn" = (
 /obj/structure/disposalpipe/segment{
@@ -44190,6 +45051,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/bridge)
+"toA" = (
+/obj/machinery/door/poddoor/incinerator_atmos_aux,
+/turf/open/floor/engine,
+/area/station/maintenance/disposal/incinerator)
 "toX" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
@@ -44205,7 +45070,7 @@
 "tpC" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
-/area/station/cargo/qm)
+/area/station/command/heads_quarters/qm)
 "tpP" = (
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark,
@@ -44387,6 +45252,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
+"tDs" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/mix)
 "tEv" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -44443,10 +45312,12 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "tIx" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos)
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/machinery/camera/autoname/directional/north,
+/turf/open/floor/iron,
+/area/station/science/ordnance)
 "tIE" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
@@ -44470,6 +45341,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
+"tJr" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Fuel Pipe to Incinerator";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "tJR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -44528,10 +45409,11 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "tOg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
-/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
-/area/station/engineering/atmos/pumproom)
+/area/station/engineering/atmos)
 "tPe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44786,12 +45668,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "ubG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/mix)
 "ubL" = (
 /turf/closed/wall,
 /area/station/security/prison/toilet)
@@ -44800,8 +45680,7 @@
 	dir = 4;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -44818,6 +45697,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"udD" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
+"udK" = (
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "ueo" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -44888,6 +45777,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"ukL" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "ulF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -44983,6 +45878,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
+"uqV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "urd" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -44990,6 +45890,14 @@
 /obj/structure/chair/sofa/bench/right,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"ust" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "usQ" = (
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
@@ -45046,9 +45954,8 @@
 /area/station/ai_monitored/security/armory)
 "uxh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/machinery/meter/monitored/waste_loop,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -45204,6 +46111,7 @@
 "uHX" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
 "uIf" = (
@@ -45331,9 +46239,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "uTS" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "uUC" = (
@@ -45380,13 +46289,15 @@
 /turf/open/floor/carpet/royalblack,
 /area/station/service/library)
 "uXX" = (
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access"
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine Room"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/turf/open/floor/plating,
-/area/station/engineering/main)
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "uYm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45505,6 +46416,10 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
+"vjx" = (
+/obj/machinery/door/poddoor/incinerator_atmos_main,
+/turf/open/floor/engine,
+/area/station/maintenance/disposal/incinerator)
 "vkP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45580,10 +46495,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "vpY" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "vqG" = (
@@ -45638,10 +46552,18 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"vwu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "vwT" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
+"vxm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/closed/wall/r_wall,
+/area/station/maintenance/disposal/incinerator)
 "vxE" = (
 /obj/structure/girder,
 /turf/open/floor/plating/airless,
@@ -45649,8 +46571,7 @@
 "vxX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "vza" = (
@@ -45696,10 +46617,9 @@
 /turf/open/floor/iron,
 /area/station/security/warden)
 "vAl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/atmos/pumproom)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/mix)
 "vDt" = (
 /obj/structure/cable,
 /turf/open/floor/carpet/red,
@@ -45855,7 +46775,6 @@
 "vKS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -45955,13 +46874,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
-"vSi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "vSn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46020,6 +46932,7 @@
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 8
 	},
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "vWD" = (
@@ -46040,6 +46953,9 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"vXG" = (
+/turf/closed/wall,
+/area/station/engineering/supermatter/room)
 "vYv" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron,
@@ -46106,6 +47022,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/theater)
+"waL" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/maintenance/disposal/incinerator)
 "wbU" = (
 /obj/structure/sign/departments/chemistry/pharmacy/directional/west,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -46137,12 +47057,26 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/station/construction)
+"wew" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/structure/tank_holder/extinguisher,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "wfu" = (
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
+"wfI" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/machinery/pipedispenser/disposal,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "whN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -46201,7 +47135,6 @@
 /obj/structure/transit_tube/curved{
 	dir = 1
 	},
-/obj/machinery/status_display/evac/directional/west,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 1
 	},
@@ -46303,16 +47236,26 @@
 "wto" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
 "wtp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
+"wus" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "wuA" = (
 /obj/machinery/atmospherics/components/binary/pump/off{
 	dir = 8;
 	name = "CO2 To Pure"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -46436,6 +47379,9 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
 	name = "O2 to Airmix"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -46602,11 +47548,18 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "wTP" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
+/obj/effect/turf_decal/tile/yellow/diagonal_centre,
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/hallway/primary/central/aft)
 "wTS" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -46692,6 +47645,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
+"xcf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/electrolyzer,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "xcq" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
@@ -46892,6 +47851,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
+"xqb" = (
+/obj/machinery/power/solar_control{
+	id = "aftport";
+	name = "Aft Port Solar Control"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/aft)
 "xqF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
@@ -46959,6 +47926,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"xsQ" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "xth" = (
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	id = "engsm";
@@ -47070,9 +48043,12 @@
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "xDt" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -47095,6 +48071,10 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"xEt" = (
+/obj/machinery/power/turbine/inlet_compressor,
+/turf/open/floor/engine,
+/area/station/maintenance/disposal/incinerator)
 "xFM" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -47164,6 +48144,11 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
+"xKq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "xKM" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/tcomms_all,
@@ -47352,9 +48337,12 @@
 /turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "xWK" = (
-/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron,
-/area/station/engineering/atmos/pumproom)
+/area/station/engineering/atmos)
 "xXd" = (
 /obj/structure/chair/stool/bar/directional/east,
 /obj/effect/landmark/start/hangover,
@@ -47370,6 +48358,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"xXy" = (
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "xXN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -47455,13 +48450,14 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "ycz" = (
-/obj/machinery/atmospherics/components/binary/pump/off{
-	dir = 8;
-	name = "Mix Out"
+/obj/structure/disposaloutlet{
+	dir = 1
 	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/engineering/atmos/pumproom)
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/disposal)
 "ycF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -47494,6 +48490,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "yeE" = (
@@ -47517,6 +48514,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"yih" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "yjd" = (
 /obj/structure/cable,
 /obj/machinery/holopad,
@@ -58008,7 +59012,7 @@ jFy
 bYw
 nsh
 bRw
-cbP
+cAS
 cAa
 cAa
 cAa
@@ -58765,7 +59769,7 @@ lug
 cjH
 aKJ
 gRN
-cgv
+ich
 cjH
 dQm
 bNe
@@ -61575,7 +62579,7 @@ iAl
 nxU
 bmI
 bnO
-aib
+cBi
 kKi
 iac
 lWu
@@ -62334,8 +63338,8 @@ aRM
 bgI
 bbC
 baz
-bbC
-bbC
+wTS
+wTS
 bbC
 bbC
 bbC
@@ -62588,11 +63592,11 @@ aSW
 aJH
 gwR
 dTV
-gwR
+hgL
 pwd
 jDR
-hgL
-bhS
+gwR
+gwR
 bdT
 pQd
 dgu
@@ -64920,7 +65924,7 @@ aQN
 bpP
 sxD
 usQ
-clI
+bjA
 aet
 bvT
 oOh
@@ -66956,7 +67960,7 @@ tBl
 biH
 pBI
 nfr
-pBI
+chE
 tTa
 diT
 bIt
@@ -69058,7 +70062,7 @@ rmn
 vsw
 bYL
 bZT
-eOT
+mgP
 eOT
 cdC
 ceM
@@ -69078,14 +70082,14 @@ cuO
 cCh
 cCh
 bcL
-ceR
-ceR
+cCh
+cCh
 tZf
 tZf
 tZf
 tZf
-tZf
-tZf
+lWL
+lWL
 aCI
 lWL
 lWL
@@ -69330,19 +70334,19 @@ lWL
 lWL
 lWL
 cCh
-cuN
+cAl
 bcL
 bcL
 bcL
 nFo
 czx
 cAq
-cBb
-cBb
-cBb
+cEp
 cBb
 cEp
 cEX
+cEu
+cEu
 qHQ
 qHQ
 cGw
@@ -69592,14 +70596,14 @@ bcL
 cCh
 cCh
 cCh
-ceR
-ceR
-rVS
-rVS
-rVS
-cDy
-cEu
+cCh
+cCh
+qsC
+gFj
+fXW
 cEY
+lWL
+lWL
 aCI
 lWL
 lWL
@@ -69839,24 +70843,24 @@ cCh
 cCh
 cCh
 cmt
-bEH
-cuN
-cuN
-cuN
-cuN
+dsX
+cwx
+cHo
+cAl
+udK
 cuN
 bcL
 cCh
 cxO
 cyA
 czz
-ceR
-lWL
-lWL
-sZd
-cDz
-fXW
+cCh
+xqb
+nrd
+cEs
 aFM
+lWL
+lWL
 aCI
 lWL
 cGE
@@ -70097,23 +71101,23 @@ ctn
 clw
 ctn
 ctn
-coZ
-cql
-cra
-pGz
+ctn
+ctn
+ctn
+ctn
 ctn
 cuS
 cwt
 mYP
 cyB
 cxP
-ceR
-ceR
-lWL
-sZd
-cDA
+cCh
+cCh
+syS
 cEs
 aFM
+lWL
+lWL
 aCI
 aCI
 cGE
@@ -70356,21 +71360,21 @@ ceR
 ceR
 ceR
 ceR
-ceR
-ceR
-cuN
-ceO
-cCh
+cBh
+cBh
+cBh
+muB
+cBh
+cBh
 cxQ
 cuN
-cuN
 cAr
-ceR
-lWL
-sZd
-cDB
-fXW
+cCh
+jDk
+cEs
 aFM
+lWL
+lWL
 aCI
 lWL
 cGE
@@ -70613,21 +71617,21 @@ aCI
 aCI
 aCI
 aCI
-aCI
-ceR
-cuN
-ceO
-cCh
-cCh
-cCh
-cCh
-cCh
-ceR
-ceR
-tZf
-cDC
-cEu
-aFM
+fjs
+qtz
+eEl
+ieb
+udD
+cBh
+cCj
+cCj
+cCj
+cCj
+cCj
+cCj
+cCj
+lWL
+lWL
 aCI
 aCI
 cGE
@@ -70870,22 +71874,22 @@ bUO
 bUO
 bUO
 bUO
-aCI
-ceR
-nXS
-ceO
+cBh
+cBh
+cBh
+oCc
+igw
+ioH
 hHE
-hHE
-hHE
-hHE
-hHE
-hHE
-czx
+emw
+oyv
+ehv
+ldo
 iit
-iit
-cEv
-aFM
-abf
+cCj
+lWL
+lWL
+abb
 lWL
 lWL
 lWL
@@ -71128,19 +72132,19 @@ cmu
 cmu
 bUO
 aCI
-ceR
-cHo
-ceO
-bEH
-cuN
-bEH
-cuN
-cuN
+cBh
+bXl
+hat
+qPO
+cBh
+osm
+avl
 cBd
-ceR
-rVS
-rVS
-rVS
+cBd
+cBd
+gaH
+dlq
+jCq
 lWL
 abb
 lWL
@@ -71385,21 +72389,21 @@ cnQ
 cpa
 bUO
 aCI
-ceR
-cto
+cBh
+fHj
 cuU
 cto
-cCh
-cCh
-cCh
-cCh
-cwt
-cCh
-cCh
-lWL
-lWL
-lWL
-abb
+cBh
+tJr
+hmd
+ust
+qic
+eOt
+cDD
+cCj
+cCj
+aCI
+aCI
 abb
 abb
 abb
@@ -71601,7 +72605,7 @@ boP
 btA
 bLv
 bGt
-mrk
+bWo
 buI
 buI
 kET
@@ -71642,19 +72646,19 @@ cnR
 cpb
 bUO
 aCI
-ceR
-cmt
-ceO
-cuN
-cCh
+cBh
+oVM
+pmx
+eVD
+cBh
 cAp
-cuN
-cuN
-bEH
-cuN
-cCh
-lWL
-lWL
+xKq
+gTl
+xcf
+cra
+kYu
+kYu
+cCj
 lWL
 aCI
 lWL
@@ -71886,7 +72890,7 @@ bXs
 ggT
 aCI
 bUO
-ccr
+iGF
 arL
 iGF
 bUO
@@ -71899,19 +72903,19 @@ arL
 afI
 bUO
 aCI
-ceR
+cBh
 ctq
-ceO
-cwx
-cCh
-cuN
-czA
-cAs
-cxO
-cuN
-cCh
-lWL
-lWL
+cuU
+mvE
+cBh
+fqV
+fLD
+cCj
+cCj
+cCj
+cCj
+kYu
+cCj
 lWL
 aCI
 lWL
@@ -72110,7 +73114,7 @@ lWL
 bGt
 bGt
 blR
-bmY
+bZa
 blS
 boP
 bqe
@@ -72143,33 +73147,33 @@ jVQ
 ggT
 aEk
 aCI
-lpc
+xGo
 aCI
 xGo
 aCI
 lpc
 aCI
 akC
-lpc
+aCI
 lpc
 aCI
 akC
 aCI
 aCI
-ceR
-ceR
+cBh
+cBh
 cuX
-ceR
-ceR
-bEH
+cBh
+cBh
+cBg
 czA
-cAt
+cCj
 cBe
-wTO
-cCh
-cCh
-lWL
-lWL
+ccr
+cCj
+ngH
+cCj
+cCj
 aCI
 lWL
 lWL
@@ -72399,8 +73403,8 @@ qst
 kaG
 ggT
 fSx
-afC
-afC
+cEv
+cEv
 bUN
 cgu
 afC
@@ -72417,17 +73421,17 @@ csk
 ctr
 cvj
 cwz
-ceR
-cAl
-cuN
+cCj
+rys
+cRa
+cMQ
 cAu
-cAu
-cuN
-cuN
-cCh
+gEo
+xEt
+kxC
+qxG
+vjx
 lWL
-lWL
-aCI
 lWL
 lWL
 lWL
@@ -72655,35 +73659,35 @@ lki
 oFn
 uxh
 bYP
-bXu
+uxh
 cgs
 apY
 cdG
 ceV
-cgs
+qik
 apY
 ciK
-bXw
+kEh
 wAA
 fUB
 cnS
-bXw
-cpg
+kEh
+mDD
 crb
 csk
-mXT
-svB
+jJX
+cDy
 dSy
-ceR
-ceR
-ceR
-ceR
-cCh
+hKW
+vxm
+vxm
+cCj
+toA
 cCj
 cCj
-cCh
-lWL
-lWL
+waL
+cCj
+cCj
 lWL
 lWL
 lWL
@@ -72908,11 +73912,11 @@ bPj
 bQA
 bMz
 bTc
+mEL
+efU
 bXu
-anG
-fCL
-fCL
 bKo
+bXw
 xqJ
 uCw
 bXw
@@ -72929,17 +73933,17 @@ bXw
 crc
 csk
 mXT
-svB
+cDy
 kIN
 pkd
 dmL
 cyC
-ceR
-cAp
-wlf
-bEH
-cCh
+csp
 lWL
+lWL
+lWL
+lWL
+aCI
 lWL
 lWL
 lWL
@@ -73165,11 +74169,11 @@ bPk
 bQB
 bMz
 bTd
-bXu
-paY
-cpg
-cpg
-cpg
+dFJ
+efU
+caU
+caU
+caU
 caU
 cdH
 cdH
@@ -73180,23 +74184,23 @@ cdH
 cdH
 ceW
 cdH
-cpg
-cpg
+cdH
+cdH
 bXw
-wiv
+sgv
 ske
 gYL
-svB
+cDy
 cwC
 pCp
 dmL
 dmL
-ceR
-cBg
-bEH
-cuN
-cCh
-cCh
+csp
+lWL
+lWL
+lWL
+lWL
+aCI
 lWL
 lWL
 lWL
@@ -73422,12 +74426,12 @@ dWU
 bQC
 bMz
 bTf
-bXu
-paY
-cpg
-cpg
-cpg
+iTr
+efU
 caU
+cpg
+cpg
+cpg
 cpg
 cpg
 caU
@@ -73436,9 +74440,9 @@ caU
 caU
 caU
 caU
+cpg
+cpg
 cdH
-cpg
-cpg
 bXw
 cre
 csk
@@ -73448,12 +74452,12 @@ cwD
 pCp
 cyD
 cyD
-ceR
-cBh
-qPO
-cuN
-cDD
-cCh
+csp
+lWL
+lWL
+lWL
+lWL
+aCI
 lWL
 lWL
 lWL
@@ -73672,30 +74676,30 @@ aNB
 xMx
 bJD
 lCe
-aMv
+cHw
 bMy
 bNO
 bPm
 bQD
 bMz
 nyY
+dFJ
+efU
+gbN
+jUy
 bXu
-paY
-cpg
-cpg
-cpg
-caU
-cpg
-cpg
+lUm
+cDz
+uqV
+qYD
+sHg
 cpg
 cpg
 cpg
 cpg
 cpg
-cpg
+qJx
 cdH
-cpg
-cpg
 bXw
 crf
 csk
@@ -73705,12 +74709,12 @@ kIN
 sRN
 cyE
 bAT
-ceR
-cBi
+csp
+lWL
 cCl
-bEH
-cHo
-cCh
+lWL
+lWL
+aCI
 lWL
 lWL
 lWL
@@ -73929,30 +74933,30 @@ aNB
 xMx
 bJD
 lCe
-bLo
-bMy
+bDr
+cqs
 bNP
 fde
 bQE
-bMz
+afy
 bTg
-oKY
+bMe
 bSm
-whT
-vSi
-vSi
-gea
 caU
+bXu
+spA
+kWX
+dck
+cDz
+dck
 cpg
-bcM
 cpg
-kIz
+cpg
+cpg
 cpg
 cpg
 cpg
 cdH
-cpg
-cpg
 bXw
 crg
 csk
@@ -73962,12 +74966,12 @@ sBq
 csp
 csp
 csp
-ceR
-ceR
-ceR
-ceR
+csp
+cBj
+cBj
+cBj
 rxT
-ceR
+cBj
 lWL
 lWL
 lWL
@@ -74187,29 +75191,29 @@ xMx
 sGt
 lCe
 dZH
-bMy
+cAs
+pTs
+cUV
 bNQ
-fWD
-bQF
-bMz
-vAl
-vAl
-bWf
-gFj
-cHw
-gFj
-raH
-mjZ
-cdJ
-ceY
-cgw
+bNQ
+cAs
+cAs
+cDC
+caU
+lUT
+jUQ
+pGz
+dck
+cDz
+dck
+cpg
+cpg
+cpg
 cpg
 cpg
 cpg
 cpg
 cdH
-cpg
-xDt
 bXw
 crh
 csm
@@ -74226,20 +75230,20 @@ cDa
 cDE
 cBj
 cBj
-lWL
-lWL
-lWL
-lWL
-lWL
-lWL
-lWL
-lWL
-lWL
-lWL
-lWL
-lWL
-lWL
-lWL
+aCI
+vFo
+vFo
+vFo
+vFo
+vFo
+vFo
+vFo
+vFo
+vFo
+vFo
+vFo
+aCI
+vFo
 lWL
 lWL
 lWL
@@ -74444,29 +75448,29 @@ xMx
 bJD
 lCe
 vQy
-bMz
-bMz
-bMz
+cAs
+djU
+mIR
 bQG
-bMz
+mIR
 hZn
-bUL
+hMm
 aOC
-buR
-bjr
-gFj
-ubG
-chE
-chE
-mXu
-chE
-chE
-chE
+caU
+bWc
+bXx
+kWX
+dck
+kWX
+dck
+cpg
+cpg
+cpg
+cpg
+cpg
 cpg
 cpg
 cdH
-bWc
-bXx
 bXw
 cri
 csk
@@ -74483,20 +75487,20 @@ iCh
 cDc
 bYU
 cBj
-aCI
-vFo
-vFo
-vFo
-vFo
-vFo
-vFo
-vFo
-vFo
-aCI
-aCI
-vFo
 lWL
 lWL
+lWL
+lWL
+lWL
+lWL
+lWL
+lWL
+lWL
+lWL
+lWL
+lWL
+lWL
+aCI
 lWL
 lWL
 lWL
@@ -74701,29 +75705,29 @@ xMx
 bJD
 lCe
 bDr
-ayX
-bQH
-bQH
-bQH
-ayX
-bTi
-smC
-tOg
-mIR
-bjr
-gFj
-hTb
+cAs
+lqW
+krK
+bQF
+cdJ
+pxi
+iYt
+xXy
+caU
 cpg
-gll
-gll
-gll
-ciO
-ciO
+bXy
+cDz
+oyI
+cDz
+hXw
+cpg
+cpg
+cpg
+cpg
+cpg
 cpg
 cpg
 cdH
-cpg
-bXy
 bXw
 jXO
 csk
@@ -74740,20 +75744,20 @@ iCh
 cDF
 obk
 cBj
-lWL
-lWL
-lWL
-lWL
-lWL
-lWL
-lWL
-lWL
-lWL
-lWL
-lWL
 aCI
+vFo
+vFo
+vFo
+vFo
+vFo
+vFo
+vFo
+vFo
+vFo
+aCI
+vFo
 lWL
-lWL
+vFo
 lWL
 lWL
 lWL
@@ -74958,34 +75962,34 @@ nig
 czM
 bKt
 bDr
-ayX
-lqW
-rpI
-rpI
+cAs
+oKM
+cyo
+cUk
 bMB
-bTj
-gLd
+adf
+cZP
 xWK
-iYa
-iYa
-jiT
-sVX
-cdH
-cdH
-cdH
-cdH
-cdH
-cdH
-cdH
-cdH
-cdH
+caU
+cpg
+cpg
+nDU
+cpg
+fZn
+qYD
+hpp
+cpg
+cpg
+cpg
+cpg
+cpg
 pqA
-oYN
-bPq
+cdH
+bXw
 cId
 cmx
 vKS
-ltG
+cwK
 cwB
 csp
 cyG
@@ -75010,7 +76014,7 @@ lWL
 lWL
 aCI
 lWL
-lWL
+vFo
 lWL
 lWL
 lWL
@@ -75215,33 +76219,33 @@ xMx
 bJD
 lCe
 bDr
-mgP
-bQH
-rpI
+cAs
+mHu
+krK
 crn
-ayX
-bTk
-cTx
-cvZ
-iYa
-cUk
-kpM
-ekt
-bXw
-cdL
-bXw
-uFd
-bXw
-ciP
-bXw
-uFd
-bXw
-cnV
-bXw
-bXw
+krK
+lFw
+csr
+tOg
+caU
+kkC
+cDz
+cDz
+cDz
+cDz
+cDz
+cDz
+cDz
+cDz
+mww
+oYN
+oYN
+oYN
+rEp
+bPq
 bXq
-csk
-ctL
+jHH
+pqo
 ltG
 cwB
 csp
@@ -75265,9 +76269,9 @@ acV
 acV
 qqK
 lWL
-aCI
+vFo
 lWL
-lWL
+vFo
 lWL
 lWL
 lWL
@@ -75472,31 +76476,31 @@ xMx
 bJD
 lCe
 bDr
-ayX
+cAs
+lSB
+qmO
+vAl
+kKT
+qKU
 bQH
-tIx
-crn
-ayX
-kVa
-ycz
-xWK
-bXD
-huJ
-gFj
-djU
-ccy
-bXw
-ceZ
-cgy
-chJ
-bXw
+cDA
+cql
+cql
+cql
+lzO
+cDz
+jaE
 cpg
-wuA
-cmD
-bXw
-cph
-cqs
-wTP
+cpg
+cpg
+cDz
+cKp
+cJV
+cJV
+cJV
+qCM
+hqM
+jiT
 csk
 mXT
 ltG
@@ -75524,7 +76528,7 @@ pFe
 lWL
 vFo
 lWL
-lWL
+vFo
 lWL
 lWL
 lWL
@@ -75729,31 +76733,31 @@ xMx
 bJD
 lCe
 aMv
-ayX
-cdO
-rpI
-crn
-ayX
-hgI
-hat
-ich
-gFj
-kpM
-gFj
-afC
-bUN
-anh
-bUN
-afC
-bUN
-anh
-bUN
-afC
-bUN
-anh
-bUN
-csk
-csk
+cAs
+iue
+krK
+vAl
+krK
+tDs
+csr
+ntK
+cdH
+cdH
+cdH
+cdH
+cdH
+cdH
+cdH
+cdH
+cdH
+cdH
+cdH
+cdH
+cdH
+cdH
+cdH
+bXw
+wiv
 csk
 ctE
 ltG
@@ -75781,7 +76785,7 @@ qqK
 lWL
 vFo
 lWL
-lWL
+vFo
 lWL
 lWL
 lWL
@@ -75972,7 +76976,7 @@ lWL
 lWL
 lWL
 bGt
-btA
+paY
 btQ
 bxO
 bzg
@@ -75986,32 +76990,32 @@ xMx
 bJD
 lCe
 bLs
-ayX
-bQH
-rpI
-bQK
-ayX
-aCI
-aCI
-cyo
-aCI
-akC
-aCI
-lpc
-aCI
-akC
-aCI
-lpc
-aCI
-akC
-aCI
-lpc
-aCI
-akC
-aCI
-aCI
-aCI
-csp
+cAs
+kpM
+vAl
+vAl
+krK
+cAt
+ubG
+xDt
+bXw
+cdL
+bXw
+uFd
+bXw
+ciP
+bXw
+uFd
+bXw
+cnV
+bXw
+bXw
+bXw
+bXw
+bXw
+bXw
+wiv
+csk
 ctF
 ltG
 cwB
@@ -76038,7 +77042,7 @@ pFe
 lWL
 vFo
 lWL
-lWL
+vFo
 lWL
 lWL
 lWL
@@ -76243,32 +77247,32 @@ xMx
 bJK
 adr
 bLt
-ayX
+cAs
 jxP
 rpI
 bQL
 ayX
-aCI
-bUO
-ijN
-arL
-afI
-bUO
-qxg
-arL
-afI
-bUO
-qxg
-arL
-afI
-bUO
-qxg
-arL
-afI
-bUO
-aCI
-aCI
-csp
+ibE
+csr
+gea
+ccy
+coZ
+ceZ
+cgy
+chJ
+coZ
+whT
+wuA
+cmD
+coZ
+cph
+hTb
+wfI
+fMY
+whT
+wew
+qJU
+csk
 ctG
 ltG
 cwB
@@ -76279,7 +77283,7 @@ seH
 yfJ
 cCt
 pff
-cDK
+vlF
 cvy
 cvy
 cvy
@@ -76295,7 +77299,7 @@ qqK
 lWL
 vFo
 lWL
-lWL
+vFo
 lWL
 lWL
 lWL
@@ -76500,32 +77504,32 @@ uac
 tky
 dIW
 bLg
-ayX
+cAs
+cld
 bQH
-bQH
-bQL
-ayX
-aCI
-bUO
-bWl
-bXF
-bYZ
-bUO
-cba
-ccz
-cdN
-bUO
-cgz
-chK
-ciR
-bUO
-clB
-cmE
-cnX
-bUO
-aCI
-aCI
-csp
+ekt
+csr
+khj
+rQj
+cDK
+aLD
+bTj
+bUN
+afC
+bUN
+anh
+bUN
+afC
+bUN
+anh
+bUN
+bUN
+bUN
+bUN
+bUN
+csk
+jLA
+csk
 ctH
 cvi
 qzx
@@ -76552,7 +77556,7 @@ pFe
 lWL
 vFo
 lWL
-lWL
+vFo
 lWL
 lWL
 lWL
@@ -76757,37 +77761,37 @@ xMx
 bJD
 lCe
 bLo
-ayX
-bQH
-lqW
+cnZ
+yih
+aCI
 bQK
-ayX
 aCI
-bUO
-bWm
-bWn
-bWn
-bUO
-iIU
-ccA
-cbb
-bUO
-cSu
-chL
-cgA
-bUO
-seT
-cmF
-clC
-bUO
+akC
+aCI
+lpc
+aCI
+akC
+aCI
+lpc
+aCI
+akC
+aCI
+lpc
+aCI
+akC
 aCI
 aCI
-csp
+aCI
+aCI
+aCI
+jLA
+cdO
+csk
 ctH
 vmF
 cwI
 cvy
-jXR
+mjZ
 eCI
 emu
 bZU
@@ -76809,7 +77813,7 @@ qqK
 lWL
 vFo
 lWL
-lWL
+vFo
 lWL
 lWL
 lWL
@@ -77014,32 +78018,32 @@ xMx
 xMx
 bzh
 epG
-ayX
-bQH
-bQH
-bQH
-ayX
+cnZ
 aCI
 bUO
-bWn
-bXG
-bWn
+ijN
+arL
+afI
 bUO
-cbb
-ccB
-cbb
+qxg
+arL
+afI
 bUO
-cgB
-chM
-cgA
+qxg
+arL
+afI
 bUO
-clC
-cmG
-clC
+qxg
+arL
+afI
 bUO
 aCI
-aCI
-csp
+lWL
+lWL
+lWL
+csk
+bUG
+csk
 ctJ
 vmF
 cwB
@@ -77066,7 +78070,7 @@ pFe
 lWL
 aCI
 lWL
-lWL
+aCI
 lWL
 lWL
 lWL
@@ -77271,32 +78275,32 @@ xMx
 bJD
 lCe
 hod
-ayX
-bQH
-cdO
-cdO
-ayX
+cnZ
 aCI
 bUO
+bWl
+bXF
+bYZ
 bUO
+cba
+ccz
+cdN
 bUO
+cgz
+chK
+ciR
 bUO
-bUO
-bUO
-bUO
-bUO
-bUO
-bUO
-bUO
-bUO
-bUO
-bUO
-bUO
-bUO
+clB
+cmE
+cnX
 bUO
 aCI
-aCI
-csp
+lWL
+cnZ
+cnZ
+csk
+csk
+csk
 ctK
 lAb
 xPE
@@ -77324,7 +78328,7 @@ cFi
 cFi
 cFi
 cFi
-lWL
+aCI
 lWL
 lWL
 lWL
@@ -77528,31 +78532,31 @@ xMx
 bJD
 lCe
 dZH
-ayX
-bQH
-bQH
-bQH
-ayX
+cnZ
 aCI
+bUO
+bWm
+bWn
+bWn
+bUO
+iIU
+ccA
+cbb
+bUO
+cSu
+chL
+cgA
+bUO
+seT
+cmF
+clC
+bUO
 aCI
-aCI
-aCI
-aCI
-aCI
-aCI
-aCI
-aCI
-aCI
-aCI
-aCI
-aCI
-aCI
-aCI
-aCI
-aCI
-aCI
-aCI
-aCI
+lWL
+cnZ
+bjr
+asK
+huJ
 csp
 ctL
 cvl
@@ -77582,7 +78586,7 @@ mAh
 nMD
 cFi
 lWL
-lWL
+aCI
 lWL
 lWL
 lWL
@@ -77785,33 +78789,33 @@ xMx
 bJD
 lCe
 bDr
-ayX
-lqW
-bQH
-bQH
-ayX
-bUG
-bUG
-bUG
-bUG
-bUG
-bUG
-bUG
-bUG
-bUG
-bUG
-bUG
-bUG
-bUG
-bUG
-bUG
-bUG
+cnZ
+aCI
+bUO
+bWn
+bXG
+bWn
+bUO
+cbb
+ccB
+cbb
+bUO
+cgB
+chM
+cgA
+bUO
+clC
+cmG
+clC
+bUO
+aCI
 cnZ
 cnZ
-cnZ
-cnZ
-csp
-qYD
+bTi
+bNZ
+fWD
+raH
+mXT
 cvl
 cwM
 csp
@@ -77839,7 +78843,7 @@ aZD
 ckR
 cFi
 lWL
-lWL
+aCI
 lWL
 lWL
 lWL
@@ -77966,7 +78970,7 @@ nSg
 amk
 arD
 aoq
-anK
+aoq
 aoq
 aoq
 lsQ
@@ -78042,30 +79046,30 @@ hGr
 bJB
 liM
 xwT
-ayX
-bQH
-bQH
-bQH
-lqW
-bQH
-bUP
-bQH
-bQH
-bQH
-bQH
-bQH
-bQH
-cdO
-bQH
-lqW
-bQH
-bQH
-bQH
-lqW
-bQH
 cnZ
+aCI
+bUO
+bUO
+bUO
+bUO
+bUO
+bUO
+bUO
+bUO
+bUO
+bUO
+bUO
+bUO
+bUO
+bUO
+bUO
+bUO
+bUO
+aCI
+cnZ
+gHX
 lyn
-qJU
+gvh
 uTS
 csq
 jlR
@@ -78096,7 +79100,7 @@ adV
 cGI
 cFi
 lWL
-lWL
+aCI
 lWL
 lWL
 lWL
@@ -78221,8 +79225,8 @@ ajv
 amk
 oLT
 amk
-hOR
-anK
+bUP
+aoq
 aoq
 app
 aoq
@@ -78299,32 +79303,32 @@ ueW
 jPX
 lCe
 bDr
-ayX
-bNX
-cdO
-bQH
-bQH
-bQH
-ayX
-ayX
-ayX
-ayX
-ayX
-lqW
-bQH
-bUP
-ibE
-ayX
-ayX
-ayX
-ayX
-bQH
-bQH
-coa
-hMY
-bNZ
+cnZ
+aCI
+aCI
+aCI
+aCI
+aCI
+aCI
+aCI
+aCI
+aCI
+aCI
+aCI
+aCI
+aCI
+aCI
+aCI
+aCI
+aCI
+aCI
+aCI
+cnZ
+jiL
+lyn
+gvh
 vxX
-csr
+csp
 piM
 msd
 fVM
@@ -78353,7 +79357,7 @@ cBr
 cBr
 cFi
 lWL
-lWL
+aCI
 lWL
 lWL
 lWL
@@ -78557,29 +79561,29 @@ iHC
 lCe
 bDr
 bMC
-ayX
-ayX
-ayX
-ayX
-ayX
-ayX
-bWo
-bXH
-bZa
-ayX
-ayX
-ayX
-ayX
-ayX
-ayX
-chN
-ciS
-ayX
-ayX
-ayX
+cnZ
+cnZ
+cnZ
+cnZ
+cnZ
+cnZ
+cnZ
+cnZ
+cnZ
+cnZ
+cnZ
+cnZ
+cnZ
+cnZ
+cnZ
+cnZ
+cnZ
+cnZ
+cnZ
+cnZ
 cnZ
 suC
-bNZ
+gvh
 gIQ
 csp
 csp
@@ -78610,7 +79614,7 @@ ckR
 ckR
 cFi
 lWL
-lWL
+aCI
 lWL
 lWL
 lWL
@@ -78820,9 +79824,9 @@ xXn
 xId
 xXn
 xXn
-xXn
-xXn
-xXn
+bNX
+ciO
+wTP
 xXn
 pBj
 xId
@@ -78867,7 +79871,7 @@ ckR
 tPz
 cFi
 lWL
-lWL
+aCI
 lWL
 lWL
 lWL
@@ -79124,7 +80128,7 @@ mnk
 pYG
 cFi
 lWL
-lWL
+aCI
 lWL
 lWL
 lWL
@@ -79249,8 +80253,8 @@ ajz
 bNa
 amk
 amk
-hOR
-anK
+bUP
+aoq
 aoq
 apt
 aoq
@@ -79345,7 +80349,7 @@ msO
 msO
 msO
 aAw
-msO
+hsq
 ubO
 cmH
 vOn
@@ -79381,7 +80385,7 @@ ckR
 nCQ
 cFi
 lWL
-lWL
+aCI
 lWL
 lWL
 lWL
@@ -79508,7 +80512,7 @@ amk
 amk
 hOR
 aoq
-anK
+aoq
 aoq
 aoq
 bbq
@@ -79638,7 +80642,7 @@ ckR
 ckR
 cFi
 lWL
-lWL
+aCI
 lWL
 lWL
 lWL
@@ -79765,7 +80769,7 @@ oiC
 xOQ
 hTP
 bak
-aCI
+anG
 aCI
 aCI
 bbq
@@ -79895,7 +80899,7 @@ ocI
 dfy
 cFi
 lWL
-lWL
+aCI
 lWL
 lWL
 lWL
@@ -80152,7 +81156,7 @@ adV
 cGI
 cFi
 lWL
-lWL
+aCI
 lWL
 lWL
 lWL
@@ -80274,7 +81278,7 @@ bLH
 bLH
 bhO
 bLH
-afy
+tva
 alx
 bak
 anc
@@ -80396,7 +81400,7 @@ cEB
 cEB
 xvx
 cHE
-cHE
+lzl
 cBu
 eIN
 cHL
@@ -80409,7 +81413,7 @@ ckR
 ckR
 cFi
 lWL
-lWL
+aCI
 lWL
 lWL
 lWL
@@ -80524,7 +81528,7 @@ bdO
 adM
 oUH
 djZ
-tva
+hMY
 bLH
 bLH
 bhO
@@ -80650,11 +81654,11 @@ cCF
 gbT
 jwA
 txQ
+rke
 txQ
 txQ
 txQ
-txQ
-txQ
+bCA
 txQ
 jwA
 txQ
@@ -80666,7 +81670,7 @@ ofb
 spB
 cFi
 lWL
-lWL
+aCI
 lWL
 lWL
 lWL
@@ -80907,11 +81911,11 @@ cFi
 wrZ
 cFi
 cFi
-cFi
-cFi
-cFi
-cFi
-cFi
+mkK
+cHb
+cHb
+cHb
+mkK
 cFi
 cFi
 cFi
@@ -80923,7 +81927,7 @@ cFi
 cFi
 cFi
 lWL
-lWL
+aCI
 lWL
 lWL
 lWL
@@ -81114,11 +82118,11 @@ bwt
 bua
 bvg
 bwz
-bzi
+ciS
 bzz
 bBh
 bCF
-bzi
+bXH
 bzi
 bwt
 bHP
@@ -81163,13 +82167,13 @@ seH
 cxY
 mPs
 cDX
-cxe
-cxe
-cvy
-lWL
-aCI
-lWL
-lWL
+vXG
+vwu
+mBj
+xsQ
+xsQ
+vwu
+cFi
 lWL
 lWL
 qDQ
@@ -81180,7 +82184,7 @@ lWL
 lWL
 lWL
 lWL
-lWL
+aCI
 lWL
 lWL
 lWL
@@ -81419,25 +82423,25 @@ xKi
 chH
 chH
 vpY
-myP
+szS
 uXX
-cHP
+kUP
 cxU
+vwu
+vwu
+vwu
+cFi
 lWL
 aCI
-lWL
-lWL
-lWL
-lWL
-lWL
-lWL
-lWL
-lWL
-lWL
-lWL
-lWL
-lWL
-lWL
+aCI
+aCI
+aCI
+aCI
+aCI
+aCI
+aCI
+aCI
+aCI
 lWL
 lWL
 lWL
@@ -81674,18 +82678,18 @@ cEM
 faS
 mDF
 amb
-cAB
+wus
 xKi
 nYr
-cxe
+vXG
 cFk
-cvy
+gyj
+cDB
+iHz
+ukL
+cFi
 lWL
 aCI
-lWL
-lWL
-lWL
-lWL
 lWL
 lWL
 lWL
@@ -81934,15 +82938,15 @@ cku
 cAB
 xKi
 cEa
-cxe
-cvy
-cvy
+vXG
+cFi
+cFi
+cFi
+cFi
+cFi
+cFi
 lWL
 aCI
-lWL
-lWL
-lWL
-lWL
 lWL
 lWL
 lWL
@@ -82195,11 +83199,11 @@ cEH
 cvy
 lWL
 lWL
+lWL
+lWL
+lWL
+lWL
 aCI
-lWL
-lWL
-lWL
-lWL
 lWL
 lWL
 lWL
@@ -82453,10 +83457,10 @@ cvy
 lWL
 aCI
 aCI
-lWL
-lWL
-lWL
-lWL
+aCI
+aCI
+aCI
+aCI
 lWL
 lWL
 lWL
@@ -87479,7 +88483,7 @@ vYD
 lWL
 pYa
 abT
-lWL
+kIz
 lWL
 lWL
 lWL
@@ -88235,7 +89239,7 @@ lWL
 adQ
 afb
 eUQ
-cVj
+cvZ
 bNi
 cfu
 vVh
@@ -88251,7 +89255,7 @@ ajB
 fzf
 abT
 lWL
-asK
+ajB
 atH
 ajB
 lWL
@@ -88762,8 +89766,8 @@ bXE
 apx
 amm
 apx
-bjA
-abT
+vVh
+chN
 arN
 ajB
 atJ
@@ -89096,7 +90100,7 @@ bLD
 bMP
 bOq
 bRA
-bLB
+fCL
 bSl
 bTJ
 bVi
@@ -89533,7 +90537,7 @@ cpf
 cVj
 bNi
 wkS
-bNi
+gRk
 gWZ
 tII
 eUQ
@@ -89869,7 +90873,7 @@ bOt
 bPI
 dcm
 bMP
-bTJ
+mXu
 bTJ
 oLS
 bYc
@@ -90066,7 +91070,7 @@ dFe
 uAa
 cUG
 uAa
-vDV
+bWf
 bwM
 gNn
 vVh
@@ -90094,11 +91098,11 @@ aIL
 aIL
 aIL
 wqU
-aIL
+bUL
 leb
 exz
 biY
-aIL
+bUL
 aIL
 aIL
 adj
@@ -90608,11 +91612,11 @@ aIL
 aIL
 aIL
 aIL
-aIL
+bUL
 bkl
 exz
 bkl
-wqU
+gnj
 aIL
 aIL
 bpl
@@ -91105,7 +92109,7 @@ qbm
 rwd
 bsV
 bsV
-bsV
+hgI
 bsV
 bsV
 bsV
@@ -91123,7 +92127,7 @@ bdv
 bey
 lIk
 fem
-gnj
+fem
 uSP
 fpk
 fem
@@ -92167,7 +93171,7 @@ ani
 dqX
 bym
 aLi
-ydt
+iYa
 ydt
 qLg
 apx
@@ -92388,7 +93392,7 @@ voD
 voD
 voD
 rpj
-agN
+tJc
 aNC
 aHT
 aOs
@@ -95699,7 +96703,7 @@ waD
 amJ
 eow
 alW
-aUZ
+coa
 fdj
 jcM
 arf
@@ -97283,7 +98287,7 @@ cux
 aUY
 sjk
 pYa
-aYW
+aUX
 bah
 bag
 bcB
@@ -97498,7 +98502,7 @@ aeG
 aeG
 aeG
 aik
-hnk
+tIx
 apJ
 aoi
 aqb
@@ -97510,7 +98514,7 @@ jqM
 jqM
 gaP
 ayW
-blZ
+qZy
 blZ
 xof
 aoH
@@ -100349,7 +101353,7 @@ sZd
 aEW
 aFJ
 aGG
-aHu
+bXD
 aIm
 aJn
 aKG
@@ -100609,7 +101613,7 @@ aEV
 aHt
 aIn
 aJo
-aHu
+bXD
 aLC
 aIo
 lWL
@@ -100620,7 +101624,7 @@ lWL
 sjk
 bao
 sjk
-mcq
+sjk
 sjk
 sjk
 bbq
@@ -100863,11 +101867,11 @@ sZd
 bfl
 aFL
 aEV
-bqw
+cTx
 aHu
 aJp
 aHt
-aLC
+ycz
 aIo
 aCI
 aCI
@@ -100877,8 +101881,8 @@ aCI
 sjk
 bao
 sjk
-fcs
-sjk
+pYa
+pYa
 aCI
 aCI
 lWL
@@ -101124,7 +102128,7 @@ aEV
 bqw
 aJq
 aKI
-aLD
+aEV
 aEV
 lWL
 lWL

--- a/StationMaps/DiscStation/DiscStation.dmm
+++ b/StationMaps/DiscStation/DiscStation.dmm
@@ -293,17 +293,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
 "adf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 8
+	},
 /obj/machinery/meter,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/mix)
 "adh" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/construction)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/construction/mining/aux_base)
 "adi" = (
 /obj/effect/landmark/start/ai/secondary,
 /obj/item/radio/intercom/directional/north{
@@ -941,8 +941,8 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "afC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "afE" = (
@@ -957,7 +957,9 @@
 /obj/machinery/meter{
 	name = "Mixed Air Tank Out"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "afK" = (
@@ -1629,6 +1631,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
+"akg" = (
+/obj/structure/chair/stool/directional/north,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/carpet/red,
+/area/station/commons/dorms)
 "akh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -1691,7 +1698,9 @@
 /area/station/hallway/secondary/entry)
 "akC" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
 /turf/open/space/basic,
 /area/space/nearstation)
 "akG" = (
@@ -2137,8 +2146,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "anh" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "ani" = (
@@ -2228,9 +2239,10 @@
 /obj/machinery/door/airlock/hatch{
 	name = "Teleporter Room"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "anM" = (
@@ -2742,10 +2754,11 @@
 /area/station/maintenance/department/science)
 "aqc" = (
 /obj/machinery/door/airlock/hatch,
-/obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
+/obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "aqd" = (
@@ -3368,6 +3381,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/white/textured,
 /area/station/science/research)
 "asS" = (
@@ -3760,6 +3774,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/white/textured,
 /area/station/science/research)
 "auC" = (
@@ -4234,10 +4249,7 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/glass/reinforced,
 /area/station/hallway/primary/starboard)
 "awM" = (
 /obj/machinery/door/airlock/maintenance,
@@ -4543,22 +4555,32 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "ayo" = (
-/turf/closed/wall,
-/area/station/construction)
-"ayp" = (
-/obj/machinery/door/airlock{
-	name = "Starboard Emergency Storage"
-	},
-/turf/open/floor/plating,
-/area/station/hallway/primary/starboard)
-"ayq" = (
-/obj/machinery/light/directional/west,
-/obj/structure/window,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"ayp" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
+"ayq" = (
+/obj/structure/table,
+/obj/item/stack/sheet/plasteel{
+	amount = 10
+	},
+/obj/item/stack/rods/fifty,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/obj/item/storage/box/lights/mixed,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/construction/mining/aux_base)
 "ays" = (
 /obj/machinery/computer/department_orders/security{
 	dir = 1
@@ -4715,21 +4737,25 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/mix)
 "ayY" = (
-/turf/open/floor/iron,
-/area/station/construction)
-"azb" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-07";
-	name = "Photosynthetic Potted plant"
+/obj/machinery/door/airlock/external{
+	name = "Construction Zone"
 	},
-/turf/open/floor/grass,
-/area/station/hallway/primary/starboard)
+/obj/effect/mapping_helpers/airlock/access/all/engineering/aux_base,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/construction/mining/aux_base)
+"azb" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/shrink_ccw,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "azc" = (
-/obj/structure/window{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/status_display/evac/directional/west,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "azd" = (
@@ -4822,14 +4848,17 @@
 /area/space/nearstation)
 "azC" = (
 /obj/structure/closet/emcloset,
-/obj/item/storage/toolbox/mechanical,
 /obj/effect/landmark/start/hangover/closet,
+/obj/item/storage/toolbox/mechanical,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "azD" = (
 /obj/machinery/airalarm/directional/west,
-/obj/item/kirbyplants/photosynthetic,
-/turf/open/floor/grass,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "azF" = (
 /obj/machinery/light/small/directional/west,
@@ -5005,13 +5034,17 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
 "aAq" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-07";
-	name = "Photosynthetic Potted plant";
-	pixel_y = 10
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/grass,
-/area/station/hallway/primary/starboard)
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/hallway)
 "aAr" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/siding/purple{
@@ -5492,9 +5525,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "aCk" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	id = "aux_base_shutters";
+	name = "Auxiliary Base Shutters"
+	},
 /turf/open/floor/plating,
-/area/station/construction)
+/area/station/construction/mining/aux_base)
 "aCm" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/rd)
@@ -5592,15 +5628,18 @@
 /area/station/maintenance/port/fore)
 "aCS" = (
 /obj/machinery/door/airlock/engineering{
-	name = "Construction Area"
+	name = "Auxiliary Base Construction"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/station/construction)
+/obj/effect/mapping_helpers/airlock/access/all/engineering/aux_base,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/construction/mining/aux_base)
 "aCW" = (
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 8
@@ -5633,7 +5672,6 @@
 /obj/item/stack/sheet/iron{
 	amount = 34
 	},
-/obj/machinery/light/directional/north,
 /obj/machinery/camera/directional/north{
 	c_tag = "Research Storage";
 	network = list("ss13","rd")
@@ -6242,24 +6280,19 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "aFl" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/station/construction)
-"aFn" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/construction)
-"aFq" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/station/construction)
+/area/station/engineering/storage/tech)
+"aFn" = (
+/obj/structure/chair/comfy/beige,
+/turf/open/floor/carpet,
+/area/station/hallway/secondary/entry)
+"aFq" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/construction/mining/aux_base)
 "aFr" = (
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
@@ -6544,19 +6577,28 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "aGm" = (
-/obj/structure/closet/crate,
-/obj/item/stack/sheet/plasteel/fifty,
-/turf/open/floor/plating,
-/area/station/construction)
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/light/directional/west,
+/obj/machinery/status_display/evac/directional/west,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "aGn" = (
-/obj/structure/closet/crate,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/turf/open/floor/plating,
-/area/station/construction)
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "aGo" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/construction)
+/area/station/engineering/atmos)
 "aGp" = (
 /obj/structure/chair{
 	name = "Judge"
@@ -6792,12 +6834,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "aGZ" = (
-/obj/structure/closet/crate,
-/obj/item/stack/sheet/glass{
-	amount = 10
-	},
-/turf/open/floor/plating,
-/area/station/construction)
+/turf/closed/wall,
+/area/station/construction/mining/aux_base)
 "aHa" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
@@ -7005,15 +7043,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "aHN" = (
-/obj/machinery/camera/autoname/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/obj/effect/turf_decal/trimline/dark_blue/corner,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "aHO" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -7366,17 +7398,10 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "aIR" = (
-/obj/machinery/door/airlock/hatch,
-/obj/effect/mapping_helpers/airlock/access/any/command/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "construction-maint-pass"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/construction)
+/obj/structure/chair/comfy/beige,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "aIU" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "robotics";
@@ -7680,40 +7705,24 @@
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "aKl" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/item/kirbyplants{
+	icon_state = "plant-13"
 	},
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "construction-maint-pass"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/construction)
+/turf/open/floor/glass/reinforced,
+/area/station/hallway/primary/starboard)
 "aKm" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
+/obj/effect/turf_decal/trimline/dark_blue/corner{
 	dir = 1
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/construction)
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "aKn" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
-/area/station/construction)
+/area/station/hallway/primary/starboard)
 "aKr" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/right/directional/east{
@@ -8605,6 +8614,7 @@
 /obj/structure/chair/sofa/bench{
 	dir = 4
 	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "aNM" = (
@@ -8769,7 +8779,9 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 9
+	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -10886,6 +10898,7 @@
 "aWY" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_blue/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "aXa" = (
@@ -11391,10 +11404,7 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "aZG" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Command Bridge"
-	},
-/obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/effect/turf_decal/trimline/dark_blue/line,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "aZI" = (
@@ -11907,7 +11917,7 @@
 /area/station/maintenance/port)
 "bcb" = (
 /obj/machinery/vending/cigarette,
-/obj/effect/turf_decal/tile/dark_blue{
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -12182,7 +12192,7 @@
 /area/station/command/bridge)
 "bdj" = (
 /obj/machinery/vending/medical,
-/obj/effect/turf_decal/tile/dark_blue{
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -12495,12 +12505,7 @@
 /area/station/command/bridge)
 "beq" = (
 /obj/machinery/vending/boozeomat,
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 4
-	},
+/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "bes" = (
@@ -12686,9 +12691,7 @@
 /obj/machinery/camera/directional/west{
 	c_tag = "AI Upload Exterior"
 	},
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "bff" = (
@@ -12911,9 +12914,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "bgg" = (
@@ -13056,10 +13057,10 @@
 /area/station/ai_monitored/command/storage/eva)
 "bgY" = (
 /obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/dark_blue{
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "bhb" = (
 /obj/machinery/door/firedoor,
@@ -13329,10 +13330,10 @@
 /obj/machinery/camera/directional/west{
 	c_tag = "Command North"
 	},
-/obj/effect/turf_decal/tile/dark_blue{
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "biB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -14735,17 +14736,10 @@
 /turf/open/floor/plating,
 /area/station/cargo/storage)
 "boB" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Bridge"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "bridge"
-	},
-/obj/effect/landmark/navigate_destination/bridge,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "boC" = (
 /obj/structure/chair{
@@ -15375,10 +15369,10 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "bri" = (
-/obj/effect/turf_decal/tile/dark_blue{
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "brj" = (
 /obj/machinery/door/firedoor,
@@ -15717,10 +15711,10 @@
 /obj/machinery/camera/directional/west{
 	c_tag = "Command South"
 	},
-/obj/effect/turf_decal/tile/dark_blue{
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "bsx" = (
 /obj/item/food/deadmouse,
@@ -16081,7 +16075,8 @@
 "bue" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "buf" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -16802,13 +16797,10 @@
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "bxu" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/station/engineering/atmos)
 "bxw" = (
 /obj/structure/filingcabinet,
 /obj/machinery/light/small/directional/north,
@@ -16953,10 +16945,10 @@
 "bxV" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/effect/turf_decal/tile/dark_blue{
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "bxX" = (
 /obj/item/paper_bin{
@@ -17333,12 +17325,11 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "bzt" = (
-/obj/machinery/airalarm/directional/east,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/dark_blue{
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "bzu" = (
 /obj/machinery/recharger,
@@ -17744,18 +17735,13 @@
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/captain/private)
 "bBe" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Bridge"
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "bridge"
-	},
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 8
-	},
+/obj/structure/table/wood,
+/obj/effect/spawner/random/entertainment/lighter,
 /turf/open/floor/iron,
-/area/station/hallway/secondary/command)
+/area/station/hallway/primary/starboard)
 "bBf" = (
 /obj/item/hand_labeler,
 /obj/item/assembly/timer,
@@ -18155,11 +18141,8 @@
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
 "bCz" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "bCA" = (
 /obj/effect/turf_decal/stripes/line{
@@ -18462,6 +18445,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/hop)
+"bDR" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/mix)
 "bDT" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor{
@@ -19411,6 +19399,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bHP" = (
@@ -20012,6 +20001,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bLf" = (
@@ -20080,6 +20070,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bLt" = (
@@ -20701,8 +20692,10 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow/diagonal_centre,
 /obj/machinery/newscaster/directional/west,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "bNZ" = (
@@ -21354,7 +21347,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/mix)
 "bQG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 8
+	},
 /obj/machinery/meter/monitored/waste_loop,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -21363,8 +21358,8 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/mix)
 "bQH" = (
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible,
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/mix)
 "bQJ" = (
@@ -21376,7 +21371,9 @@
 /area/station/hallway/primary/central)
 "bQK" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
+	dir = 4
+	},
 /turf/open/space/basic,
 /area/space/nearstation)
 "bQL" = (
@@ -21495,7 +21492,6 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "bRn" = (
-/obj/effect/landmark/start/assistant,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
 /turf/open/floor/iron,
@@ -21681,7 +21677,9 @@
 /turf/open/floor/iron,
 /area/station/service/theater)
 "bSm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -21922,8 +21920,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "bTj" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/plating/airless,
 /area/station/engineering/atmos)
 "bTm" = (
@@ -22696,13 +22696,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bWf" = (
-/obj/structure/sign/poster/official/random/directional/west,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/camera/autoname/directional/west,
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible,
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/engineering/atmos/mix)
 "bWg" = (
 /obj/machinery/newscaster/directional/east,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
@@ -23054,11 +23050,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "bXu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bXw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bXx" = (
@@ -23262,6 +23260,7 @@
 /obj/effect/turf_decal/tile/green/anticorner/contrasted{
 	dir = 4
 	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "bYw" = (
@@ -23466,6 +23465,14 @@
 /obj/structure/dresser,
 /turf/open/floor/iron/checker,
 /area/station/service/theater)
+"bZv" = (
+/obj/machinery/computer/shuttle/mining{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron,
+/area/station/construction/mining/aux_base)
 "bZx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -23780,7 +23787,9 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "caH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -23873,7 +23882,9 @@
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
 "caU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "caZ" = (
@@ -24600,7 +24611,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cdH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cdI" = (
@@ -24626,6 +24637,7 @@
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
 "cdO" = (
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "cdP" = (
@@ -25048,10 +25060,11 @@
 /turf/open/floor/engine/air,
 /area/station/engineering/atmos)
 "ceV" = (
-/obj/machinery/light/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -25063,9 +25076,8 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ceZ" = (
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -25396,15 +25408,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "cgs" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cgu" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "cgv" = (
@@ -25412,9 +25423,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "cgy" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Atmospherics East"
-	},
 /obj/machinery/atmospherics/components/binary/pump/off{
 	dir = 8;
 	name = "Plasma To Pure"
@@ -25452,6 +25460,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/commons/dorms)
+"cgF" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/construction/mining/aux_base)
 "cgH" = (
 /obj/effect/spawner/random/entertainment/arcade,
 /turf/open/floor/carpet/red,
@@ -25945,9 +25962,8 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow/diagonal_centre,
-/obj/machinery/vending/assist,
 /obj/machinery/status_display/evac/directional/west,
+/obj/machinery/vending/coffee,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "ciP" = (
@@ -26409,6 +26425,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "ckN" = (
@@ -26476,7 +26493,8 @@
 /obj/machinery/atmospherics/pipe/color_adapter{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/station/engineering/atmos/mix)
 "clh" = (
 /obj/machinery/door/firedoor,
@@ -26490,14 +26508,15 @@
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "cli" = (
-/obj/structure/window{
+/obj/machinery/computer/camera_advanced/base_construction/aux{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/construction/mining/aux_base)
 "clj" = (
 /turf/open/floor/iron,
 /area/station/security/prison)
@@ -26817,6 +26836,7 @@
 /area/station/engineering/storage/tech)
 "cmO" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
 "cmP" = (
@@ -27130,6 +27150,7 @@
 	name = "Secure Tech Storage"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
 "coj" = (
@@ -27326,7 +27347,9 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "coZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
@@ -27371,13 +27394,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cph" = (
-/obj/machinery/light/directional/east,
-/obj/machinery/space_heater,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/hallway/secondary/command)
 "cpn" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -27650,6 +27672,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
+"cqi" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/camera/autoname/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "cqj" = (
 /obj/machinery/flasher/portable,
 /obj/machinery/flasher/portable,
@@ -27660,7 +27689,7 @@
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
 "cql" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cqn" = (
@@ -27855,7 +27884,9 @@
 /obj/machinery/light/directional/west,
 /obj/item/multitool,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "crf" = (
@@ -27866,7 +27897,9 @@
 /obj/item/t_scanner,
 /obj/item/t_scanner,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "crg" = (
@@ -27879,19 +27912,25 @@
 	},
 /obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "crh" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cri" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -27977,6 +28016,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "crB" = (
@@ -28877,7 +28917,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine/atmos)
@@ -28895,7 +28937,9 @@
 /obj/machinery/door/airlock/glass{
 	name = "Atmospherics Corridor"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine/atmos)
 "cve" = (
@@ -28917,7 +28961,9 @@
 /turf/open/floor/iron/white,
 /area/station/commons/dorms)
 "cvi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -28936,7 +28982,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "cvl" = (
@@ -29234,15 +29282,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "cwC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
-/area/station/engineering/hallway)
+/area/station/engineering/atmos/mix)
 "cwD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -29322,6 +29366,7 @@
 /area/station/security/checkpoint/engineering)
 "cwT" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)
 "cwU" = (
@@ -29560,7 +29605,7 @@
 	name = "Engine Room"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
@@ -29579,6 +29624,7 @@
 /area/station/engineering/supermatter/room)
 "cxV" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/checkpoint/engineering)
 "cxW" = (
@@ -30069,7 +30115,9 @@
 /turf/open/floor/iron/checker,
 /area/station/service/theater)
 "cAp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/all_access{
 	pixel_y = 24;
@@ -30098,13 +30146,17 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos/mix)
 "cAt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
+	dir = 8
+	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/mix)
 "cAu" = (
 /obj/machinery/air_sensor/incinerator_tank,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 9
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
@@ -30235,7 +30287,9 @@
 	pixel_x = -8;
 	pixel_y = -40
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
@@ -30291,7 +30345,7 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "cBt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
@@ -30301,7 +30355,9 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "cBv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -30564,7 +30620,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
 "cCO" = (
@@ -30704,7 +30760,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "cDz" = (
@@ -30712,7 +30770,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cDA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
@@ -30727,7 +30785,9 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
 /obj/structure/cable,
 /obj/structure/fireaxecabinet/directional/north,
 /turf/open/floor/iron,
@@ -30800,8 +30860,10 @@
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/ce)
 "cDK" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /turf/open/floor/plating/airless,
 /area/station/engineering/atmos)
 "cDN" = (
@@ -30869,7 +30931,7 @@
 /turf/open/space/basic,
 /area/station/maintenance/solars/port/aft)
 "cEv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
@@ -31099,6 +31161,11 @@
 "cFE" = (
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"cFF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/dark_blue/warning,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "cFH" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -31334,10 +31401,11 @@
 /turf/open/floor/iron/solarpanel/airless,
 /area/station/solars/port/aft)
 "cHn" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/light/small/directional/east,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 9
+	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/engineering/atmos)
 "cHo" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating,
@@ -31411,11 +31479,12 @@
 /area/station/maintenance/department/bridge)
 "cHy" = (
 /obj/machinery/door/airlock/hatch,
-/obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/command/minisat,
+/obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "cHz" = (
@@ -31469,7 +31538,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -31494,7 +31565,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "cJV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cKb" = (
@@ -31587,7 +31658,7 @@
 	cycle_id = "incinerator"
 	},
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
@@ -31645,6 +31716,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"cPQ" = (
+/obj/machinery/camera/autoname/directional/east,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "cQM" = (
 /obj/structure/sign/poster/official/random/directional/west,
 /obj/effect/turf_decal/tile/blue{
@@ -31653,7 +31731,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "cRa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos{
 	dir = 4
@@ -31665,11 +31743,8 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "cRn" = (
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/item/cigbutt,
+/turf/open/floor/glass/reinforced,
 /area/station/hallway/primary/starboard)
 "cRs" = (
 /obj/effect/turf_decal/delivery,
@@ -31694,6 +31769,12 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
+"cSN" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos/mix)
 "cTq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31776,6 +31857,7 @@
 /area/station/medical/medbay/central)
 "cXe" = (
 /obj/structure/sign/departments/engineering/directional/west,
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "cXV" = (
@@ -31792,9 +31874,16 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"cZv" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/carpet,
+/area/station/service/theater)
 "cZP" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/mix)
 "cZZ" = (
@@ -31859,6 +31948,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"ddV" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "ddW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31968,7 +32063,9 @@
 /area/station/hallway/primary/central)
 "djU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 1
+	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
@@ -32016,10 +32113,17 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/service/lawoffice)
+"dlN" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "dlY" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "dlZ" = (
 /obj/structure/chair{
 	dir = 4
@@ -32071,7 +32175,10 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "doy" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -32128,9 +32235,7 @@
 /area/station/service/chapel)
 "dqV" = (
 /obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/drinks/shaker{
-	pixel_y = 0
-	},
+/obj/item/reagent_containers/food/drinks/shaker,
 /obj/item/book/manual/wiki/barman_recipes{
 	pixel_y = 5;
 	pixel_x = 14
@@ -32337,10 +32442,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "dFe" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/door/firedoor,
+/obj/structure/sign/poster/official/random/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "dFl" = (
@@ -32595,6 +32700,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/janitor)
+"dWW" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
+/turf/open/floor/plating,
+/area/station/hallway/primary/starboard)
 "dXf" = (
 /obj/machinery/ntnet_relay,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -32727,9 +32843,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/bridge)
 "efU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -32751,6 +32869,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
+"eiO" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "eiQ" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/west,
@@ -32773,7 +32897,9 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "ekt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
+	dir = 4
+	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/mix)
@@ -33103,7 +33229,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "eCI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -33356,10 +33484,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "eRV" = (
-/obj/structure/closet/firecloset,
-/obj/effect/landmark/start/hangover/closet,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/engineering/atmos)
 "eSg" = (
 /obj/effect/turf_decal/tile/green/anticorner/contrasted{
 	dir = 1
@@ -33367,10 +33494,16 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "eSj" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/open/floor/plating,
-/area/station/construction)
+/area/station/hallway/primary/starboard)
 "eSl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33420,6 +33553,19 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"eTA" = (
+/obj/docking_port/stationary{
+	dheight = 4;
+	dwidth = 4;
+	height = 9;
+	id = "aux_base_zone";
+	name = "Aux Base Zone";
+	roundstart_template = /datum/map_template/shuttle/aux_base/default;
+	width = 9;
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/construction/mining/aux_base)
 "eUD" = (
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/white,
@@ -33652,7 +33798,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/door/firedoor,
+/obj/structure/window{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "feO" = (
@@ -33809,6 +33957,16 @@
 /obj/structure/marker_beacon/cerulean,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"fnw" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/holopad,
+/turf/open/floor/iron,
+/area/station/construction/mining/aux_base)
 "fob" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -33897,21 +34055,29 @@
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "fqV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/warning/fire/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
+"fqX" = (
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos/mix)
 "frA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/dark_blue{
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "frV" = (
 /turf/closed/wall/r_wall,
@@ -33948,7 +34114,9 @@
 /area/station/maintenance/department/bridge)
 "fux" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 5
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -33992,6 +34160,9 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"fyF" = (
+/turf/open/floor/glass/reinforced,
+/area/station/hallway/primary/starboard)
 "fzd" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
@@ -34007,7 +34178,7 @@
 /obj/item/storage/secure/safe/caps_spare/directional/west{
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/tile/dark_blue{
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -34038,13 +34209,8 @@
 /turf/open/floor/iron/dark,
 /area/station/service/theater)
 "fDb" = (
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 4
-	},
 /obj/structure/sign/departments/aiupload/directional/west,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "fEr" = (
@@ -34272,21 +34438,37 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "fSx" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "fST" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/dark_blue{
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/machinery/button/door/directional/south{
+	id = "bridgedoors";
+	name = "Bridge Access Blast Doors";
+	pixel_x = 24;
+	req_access = list("command");
+	pixel_y = 0
+	},
+/turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "fTf" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
+"fUk" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/obj/structure/closet/toolcloset,
+/turf/open/floor/iron,
+/area/station/construction/mining/aux_base)
 "fUB" = (
 /obj/machinery/atmospherics/components/binary/pump/off{
 	dir = 4;
@@ -34319,6 +34501,13 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"fWL" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/wood,
+/area/station/service/cafeteria)
 "fXy" = (
 /obj/structure/sign/poster/official/random/directional/north,
 /obj/effect/turf_decal/tile/neutral{
@@ -34375,6 +34564,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"gbp" = (
+/obj/structure/closet/firecloset,
+/obj/effect/landmark/start/hangover/closet,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "gbt" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34462,7 +34657,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "gev" = (
@@ -34597,6 +34792,11 @@
 /obj/effect/spawner/random/structure/table_or_rack,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"gnA" = (
+/obj/structure/chair/wood,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/wood,
+/area/station/service/cafeteria)
 "gnB" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay"
@@ -34747,6 +34947,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"guT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "gvh" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -34861,6 +35068,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"gAk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "gAq" = (
 /obj/structure/closet/secure_closet/medical2,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
@@ -34934,6 +35147,14 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
+"gFd" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/vending/cigarette,
+/obj/structure/sign/clock/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "gFj" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -35022,10 +35243,10 @@
 /area/station/maintenance/department/medical)
 "gNn" = (
 /obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "gNN" = (
@@ -35214,6 +35435,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"gUs" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_blue,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "gUX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35232,6 +35458,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"gVE" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "gWj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35261,7 +35491,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "hat" = (
@@ -35271,7 +35501,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/blobstart,
 /turf/open/floor/iron,
@@ -35316,6 +35548,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
+"hdU" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "hdY" = (
 /obj/structure/sign/painting/library{
 	pixel_y = 32
@@ -35350,6 +35588,12 @@
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
+"hfO" = (
+/obj/effect/turf_decal/trimline/dark_blue/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "hgf" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -35379,7 +35623,7 @@
 /area/station/commons/fitness/recreation)
 "hhB" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -35394,6 +35638,12 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"hiX" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "hjc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -35697,6 +35947,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"hBT" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "hDb" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -35735,6 +35989,16 @@
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/station/maintenance/department/bridge)
+"hFW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "hGr" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -35751,7 +36015,9 @@
 /area/station/security/execution/transfer)
 "hHE" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 5
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35783,6 +36049,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
+"hJq" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "hKi" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L14"
@@ -35802,9 +36074,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
+"hMh" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "hMm" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/mix)
 "hMP" = (
@@ -35817,11 +36094,11 @@
 /area/station/maintenance/port/aft)
 "hMY" = (
 /obj/machinery/door/airlock/maintenance_hatch,
-/obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "hNu" = (
@@ -35913,11 +36190,11 @@
 /area/station/hallway/primary/central)
 "hTE" = (
 /obj/machinery/door/airlock/maintenance_hatch,
-/obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/satellite)
 "hTP" = (
@@ -35958,6 +36235,11 @@
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
+"hXh" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "hXw" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
 	dir = 1
@@ -35968,6 +36250,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
+"hYn" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/button/door/directional/west{
+	id = "construction";
+	name = "Auxiliary Construction Shutters";
+	req_access = list("aux_base");
+	pixel_x = 24
+	},
+/turf/open/floor/iron,
+/area/station/construction/mining/aux_base)
 "hYw" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
@@ -36078,7 +36372,7 @@
 /area/station/cargo/miningdock)
 "igw" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -36124,15 +36418,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "iiB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 6
 	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "ije" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36146,7 +36437,9 @@
 /area/station/cargo/storage)
 "ijN" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
+	dir = 4
+	},
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "ijO" = (
@@ -36262,7 +36555,7 @@
 /area/station/science/xenobiology)
 "ioH" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /obj/machinery/door/airlock/atmos{
 	name = "Incinerator"
 	},
@@ -36275,7 +36568,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "iph" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36321,6 +36615,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/mix)
 "ivL" = (
@@ -36360,7 +36655,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "ixC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -36478,7 +36775,9 @@
 /obj/machinery/meter{
 	name = "Mixed Air Tank Out"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "iHx" = (
@@ -36871,7 +37170,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "jiT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 9
+	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -36961,6 +37262,7 @@
 	dir = 4
 	},
 /obj/structure/chair/sofa/bench,
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "jpY" = (
@@ -37073,10 +37375,8 @@
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "jwv" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 8
-	},
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "jwA" = (
@@ -37225,6 +37525,12 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"jGQ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "jHg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
@@ -37242,7 +37548,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "jHH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "jHW" = (
@@ -37263,10 +37569,10 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/dark_blue{
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "jIZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37327,9 +37633,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "jKB" = (
-/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/construction)
+/area/station/construction/mining/aux_base)
 "jLg" = (
 /obj/structure/chair{
 	dir = 4;
@@ -37357,6 +37666,10 @@
 "jLA" = (
 /obj/machinery/door/airlock/external{
 	name = "Engineering External Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "atmos-1"
 	},
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
@@ -37434,7 +37747,9 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
 "jUy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 8
+	},
 /obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -37531,7 +37846,9 @@
 /area/station/maintenance/port/fore)
 "jXO" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
@@ -37553,7 +37870,9 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "jZk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -37623,6 +37942,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"kgX" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "kgY" = (
 /obj/structure/table,
 /obj/machinery/light/small/directional/west,
@@ -37646,8 +37974,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "khj" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/mix)
 "khu" = (
@@ -37682,6 +38012,13 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"kix" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
+	dir = 8
+	},
+/obj/machinery/meter,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "kjc" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/corner,
@@ -37734,6 +38071,12 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"klU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/navigate_destination/bridge,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "kmj" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -37770,7 +38113,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "kom" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -37798,6 +38143,9 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "kpJ" = (
@@ -37810,11 +38158,12 @@
 /area/station/hallway/primary/starboard)
 "kpM" = (
 /obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
+	dir = 6
+	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/mix)
 "kpO" = (
@@ -37889,6 +38238,7 @@
 /obj/effect/turf_decal/tile/dark_blue{
 	dir = 4
 	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "ksV" = (
@@ -38057,7 +38407,9 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "kEh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
@@ -38245,6 +38597,11 @@
 /obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"kRe" = (
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "kRv" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8
@@ -38291,7 +38648,9 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "kWX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
+	dir = 1
+	},
 /obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -38409,6 +38768,12 @@
 /obj/structure/sign/warning/secure_area/directional/west,
 /turf/open/floor/iron,
 /area/station/maintenance/central)
+"lfk" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "lfD" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Atmospherics N2 Tank"
@@ -38511,7 +38876,8 @@
 "lme" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "lmT" = (
 /obj/effect/turf_decal/tile/purple,
@@ -38540,20 +38906,18 @@
 /area/station/security/courtroom)
 "lpc" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
 /turf/open/space/basic,
 /area/space/nearstation)
 "lpe" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/floor,
-/turf/open/floor/plating,
-/area/station/construction)
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "lqc" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 8;
@@ -38566,7 +38930,9 @@
 /area/station/science/auxlab)
 "lqW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
@@ -38595,7 +38961,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -38899,6 +39267,7 @@
 "lMh" = (
 /obj/structure/cable,
 /obj/structure/sign/departments/medbay/alt/directional/east,
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "lMC" = (
@@ -38996,7 +39365,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "lSB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 10
+	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
@@ -39060,7 +39431,7 @@
 "lUm" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
-	name = "South Port to Filter"
+	name = "South Ports to Filter"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -39167,6 +39538,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
+"mcc" = (
+/obj/structure/table,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/pipe_dispenser,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 4
+	},
+/obj/item/storage/toolbox/mechanical,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/iron,
+/area/station/construction/mining/aux_base)
 "mcq" = (
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
@@ -39297,7 +39683,10 @@
 	department = "Bridge";
 	name = "Bridge Requests Console"
 	},
-/obj/effect/turf_decal/tile/dark_blue{
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -39311,6 +39700,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"mkQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "mlK" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/yellow{
@@ -39346,10 +39739,10 @@
 "mna" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/dark_blue{
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "mnk" = (
 /obj/structure/reflector/box/anchored{
@@ -39664,6 +40057,15 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"mEZ" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "mGm" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -39685,7 +40087,9 @@
 /turf/open/floor/iron,
 /area/station/medical/abandoned)
 "mHu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
@@ -39724,7 +40128,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "mIR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
@@ -39811,6 +40215,18 @@
 /obj/item/stack/sheet/iron/fifty,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"mQL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "mRl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39907,6 +40323,7 @@
 /obj/structure/chair{
 	dir = 8
 	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "mYJ" = (
@@ -40034,10 +40451,11 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "ndz" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "ndG" = (
 /obj/effect/turf_decal/stripes/line{
@@ -40224,6 +40642,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"nnZ" = (
+/obj/effect/turf_decal/trimline/dark_blue/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "nov" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40344,7 +40768,9 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "ntK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
+	dir = 8
+	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
@@ -40406,6 +40832,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
+"nxm" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/sign/warning/vacuum/external/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "nxu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -40566,6 +40999,7 @@
 /obj/structure/chair/sofa/bench{
 	dir = 4
 	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "nIa" = (
@@ -40632,6 +41066,13 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
+"nLY" = (
+/obj/structure/cable,
+/obj/structure/window{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "nMm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40698,6 +41139,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
+"nPs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_blue/warning,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "nQf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -40810,11 +41257,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "nYo" = (
-/obj/item/paper/crumpled{
-	info = "THIS ROOM FUCKING SUCKS. I HATE IT. I HATE IT SO MUCH. PLEASE JUST MAKE IT NOT SUCK SO MUCH."
-	},
-/turf/open/floor/iron,
-/area/station/construction)
+/obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "nYr" = (
 /obj/structure/rack{
 	dir = 8;
@@ -41019,6 +41466,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"omK" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "omO" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Laser Room"
@@ -41050,10 +41503,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "ood" = (
-/obj/structure/disposalpipe/junction/flip,
-/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/engineering/atmos)
 "ooE" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
@@ -41091,7 +41545,9 @@
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "osm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -41112,7 +41568,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
 "oua" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 4
+	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -41225,11 +41683,19 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 6
+	},
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine/atmos)
+"oCd" = (
+/obj/structure/chair/comfy/beige{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/station/hallway/secondary/entry)
 "oCl" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron,
@@ -41288,12 +41754,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"oEf" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_blue/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "oEP" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "oFn" = (
@@ -41351,9 +41822,22 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "oIK" = (
-/obj/machinery/airalarm/directional/north,
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for the Auxiliary Mining Base.";
+	dir = 8;
+	name = "Auxiliary Base Monitor";
+	network = list("auxbase");
+	pixel_y = null;
+	pixel_x = 28
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/cable,
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron,
-/area/station/construction)
+/area/station/construction/mining/aux_base)
 "oIP" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
@@ -41379,7 +41863,9 @@
 /area/station/engineering/main)
 "oKM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
@@ -41422,16 +41908,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "oMQ" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Bridge"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "bridge"
-	},
-/turf/open/floor/iron,
+/turf/closed/wall/r_wall,
 /area/station/hallway/secondary/command)
 "oNl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41609,6 +42088,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"oYi" = (
+/obj/machinery/camera/autoname/directional/west,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "oYp" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/carpet/red,
@@ -41618,8 +42104,14 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"oYJ" = (
+/obj/effect/turf_decal/trimline/dark_blue/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "oYN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "oZK" = (
@@ -41693,6 +42185,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/commons/lounge)
+"pbU" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "pcn" = (
 /obj/structure/window/reinforced/plasma{
 	dir = 8
@@ -41776,6 +42275,7 @@
 /area/station/medical/medbay/lobby)
 "pgS" = (
 /obj/machinery/holopad,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
 "piM" = (
@@ -41811,11 +42311,12 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "pkW" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/construction)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/space/basic,
+/area/space/nearstation)
 "pmx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41824,7 +42325,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine/atmos)
@@ -41860,6 +42363,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
+"poU" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/line,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "ppM" = (
 /obj/structure/cable/multilayer/connected,
 /turf/open/floor/engine,
@@ -41879,7 +42386,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "pqA" = (
@@ -41942,6 +42449,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)
 "puZ" = (
@@ -42155,9 +42663,8 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "pON" = (
-/obj/structure/grille,
-/obj/structure/window/fulltile,
 /obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/storage)
 "pOS" = (
@@ -42291,7 +42798,9 @@
 /area/station/cargo/office)
 "pTs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 6
+	},
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos/mix)
 "pTN" = (
@@ -42396,6 +42905,15 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
+"qbd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "qbm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42461,6 +42979,10 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/wood,
 /area/station/service/library/lounge)
+"qfj" = (
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/glass/reinforced,
+/area/station/hallway/primary/starboard)
 "qfq" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/effect/turf_decal/bot{
@@ -42709,7 +43231,9 @@
 /area/station/maintenance/department/bridge)
 "qxg" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "qxB" = (
@@ -42722,7 +43246,7 @@
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
 "qxL" = (
-/obj/structure/sign/directions/command{
+/obj/structure/sign/directions/upload{
 	dir = 1
 	},
 /turf/closed/wall/r_wall,
@@ -42776,7 +43300,7 @@
 /area/station/ai_monitored/command/nuke_storage)
 "qzx" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -42826,15 +43350,14 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "qCf" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/station/construction)
+/turf/open/floor/plating,
+/area/station/construction/mining/aux_base)
 "qCk" = (
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/turf_decal/tile/dark_blue{
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "qCy" = (
 /obj/item/radio/intercom/directional/east,
@@ -43005,7 +43528,7 @@
 /turf/open/floor/wood,
 /area/station/service/library/lounge)
 "qKU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/mix)
@@ -43110,9 +43633,7 @@
 "qUP" = (
 /obj/structure/cable,
 /obj/structure/fireaxecabinet/directional/south,
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "qVY" = (
@@ -43152,6 +43673,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/cargo/storage)
+"qXQ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "qYD" = (
 /turf/closed/wall,
 /area/station/engineering/atmos)
@@ -43269,6 +43796,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"riL" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "rjj" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -43328,13 +43864,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "rlI" = (
-/obj/structure/chair{
-	dir = 4
+/obj/item/kirbyplants{
+	icon_state = "plant-05"
 	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/glass/reinforced,
 /area/station/hallway/primary/starboard)
 "rme" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43374,6 +43907,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"rnV" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump/off{
+	dir = 8;
+	name = "Mix Out"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos/mix)
 "roc" = (
 /mob/living/simple_animal/pet/cat{
 	desc = "Yoss, queen, slay.";
@@ -43392,10 +43936,8 @@
 /area/station/hallway/primary/starboard)
 "roJ" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 8
-	},
 /obj/structure/sign/calendar/directional/south,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "roK" = (
@@ -43412,17 +43954,23 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
-"rpI" = (
-/obj/machinery/atmospherics/components/binary/pump/off{
-	dir = 8;
-	name = "Mix Out"
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+"rpD" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/structure/window{
+	dir = 1
+	},
 /turf/open/floor/iron,
-/area/station/engineering/atmos/mix)
+/area/station/hallway/primary/starboard)
+"rpI" = (
+/obj/structure/chair/comfy/beige{
+	dir = 4
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "rpQ" = (
 /obj/machinery/hydroponics/constructable,
 /obj/structure/cable,
@@ -43502,6 +44050,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"rvP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "rvQ" = (
 /obj/effect/turf_decal/tile/dark_blue{
 	dir = 4
@@ -43559,7 +44113,9 @@
 /obj/machinery/airlock_sensor/incinerator_atmos{
 	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/engine,
@@ -43632,11 +44188,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "rAA" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/station/hallway/primary/starboard)
 "rBb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43701,6 +44255,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
+"rDE" = (
+/obj/docking_port/stationary/public_mining_dock{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/construction/mining/aux_base)
 "rDR" = (
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/wood,
@@ -44002,11 +44562,11 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "rYs" = (
-/obj/effect/turf_decal/tile/dark_blue{
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "rZi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -44023,6 +44583,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"sao" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/station/engineering/hallway)
 "sap" = (
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/wood,
@@ -44110,7 +44682,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "sgd" = (
 /obj/machinery/door/firedoor,
@@ -44127,10 +44700,18 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation)
 "sgv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 6
+	},
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"sgz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "sgL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44222,7 +44803,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /obj/structure/cable,
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "skl" = (
@@ -44298,7 +44879,7 @@
 "spA" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
-	name = "North Port to Filter"
+	name = "North Ports to Filter"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -44315,6 +44896,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"sqw" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/structure/window,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "sqE" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
@@ -44324,6 +44912,11 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/security/brig)
+"srg" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_blue/warning,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "ssg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44436,6 +45029,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"sxs" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/shrink_cw,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "sxw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44451,11 +45048,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/item/kirbyplants{
+	icon_state = "plant-07";
+	name = "Photosynthetic Potted plant"
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/turf/open/floor/grass,
 /area/station/hallway/primary/starboard)
 "sxX" = (
 /obj/effect/landmark/navigate_destination/dockesc,
@@ -44473,6 +45070,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"syu" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 6
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "syC" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -44626,6 +45230,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"sHx" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/structure/sign/directions/vault/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "sHI" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office"
@@ -44678,7 +45289,7 @@
 /turf/open/floor/wood,
 /area/station/service/library/lounge)
 "sLt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -44697,10 +45308,10 @@
 "sMu" = (
 /obj/structure/cable,
 /obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/tile/dark_blue{
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "sMM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -44789,9 +45400,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "maint-dome-3"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
 /obj/machinery/door/airlock/external/glass,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44873,10 +45481,10 @@
 /area/station/engineering/engine_smes)
 "tcj" = (
 /obj/machinery/door/airlock/maintenance_hatch,
-/obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "tcn" = (
@@ -44934,6 +45542,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
+"thg" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "thO" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/west{
@@ -45141,10 +45756,10 @@
 /area/station/hallway/primary/central)
 "tva" = (
 /obj/machinery/door/airlock/maintenance_hatch,
-/obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "tvb" = (
@@ -45248,13 +45863,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/dark_blue{
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "tDs" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/atmospherics/components/binary/pump/off{
+	name = "Pure to Mix";
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/mix)
 "tEv" = (
@@ -45332,7 +45951,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "tIJ" = (
-/obj/effect/turf_decal/tile/dark_blue{
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -45625,10 +46244,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/dark_blue{
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "ubu" = (
 /obj/structure/cable,
@@ -45665,7 +46284,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "ubG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/mix)
@@ -45787,12 +46406,23 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "umz" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "bridge"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "bridgedoors";
+	name = "Bridge Access Blast Door"
+	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/dark_blue{
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/turf/open/floor/iron/dark,
+/area/station/hallway/secondary/command)
 "uns" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45826,6 +46456,10 @@
 /obj/structure/sign/warning/docking/directional/east,
 /turf/open/space/basic,
 /area/space/nearstation)
+"uoO" = (
+/obj/structure/sign/warning/yes_smoking/circle/directional/south,
+/turf/open/floor/glass/reinforced,
+/area/station/hallway/primary/starboard)
 "upm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45876,7 +46510,9 @@
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "uqV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+	dir = 5
+	},
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -45949,7 +46585,9 @@
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
 "uxh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 9
+	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
@@ -46124,6 +46762,7 @@
 "uJu" = (
 /obj/structure/chair/stool/directional/north,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "uJy" = (
@@ -46182,7 +46821,8 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "uNx" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -46248,6 +46888,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"uUO" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/construction/mining/aux_base)
 "uUU" = (
 /obj/effect/landmark/start/hangover,
 /obj/effect/turf_decal/tile/neutral{
@@ -46271,10 +46920,11 @@
 /obj/structure/sign/poster/official/science{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/item/kirbyplants{
+	icon_state = "plant-07";
+	name = "Photosynthetic Potted plant"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/grass,
 /area/station/hallway/primary/starboard)
 "uWM" = (
 /obj/effect/turf_decal/bot_white,
@@ -46354,18 +47004,23 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "vbW" = (
+/obj/structure/cable,
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge"
 	},
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "bridge"
 	},
-/obj/effect/turf_decal/tile/dark_blue{
+/obj/machinery/door/poddoor/preopen{
+	id = "bridgedoors";
+	name = "Bridge Access Blast Door"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "vcA" = (
 /obj/structure/sign/poster/contraband/random/directional/south,
@@ -46417,6 +47072,15 @@
 /obj/machinery/door/poddoor/incinerator_atmos_main,
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
+"vkI" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/science{
+	pixel_x = 32
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "vkP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46601,6 +47265,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/bridge)
+"vAh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "vAj" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -46837,6 +47508,12 @@
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"vPL" = (
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "vQy" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -47024,6 +47701,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
+"wbJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/violet/visible,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/mix)
 "wbU" = (
 /obj/structure/sign/departments/chemistry/pharmacy/directional/west,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -47050,11 +47731,9 @@
 /area/station/cargo/sorting)
 "wdw" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron,
-/area/station/construction)
+/obj/effect/turf_decal/trimline/dark_blue/filled/shrink_cw,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "wew" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -47190,12 +47869,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "wqY" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
+/turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "wrn" = (
 /obj/effect/landmark/start/hangover,
@@ -47353,10 +48029,10 @@
 "wzk" = (
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/tile/dark_blue{
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "wzE" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
@@ -47445,9 +48121,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "wHk" = (
-/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 10
+	},
 /turf/open/floor/iron,
-/area/station/construction)
+/area/station/engineering/atmos)
 "wIu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
@@ -47462,6 +48140,13 @@
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
+"wJz" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_blue/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "wJI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -47551,7 +48236,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow/diagonal_centre,
 /obj/structure/chair{
 	dir = 4
 	},
@@ -47691,6 +48375,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/courtroom)
+"xeb" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_blue/filled/shrink_ccw,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "xej" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
@@ -47710,11 +48399,9 @@
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
 "xfI" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron,
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/grass,
 /area/station/hallway/primary/starboard)
 "xfS" = (
 /obj/structure/disposalpipe/segment,
@@ -47781,7 +48468,9 @@
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
 "xlO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -47890,6 +48579,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"xqW" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/sign/warning/engine_safety/directional/south,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "xqX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -47922,6 +48617,7 @@
 /obj/structure/chair/sofa/bench{
 	dir = 4
 	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "xsQ" = (
@@ -47970,7 +48666,7 @@
 /obj/machinery/door/airlock/engineering{
 	name = "SMES Room"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/engine_equipment,
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
 "xwT" = (
@@ -48009,6 +48705,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
+"xAg" = (
+/obj/structure/chair/comfy/beige{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/station/hallway/secondary/entry)
 "xAq" = (
 /obj/machinery/holopad/secure,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -48083,7 +48785,9 @@
 /area/station/security/checkpoint/escape)
 "xGo" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
 /turf/open/space/basic,
 /area/space/nearstation)
 "xGr" = (
@@ -48270,6 +48974,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
+"xSC" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "xTf" = (
 /obj/structure/transit_tube/curved{
 	dir = 1
@@ -48284,6 +48997,25 @@
 /obj/machinery/rnd/production/techfab/department/medical,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
+"xTF" = (
+/obj/structure/rack,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/wallframe/camera,
+/obj/item/wallframe/camera,
+/obj/item/wallframe/camera,
+/obj/item/wallframe/camera,
+/obj/item/assault_pod/mining,
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/construction/mining/aux_base)
 "xTJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48338,7 +49070,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "xXd" = (
@@ -48426,6 +49158,12 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
+"yak" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "yaz" = (
 /obj/machinery/rnd/server/master,
 /turf/open/floor/circuit/telecomms/server,
@@ -48496,6 +49234,10 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
+"yfg" = (
+/obj/item/toy/plush/space_lizard_plushie,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "yfr" = (
 /turf/closed/wall,
 /area/station/hallway/secondary/service)
@@ -60029,7 +60771,7 @@ cjH
 vbC
 gRN
 cgv
-bWO
+aGm
 dmF
 wpd
 dmF
@@ -68999,14 +69741,14 @@ bcU
 ayi
 beV
 bfI
-bgQ
+fWL
 bjH
 bjH
 rcW
 ptb
 bjH
 bjH
-beV
+gnA
 bfI
 bgQ
 bGt
@@ -73405,15 +74147,15 @@ qst
 kaG
 ggT
 fSx
-cEv
+syu
 cEv
 bUN
 cgu
-afC
+iiB
 afC
 bUN
 anh
-afC
+iiB
 afC
 bUN
 anh
@@ -73659,10 +74401,10 @@ bMz
 bTb
 lki
 oFn
-uxh
+mEZ
 bYP
 uxh
-cgs
+ceV
 apY
 cdG
 ceV
@@ -73915,7 +74657,7 @@ bQA
 bMz
 bTc
 mEL
-efU
+xSC
 bXu
 bKo
 bXw
@@ -73931,7 +74673,7 @@ xqJ
 uCw
 bXw
 cHV
-bXw
+lfk
 crc
 csk
 mXT
@@ -74173,27 +74915,27 @@ bMz
 bTd
 dFJ
 efU
-caU
-caU
-caU
-caU
+omK
+cgs
+cgs
+hJq
+hdU
+cdH
+ceW
+ceW
+yak
 cdH
 cdH
 ceW
-ceW
+yak
 cdH
-cdH
-cdH
-ceW
-cdH
-cdH
-cdH
-bXw
+hiX
+aGn
 sgv
 ske
 gYL
-cDy
-cwC
+sao
+kIN
 pCp
 dmL
 dmL
@@ -74436,16 +75178,16 @@ cpg
 cpg
 cpg
 cpg
-caU
+cPQ
 xRQ
-caU
-caU
-caU
-caU
+cgs
+cgs
+cgs
+hJq
 cpg
 cpg
-cdH
-bXw
+rYs
+aGn
 cre
 csk
 ctv
@@ -74686,12 +75428,12 @@ bQD
 bMz
 nyY
 dFJ
-efU
+qbd
 gbN
 jUy
-bXu
+eRV
 lUm
-cDz
+dlY
 uqV
 qYD
 sHg
@@ -74701,8 +75443,8 @@ cpg
 cpg
 cpg
 qJx
-cdH
-bXw
+rYs
+aGn
 crf
 csk
 ctw
@@ -74945,11 +75687,11 @@ bTg
 bMe
 bSm
 caU
-bXu
+ddV
 spA
-kWX
+kix
 dck
-cDz
+ceZ
 dck
 cpg
 cpg
@@ -74958,8 +75700,8 @@ cpg
 cpg
 cpg
 cpg
-cdH
-bXw
+rYs
+aGn
 crg
 csk
 ctx
@@ -75206,7 +75948,7 @@ lUT
 jUQ
 pGz
 dck
-cDz
+ceZ
 dck
 cpg
 cpg
@@ -75215,8 +75957,8 @@ cpg
 cpg
 cpg
 cpg
-cdH
-bXw
+rYs
+aGn
 crh
 csm
 cty
@@ -75472,8 +76214,8 @@ cpg
 cpg
 cpg
 cpg
-cdH
-bXw
+rYs
+aGn
 cri
 csk
 ctz
@@ -75718,9 +76460,9 @@ xXy
 caU
 cpg
 bXy
-cDz
+jGQ
 oyI
-cDz
+ceZ
 hXw
 cpg
 cpg
@@ -75729,8 +76471,8 @@ cpg
 cpg
 cpg
 cpg
-cdH
-bXw
+rYs
+aGn
 jXO
 csk
 ctA
@@ -75972,7 +76714,7 @@ bMB
 adf
 cZP
 xWK
-caU
+mkQ
 cpg
 cpg
 nDU
@@ -75986,8 +76728,8 @@ cpg
 cpg
 cpg
 pqA
-cdH
-bXw
+rYs
+aGn
 cId
 cmx
 vKS
@@ -76229,16 +76971,16 @@ krK
 lFw
 csr
 tOg
-caU
+wHk
 kkC
+dlY
+gAk
+rvP
 cDz
-cDz
-cDz
-cDz
-cDz
-cDz
-cDz
-cDz
+bxu
+dlY
+dlY
+rvP
 mww
 oYN
 oYN
@@ -76248,7 +76990,7 @@ bPq
 bXq
 jHH
 pqo
-ltG
+aAq
 cwB
 csp
 cyG
@@ -76490,12 +77232,12 @@ cql
 cql
 cql
 lzO
-cDz
+vPL
 jaE
 cpg
 cpg
 cpg
-cDz
+qXQ
 cKp
 cJV
 cJV
@@ -76738,27 +77480,27 @@ aMv
 cAs
 iue
 krK
-vAl
-krK
+fqX
+cwC
 tDs
-csr
+bDR
 ntK
 cdH
 cdH
 cdH
+ood
+cdH
+yak
+cdH
+ood
 cdH
 cdH
 cdH
 cdH
 cdH
 cdH
-cdH
-cdH
-cdH
-cdH
-cdH
-cdH
-bXw
+cHn
+aGn
 wiv
 csk
 ctE
@@ -76994,9 +77736,9 @@ lCe
 bLs
 cAs
 kpM
-vAl
-vAl
-krK
+bWf
+wbJ
+cSN
 cAt
 ubG
 xDt
@@ -77015,7 +77757,7 @@ bXw
 bXw
 bXw
 bXw
-bXw
+eiO
 wiv
 csk
 ctF
@@ -77251,15 +77993,15 @@ adr
 bLt
 cAs
 jxP
-rpI
 bQL
+rnV
 ayX
 ibE
 csr
 gea
 ccy
 coZ
-ceZ
+whT
 cgy
 chJ
 coZ
@@ -77267,7 +78009,7 @@ whT
 wuA
 cmD
 coZ
-cph
+hTb
 hTb
 wfI
 fMY
@@ -77508,7 +78250,7 @@ dIW
 bLg
 cAs
 cld
-bQH
+csr
 ekt
 csr
 khj
@@ -77517,11 +78259,11 @@ cDK
 aLD
 bTj
 bUN
-afC
+aGo
 bUN
 anh
 bUN
-afC
+aGo
 bUN
 anh
 bUN
@@ -77993,7 +78735,7 @@ lWL
 baK
 fDb
 bfd
-tyB
+guT
 bxS
 bir
 bjP
@@ -78248,9 +78990,9 @@ aRb
 baK
 baK
 baK
-rYs
-aVJ
-tyB
+uxX
+hXh
+guT
 bxS
 bis
 xcq
@@ -78501,13 +79243,13 @@ aRb
 aRb
 aRb
 aYr
-cid
+xeb
 baL
 fAw
 mkl
-bwn
-bwn
-tyB
+kgX
+kgX
+mQL
 bxS
 blY
 blb
@@ -78758,13 +79500,13 @@ aRb
 ufJ
 aWT
 bwn
-cid
+srg
 cXe
-bwn
-bde
-bel
-bwn
-tyB
+aHN
+hfO
+hfO
+nnZ
+vAh
 bxS
 biu
 bjS
@@ -79015,13 +79757,13 @@ iGi
 ufJ
 aWU
 omr
-cid
+wdw
 baO
-bwn
-bdf
-bem
-bwn
-tyB
+aZG
+bde
+bel
+oYJ
+vAh
 bxS
 biv
 iOF
@@ -79272,12 +80014,12 @@ aUE
 bLE
 aWV
 aYt
-cid
+hMh
 baO
-bwn
-bdg
-ben
-bwn
+aZG
+bdf
+bem
+oYJ
 bgb
 bxS
 biw
@@ -79529,13 +80271,13 @@ ufJ
 bwn
 aWW
 mxz
-cid
+xeb
 baO
-bwn
-bwn
-dlY
-bwn
-tyB
+aZG
+bdg
+ben
+oYJ
+vAh
 bxS
 bxS
 bRm
@@ -79786,13 +80528,13 @@ ele
 aVI
 slV
 slV
+nPs
 slV
-slV
-slV
-cid
-cid
-bwn
-bff
+oEf
+wJz
+wJz
+aKm
+tyB
 jIX
 bix
 frA
@@ -79804,14 +80546,14 @@ bgY
 bri
 bri
 bsv
-bri
+cph
 bri
 bri
 bgY
 uad
-bBe
+umz
 bCz
-bBe
+bCz
 umz
 tIJ
 bJD
@@ -80044,9 +80786,9 @@ aVJ
 aWY
 aYv
 aZG
-bwn
+nYo
 ije
-ije
+sgz
 aDP
 ije
 bff
@@ -80069,8 +80811,8 @@ sfu
 oMQ
 ndz
 boB
-rAA
-aiP
+oMQ
+klU
 xri
 uJy
 rgR
@@ -80300,34 +81042,34 @@ aUJ
 mNG
 bps
 whV
-whV
-whV
+cFF
 whV
 bwn
-cid
-cid
-cid
+bwn
+gUs
+ayp
+ayp
 doa
-fST
-fST
-fST
+bzt
+bzt
+bzt
 tCv
 bxV
-fST
-fST
-fST
+bzt
+bzt
+bzt
 mna
 sMu
-fST
-fST
+bzt
+bzt
 wzk
 fST
 bzt
 vbW
 wqY
+wqY
 vbW
-bxu
-geH
+pbU
 geH
 qwq
 bJP
@@ -80557,7 +81299,7 @@ ojf
 bwn
 aXa
 heW
-bwn
+sxs
 baO
 bwn
 bwn
@@ -80814,7 +81556,7 @@ aUK
 mpA
 aXb
 dqd
-bwn
+poU
 baO
 bwn
 bwn
@@ -81071,7 +81813,7 @@ wlQ
 ojf
 aXc
 oty
-bwn
+azb
 baO
 bwn
 bwn
@@ -81328,7 +82070,7 @@ aRb
 ojf
 aXd
 bwn
-cid
+srg
 lMh
 cid
 cid
@@ -81393,7 +82135,7 @@ cwU
 cxV
 oKr
 chH
-jBC
+xqW
 cFi
 ybE
 gvk
@@ -81585,7 +82327,7 @@ aRb
 aRb
 aRb
 aYy
-cid
+wdw
 baL
 bcb
 bdj
@@ -82410,7 +83152,7 @@ lAL
 csw
 aCI
 cmO
-coj
+aFl
 cps
 coj
 cmO
@@ -83946,7 +84688,7 @@ jJr
 ccE
 bUV
 cfh
-cfc
+akg
 asJ
 lAL
 rnn
@@ -86246,7 +86988,7 @@ lCe
 cSi
 bMO
 bOk
-bPC
+aIR
 bOk
 bSf
 bLw
@@ -86412,7 +87154,7 @@ aCI
 aCI
 aCI
 aCI
-abT
+hSL
 oVB
 lWL
 aCI
@@ -86669,7 +87411,7 @@ aCI
 lWL
 qKB
 pYa
-abT
+hSL
 oVB
 pYa
 aCI
@@ -86926,7 +87668,7 @@ pYa
 pYa
 pYa
 pYa
-abT
+hSL
 jub
 pYa
 pYa
@@ -87018,7 +87760,7 @@ cSi
 nGA
 bOk
 bOi
-bQW
+rpI
 cfN
 bTB
 bVb
@@ -87213,18 +87955,18 @@ lWL
 lWL
 lWL
 lWL
-ayo
-ayo
-ayo
-ayo
-ayo
+lWL
 lWL
 aCI
 lWL
 lWL
-aFk
-aKl
-fEG
+lWL
+aCI
+lWL
+lWL
+lWL
+lpe
+lWL
 lWL
 lWL
 lWL
@@ -87467,21 +88209,21 @@ aCI
 aCI
 aCI
 aCI
-aCI
-aCI
-ayo
-ayo
+aGZ
+aGZ
+aGZ
+aGZ
+aGZ
+aGZ
+aGZ
+aGZ
+aGZ
+aGZ
+aGZ
 lWL
-ayo
-aGo
-ayo
-ayo
-ayo
 lWL
-lWL
-aIQ
 lpe
-fEG
+lWL
 lWL
 lWL
 lWL
@@ -87724,21 +88466,21 @@ lWL
 lWL
 lWL
 lWL
-aCI
-aCI
+aGZ
+qCf
+qCf
+qCf
+qCf
+qCf
+qCf
+qCf
+qCf
+qCf
+aGZ
 lWL
 lWL
+lpe
 lWL
-ayo
-aGo
-aGo
-aGo
-ayo
-ayo
-lWL
-aIQ
-aKm
-fEG
 lWL
 aRj
 aRj
@@ -87980,22 +88722,22 @@ hSL
 lWL
 lWL
 lWL
+lWL
+aGZ
+qCf
+qCf
+qCf
+qCf
+qCf
+qCf
+qCf
+qCf
+qCf
+aGZ
 aCI
 aCI
-lWL
-lWL
-lWL
-lWL
-ayo
-aGo
-aGo
-aGo
-aGm
-ayo
-ayo
-aIQ
-aKm
-fEG
+lpe
+aCI
 aRj
 aRj
 aRj
@@ -88046,7 +88788,7 @@ cSi
 nGA
 bOl
 eXz
-bQW
+rpI
 sMp
 xKR
 vFh
@@ -88234,25 +88976,25 @@ lWL
 lWL
 pYa
 hSL
-pYa
-lWL
-lWL
-ayo
+yfg
 lWL
 lWL
 lWL
-aCI
-lWL
-eSj
-aGo
-aGo
-aFl
-aGn
 aGZ
-ayo
-aIQ
-aKm
-fEG
+qCf
+qCf
+qCf
+qCf
+qCf
+qCf
+qCf
+qCf
+qCf
+aGZ
+lWL
+lWL
+lpe
+lWL
 aRj
 aRj
 ayn
@@ -88460,12 +89202,12 @@ aCI
 aCI
 lWL
 lWL
-abT
-abT
-abT
-abT
-abT
-abT
+hSL
+hSL
+hSL
+hSL
+hSL
+hSL
 adQ
 adQ
 adQ
@@ -88484,7 +89226,7 @@ lWL
 vYD
 lWL
 pYa
-abT
+hSL
 kIz
 lWL
 lWL
@@ -88493,23 +89235,23 @@ lWL
 abT
 ajB
 ajB
-ayo
-ayo
+ajB
+ajB
+aGZ
+qCf
+qCf
+qCf
+qCf
+qCf
+qCf
+qCf
+qCf
+qCf
+aGZ
 lWL
 lWL
+lpe
 lWL
-aCI
-aCI
-ayo
-aGo
-aGo
-aGo
-aGo
-aGo
-ayo
-ayo
-aKm
-fEG
 aRj
 aRj
 fIs
@@ -88741,7 +89483,7 @@ bDE
 pYa
 enH
 pYa
-abT
+hSL
 lWL
 lWL
 lWL
@@ -88750,23 +89492,23 @@ lWL
 ajB
 rlI
 awL
-ayo
-lWL
-lWL
-lWL
-lWL
-lWL
-lWL
-ayo
-aGo
-aGo
+awL
+aKl
+aGZ
+qCf
+qCf
+qCf
+qCf
+eTA
+qCf
+qCf
+qCf
+qCf
+aGZ
 pkW
-pkW
-pkW
-pkW
-aIR
-aKn
-fEG
+lpe
+lpe
+aCI
 aRj
 aRj
 jHW
@@ -88998,31 +89740,31 @@ pYa
 pYa
 pYa
 pmF
-ajB
+gVE
 lWL
 pYa
 atG
 lWL
 lWL
 ajB
-bNi
+fyF
 cRn
-ayo
-ayo
-ayo
-ayo
-ayo
-ayo
-ayo
-ayo
-ayo
-ayo
-aFn
-ayo
-ayo
-ayo
-ayo
-rVS
+qfj
+uoO
+aGZ
+qCf
+qCf
+qCf
+qCf
+qCf
+qCf
+qCf
+qCf
+qCf
+aGZ
+pkW
+lWL
+lWL
 lWL
 aRj
 aRj
@@ -89262,23 +90004,23 @@ atH
 ajB
 lWL
 ajB
-bNi
-vVh
-ayo
-ayY
-ayY
-ayY
-ayY
-ayY
-ayY
+bBe
+apx
+hBT
+dlN
+aGZ
 qCf
-ayY
-ayY
-adh
-ayY
-ayY
-ayY
-ayo
+qCf
+qCf
+qCf
+qCf
+qCf
+qCf
+qCf
+qCf
+aGZ
+pkW
+lWL
 lWL
 lWL
 aRj
@@ -89519,25 +90261,25 @@ atI
 ajB
 abT
 abT
-bNi
-vVh
+gFd
+hBT
+aiV
 ayo
-ayo
-wHk
-ayY
-ayY
-ayY
-ayY
-ayY
-ayY
-ayY
-adh
-ayY
-jKB
-ayo
-ayo
-lWL
-lWL
+aGZ
+qCf
+qCf
+qCf
+qCf
+qCf
+qCf
+qCf
+qCf
+qCf
+aGZ
+pkW
+aCI
+aCI
+aCI
 aRj
 aRj
 aRj
@@ -89777,22 +90519,22 @@ ajB
 aeY
 abT
 bNi
+apx
+apx
 vVh
-abT
-ayo
-ayY
-ayY
-ayY
-ayY
-nYo
-ayY
-ayY
-ayY
-adh
-ayY
-ayY
-ayo
-aCI
+aGZ
+qCf
+qCf
+qCf
+qCf
+rDE
+qCf
+qCf
+qCf
+qCf
+aGZ
+pkW
+lWL
 lWL
 lWL
 aCI
@@ -90032,24 +90774,24 @@ aRI
 aRI
 aRI
 aRI
-aRI
+hFW
 gjY
-aRI
-abT
-ayo
-ayo
-ayY
-ayY
-ayY
-ayY
-ayY
-ayY
-ayY
+gjY
+apx
+cqi
+aGZ
+aGZ
+adh
+adh
 adh
 ayY
-ayo
-ayo
-aCI
+adh
+adh
+adh
+adh
+aGZ
+pkW
+lWL
 lWL
 aCI
 aCI
@@ -90278,7 +91020,7 @@ apx
 apx
 apx
 apx
-apx
+rAA
 apx
 apx
 lAa
@@ -90291,22 +91033,22 @@ apx
 apx
 rBM
 apx
-aHN
-abT
-eRV
-ayo
-ayo
-ayY
-ayY
-ayY
-adh
-adh
-wdw
+gjY
+apx
+vVh
+gbp
+aGZ
+xTF
 aFq
-ayo
-ayo
-lWL
-aCI
+aFq
+cgF
+fUk
+aFq
+aFq
+cli
+aGZ
+eSj
+abT
 aCI
 aCI
 lWL
@@ -90366,7 +91108,7 @@ bTJ
 oLS
 bYc
 bFE
-cat
+cZv
 cbE
 lSL
 cef
@@ -90548,22 +91290,22 @@ gRk
 lTM
 bsV
 lAa
-aRI
-ayp
-cHn
+gjY
+apx
+vVh
 azC
-ayo
-ayo
-ayo
+aGZ
+mcc
+ayq
 oIK
-adh
+fnw
 jKB
-ayo
-ayo
-ayo
-aCI
-aCI
-aCI
+uUO
+hYn
+bZv
+aGZ
+aKn
+abT
 lWL
 aCI
 aCI
@@ -90805,22 +91547,22 @@ adQ
 adQ
 bsV
 apx
-iiB
+gjY
+apx
+vVh
 abT
-abT
-abT
-abT
-abT
-ayo
-aCk
+aGZ
+aGZ
+aGZ
+aGZ
 aCS
 aCk
-ayo
+aCk
+aGZ
+aGZ
+aGZ
+dWW
 abT
-abT
-ajB
-ajB
-ajB
 ajB
 ajB
 ajB
@@ -91062,22 +91804,22 @@ hVl
 adQ
 bsV
 apx
-aRI
-ayq
-azb
+gjY
+apx
+vVh
 azD
-aAq
-cli
+uAa
+uAa
 dFe
 uAa
 cUG
 uAa
-bWf
-bwM
+uAa
+oYi
 gNn
-vVh
-vVh
-vVh
+azc
+riL
+nxm
 bwP
 aLr
 nZw
@@ -91321,19 +92063,19 @@ bsV
 apx
 gjY
 akG
-azc
-azc
-azc
 akG
-cTq
+akG
+akG
+akG
+akG
 akG
 gjY
 akG
 akG
 akG
 akG
-akG
-akG
+cTq
+gjY
 akG
 akG
 akG
@@ -91582,15 +92324,15 @@ bug
 bug
 bug
 bug
-ood
+aBD
 bug
 nrc
 aiT
 bug
 bug
 bug
-bug
-bug
+bOA
+hnO
 bug
 bwN
 aBD
@@ -91837,8 +92579,8 @@ gjY
 cfu
 cfu
 cfu
-cfu
-cfu
+nLY
+nLY
 fen
 cfu
 cfu
@@ -91846,7 +92588,7 @@ cfu
 cfu
 mgT
 cfu
-cfu
+kRe
 cfu
 cfu
 olW
@@ -92091,19 +92833,19 @@ asO
 qbm
 cfu
 akG
-bsV
+vkI
 mxO
-bsV
+sqw
 uWA
 xfI
 sxG
-rwd
+rpD
 bsV
 bsV
 bsV
 bsV
 bsV
-bsV
+thg
 fyk
 bsV
 bsV
@@ -92129,7 +92871,7 @@ bdv
 bey
 lIk
 fem
-fem
+sHx
 uSP
 fpk
 fem
@@ -96004,11 +96746,11 @@ bEu
 bCX
 gRT
 bEu
-bGY
+aFn
 bIn
 bIn
 bKd
-bKH
+oCd
 bEu
 akA
 bGU
@@ -96518,11 +97260,11 @@ bEu
 bCZ
 nyw
 bEu
-bGY
+aFn
 bIp
 bIp
 bIp
-bKH
+oCd
 bEu
 pRY
 bGU
@@ -96776,9 +97518,9 @@ bEu
 nyw
 bEu
 bGZ
+xAg
 bIq
-bIq
-bIq
+xAg
 bGZ
 bEu
 bhi

--- a/StationMaps/DiscStation/DiscStation.dmm
+++ b/StationMaps/DiscStation/DiscStation.dmm
@@ -516,7 +516,6 @@
 	c_tag = "MiniSat Atmospherics";
 	network = list("minisat")
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "adN" = (
@@ -666,6 +665,7 @@
 /obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
 	dir = 1
 	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "aew" = (
@@ -1033,6 +1033,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "agn" = (
@@ -1063,7 +1064,7 @@
 	name = "Turret Maintenance Hatch"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
-/turf/open/floor/iron/dark,
+/turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "agD" = (
 /obj/machinery/door/poddoor/shutters{
@@ -3303,6 +3304,9 @@
 "asp" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "asq" = (
@@ -3551,6 +3555,9 @@
 "atr" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/electrical)
 "ats" = (
@@ -3773,10 +3780,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "auz" = (
-/obj/machinery/status_display/evac/directional/west,
-/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/area/station/commons/dorms)
 "auA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -4147,13 +4156,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "awh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/wood,
+/area/station/commons/dorms)
 "awk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4678,6 +4685,7 @@
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "ayM" = (
@@ -5474,6 +5482,8 @@
 "aBZ" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "aCb" = (
@@ -6328,6 +6338,7 @@
 /obj/structure/closet/l3closet/scientist,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aFz" = (
@@ -6477,6 +6488,7 @@
 	},
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "aFS" = (
@@ -7082,6 +7094,7 @@
 /area/station/maintenance/department/bridge)
 "aHT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "aHU" = (
@@ -7402,12 +7415,13 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "aIR" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "aIU" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "robotics";
@@ -7685,13 +7699,13 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/bridge)
 "aKf" = (
 /obj/item/wrench,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/bridge)
 "aKg" = (
@@ -7699,9 +7713,6 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/bridge)
 "aKj" = (
@@ -7973,6 +7984,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "aLi" = (
@@ -8025,11 +8037,13 @@
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "aLr" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "aLs" = (
@@ -8129,6 +8143,7 @@
 /area/station/command/heads_quarters/cmo)
 "aLN" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/cmo)
 "aLO" = (
@@ -8299,12 +8314,12 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "aMs" = (
-/obj/machinery/door/airlock/external{
-	name = "Arrival Airlock";
-	space_dir = 2
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "arrivals-upper-2"
+	},
+/obj/machinery/door/airlock/external/glass{
+	name = "Arrival Airlock";
+	space_dir = 2
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
@@ -8559,6 +8574,7 @@
 /area/station/science/robotics/mechbay)
 "aND" = (
 /obj/machinery/computer/exodrone_control_console,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
 "aNE" = (
@@ -8604,13 +8620,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "aNJ" = (
-/obj/machinery/status_display/evac/directional/west,
-/obj/structure/chair{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/wood,
+/area/station/commons/dorms)
 "aNL" = (
 /obj/structure/sign/poster/official/random/directional/west,
 /obj/effect/turf_decal/tile/neutral{
@@ -8742,10 +8759,14 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "aOu" = (
 /obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "aOv" = (
@@ -9132,6 +9153,9 @@
 "aPQ" = (
 /obj/machinery/light/directional/east,
 /obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "aPR" = (
@@ -9541,6 +9565,9 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "aRs" = (
@@ -9602,6 +9629,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "aRH" = (
@@ -9784,10 +9812,10 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "aSq" = (
-/obj/structure/lattice,
-/obj/item/stack/tile/iron,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/central)
 "aSr" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
@@ -12629,6 +12657,7 @@
 	pixel_x = 6
 	},
 /obj/item/reagent_containers/syringe,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "beQ" = (
@@ -13114,7 +13143,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "bhi" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -13138,7 +13166,6 @@
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/command/nuke_storage)
 "bhr" = (
-/obj/machinery/light/directional/north,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/command/nuke_storage)
@@ -13681,6 +13708,7 @@
 /obj/structure/closet/crate/silvercrate,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
 /obj/effect/turf_decal/bot_white/right,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "bki" = (
@@ -13701,7 +13729,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
@@ -14213,6 +14240,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/bridge)
 "blV" = (
@@ -14231,6 +14261,7 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "blY" = (
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain)
 "blZ" = (
@@ -14538,13 +14569,11 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "bnI" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Terrarium"
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
+/area/station/science/robotics/mechbay)
 "bnN" = (
 /obj/effect/landmark/blobstart,
 /obj/machinery/light/small/directional/west,
@@ -15813,10 +15842,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "bsO" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/item/radio/intercom/directional/west,
+/obj/structure/disposalpipe/junction,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "bsP" = (
@@ -15856,6 +15885,7 @@
 	c_tag = "Chapel East"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "btd" = (
@@ -16424,6 +16454,7 @@
 "bvL" = (
 /obj/machinery/light/directional/north,
 /obj/structure/chair/wood,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "bvM" = (
@@ -16447,6 +16478,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/landmark/navigate_destination/chemfactory,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bvR" = (
@@ -16643,9 +16675,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "bwP" = (
-/obj/effect/spawner/random/vending/snackvend,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
@@ -16827,9 +16861,6 @@
 /area/station/security/detectives_office)
 "bxz" = (
 /obj/structure/table/wood,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /obj/item/taperecorder{
 	pixel_x = 3
 	},
@@ -17024,12 +17055,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "byn" = (
-/obj/machinery/door/airlock/external{
-	name = "Arrival Airlock";
-	space_dir = 1
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "arrivals-lower-1"
+	},
+/obj/machinery/door/airlock/external/glass{
+	name = "Arrival Airlock";
+	space_dir = 1
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
@@ -17509,6 +17540,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bzZ" = (
@@ -19023,12 +19055,12 @@
 /turf/open/floor/engine,
 /area/station/science/ordnance/freezerchamber)
 "bFZ" = (
-/obj/machinery/door/airlock/external{
-	name = "Arrival Airlock";
-	space_dir = 1
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "arrivals-lower-2"
+	},
+/obj/machinery/door/airlock/external/glass{
+	name = "Arrival Airlock";
+	space_dir = 1
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
@@ -20053,9 +20085,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bLl" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/interrogation)
 "bLo" = (
 /obj/machinery/camera/autoname/directional/south,
 /obj/effect/turf_decal/tile/neutral{
@@ -20071,6 +20105,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/assistant,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bLt" = (
@@ -20425,7 +20460,6 @@
 "bMX" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/status_display/evac/directional/south,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -20540,9 +20574,6 @@
 "bNv" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "bNw" = (
@@ -21007,7 +21038,6 @@
 /obj/structure/table,
 /obj/item/folder/red,
 /obj/item/taperecorder,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "bPb" = (
@@ -21530,6 +21560,7 @@
 /obj/machinery/light/directional/south,
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "bRz" = (
@@ -21625,6 +21656,8 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "bRO" = (
@@ -21764,7 +21797,6 @@
 /turf/open/space,
 /area/space/nearstation)
 "bSG" = (
-/obj/structure/sign/poster/official/random/directional/south,
 /obj/machinery/camera/autoname/directional/south,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -21893,9 +21925,6 @@
 "bTd" = (
 /obj/structure/closet/wardrobe/atmospherics_yellow,
 /obj/item/clothing/suit/hooded/wintercoat/engineering/atmos,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/structure/cable,
@@ -22685,9 +22714,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "bVW" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -22915,13 +22941,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "bWU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
 /obj/machinery/camera/autoname/directional/west,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/station/security)
 "bWV" = (
@@ -23049,6 +23075,9 @@
 "bXs" = (
 /obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "bXu" = (
@@ -24581,7 +24610,7 @@
 /turf/open/floor/iron,
 /area/station/security)
 "cdD" = (
-/obj/effect/landmark/xeno_spawn,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/engine/air,
 /area/station/engineering/atmos)
 "cdE" = (
@@ -24937,10 +24966,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -24961,12 +24990,12 @@
 /obj/structure/table,
 /obj/item/folder/red,
 /obj/item/restraints/handcuffs,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/security)
 "ceK" = (
@@ -25042,9 +25071,12 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/aft)
 "ceS" = (
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/engine/air,
-/area/station/engineering/atmos)
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/iron,
+/area/station/security)
 "ceT" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/air_input{
 	dir = 4
@@ -25440,9 +25472,12 @@
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
 "cgB" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/engine/plasma,
-/area/station/engineering/atmos)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "cgD" = (
 /obj/structure/window/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -25899,11 +25934,12 @@
 /turf/open/floor/iron,
 /area/station/security/warden)
 "ciF" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/security)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "ciG" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -25913,7 +25949,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/security/hos,
-/turf/open/floor/iron,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
 /area/station/security)
 "ciI" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
@@ -26320,12 +26357,15 @@
 "ckh" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "cki" = (
 /obj/structure/chair,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "ckk" = (
@@ -27002,6 +27042,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "cnG" = (
@@ -27340,9 +27383,15 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cpa" = (
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/engine/o2,
-/area/station/engineering/atmos)
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "cpb" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/oxygen_input{
 	dir = 4
@@ -29810,6 +29859,7 @@
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "cyU" = (
@@ -30302,9 +30352,6 @@
 /obj/item/storage/toolbox/electrical{
 	pixel_y = 5
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/engineering/main)
@@ -30446,7 +30493,7 @@
 	active_power_usage = 0
 	},
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "cCm" = (
 /obj/machinery/suit_storage_unit/ce,
 /turf/open/floor/iron/dark,
@@ -31223,6 +31270,7 @@
 "cGl" = (
 /obj/structure/chair/stool/directional/east,
 /obj/structure/cable,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "cGr" = (
@@ -31269,6 +31317,8 @@
 "cGF" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "cGG" = (
@@ -31584,6 +31634,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "cKT" = (
@@ -31730,10 +31781,9 @@
 /turf/open/floor/glass/reinforced,
 /area/station/hallway/primary/starboard)
 "cRo" = (
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/grass,
+/area/station/service/hydroponics/garden)
 "cRs" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -31914,6 +31964,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/closet/gmcloset,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/service/theater)
 "dcJ" = (
@@ -31948,6 +31999,11 @@
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
+"dev" = (
+/obj/structure/cable,
+/obj/machinery/light_switch/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/department/electrical)
 "deP" = (
 /turf/closed/wall,
 /area/station/cargo/drone_bay)
@@ -32139,6 +32195,10 @@
 /obj/effect/spawner/random/aimodule/harmless,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"dnC" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/security/interrogation)
 "doa" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32430,6 +32490,10 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"dFP" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/engine/o2,
+/area/station/engineering/atmos)
 "dGk" = (
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 8
@@ -32483,6 +32547,8 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "dIr" = (
@@ -32604,6 +32670,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "dRs" = (
@@ -32793,6 +32860,12 @@
 /obj/effect/landmark/start/paramedic,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"efr" = (
+/obj/docking_port/stationary/mining_home/common{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/hallway/primary/starboard)
 "efJ" = (
 /obj/structure/cable,
 /obj/effect/landmark/event_spawn,
@@ -33097,6 +33170,13 @@
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron,
 /area/station/security/prison)
+"exw" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/security)
 "exz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33399,6 +33479,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"eOi" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "eOt" = (
 /obj/structure/chair/stool/directional/south,
 /obj/effect/decal/cleanable/dirt,
@@ -33575,6 +33662,14 @@
 	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
+"eVs" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/warning{
+	dir = 1
+	},
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/iron,
+/area/station/security/prison)
 "eVD" = (
 /obj/machinery/shieldgen,
 /obj/effect/decal/cleanable/dirt,
@@ -34625,6 +34720,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
 	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "gej" = (
@@ -34648,6 +34744,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"gfc" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/engine/n2,
+/area/station/engineering/atmos)
 "gff" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/hop)
@@ -34717,7 +34817,6 @@
 	dir = 8
 	},
 /obj/machinery/status_display/evac/directional/west,
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "gjr" = (
@@ -34858,6 +34957,16 @@
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/department/bridge)
+"gqg" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/structure/chair/sofa/bench/right{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "gqk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -35194,6 +35303,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/theater)
+"gKh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "gKw" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
 	dir = 4
@@ -35207,6 +35325,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
+"gMC" = (
+/obj/machinery/newscaster/directional/west,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron,
+/area/station/maintenance/department/science/xenobiology)
 "gMG" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -35346,6 +35469,13 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"gSn" = (
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "gSD" = (
 /obj/structure/transit_tube/curved{
 	dir = 8
@@ -35462,6 +35592,13 @@
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
+"gZk" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
 "gZV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
 /obj/machinery/camera/autoname/directional/west,
@@ -35564,6 +35701,10 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname/directional/east,
+/obj/structure/chair/sofa/bench{
+	dir = 8
+	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "hgL" = (
@@ -35804,6 +35945,13 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"hsH" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/electrical)
 "hsP" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
@@ -35821,7 +35969,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/sign/warning/vacuum/external/directional/west,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "huJ" = (
@@ -36116,6 +36266,8 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "hQY" = (
@@ -36205,6 +36357,8 @@
 /area/station/engineering/atmos)
 "hXB" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "hYw" = (
@@ -36276,6 +36430,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
 	},
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/mix)
 "ibO" = (
@@ -37324,6 +37479,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
+"jwg" = (
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/wood,
+/area/station/command/meeting_room)
 "jwv" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -37546,12 +37705,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "jJc" = (
-/obj/machinery/door/airlock/external{
-	name = "Arrival Airlock";
-	space_dir = 2
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "arrivals-upper-1"
+	},
+/obj/machinery/door/airlock/external/glass{
+	name = "Arrival Airlock";
+	space_dir = 2
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
@@ -37709,6 +37868,11 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
+"jUt" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plating,
+/area/station/maintenance/department/electrical)
 "jUy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
 	dir = 8
@@ -37754,6 +37918,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
+"jWp" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "jWB" = (
 /obj/machinery/door/airlock{
 	name = "Crematorium"
@@ -37776,6 +37947,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"jWJ" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/security/interrogation)
 "jXd" = (
 /turf/open/floor/wood,
 /area/station/service/library/lounge)
@@ -38042,6 +38221,7 @@
 /obj/machinery/computer/warrant{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "kmH" = (
@@ -38466,6 +38646,7 @@
 	},
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/station/maintenance/central)
 "kJM" = (
@@ -38507,6 +38688,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"kMV" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/computer/shuttle/mining/common{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/station/hallway/primary/starboard)
 "kNb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38704,8 +38895,16 @@
 /obj/effect/turf_decal/tile/dark_blue{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/security)
+"lcD" = (
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "ldb" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -38789,7 +38988,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/secequipment,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/dark_blue{
 	dir = 8
@@ -38863,12 +39061,11 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "lpe" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/light/small/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/hallway/primary/starboard)
+/area/station/maintenance/central)
 "lqc" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 8;
@@ -39551,10 +39748,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "mdC" = (
-/obj/machinery/camera/autoname/directional/west,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "meR" = (
@@ -39895,6 +40092,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter)
+"mwr" = (
+/obj/machinery/light/directional/north,
+/obj/structure/table,
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "mww" = (
 /obj/machinery/atmospherics/components/binary/pump/off{
 	name = "Ports to Engine"
@@ -40029,6 +40232,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "mEv" = (
@@ -40098,6 +40302,9 @@
 /area/station/engineering/atmos/mix)
 "mHO" = (
 /obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "mHP" = (
@@ -40254,6 +40461,9 @@
 	req_access = list("robotics")
 	},
 /obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "mUE" = (
@@ -40363,6 +40573,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/bot_white/left,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "mYZ" = (
@@ -40615,6 +40826,13 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"nmK" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/textured_half,
+/area/station/science/robotics/mechbay)
 "nnI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40976,6 +41194,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"nDd" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "nDk" = (
 /obj/structure/table,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -41093,6 +41318,7 @@
 /obj/structure/chair/sofa/bench/right{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "nLx" = (
@@ -41311,14 +41537,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "nZw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/engineering/main)
 "oaw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41521,13 +41745,13 @@
 /area/station/engineering/supermatter/room)
 "onE" = (
 /obj/structure/cable,
-/obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/item/radio/intercom/prison/directional/north,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "onH" = (
@@ -41917,6 +42141,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"oLu" = (
+/obj/machinery/door/airlock/external{
+	name = "Common Mining Dock"
+	},
+/obj/effect/landmark/navigate_destination,
+/turf/open/floor/plating,
+/area/station/hallway/primary/starboard)
 "oLC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41992,6 +42223,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/explab)
+"oQx" = (
+/obj/machinery/status_display/evac,
+/turf/closed/wall,
+/area/station/security/checkpoint/escape)
 "oQB" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
@@ -42071,6 +42306,7 @@
 	listening = 0;
 	name = "Interrogation Intercom"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "oVy" = (
@@ -42255,6 +42491,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"pdV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/iron,
+/area/station/commons/fitness/recreation)
 "pff" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42337,12 +42583,9 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "pkW" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/sign/warning/docking,
+/turf/closed/wall/r_wall,
+/area/station/hallway/primary/starboard)
 "pmx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42491,6 +42734,12 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
+"pvh" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/interrogation)
 "pwd" = (
 /obj/structure/bed/roller,
 /obj/item/radio/intercom/directional/west,
@@ -42801,7 +43050,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "pRY" = (
-/obj/structure/cable,
 /obj/item/radio/intercom/directional/south,
 /obj/machinery/camera/autoname/directional/south,
 /obj/effect/turf_decal/tile/neutral{
@@ -42964,13 +43212,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "qce" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/floor,
-/obj/effect/turf_decal/tile/brown/opposingcorners,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/station/maintenance/central)
+/area/station/science/robotics/mechbay)
 "qcS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -42980,6 +43226,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"qdd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "qdz" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -43049,6 +43305,10 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
+"qiU" = (
+/obj/machinery/atmospherics/components/tank/air,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "qjk" = (
 /obj/machinery/atmospherics/components/binary/valve/digital,
 /turf/open/floor/iron/dark,
@@ -43171,16 +43431,12 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "qqq" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/turf/open/floor/plating,
-/area/station/hallway/primary/starboard)
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "qqK" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
@@ -43232,6 +43488,13 @@
 /obj/structure/transit_tube/diagonal,
 /turf/open/space/basic,
 /area/space/nearstation)
+"qub" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/camera/autoname/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "qvO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43363,15 +43626,8 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "qzZ" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/turf/open/floor/plating,
+/obj/structure/sign/warning/docking,
+/turf/closed/wall,
 /area/station/hallway/primary/starboard)
 "qAo" = (
 /obj/structure/marker_beacon/burgundy,
@@ -43687,6 +43943,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"qSf" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "qTH" = (
 /obj/structure/sign/departments/psychology/directional/west,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
@@ -43829,6 +44092,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"rfu" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron,
+/area/station/engineering/hallway)
 "rfL" = (
 /obj/machinery/door/airlock/external{
 	name = "Auxiliary Dock"
@@ -44259,6 +44529,10 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"rBO" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/circuit/green,
+/area/station/ai_monitored/command/nuke_storage)
 "rCp" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Atmospherics Air Tank"
@@ -44427,6 +44701,13 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
+"rLr" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "rLE" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
@@ -44671,6 +44952,18 @@
 /obj/machinery/bluespace_vendor/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"sch" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plating,
+/area/station/engineering/storage/tech)
+"scv" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "scA" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/neutral{
@@ -45128,6 +45421,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/holopad,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "sAV" = (
@@ -45419,9 +45715,6 @@
 	cycle_id = "maint-dome-3"
 	},
 /obj/machinery/door/airlock/external/glass,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/bridge)
 "sVB" = (
@@ -45700,6 +45993,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
+"tpg" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "tpv" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45775,9 +46073,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
 "tuj" = (
-/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/station/commons/storage/emergency/port)
 "tva" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45858,6 +46156,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "maint-service-pass-1"
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "tAZ" = (
@@ -46772,6 +47073,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"uFu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/science/robotics/mechbay)
 "uGp" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Interrogation room";
@@ -47105,12 +47415,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "vfg" = (
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/chair/sofa/bench/right{
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
+	},
+/obj/structure/chair/sofa/bench/left{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
@@ -47277,6 +47586,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
+"vwZ" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/science/robotics/mechbay)
 "vxm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/closed/wall/r_wall,
@@ -47337,6 +47652,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/mix)
+"vBt" = (
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "vDt" = (
 /obj/structure/cable,
 /turf/open/floor/carpet/red,
@@ -47560,11 +47883,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "vOS" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/space/basic,
-/area/space)
+/obj/structure/cable,
+/obj/effect/landmark/event_spawn,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "vQy" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -47626,6 +47949,7 @@
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "vUz" = (
@@ -47794,6 +48118,7 @@
 	dir = 4
 	},
 /obj/structure/tank_holder/extinguisher,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "wfu" = (
@@ -48130,9 +48455,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "wBU" = (
@@ -48281,6 +48604,11 @@
 "wSW" = (
 /turf/closed/wall,
 /area/station/security/prison/safe)
+"wSZ" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/gravity_generator)
 "wTh" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Escape Bar";
@@ -48587,6 +48915,8 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "maint-service-pass-1"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "xof" = (
@@ -48617,6 +48947,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
+"xqm" = (
+/obj/structure/marker_beacon/bronze,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "xqF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
@@ -48676,15 +49011,10 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "xsN" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/chair/sofa/bench{
-	dir = 4
-	},
-/obj/effect/landmark/start/assistant,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/engineering/gravity_generator)
 "xsQ" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 4
@@ -59519,10 +59849,10 @@ aUn
 aUn
 aUn
 aUn
-aNJ
 bEB
 bEB
-auz
+bEB
+aUn
 aUn
 bWP
 uvG
@@ -59781,7 +60111,7 @@ bGS
 bGS
 bGS
 bSG
-bUf
+oQx
 bUe
 jFy
 bYw
@@ -62590,7 +62920,7 @@ bDP
 bDP
 bDP
 cbS
-qft
+gZk
 bVy
 fQi
 bIB
@@ -64102,7 +64432,7 @@ dUr
 aNj
 aNj
 nXF
-cWu
+tpg
 mIV
 bgI
 ncu
@@ -64332,7 +64662,7 @@ aqy
 ars
 asn
 aso
-dmv
+dev
 auZ
 avM
 bMa
@@ -64588,8 +64918,8 @@ auY
 uMJ
 bga
 aso
-bga
-bsU
+hsH
+jUt
 bsU
 auc
 bMa
@@ -65944,7 +66274,7 @@ axE
 siP
 axD
 bKW
-bNn
+tuj
 bOU
 bQl
 bQl
@@ -66740,7 +67070,7 @@ coS
 iny
 nsP
 cse
-euI
+eVs
 cny
 cwo
 saW
@@ -67731,7 +68061,7 @@ aot
 mxi
 aot
 eOu
-pax
+rLr
 pax
 aGU
 pax
@@ -68258,7 +68588,7 @@ rrv
 uIf
 bvX
 bMj
-tRI
+bLl
 tRI
 bYB
 dHA
@@ -68515,7 +68845,7 @@ axU
 aSR
 bvX
 bNu
-bNu
+jWJ
 hXB
 bRM
 hPU
@@ -68707,7 +69037,7 @@ bIt
 cjE
 cpR
 bIt
-bIt
+qqq
 tBl
 bIt
 aBa
@@ -69030,7 +69360,7 @@ jsF
 bvX
 bNw
 bNw
-tRI
+pvh
 bRO
 bRO
 bUs
@@ -69285,14 +69615,14 @@ bJB
 egK
 nwC
 bvX
-tRI
+dnC
 uGp
 tRI
 bRO
 gtw
 cns
 bVN
-kyb
+ceS
 kyb
 bZQ
 cch
@@ -69558,7 +69888,7 @@ gBL
 ceH
 bkn
 lkE
-ciF
+cjF
 ckh
 clq
 cmo
@@ -70070,7 +70400,7 @@ aXm
 cck
 cdB
 ceJ
-oGi
+exw
 lcA
 ciG
 cnD
@@ -72369,7 +72699,7 @@ bJD
 jXm
 ciN
 eLE
-bNG
+cpa
 bNG
 bQx
 nil
@@ -72398,10 +72728,10 @@ eEl
 ieb
 udD
 cBh
-cCj
-cCj
-cCj
-cCj
+ceR
+ceR
+ceR
+ceR
 cCj
 cCj
 cCj
@@ -72899,11 +73229,11 @@ cdD
 ccp
 bUO
 chC
-chC
+gfc
 chC
 bUO
 cmu
-cmu
+dFP
 cmu
 bUO
 aCI
@@ -73153,7 +73483,7 @@ aCI
 bUO
 rCp
 cdE
-ceS
+ccp
 bUO
 lfD
 ciI
@@ -73161,7 +73491,7 @@ ckn
 bUO
 bMV
 cnQ
-cpa
+cmu
 bUO
 aCI
 cBh
@@ -73909,7 +74239,7 @@ dKs
 xMx
 bJD
 lCe
-tuj
+bJD
 iaE
 bNJ
 bNJ
@@ -74166,7 +74496,7 @@ aNB
 xMx
 bJD
 lCe
-bLl
+dZH
 bMy
 bMy
 bMy
@@ -76251,7 +76581,7 @@ cri
 csk
 ctz
 svB
-cwB
+rfu
 csp
 cyF
 cHP
@@ -78028,7 +78358,7 @@ bQL
 aGm
 ayX
 ibE
-csr
+cAs
 gea
 ccy
 coZ
@@ -79575,7 +79905,7 @@ cbb
 ccB
 cbb
 bUO
-cgB
+cgA
 chM
 cgA
 bUO
@@ -80308,7 +80638,7 @@ aZG
 bdg
 ben
 eTc
-cwC
+aIR
 bxS
 bxS
 bRm
@@ -81878,7 +82208,7 @@ bJB
 bjc
 jAW
 bMH
-bSZ
+vBt
 bZe
 bZe
 bZe
@@ -82119,7 +82449,7 @@ qHy
 nMF
 brm
 bwt
-bzi
+jwg
 bvd
 bww
 bxX
@@ -82413,7 +82743,7 @@ ckA
 clD
 cmM
 vwT
-pgc
+sch
 pgc
 crx
 csv
@@ -82938,7 +83268,7 @@ csv
 cyV
 eCp
 sqv
-seH
+nZw
 cxY
 mPs
 cDX
@@ -83157,7 +83487,7 @@ bwt
 bwt
 bwt
 bwt
-bVt
+gSn
 xMx
 sGt
 lCe
@@ -83693,7 +84023,7 @@ cdY
 cvg
 cgE
 asJ
-lAL
+auz
 csw
 aCI
 cmO
@@ -84728,7 +85058,7 @@ aTN
 wLl
 csw
 cmQ
-wLl
+aNJ
 czk
 caZ
 cvv
@@ -86197,7 +86527,7 @@ aCI
 sZd
 aHQ
 inn
-vSn
+bUA
 bUA
 aMb
 fHr
@@ -86221,7 +86551,7 @@ bet
 bfh
 avm
 gou
-bUA
+vSn
 bhj
 avm
 lWL
@@ -86735,7 +87065,7 @@ aCI
 lWL
 avm
 bAo
-bUA
+vSn
 bUA
 avm
 lWL
@@ -87225,7 +87555,7 @@ aCI
 lWL
 lWL
 pYa
-kNb
+pYa
 iXk
 lWL
 lWL
@@ -87249,7 +87579,7 @@ aCI
 lWL
 lWL
 pYa
-pYa
+kNb
 pYa
 lWL
 lWL
@@ -87275,7 +87605,7 @@ bJD
 lCe
 vNo
 nGA
-bOl
+mwr
 bOi
 bQX
 tdH
@@ -87482,31 +87812,31 @@ cHt
 afB
 afB
 afE
-prW
-afE
-afB
-afB
-afB
-aoz
-aoz
-afB
-afB
-afB
-afB
-afB
-cHt
-afB
-afB
-afB
-afB
-afB
-afB
-afB
-cHt
-afB
-afB
-afE
 gBv
+afE
+afB
+afB
+afB
+cHt
+cHt
+afB
+afB
+afB
+afB
+afB
+cHt
+afB
+afB
+afB
+afB
+afB
+afB
+afB
+cHt
+afB
+afB
+afE
+prW
 afE
 afB
 afB
@@ -87739,7 +88069,7 @@ aCI
 lWL
 lWL
 eED
-kNb
+pYa
 pYa
 lWL
 lWL
@@ -87763,7 +88093,7 @@ aCI
 lWL
 lWL
 qKB
-pYa
+kNb
 pYa
 lWL
 lWL
@@ -87996,7 +88326,7 @@ aCI
 lWL
 lWL
 lWL
-aIR
+aCI
 lWL
 lWL
 lWL
@@ -88015,7 +88345,7 @@ lWL
 lWL
 lWL
 lWL
-vOS
+lWL
 aCI
 lWL
 lWL
@@ -88253,7 +88583,7 @@ aGZ
 aGZ
 lWL
 lWL
-aIR
+aCI
 lWL
 lWL
 lWL
@@ -88277,13 +88607,13 @@ aCI
 lWL
 lWL
 buf
-adj
+lpe
 xnQ
-adj
-adj
-adj
-adj
-adj
+lpe
+lpe
+lpe
+lpe
+lpe
 bqs
 bwI
 bwI
@@ -88510,7 +88840,7 @@ aFn
 aGZ
 lWL
 lWL
-aIR
+aCI
 lWL
 lWL
 aRj
@@ -88540,7 +88870,7 @@ bmi
 bmi
 bmi
 aIL
-adj
+lpe
 aZQ
 brw
 bsA
@@ -88574,7 +88904,7 @@ sKu
 ccS
 csw
 cft
-con
+awh
 chZ
 jwI
 gHx
@@ -88767,18 +89097,18 @@ aFn
 aGZ
 aCI
 aCI
-aIR
+aCI
+aCI
 aCI
 aRj
+ayn
+pRp
+ayn
+ayn
 aRj
 aRj
 aRj
 aRj
-aRj
-aRj
-aCI
-aSq
-aCI
 aVS
 aVO
 aXh
@@ -88797,7 +89127,7 @@ aCI
 aCI
 bmi
 aIL
-adj
+lpe
 aZQ
 brw
 bsA
@@ -88811,7 +89141,7 @@ bCR
 enV
 mUJ
 pAU
-xHA
+eOi
 xMx
 bJD
 lCe
@@ -88844,7 +89174,7 @@ crH
 czk
 sDI
 cvH
-cug
+qiU
 cvz
 pPt
 czZ
@@ -89024,18 +89354,18 @@ aFn
 aGZ
 lWL
 lWL
-aIR
+aCI
+lWL
 lWL
 aRj
-aRj
-ayn
-pRp
-ayn
-ayn
-aRj
-aRj
-aRj
-aRj
+fIs
+qQQ
+aMq
+aPI
+aQu
+aRe
+eiQ
+aTC
 aVS
 aVP
 aYC
@@ -89054,13 +89384,13 @@ dRs
 aCI
 buf
 adj
-adj
+lpe
 aZQ
 brx
 iMu
 bud
 bsA
-bwI
+byd
 aVK
 bsA
 bsA
@@ -89281,18 +89611,18 @@ aFn
 aGZ
 lWL
 lWL
-aIR
+aCI
+lWL
 lWL
 aRj
-aRj
-fIs
-qQQ
-aMq
-aPI
-aQu
-aRe
-eiQ
-aTC
+jHW
+ayn
+aPb
+ane
+aQt
+mSl
+axF
+aTD
 aVS
 aVQ
 aXj
@@ -89305,13 +89635,13 @@ aVS
 aCI
 dRs
 bhq
-biS
+rBO
 biS
 dRs
 aCI
 buf
 aIL
-adj
+lpe
 aZQ
 bry
 bsA
@@ -89536,20 +89866,20 @@ aFn
 aFn
 aFn
 aGZ
-pkW
-aIR
-aIR
+aCI
+aCI
+aCI
+aCI
 aCI
 aRj
-aRj
-jHW
-ayn
-aPb
-ane
-aQt
-mSl
+aMq
+qQQ
+fIs
+tyO
+aQu
+aRf
 axF
-aTD
+aTE
 aVS
 vaF
 aXk
@@ -89793,20 +90123,20 @@ aFn
 aFn
 aFn
 aGZ
-pkW
 lWL
+lWL
+xqm
 lWL
 lWL
 aRj
-aRj
-aMq
-qQQ
-fIs
-tyO
+ayn
+gSd
+aAd
+ayn
 aQu
-aRf
-axF
-aTE
+agO
+bVq
+aTF
 aVS
 jbU
 bdr
@@ -89825,7 +90155,7 @@ dRs
 aCI
 buf
 aIL
-adj
+lpe
 aZQ
 brz
 bsA
@@ -90050,20 +90380,20 @@ aFn
 aFn
 aFn
 aGZ
-pkW
-lWL
-lWL
-lWL
+abT
+abT
+ajB
+qzZ
+ajB
 aRj
 aRj
-ayn
-gSd
-aAd
-ayn
-aQu
+aRj
+aRj
+aRj
+aRj
 agO
-bVq
-aTF
+xsN
+wSZ
 aVS
 aVT
 aYC
@@ -90082,7 +90412,7 @@ dRs
 aCI
 buf
 aIL
-adj
+lpe
 aZQ
 brz
 bsA
@@ -90307,16 +90637,16 @@ aFn
 aFn
 aFn
 aGZ
-pkW
-aCI
-aCI
-aCI
-aRj
-aRj
-aRj
-aRj
-aRj
-aRj
+atI
+atI
+atI
+atI
+atI
+atI
+atI
+adQ
+lWL
+lWL
 aRj
 agO
 aSv
@@ -90339,13 +90669,13 @@ dRs
 aCI
 buf
 aIL
-adj
+lpe
 aZQ
 bBn
 bBn
 byh
 bvm
-byd
+bwI
 aVK
 wIu
 bBr
@@ -90564,16 +90894,16 @@ aFn
 aFn
 aFn
 aGZ
-pkW
+atI
+atI
+atI
+atI
+atI
+atI
+atI
+adQ
 lWL
 lWL
-lWL
-aCI
-aRj
-aRj
-aRj
-aRj
-aRj
 aRj
 aRi
 hEg
@@ -90821,14 +91151,14 @@ ayY
 ayY
 ayY
 aGZ
-pkW
-lWL
-lWL
-aCI
-aCI
-aCI
-aCI
-aCI
+atI
+atI
+atI
+atI
+atI
+atI
+atI
+adQ
 aCI
 aCI
 aRj
@@ -90853,7 +91183,7 @@ dRs
 aCI
 buf
 bok
-adj
+lpe
 aZQ
 brB
 bsB
@@ -91078,14 +91408,14 @@ aFq
 aFq
 ayo
 aGZ
-qqq
-abT
-aCI
-aCI
-lWL
-lWL
-lWL
-lWL
+atI
+atI
+atI
+atI
+atI
+atI
+atI
+adQ
 lWL
 lWL
 aRj
@@ -91110,7 +91440,7 @@ dRs
 aCI
 buf
 adj
-adj
+lpe
 aZQ
 brB
 bsB
@@ -91148,7 +91478,7 @@ rNi
 bMP
 cjk
 iXM
-lAL
+auz
 csw
 csw
 csw
@@ -91335,16 +91665,16 @@ jAe
 uTk
 qCf
 aGZ
-lpe
-abT
+atI
+atI
+atI
+efr
+atI
+atI
+atI
+adQ
 lWL
-aCI
-aCI
-aCI
-aCI
-aCI
-aCI
-aCI
+lWL
 aRj
 aRl
 rBb
@@ -91361,13 +91691,13 @@ aVS
 aCI
 aCI
 buf
-qce
+exz
 buf
 aCI
 aCI
 bmi
 bol
-aIL
+aSq
 aZQ
 brA
 bsB
@@ -91595,13 +91925,13 @@ aGZ
 qzZ
 abT
 ajB
+oLu
+ajB
+kMV
+abT
+pkW
 ajB
 ajB
-abT
-abT
-adQ
-adQ
-adQ
 aRj
 aRj
 aSA
@@ -91624,7 +91954,7 @@ bmi
 bmi
 bmi
 bom
-aIL
+aSq
 aZQ
 ubz
 bsC
@@ -91842,7 +92172,7 @@ azD
 uAa
 uAa
 dFe
-uAa
+qub
 cUG
 uAa
 uAa
@@ -91852,15 +92182,15 @@ gjl
 wBz
 huo
 bwP
-aLr
-nZw
-bsO
-ebD
-xsN
-vfg
+vVh
+vVh
+vVh
+scv
+vVh
+vVh
 vVh
 vDV
-uAa
+nDd
 ncd
 uAa
 dHf
@@ -91881,7 +92211,7 @@ bUL
 aIL
 aIL
 adj
-aIL
+aSq
 aZQ
 aZQ
 aZQ
@@ -92103,14 +92433,14 @@ akG
 gjY
 akG
 akG
-akG
-akG
 cTq
-gjY
 akG
 akG
 akG
-awh
+akG
+bKC
+akG
+akG
 akG
 aNv
 aNv
@@ -92360,14 +92690,14 @@ bug
 nrc
 aiT
 bug
-bug
-bug
 bOA
-hnO
 bug
-bwN
+bug
+bug
+bug
+bsO
 aBD
-aMg
+bug
 bhD
 ayN
 aOo
@@ -92617,9 +92947,9 @@ cfu
 cfu
 cfu
 cfu
-mgT
+vOS
 cfu
-cRo
+cfu
 cfu
 cfu
 olW
@@ -92874,18 +93204,18 @@ ceZ
 bsV
 bsV
 bsV
-bsV
-bsV
 aYk
+bsV
+bsV
 fyk
 bsV
 bsV
 qbm
 rwd
 bsV
-bsV
+gqg
 hgI
-bsV
+vfg
 bsV
 bsV
 bsV
@@ -92896,7 +93226,7 @@ aWh
 gjY
 fem
 iMm
-fem
+jWp
 crA
 bdv
 bey
@@ -93455,7 +93785,7 @@ ssg
 caw
 tsz
 qsb
-qsb
+pdV
 qsb
 hgQ
 rOi
@@ -93915,8 +94245,8 @@ ewn
 iog
 mEi
 sAv
-iog
-iog
+uFu
+uFu
 mUn
 aNy
 cJA
@@ -94170,21 +94500,21 @@ rpj
 tJc
 aNC
 aHT
-aOs
+bnI
 aPg
 aPO
 aPg
-aos
+nmK
 aSE
 bLY
 cfd
 aXx
-abT
-abT
-abT
-abT
-abT
-abT
+aYQ
+aYQ
+aYQ
+aYQ
+aYQ
+aYQ
 bfm
 bmp
 abT
@@ -94431,11 +94761,11 @@ uZz
 krU
 rTc
 krU
-aos
+nmK
 aSE
 bLY
 cfd
-aXx
+aLr
 aYQ
 aZS
 baZ
@@ -94469,7 +94799,7 @@ bIf
 bJg
 bIf
 bGU
-gGn
+qSf
 akA
 bGU
 bPN
@@ -94683,12 +95013,12 @@ uqO
 aiK
 aMP
 aNC
-aOs
+aos
 rCX
 aPi
 bho
 aPi
-aos
+nmK
 aSE
 bLY
 cfd
@@ -94940,11 +95270,11 @@ aLy
 aMm
 aMQ
 aNC
-aOs
+vwZ
 aOu
 aPQ
 mHO
-aOs
+qce
 aRr
 aNy
 wXd
@@ -96004,15 +96334,15 @@ bwQ
 bzV
 bBw
 bqz
-jvg
-rjj
+qdd
+ciF
 bGU
 bIk
 bGU
 bGU
 bGU
-gGn
-akA
+cgB
+ciF
 bGU
 tcb
 bRp
@@ -96263,13 +96593,13 @@ bqz
 bqz
 jvg
 rce
-rce
+gKh
 rce
 elu
 bKc
 fdF
 bEu
-akA
+rjj
 bGU
 bRo
 vSS
@@ -96526,7 +96856,7 @@ jGM
 bEu
 bEu
 bEu
-akA
+rjj
 bGU
 awP
 bRn
@@ -96783,7 +97113,7 @@ bIn
 bKd
 tUC
 bEu
-akA
+rjj
 bGU
 cel
 hxh
@@ -97555,7 +97885,7 @@ fFQ
 bGZ
 bEu
 bhi
-bnI
+bOH
 wfu
 aKT
 xbJ
@@ -97825,7 +98155,7 @@ boq
 bPZ
 cdi
 bPZ
-bPZ
+cRo
 bPZ
 cqM
 nvl
@@ -98040,7 +98370,7 @@ wTz
 bag
 bdJ
 aUX
-pKC
+lcD
 bHx
 dYP
 iYV
@@ -99599,8 +99929,8 @@ aCI
 aCI
 bwU
 byo
+bEu
 bwU
-bwU
 lWL
 lWL
 lWL
@@ -99609,7 +99939,7 @@ lWL
 lWL
 lWL
 bwU
-bwU
+bEu
 bDe
 bGU
 bRq
@@ -100370,8 +100700,8 @@ lWL
 aCI
 bwU
 byo
+bEu
 bwU
-bwU
 lWL
 lWL
 lWL
@@ -100380,9 +100710,9 @@ lWL
 lWL
 lWL
 bwU
-bwU
+bEu
 bDe
-bGU
+bwU
 lWL
 lWL
 bOJ
@@ -103167,7 +103497,7 @@ lWL
 lWL
 sjk
 sjk
-aRB
+gMC
 cgQ
 aSQ
 sjk

--- a/StationMaps/DiscStation/DiscStation.dmm
+++ b/StationMaps/DiscStation/DiscStation.dmm
@@ -1585,6 +1585,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"ajS" = (
+/obj/structure/sign/flag/nanotrasen/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "ajT" = (
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/burnchamber)
@@ -7574,15 +7578,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "aJS" = (
-/obj/structure/closet/cabinet,
-/turf/open/floor/plating,
-/area/station/maintenance/port/central)
-"aJT" = (
-/obj/structure/chair/wood{
-	dir = 4
+/obj/machinery/telecomms/server{
+	name = "TheServer";
+	desc = "It appears to not be functional, how cringe."
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"aJT" = (
+/obj/structure/sink/kitchen/directional/east,
+/turf/open/floor/iron,
+/area/station/security/prison)
 "aJU" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -11654,8 +11659,7 @@
 /turf/closed/wall/r_wall,
 /area/station/command/bridge)
 "baL" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/station/command/bridge)
 "baO" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -12118,7 +12122,7 @@
 /area/station/maintenance/port/central)
 "bcY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
@@ -16041,9 +16045,7 @@
 /obj/structure/mirror/directional/north{
 	pixel_y = 33
 	},
-/obj/structure/sink/kitchen{
-	pixel_y = 12
-	},
+/obj/structure/sink/kitchen/directional/west,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/captain/private)
 "btX" = (
@@ -16549,11 +16551,9 @@
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain/private)
 "bwr" = (
-/obj/machinery/shower{
-	dir = 4
-	},
 /obj/item/soap/deluxe,
 /obj/item/bikehorn/rubberducky,
+/obj/machinery/shower/directional/east,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/captain/private)
 "bws" = (
@@ -20386,7 +20386,7 @@
 /area/station/commons/lounge)
 "bMN" = (
 /turf/closed/wall,
-/area/station/service/bar)
+/area/station/service/bar/backroom)
 "bMO" = (
 /obj/structure/grille,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -21672,7 +21672,8 @@
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "bSj" = (
-/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "bSl" = (
@@ -22060,6 +22061,7 @@
 /area/station/commons/lounge)
 "bTF" = (
 /obj/machinery/airalarm/directional/east,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "bTG" = (
@@ -22784,9 +22786,6 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "bWv" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 30
-	},
 /obj/machinery/food_cart,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
@@ -23143,6 +23142,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "bXT" = (
@@ -23188,11 +23189,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "bXZ" = (
 /obj/machinery/light/directional/south,
-/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -23377,7 +23378,6 @@
 /area/station/engineering/atmos)
 "bYU" = (
 /obj/machinery/newscaster/directional/south,
-/mob/living/simple_animal/parrot/poly,
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
@@ -23441,7 +23441,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /turf/open/floor/wood,
-/area/station/service/bar)
+/area/station/service/bar/backroom)
 "bZp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23670,12 +23670,8 @@
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
 "caj" = (
-/obj/structure/sink/kitchen{
-	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
-	name = "old sink";
-	pixel_y = 28
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/sink/kitchen/directional/south,
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
 "cak" = (
@@ -23687,12 +23683,8 @@
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
 "cal" = (
-/obj/structure/sink/kitchen{
-	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
-	name = "old sink";
-	pixel_y = 28
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/sink/kitchen/directional/south,
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
 "cam" = (
@@ -23701,19 +23693,19 @@
 /area/station/service/kitchen/coldroom)
 "can" = (
 /turf/open/floor/wood,
-/area/station/service/bar)
+/area/station/service/bar/backroom)
 "cap" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/wood,
-/area/station/service/bar)
+/area/station/service/bar/backroom)
 "caq" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
 /obj/item/storage/photo_album/bar,
 /turf/open/floor/wood,
-/area/station/service/bar)
+/area/station/service/bar/backroom)
 "car" = (
 /obj/structure/table/wood,
 /obj/item/stack/package_wrap,
@@ -23723,7 +23715,7 @@
 	c_tag = "Maltese Falcon - Backroom"
 	},
 /turf/open/floor/wood,
-/area/station/service/bar)
+/area/station/service/bar/backroom)
 "cas" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/carpet,
@@ -24038,11 +24030,11 @@
 	},
 /obj/effect/landmark/start/bartender,
 /turf/open/floor/wood,
-/area/station/service/bar)
+/area/station/service/bar/backroom)
 "cbA" = (
 /obj/structure/closet/secure_closet/bar,
 /turf/open/floor/wood,
-/area/station/service/bar)
+/area/station/service/bar/backroom)
 "cbB" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -24396,6 +24388,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/structure/sink/kitchen/directional/north,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "ccL" = (
@@ -24423,16 +24416,16 @@
 /obj/structure/table/wood,
 /obj/item/vending_refill/cigarette,
 /turf/open/floor/wood,
-/area/station/service/bar)
+/area/station/service/bar/backroom)
 "ccT" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/vending/wardrobe/bar_wardrobe,
 /turf/open/floor/wood,
-/area/station/service/bar)
+/area/station/service/bar/backroom)
 "ccV" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/wood,
-/area/station/service/bar)
+/area/station/service/bar/backroom)
 "ccX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -26131,11 +26124,6 @@
 	},
 /obj/item/clothing/gloves/color/fyellow,
 /obj/effect/spawner/random/maintenance,
-/obj/structure/sink/kitchen{
-	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
-	name = "old sink";
-	pixel_y = 28
-	},
 /obj/item/storage/belt/utility,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
@@ -26844,7 +26832,6 @@
 /area/station/commons/dorms)
 "cmR" = (
 /obj/structure/bed,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/item/bedsheet/dorms,
 /obj/machinery/button/door/directional/east{
 	id = "Cabin2";
@@ -26868,9 +26855,7 @@
 /turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "cmX" = (
-/obj/machinery/shower{
-	dir = 4
-	},
+/obj/machinery/shower/directional/east,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
 "cmY" = (
@@ -26878,10 +26863,8 @@
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
 "cmZ" = (
-/obj/machinery/shower{
-	dir = 8
-	},
 /obj/effect/landmark/start/assistant,
+/obj/machinery/shower/directional/west,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
 "cna" = (
@@ -27139,6 +27122,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
 "coi" = (
@@ -27163,9 +27147,15 @@
 /obj/structure/chair/wood{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "com" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "con" = (
@@ -27409,7 +27399,6 @@
 	layer = 2.9
 	},
 /obj/effect/spawner/random/techstorage/security_all,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
 "cpq" = (
@@ -27444,10 +27433,8 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
 "cpu" = (
-/obj/machinery/shower{
-	dir = 4
-	},
 /obj/structure/mirror/directional/west,
+/obj/machinery/shower/directional/east,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
 "cpv" = (
@@ -27456,9 +27443,7 @@
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
 "cpw" = (
-/obj/machinery/shower{
-	dir = 8
-	},
+/obj/machinery/shower/directional/west,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
 "cpx" = (
@@ -27494,9 +27479,6 @@
 /area/station/commons/dorms)
 "cpA" = (
 /obj/structure/bed,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /obj/item/bedsheet/dorms,
 /obj/machinery/button/door/directional/north{
 	id = "Cabin5";
@@ -28810,15 +28792,13 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/toilet)
 "cuH" = (
-/obj/machinery/shower{
-	dir = 8
-	},
 /obj/item/soap,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
+/obj/machinery/shower/directional/west,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/toilet)
 "cuI" = (
@@ -30270,10 +30250,8 @@
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/ce)
 "cBl" = (
-/obj/machinery/shower{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/shower/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cBm" = (
@@ -30809,6 +30787,7 @@
 /obj/item/stock_parts/cell/high,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/mob/living/simple_animal/parrot/poly,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "cDJ" = (
@@ -30909,8 +30888,8 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "cEy" = (
-/obj/structure/closet/secure_closet/engineering_chief,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/pdapainter/engineering,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "cEz" = (
@@ -31796,8 +31775,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "cXe" = (
-/obj/structure/cable,
-/obj/structure/sign/departments/engineering/directional/south,
+/obj/structure/sign/departments/engineering/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "cXV" = (
@@ -32150,9 +32128,12 @@
 /area/station/service/chapel)
 "dqV" = (
 /obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/drinks/shaker,
+/obj/item/reagent_containers/food/drinks/shaker{
+	pixel_y = 0
+	},
 /obj/item/book/manual/wiki/barman_recipes{
-	pixel_y = 5
+	pixel_y = 5;
+	pixel_x = 14
 	},
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
@@ -32275,6 +32256,10 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"dzw" = (
+/obj/structure/sink/kitchen/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "dAv" = (
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
@@ -32282,7 +32267,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
-/area/station/service/bar)
+/area/station/service/bar/backroom)
 "dAF" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
@@ -32922,6 +32907,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "eqN" = (
@@ -35312,10 +35298,8 @@
 "hcT" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/table/wood,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
 /obj/machinery/newscaster/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "hdt" = (
@@ -35527,7 +35511,7 @@
 	pixel_y = 28
 	},
 /turf/open/floor/wood,
-/area/station/service/bar)
+/area/station/service/bar/backroom)
 "hoj" = (
 /obj/machinery/holopad/secure,
 /obj/machinery/camera/autoname/directional/west,
@@ -35773,6 +35757,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
+"hIi" = (
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/station/commons/dorms)
 "hIl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36291,7 +36282,7 @@
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/station/service/bar)
+/area/station/service/bar/backroom)
 "iqX" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -37937,12 +37928,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
 "kvZ" = (
-/obj/machinery/shower{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/shower/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "kwX" = (
@@ -38228,6 +38217,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison)
+"kOT" = (
+/obj/structure/chair/comfy/beige{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "kPj" = (
 /obj/machinery/camera/autoname/directional/south,
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted,
@@ -38901,12 +38897,10 @@
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain)
 "lMh" = (
-/obj/structure/sink/kitchen{
-	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
-	name = "old sink"
-	},
-/turf/open/floor/iron,
-/area/station/security/prison)
+/obj/structure/cable,
+/obj/structure/sign/departments/medbay/alt/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "lMC" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -40142,6 +40136,7 @@
 "nhn" = (
 /mob/living/carbon/human/species/monkey/punpun,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "nhF" = (
@@ -40754,9 +40749,6 @@
 /area/station/security/execution/transfer)
 "nUx" = (
 /obj/structure/bed,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /obj/item/bedsheet/dorms,
 /obj/machinery/button/door/directional/north{
 	id = "Cabin6";
@@ -40893,7 +40885,7 @@
 	department = "Chief Engineer's Desk";
 	name = "Chief Engineer's Requests Console"
 	},
-/obj/machinery/pdapainter/engineering,
+/obj/structure/closet/secure_closet/engineering_chief,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "ocE" = (
@@ -42553,6 +42545,11 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"qlN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron,
+/area/station/commons/storage/primary)
 "qmL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -43049,9 +43046,10 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "qNt" = (
-/obj/structure/sign/departments/medbay/alt/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/service/bar)
 "qPa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -43943,6 +43941,7 @@
 "rUO" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "rVz" = (
@@ -44673,7 +44672,7 @@
 "sKu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
-/area/station/service/bar)
+/area/station/service/bar/backroom)
 "sKN" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -44902,12 +44901,14 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "tdZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/station/commons/dorms)
 "teu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45298,7 +45299,6 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "tHI" = (
-/obj/structure/extinguisher_cabinet/directional/east,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -45537,14 +45537,11 @@
 "tWm" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
-/obj/machinery/shower{
-	name = "emergency shower";
-	pixel_y = 16
-	},
 /obj/effect/turf_decal/trimline/blue/end,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 1
 	},
+/obj/machinery/shower/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "tWC" = (
@@ -45903,7 +45900,6 @@
 /area/station/medical/medbay/lobby)
 "usZ" = (
 /obj/structure/bed,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/item/bedsheet/dorms,
 /obj/machinery/button/door/directional/east{
 	id = "Cabin1";
@@ -46008,8 +46004,9 @@
 /area/station/engineering/supermatter/room)
 "uBy" = (
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/wood,
-/area/station/service/bar)
+/area/station/service/bar/backroom)
 "uCw" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
 	dir = 8
@@ -46558,6 +46555,7 @@
 /area/station/engineering/supermatter/room)
 "vwT" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
 "vxm" = (
@@ -47244,11 +47242,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "wus" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
+/obj/structure/sign/flag/nanotrasen/directional/east,
 /turf/open/floor/iron,
-/area/station/engineering/main)
+/area/station/hallway/primary/central)
 "wuA" = (
 /obj/machinery/atmospherics/components/binary/pump/off{
 	dir = 8;
@@ -47317,6 +47313,7 @@
 "wxk" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "wxt" = (
@@ -47495,6 +47492,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "wLs" = (
@@ -48514,6 +48512,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"yhs" = (
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "yih" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/components/unary/passive_vent{
@@ -63912,7 +63914,7 @@ csc
 euI
 clj
 cwh
-clj
+aJT
 cyq
 czn
 cAd
@@ -64169,7 +64171,7 @@ wSW
 cjS
 cyr
 vHd
-lMh
+clj
 cyr
 cyr
 czo
@@ -69746,7 +69748,7 @@ ayi
 ayi
 aCI
 ayi
-bcU
+aOh
 aLY
 aNo
 aNo
@@ -70003,7 +70005,7 @@ ayi
 lWL
 lWL
 ayi
-bcU
+aOh
 aLY
 cND
 sRp
@@ -70260,7 +70262,7 @@ ayV
 lWL
 ayi
 ayi
-bcU
+aOh
 aLY
 aMH
 aMH
@@ -70773,7 +70775,7 @@ aUx
 ayi
 lWL
 ayi
-aJT
+bcU
 bcU
 ayi
 lWL
@@ -78500,7 +78502,7 @@ aRb
 aRb
 aYr
 cid
-baO
+baL
 fAw
 mkl
 bwn
@@ -78757,7 +78759,7 @@ ufJ
 aWT
 bwn
 cid
-bwn
+cXe
 bwn
 bde
 bel
@@ -78786,7 +78788,7 @@ bFm
 gff
 bVt
 xMx
-bJD
+wus
 lCe
 bDr
 cnZ
@@ -79270,7 +79272,7 @@ aUE
 bLE
 aWV
 aYt
-cXe
+cid
 baO
 bwn
 bdg
@@ -80042,7 +80044,7 @@ aVJ
 aWY
 aYv
 aZG
-baO
+bwn
 ije
 ije
 aDP
@@ -80812,7 +80814,7 @@ aUK
 mpA
 aXb
 dqd
-qNt
+bwn
 baO
 bwn
 bwn
@@ -81125,7 +81127,7 @@ clD
 cmK
 uEw
 cpp
-pgc
+bbU
 crv
 csv
 kzT
@@ -81327,7 +81329,7 @@ ojf
 aXd
 bwn
 cid
-cid
+lMh
 cid
 cid
 jwv
@@ -81356,7 +81358,7 @@ bFt
 bwt
 bVt
 xMx
-bJD
+ajS
 lCe
 mno
 bMI
@@ -81638,8 +81640,8 @@ ckA
 clD
 cmM
 vwT
-bbU
-bbU
+pgc
+pgc
 crx
 csv
 nNJ
@@ -82678,7 +82680,7 @@ cEM
 faS
 mDF
 amb
-wus
+cAB
 xKi
 nYr
 vXG
@@ -83449,7 +83451,7 @@ dZL
 czP
 bby
 cBA
-cAB
+cDh
 xKi
 myP
 cEI
@@ -84692,7 +84694,7 @@ avm
 bzI
 tHI
 bCN
-hIZ
+qlN
 bFC
 bGL
 ohq
@@ -84708,7 +84710,7 @@ jrg
 qlf
 paS
 bWx
-tdZ
+cac
 bZi
 sAV
 cac
@@ -86506,7 +86508,7 @@ bQX
 tdH
 bTA
 dqV
-vNv
+qNt
 bXT
 cep
 cak
@@ -86763,7 +86765,7 @@ eXz
 oeb
 bTA
 bVa
-vNv
+qNt
 bXU
 cep
 cal
@@ -87277,7 +87279,7 @@ bOk
 uVS
 pbE
 cAL
-vNv
+qNt
 bXW
 cep
 cep
@@ -88303,7 +88305,7 @@ bOk
 bPC
 bOk
 bxh
-bOi
+yhs
 bxh
 bTC
 bbs
@@ -88558,7 +88560,7 @@ vNo
 nGA
 bOk
 bPD
-bQX
+kOT
 bSj
 bTF
 euw
@@ -88578,7 +88580,7 @@ cgJ
 cnf
 csw
 hcT
-col
+tdZ
 czk
 caZ
 cuh
@@ -88835,7 +88837,7 @@ cgJ
 oLC
 cov
 con
-mhI
+hIi
 czk
 bZW
 cFE
@@ -89863,7 +89865,7 @@ lAL
 oLC
 coy
 con
-mhI
+hIi
 czk
 bme
 sDI
@@ -97825,7 +97827,7 @@ bPZ
 bPZ
 czk
 cjA
-cFE
+dzw
 ctY
 ctY
 ctY

--- a/StationMaps/DiscStation/information.txt
+++ b/StationMaps/DiscStation/information.txt
@@ -13,4 +13,4 @@
 
 
 Most Modern Base Commit Used:
-https://github.com/tgstation/tgstation/commit/b59521952d38b50af0c5cfbd2cb5c393d4dd269d
+https://github.com/tgstation/tgstation/commit/91fc367432aadae0a298c64b0b0b8e3fe0c2af71


### PR DESCRIPTION
# Changelog (updated)
+Absolutely enormous overhaul of the Atmoshperics department. Now 35% larger!
+Sacrificed some nice maint rooms to squeeze in an Incinerator for atmos.
*Updated the following type paths following upstream changes: pAI cards, Quartermasters Office, firesuits, radsuits, straight-jackets
+Added a keycard auth device in QM's Office
+Added those fancy new decorations, including clocks, calendars, and location signs
+Added some grille spawners outside the vault
+Most stations have obstructions to block meteors from striking the supermatter's cooling pipes (AI satellite, asterioids, etc). Disc's setup is especially vulnerable. Added an extra layer of grilles to help.
+Added a freezer/mix room for the Supermatter Engine.
*Slight modification of disposals conveyors to slay an instance of in-wall piping
*Cryogenics now has glass doors and some new windows. Don't neglect patients trapped in the tube!
+More lights
+More cameras
+More action (haha, funny)
-Removed a window that had a great view of an iron wall
*Fixed orphaned air vent in atmospherics
+Extra meter to SM pipes
+Added some firedoors
*Minor single-tile tweaks and fixes
*Added an R&D console to the bridge. The Research Director is now slightly less neglected
+Copied the supplied AI modules from MetaStation
+Gave Sci Maint an APC
*Replaced the miserable Construction area with an Auxiliary Base Construction Area
*The area around the old construction area has been touched up due to the significant structural change
*Tweaks to the bridge. Now includes blast doors at the entrance
*Swapped a part-mart with a coffee machine
*Moved some mounted stuff off of windows and onto walls
*Moved a Primary Hall Air Alarm out of those strange window plant things
+Added more assistant spawns and dispersed existing spawns
+Electrified some windows in and around engineering
*Changed up one or two access helpers in the AI Satellite
*SMES room now uses Engineering General access instead of Construction
*Amended multiple instances of vents & scrubbers hidden under structures or overtop of terminals
+Added a vent & scrubber to Bridge Hall
+Added a public mining shuttle dock
*Gravity Generator's walling has been reduced to just one layer of reinforced walls
*Gravity Generator room has been shifted about 2 tiles outward
*Re-routed pipes and wires due to mining dock installation
+Heard the news? Added a ton of new newscasters around the station
+Electrified CMO's windows similar to other stations
*Moved disposal pipes out from under the HOS's electrified windows
+Added pump & scrubber to Electrical Maintenance
*Moved some xeno spawns
*Various light changes
*The maintenance areas are hungry and have eaten their share of walls to occupy
*(Hopefully) Fixed every instance of unconnected vents and scrubbers.
*Prison's intercom is now the right type
*Arrivals can be confusing, so the airlocks that lead to space are now glass types. Please don't walk out into space!
*Miscellaneous minor changes
## Changes made by San7890
*Bridge tweak
*Fixed conflicting APC and fire extinguisher on same turf
+Added some more flags because they look nice
*Moved the bartender's book
*Fixed scrubbers and vents under tables in dorms
*Showers fix
*CE office shuffle
*Implemented the Bar Backroom area
*Fixed a space tile in kitchen (may have been me but it's fixed)
*Also APC movements in the bar
*Manually fixes some sinks

## To-do:
-Inconsistent use of Reinforced Walls