### PR TITLE
Update Northstar

### DIFF
--- a/StationMaps/NorthStar/north_star.dmm
+++ b/StationMaps/NorthStar/north_star.dmm
@@ -20106,7 +20106,7 @@
 "fkE" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/light_construct/directional/north,
-/obj/item/bot_assembly/floorbot,
+/obj/item/bot_assembly/repairbot,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port)
 "fkG" = (
@@ -25955,7 +25955,7 @@
 "gLt" = (
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/north,
-/mob/living/simple_animal/bot/floorbot,
+/mob/living/basic/bot/repairbot,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "gLy" = (
@@ -36710,7 +36710,7 @@
 "jBf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
-/obj/item/bot_assembly/floorbot,
+/obj/item/bot_assembly/repairbot,
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor2/starboard/aft)
 "jBm" = (
@@ -65672,7 +65672,7 @@
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "qSD" = (
-/obj/structure/aquarium/lawyer,
+/obj/item/fish_tank/lawyer,
 /turf/open/floor/wood/parquet,
 /area/station/service/lawoffice)
 "qSJ" = (
@@ -78297,7 +78297,7 @@
 	},
 /area/station/security/office)
 "ujv" = (
-/obj/docking_port/stationary/mining_home/common/northstar{
+/obj/docking_port/stationary/mining_home/common{
 	dir = 2
 	},
 /turf/open/floor/plating/airless,
@@ -87416,7 +87416,7 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/floor1/port)
 "wxW" = (
-/obj/docking_port/stationary/mining_home/northstar{
+/obj/docking_port/stationary/mining_home{
 	dir = 4
 	},
 /turf/open/floor/pod,

--- a/StationMaps/NorthStar/northstar.json
+++ b/StationMaps/NorthStar/northstar.json
@@ -2,7 +2,7 @@
 {
 	"version": 1,
 	"map_name": "NorthStar",
-	"map_path": "map_files/NorthStar",
+	"map_path": "custom",
 	"map_file": "north_star.dmm",
 	"shuttles": {
 		"emergency": "emergency_northstar",

--- a/StationMaps/NorthStar/northstar_readme.txt
+++ b/StationMaps/NorthStar/northstar_readme.txt
@@ -1,1 +1,2 @@
 replaced by nebulastation https://github.com/tgstation/tgstation/pull/84826 and removed in https://github.com/tgstation/tgstation/pull/87937
+1/20/25: update through 5ea3aa27021


### PR DESCRIPTION
Updates Northstar through the current update path scripts.

This is not currently playable due to the deletion of Northstar's custom shuttles in https://github.com/tgstation/tgstation/pull/87937. 

Currently loading this map will result in a broken cargo department (creating a large volume of runtimes) and latejoin players being sent to the error room due to the lack of the arrivals shuttle. Discussion with the other Maptainers in progress to determine how to resolve this.