### PR TITLE
Update Omegastation through virologist job removal

### DIFF
--- a/StationMaps/OmegaStation/Modernized+Heads of Staff (2024)/OmegaStation.dmm
+++ b/StationMaps/OmegaStation/Modernized+Heads of Staff (2024)/OmegaStation.dmm
@@ -16331,7 +16331,6 @@
 /area/station/maintenance/department/engine)
 "aSJ" = (
 /obj/structure/chair/office/light,
-/obj/effect/landmark/start/virologist,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
@@ -21193,7 +21192,6 @@
 	},
 /area/station/medical/treatment_center)
 "bfH" = (
-/obj/effect/landmark/start/virologist,
 /obj/effect/mapping_helpers/apc/cell_5k,
 /obj/machinery/camera/directional/north{
 	c_tag = "Medical - Virology";
@@ -28440,10 +28438,6 @@
 	pixel_y = -1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/item/toy/figure/virologist{
-	pixel_x = -2;
-	pixel_y = -1
-	},
 /turf/open/floor/iron/freezer,
 /area/station/medical/virology)
 "kpi" = (


### PR DESCRIPTION
As it says on the tin, currently running on Bagil.