### PR TITLE
Includes the Submodule's DME Take Two

### DIFF
--- a/map_depot.dme
+++ b/map_depot.dme
@@ -11,6 +11,9 @@
 #define DEBUG
 // END_PREFERENCES
 
+// Include the tgstation DME here.
+#include "tgstation\tgstation.dme"
+
 // BEGIN_INCLUDE
 #include "submodules.dm"
 // END_INCLUDE


### PR DESCRIPTION
Hey there,

I took a look at how Goon does it here:

https://github.com/goonstation/goonstation/blob/master/goonstation.dme

![image](https://user-images.githubusercontent.com/34697715/185772442-177b50a1-6c0a-4bd9-baa7-d4da1eaaf09a.png)

And I realized I did it wrong the first time. Whoops. Should work great this time. I even tried it out using Ctrl+Click in the highlighter, and the lang-server even recognized the DME. Perfect! Let's do this.