### PR TITLE
Fix Cerestation Json for Custom Use

### DIFF
--- a/StationMaps/Cerestation/cerestation.json
+++ b/StationMaps/Cerestation/cerestation.json
@@ -1,7 +1,7 @@
 {
 	"version": 1,
-	"map_name": "cerestation",
-	"map_path": "map_files/Cerestation",
+	"map_name": "Cerestation",
+	"map_path": "custom",
 	"map_file": "cerestation.dmm",
 	"shuttles": {
 		"arrival": "arrival_box",


### PR DESCRIPTION
This **just** fixes the json file so that it can be run as a custom map without silently failing or hanging the custom map uploader.

This map probably should not be run on a live server as there are a very, large numbers of errors. This includes pre-access-helper, pre-list-access var definitions on doors and broken area definitions. This is throwing 300+ runtimes got me, several of which are for important things. Large amounts of game content may be missing or broken.