### PR TITLE
BoxStation update 2

### DIFF
--- a/StationMaps/BoxStation/BoxStation 2024/BoxStation.dmm
+++ b/StationMaps/BoxStation/BoxStation 2024/BoxStation.dmm
@@ -1603,10 +1603,10 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "afv" = (
-/obj/machinery/photobooth,
-/obj/effect/turf_decal/siding/thinplating_new/dark,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/hallway/primary/central)
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/security/execution/transfer)
 "afB" = (
 /obj/item/radio/intercom/directional/east,
 /obj/structure/cable,
@@ -3812,13 +3812,15 @@
 	pixel_y = -6;
 	id = "outerbrig";
 	name = "Brig Exterior Doors Control";
-	req_access = list("brig")
+	req_access = list("brig");
+	normaldoorcontrol = 1
 	},
 /obj/machinery/button/door/directional/west{
 	pixel_y = 6;
 	id = "innerbrig";
 	req_access = list("brig");
-	name = "Brig Interior Doors Control"
+	name = "Brig Interior Doors Control";
+	normaldoorcontrol = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -18142,6 +18144,11 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
+/area/station/hallway/primary/central)
+"bkT" = (
+/obj/machinery/photobooth,
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/turf/open/floor/iron/dark/textured_large,
 /area/station/hallway/primary/central)
 "bkX" = (
 /obj/structure/table/wood,
@@ -32584,7 +32591,7 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/storage)
 "crr" = (
-/obj/structure/chair/sofa/left/maroon,
+/obj/structure/chair/sofa/right/maroon,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "crt" = (
@@ -42574,24 +42581,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
-"gSF" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Bridge Maintenance"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/command/maintenance,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "gSI" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
@@ -48874,6 +48863,7 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 4
 	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "kJq" = (
@@ -51777,11 +51767,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/security/prison)
-"myh" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/security/execution/transfer)
 "mzb" = (
 /obj/structure/table,
 /obj/item/electropack,
@@ -61266,10 +61251,6 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
-"sxu" = (
-/obj/structure/chair/sofa/right/maroon,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "sxD" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
@@ -62439,6 +62420,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
+"thM" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Bridge Maintenance"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/command/maintenance,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "thV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 4
@@ -63469,7 +63468,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/bridge_pipe/purple/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/supply/hidden{
 	dir = 4
 	},
@@ -68923,6 +68922,10 @@
 	dir = 8
 	},
 /area/station/hallway/primary/central)
+"xko" = (
+/obj/structure/chair/sofa/left/maroon,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "xkv" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -93038,7 +93041,7 @@ kga
 gSI
 fyS
 clZ
-sxu
+crr
 lWm
 gXs
 aaa
@@ -93295,7 +93298,7 @@ xzW
 qSI
 aft
 clZ
-crr
+xko
 aaH
 gXs
 aaa
@@ -93807,7 +93810,7 @@ rlH
 kCk
 xzW
 qSI
-myh
+afv
 clZ
 gXs
 gXs
@@ -95659,7 +95662,7 @@ bcX
 aZM
 bjz
 bjz
-gSF
+thM
 bjz
 bjz
 jXq
@@ -95919,7 +95922,7 @@ bie
 bjA
 bmp
 bjz
-afv
+bkT
 bpa
 bHC
 cBr

--- a/StationMaps/BoxStation/BoxStation 2024/BoxStation.dmm
+++ b/StationMaps/BoxStation/BoxStation 2024/BoxStation.dmm
@@ -4,7 +4,9 @@
 /area/space)
 "aab" = (
 /obj/machinery/firealarm/directional/east,
-/obj/item/radio/intercom/directional/north,
+/obj/item/radio/intercom/directional/north{
+	pixel_x = -3
+	},
 /obj/structure/sign/picture_frame/portrait/bar{
 	pixel_y = 32;
 	pixel_x = 32
@@ -12,6 +14,13 @@
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks{
 	dir = 8
+	},
+/obj/machinery/button/door/directional/north{
+	id = "shutters-bar";
+	name = "Bar Shutters Control";
+	req_access = list("bar");
+	pixel_y = 27;
+	pixel_x = 13
 	},
 /turf/open/floor/wood/large,
 /area/station/service/bar)
@@ -292,10 +301,7 @@
 /area/station/command/heads_quarters/hos)
 "abl" = (
 /obj/machinery/vending/security,
-/obj/effect/turf_decal/stripes/red/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/full,
+/obj/effect/turf_decal/tile/dark_red/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/lockers)
 "abm" = (
@@ -303,14 +309,14 @@
 /obj/item/storage/box/firingpins,
 /obj/item/storage/box/firingpins,
 /obj/item/key/security,
-/obj/effect/turf_decal/tile/red/full,
+/obj/effect/turf_decal/tile/dark_red/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/security/armory)
 "abn" = (
 /obj/structure/rack,
 /obj/machinery/firealarm/directional/north,
 /obj/effect/spawner/random/armory/dragnet,
-/obj/effect/turf_decal/tile/red/full,
+/obj/effect/turf_decal/tile/dark_red/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/security/armory)
 "abo" = (
@@ -348,16 +354,15 @@
 /area/station/security/prison)
 "abx" = (
 /obj/machinery/door/airlock/security/glass{
-	id_tag = "permaouter";
+	id_tag = "permainner";
 	name = "Permabrig Transfer"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured_half,
-/area/station/security/execution/transfer)
-"abz" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
 /area/station/security/execution/transfer)
 "abB" = (
 /obj/structure/chair/stool/directional/south,
@@ -368,16 +373,21 @@
 "abC" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/west,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/dark_red,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/prison/visit)
 "abD" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/east,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/dark_red,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/prison/visit)
 "abE" = (
 /obj/structure/chair/stool/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/prison/visit)
 "abF" = (
 /obj/machinery/airalarm/directional/east,
@@ -394,7 +404,7 @@
 	pixel_x = -3
 	},
 /obj/item/storage/lockbox/loyalty,
-/obj/effect/turf_decal/tile/red/full,
+/obj/effect/turf_decal/tile/dark_red/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/security/armory)
 "abI" = (
@@ -402,7 +412,7 @@
 /obj/machinery/light/directional/north,
 /obj/effect/spawner/random/armory/bulletproof_armor,
 /obj/effect/spawner/random/armory/bulletproof_helmet,
-/obj/effect/turf_decal/tile/red/full,
+/obj/effect/turf_decal/tile/dark_red/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/security/armory)
 "abJ" = (
@@ -413,7 +423,7 @@
 /obj/effect/spawner/random/armory/riot_armor,
 /obj/effect/spawner/random/armory/riot_helmet,
 /obj/effect/spawner/random/armory/riot_shield,
-/obj/effect/turf_decal/tile/red/full,
+/obj/effect/turf_decal/tile/dark_red/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/security/armory)
 "abN" = (
@@ -437,7 +447,8 @@
 	pixel_x = 3;
 	pixel_y = 2
 	},
-/obj/effect/turf_decal/tile/red/full,
+/obj/effect/turf_decal/tile/dark_red/full,
+/obj/item/gun/grenadelauncher,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/security/armory)
 "abO" = (
@@ -448,8 +459,8 @@
 /area/station/engineering/atmos/storage/gas)
 "abP" = (
 /obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral/full,
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/tile/dark_red/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/lockers)
 "abQ" = (
@@ -458,14 +469,15 @@
 /obj/item/gun/energy/ionrifle,
 /obj/item/gun/energy/temperature/security,
 /obj/item/clothing/suit/hooded/ablative,
-/obj/effect/turf_decal/tile/red/full,
+/obj/effect/turf_decal/tile/dark_red/full,
+/obj/item/gun/ballistic/automatic/battle_rifle,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/security/armory)
 "abR" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/machinery/light/directional/east,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral/full,
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/tile/dark_red/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/lockers)
 "abT" = (
@@ -542,7 +554,7 @@
 /turf/closed/wall,
 /area/station/security/interrogation)
 "aci" = (
-/obj/effect/turf_decal/tile/red/full,
+/obj/effect/turf_decal/tile/dark_red/full,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/closet/crate/secure/weapon{
@@ -609,7 +621,6 @@
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/red/corner,
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/smooth_large,
 /area/station/ai_monitored/security/armory)
@@ -619,7 +630,8 @@
 /area/station/command/heads_quarters/hos)
 "aco" = (
 /obj/structure/closet/bombcloset/security,
-/obj/effect/turf_decal/tile/neutral/full,
+/obj/effect/turf_decal/tile/dark_red/full,
+/obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/lockers)
 "acp" = (
@@ -631,9 +643,9 @@
 /area/station/hallway/secondary/dock)
 "acq" = (
 /obj/effect/landmark/secequipment,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/bot_white,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/full,
+/obj/effect/turf_decal/tile/dark_red/full,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
@@ -697,9 +709,6 @@
 /turf/open/floor/plating,
 /area/station/security/prison/visit)
 "acE" = (
-/obj/structure/chair{
-	dir = 8
-	},
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding{
@@ -718,7 +727,10 @@
 "acH" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/west,
 /obj/structure/chair/stool/directional/north,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/prison/visit)
 "acL" = (
 /obj/effect/turf_decal/stripes/line{
@@ -754,14 +766,19 @@
 /obj/machinery/camera/directional/west{
 	c_tag = "Security - Gear Room South"
 	},
-/obj/effect/turf_decal/tile/neutral/full,
+/obj/effect/turf_decal/tile/dark_red/full,
 /obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/lockers)
 "acQ" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
 /obj/item/stamp/head/hos,
+/obj/item/pai_card{
+	pixel_x = 13;
+	pixel_y = 3
+	},
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/hos)
 "acR" = (
@@ -778,6 +795,7 @@
 	pixel_x = -3;
 	pixel_y = 0
 	},
+/obj/item/pen/red,
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/hos)
 "acS" = (
@@ -810,6 +828,12 @@
 	pixel_y = 6
 	},
 /obj/item/pen,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/security/armory)
 "acU" = (
@@ -873,12 +897,10 @@
 	network = list("ss13","prison")
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/prison/visit)
 "add" = (
-/obj/structure/chair{
-	dir = 8
-	},
+/obj/machinery/photobooth/security,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/corner{
 	color = "#ff8300";
@@ -911,9 +933,6 @@
 	name = "Armoury Shutters Control";
 	id = "armory"
 	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/dark_red,
 /turf/open/floor/iron/smooth_large,
 /area/station/ai_monitored/security/armory)
@@ -925,7 +944,7 @@
 /area/station/command/heads_quarters/hos)
 "adi" = (
 /obj/machinery/flasher/portable,
-/obj/effect/turf_decal/tile/red/full,
+/obj/effect/turf_decal/tile/dark_red/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/security/armory)
 "adj" = (
@@ -950,9 +969,12 @@
 	name = "Armoury Shutters";
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/siding/dark_red/corner{
+/obj/effect/turf_decal/delivery/white,
+/obj/effect/turf_decal/siding/dark_red{
 	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/security/armory)
@@ -1060,6 +1082,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark_red,
 /turf/open/floor/iron/dark/textured_half,
 /area/station/security/execution/transfer)
 "adH" = (
@@ -1085,7 +1108,10 @@
 "adL" = (
 /obj/structure/closet/secure_closet/evidence,
 /obj/machinery/light_switch/directional/north,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/small,
 /area/station/security/evidence)
 "adM" = (
 /obj/machinery/light/directional/south,
@@ -1159,6 +1185,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "adX" = (
@@ -1170,17 +1199,11 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "aeb" = (
-/obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/station/security/execution/transfer)
-"aeg" = (
-/obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "aei" = (
@@ -1240,7 +1263,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "aeo" = (
-/obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
@@ -1300,10 +1322,21 @@
 	pixel_x = 39;
 	pixel_y = 1
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/dark_red,
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/security/lockers)
 "aew" = (
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/dark_red,
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/security/lockers)
 "aey" = (
 /obj/machinery/door/airlock/command{
@@ -1325,10 +1358,18 @@
 /obj/effect/turf_decal/siding/dark_red/corner{
 	dir = 8
 	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/office)
 "aeB" = (
 /obj/effect/turf_decal/siding/dark_red,
+/obj/structure/table,
+/obj/item/stack/package_wrap,
+/obj/item/hand_labeler{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/office)
 "aeC" = (
@@ -1409,11 +1450,16 @@
 /obj/effect/mapping_helpers/requests_console/assistance,
 /obj/effect/mapping_helpers/requests_console/information,
 /obj/effect/mapping_helpers/requests_console/supplies,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/thinplating_new/dark/corner,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/warden)
 "aeY" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/dark_red,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/security/armory)
 "afa" = (
@@ -1430,22 +1476,19 @@
 "afb" = (
 /obj/machinery/recharger,
 /obj/structure/table,
-/obj/effect/turf_decal/tile/neutral/full,
+/obj/effect/turf_decal/tile/dark_red/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/lockers)
 "afc" = (
 /obj/structure/table,
 /obj/machinery/recharger,
-/obj/effect/turf_decal/stripes/red/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/full,
+/obj/effect/turf_decal/tile/dark_red/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/lockers)
 "afd" = (
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/tile/neutral/full,
+/obj/effect/turf_decal/tile/dark_red/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/lockers)
 "afg" = (
@@ -1495,6 +1538,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/security/office)
 "afo" = (
@@ -1555,33 +1599,14 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/main)
 "aft" = (
-/obj/structure/closet/secure_closet/brig,
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "afv" = (
-/obj/structure/table,
-/obj/item/storage/box/prisoner{
-	pixel_y = 8
-	},
-/obj/item/storage/box/prisoner,
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/turf/open/floor/iron/dark,
-/area/station/security/execution/transfer)
-"afz" = (
-/obj/structure/table,
-/obj/item/storage/box/hug{
-	pixel_x = 4;
-	pixel_y = 3
-	},
-/obj/item/razor{
-	pixel_x = -8;
-	pixel_y = 3
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/turf/open/floor/iron/dark,
-/area/station/security/execution/transfer)
+/obj/machinery/photobooth,
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/hallway/primary/central)
 "afB" = (
 /obj/item/radio/intercom/directional/east,
 /obj/structure/cable,
@@ -1593,19 +1618,30 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "afD" = (
-/obj/structure/table,
-/obj/item/assembly/signaler,
 /obj/machinery/camera/directional/east{
 	network = list("ss13","prison");
 	c_tag = "Prison Wing - Transfer Centre East"
 	},
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/obj/structure/table,
+/obj/item/razor{
+	pixel_x = -8;
+	pixel_y = 3
+	},
+/obj/item/storage/box/hug{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "afE" = (
-/obj/machinery/light/floor,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/exit/departure_lounge)
 "afF" = (
 /obj/effect/spawner/random/entertainment/arcade,
@@ -1646,22 +1682,29 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark_red,
+/turf/open/floor/iron/dark/textured_half,
 /area/station/security/evidence)
 "afL" = (
 /obj/structure/closet/secure_closet/evidence,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/small,
 /area/station/security/evidence)
 "afM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/station/security/evidence)
 "afN" = (
 /obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/station/security/evidence)
 "afO" = (
 /obj/structure/chair/office{
@@ -1697,7 +1740,11 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/dark_red,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_half,
 /area/station/security/lockers)
 "afU" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -1734,6 +1781,7 @@
 /area/station/security/office)
 "agb" = (
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/security/office)
 "agc" = (
@@ -1783,13 +1831,15 @@
 /area/station/security/warden)
 "ago" = (
 /obj/machinery/computer/security,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/warden)
 "agp" = (
 /obj/machinery/computer/prisoner/management,
 /obj/machinery/light/directional/north,
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/warden)
 "agr" = (
 /obj/structure/table/wood,
@@ -1812,7 +1862,8 @@
 	fax_name = "Warden's Office";
 	name = "Warden's Fax Machine"
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/dark_red/diagonal_centre,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/security/warden)
 "agv" = (
 /obj/machinery/camera/directional/west{
@@ -1835,6 +1886,7 @@
 /area/station/security/office)
 "agz" = (
 /obj/structure/table,
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/security/office)
 "agA" = (
@@ -1904,6 +1956,7 @@
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/light/directional/east,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/security/office)
 "agJ" = (
@@ -1970,7 +2023,10 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "agS" = (
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/warden)
 "agT" = (
 /obj/machinery/door/poddoor/preopen{
@@ -1981,17 +2037,20 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/textured,
+/turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/main)
 "agV" = (
 /obj/structure/cable,
 /obj/machinery/holopad/secure,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
+	},
 /obj/effect/turf_decal/box/white{
 	color = "#DE3A3A"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/warden)
 "agX" = (
 /obj/structure/table,
@@ -2003,7 +2062,8 @@
 	pixel_x = 6;
 	pixel_y = 3
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/dark_red/diagonal_centre,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/security/warden)
 "agY" = (
 /obj/structure/table,
@@ -2056,6 +2116,7 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/mail_sorting/security/general,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/security/office)
 "ahj" = (
@@ -2146,7 +2207,10 @@
 "ahv" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/warden)
 "ahw" = (
 /obj/machinery/computer/shuttle/mining{
@@ -2166,11 +2230,12 @@
 	name = "engineering security door"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/dark/textured,
+/turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/main)
 "ahz" = (
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/dark_red/diagonal_centre,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/security/warden)
 "ahA" = (
 /obj/structure/disposalpipe/segment{
@@ -2208,6 +2273,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/turf_decal/siding/yellow,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "ahG" = (
@@ -2269,12 +2335,18 @@
 "ahQ" = (
 /obj/structure/closet/secure_closet/warden,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/thinplating_new/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/warden)
 "ahR" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/start/warden,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/warden)
 "ahS" = (
 /obj/structure/table,
@@ -2292,14 +2364,20 @@
 	pixel_y = 8;
 	req_access = list("armory")
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/warden)
 "ahU" = (
 /obj/structure/closet/secure_closet/evidence,
 /obj/machinery/camera/directional/south{
 	c_tag = "Security - Evidence Lockup"
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/small,
 /area/station/security/evidence)
 "ahV" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
@@ -2317,7 +2395,10 @@
 /obj/machinery/computer/crew{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/warden)
 "ahZ" = (
 /obj/structure/disposalpipe/segment{
@@ -2363,14 +2444,30 @@
 /obj/structure/table,
 /obj/item/folder/red,
 /obj/item/pen,
-/obj/item/hand_labeler,
-/obj/item/book/manual/wiki/security_space_law,
-/turf/open/floor/iron/dark,
+/obj/item/hand_labeler{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_x = -9;
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/siding/thinplating_new/dark/corner{
+	dir = 1
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = 10;
+	pixel_y = 4
+	},
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/warden)
 "aih" = (
 /obj/structure/closet/secure_closet/evidence,
 /obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/small,
 /area/station/security/evidence)
 "aii" = (
 /obj/structure/disposalpipe/segment{
@@ -2386,7 +2483,8 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/dark_red/diagonal_centre,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/security/warden)
 "aik" = (
 /obj/structure/cable,
@@ -2401,6 +2499,7 @@
 	c_tag = "Security - Interrogation Room"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "aim" = (
@@ -2447,7 +2546,6 @@
 /area/station/security/office)
 "air" = (
 /obj/machinery/light_switch/directional/west,
-/obj/item/radio/intercom/directional/north,
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/wood/large,
@@ -2536,7 +2634,6 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/medical)
 "aiE" = (
-/obj/machinery/light/small/directional/west,
 /obj/machinery/newscaster/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -2574,13 +2671,17 @@
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/dark_red,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/security/warden)
 "aiL" = (
-/obj/structure/closet/radiation,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
+/obj/structure/closet/radiation,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "aiM" = (
@@ -2589,7 +2690,15 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
 /area/station/security/warden)
 "aiO" = (
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -2630,6 +2739,10 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark_red,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured_half,
 /area/station/security/interrogation)
 "aiX" = (
@@ -2650,7 +2763,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/station/security/evidence)
 "ajd" = (
 /obj/structure/plaque/static_plaque/golden{
@@ -2728,7 +2841,7 @@
 	},
 /obj/effect/turf_decal/tile/yellow/half,
 /obj/machinery/button/door/directional/north{
-	id = "courtroom_privacy";
+	id = "courtroom_shutters";
 	name = "Gallery Shutters Control";
 	req_access = list("court")
 	},
@@ -2763,14 +2876,7 @@
 	dir = 4
 	},
 /area/station/security/courtroom)
-"ajo" = (
-/obj/structure/cable,
-/obj/machinery/status_display/ai/directional/south,
-/obj/effect/turf_decal/tile/blue/half,
-/turf/open/floor/iron/edge,
-/area/station/command/bridge)
 "ajq" = (
-/obj/structure/closet/secure_closet/engineering_personal,
 /obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
@@ -2779,10 +2885,12 @@
 /area/station/engineering/main)
 "ajr" = (
 /obj/machinery/computer/prisoner/gulag_teleporter_computer,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
 "ajs" = (
 /obj/machinery/gulag_teleporter,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
 "ajt" = (
@@ -2791,10 +2899,12 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Security - Labor Shuttle Dock"
 	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
 "aju" = (
 /obj/machinery/computer/security/labor,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
 "ajv" = (
@@ -2894,7 +3004,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
 "ajI" = (
-/obj/structure/closet/secure_closet/engineering_personal,
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
@@ -2905,10 +3014,10 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Engineering - East"
 	},
-/obj/structure/closet/radiation,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
+/obj/structure/closet/secure_closet/engineering_personal,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "ajM" = (
@@ -2995,8 +3104,11 @@
 /obj/structure/bodycontainer/morgue/beeper_off{
 	dir = 8
 	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
 /obj/effect/turf_decal/delivery/white,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "ajZ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -3009,10 +3121,16 @@
 /obj/structure/chair{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
 "akb" = (
 /obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
 "ake" = (
@@ -3036,7 +3154,15 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
 /area/station/security/processing)
 "akg" = (
 /obj/machinery/camera/directional/south{
@@ -3147,6 +3273,9 @@
 "akz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
 "akA" = (
@@ -3276,7 +3405,11 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/dark_red,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_half,
 /area/station/security/brig)
 "akW" = (
 /obj/machinery/door/airlock/security/glass{
@@ -3428,13 +3561,6 @@
 "alv" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/ai_upload_foyer)
-"alw" = (
-/obj/machinery/light/small/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig)
 "alx" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -3443,6 +3569,9 @@
 /obj/item/radio/intercom/prison/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 9
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
@@ -3484,7 +3613,15 @@
 	req_access = list("security");
 	pixel_x = 3
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
 /area/station/security/brig)
 "alB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -3598,6 +3735,9 @@
 /obj/machinery/computer/shuttle/labor{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
 "ame" = (
@@ -3609,12 +3749,18 @@
 /obj/machinery/flasher/directional/west{
 	id = "Cell 1"
 	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 10
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "amg" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 1";
 	name = "Cell 1 Locker"
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 6
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
@@ -3624,12 +3770,18 @@
 /obj/machinery/flasher/directional/west{
 	id = "Cell 2"
 	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 10
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "ami" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 2";
 	name = "Cell 2 Locker"
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 6
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
@@ -3639,12 +3791,18 @@
 /obj/machinery/flasher/directional/west{
 	id = "Cell 3"
 	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 10
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "amk" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 3";
 	name = "Cell 3 Locker"
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 6
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
@@ -3684,7 +3842,15 @@
 	req_access = list("security");
 	pixel_x = 3
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
 /area/station/security/brig)
 "amn" = (
 /obj/structure/chair/office{
@@ -3706,6 +3872,7 @@
 /obj/machinery/light/small/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark_red,
 /turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
 "amr" = (
@@ -3728,6 +3895,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark_red,
 /turf/open/floor/iron/dark/textured_half,
 /area/station/security/courtroom)
 "amv" = (
@@ -3868,17 +4039,18 @@
 	},
 /obj/item/clothing/glasses/sunglasses{
 	pixel_x = 3;
-	pixel_y = 3
+	pixel_y = 9
 	},
 /obj/item/clothing/ears/earmuffs{
 	pixel_x = -3;
 	pixel_y = -2
 	},
 /obj/item/clothing/ears/earmuffs{
-	pixel_x = -3;
+	pixel_x = 3;
 	pixel_y = -2
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/dark_red/diagonal_centre,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/security/warden)
 "amP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3944,6 +4116,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "brig_front"
 	},
+/obj/machinery/scanner_gate/preset_guns,
 /turf/open/floor/iron/dark/side{
 	dir = 5
 	},
@@ -3963,6 +4136,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "brig_front"
 	},
+/obj/machinery/scanner_gate/preset_guns,
 /turf/open/floor/iron/dark/side{
 	dir = 9
 	},
@@ -4019,16 +4193,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/maintenance/port/aft)
-"ank" = (
-/obj/structure/reagent_dispensers/plumbed{
-	dir = 4;
-	name = "med/sci reservoir"
-	},
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/greater)
 "ano" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -4067,6 +4231,9 @@
 "ant" = (
 /obj/machinery/gulag_item_reclaimer{
 	pixel_y = 24
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
@@ -4224,7 +4391,15 @@
 	name = "Courtroom"
 	},
 /obj/effect/landmark/navigate_destination/court,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
 /area/station/security/courtroom)
 "anV" = (
 /obj/machinery/light/small/directional/south,
@@ -4342,6 +4517,9 @@
 /area/station/security/processing)
 "aos" = (
 /obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
 "aot" = (
@@ -4443,6 +4621,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "aoH" = (
+/obj/machinery/vending/coffee,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "aoJ" = (
@@ -5195,6 +5374,7 @@
 /obj/structure/filingcabinet,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/siding/wood,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
 "asa" = (
@@ -5277,6 +5457,7 @@
 	},
 /obj/structure/closet/masks,
 /obj/effect/landmark/start/hangover/closet,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "asr" = (
@@ -5459,6 +5640,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/dark_red,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured_half,
 /area/station/security/courtroom)
 "atg" = (
@@ -6149,6 +6334,9 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 9
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
 "awe" = (
@@ -6274,6 +6462,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "awy" = (
@@ -6351,7 +6542,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi';
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/commons/locker)
 "awI" = (
 /obj/structure/cable,
@@ -6809,9 +7000,7 @@
 /turf/open/space,
 /area/space/nearstation)
 "ayR" = (
-/obj/structure/chair{
-	dir = 8
-	},
+/obj/structure/chair,
 /obj/machinery/camera/directional/east{
 	c_tag = "Prison Wing - Entryway";
 	network = list("ss13","prison")
@@ -6849,7 +7038,7 @@
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/table/wood/fancy,
 /obj/item/dyespray,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/commons/locker)
 "ayX" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
@@ -7035,9 +7224,12 @@
 "azV" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/weather/snow,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "azY" = (
@@ -7283,7 +7475,12 @@
 /area/station/service/hydroponics/garden)
 "aAS" = (
 /obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 8
+	},
+/turf/open/floor/iron/edge{
+	dir = 8
+	},
 /area/station/service/hydroponics/garden)
 "aAT" = (
 /obj/machinery/seed_extractor,
@@ -7297,7 +7494,12 @@
 /area/station/service/hydroponics/garden)
 "aAU" = (
 /obj/structure/sink/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 8
+	},
+/turf/open/floor/iron/edge{
+	dir = 8
+	},
 /area/station/service/hydroponics/garden)
 "aAW" = (
 /obj/machinery/door/airlock/maintenance{
@@ -7444,6 +7646,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/service/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/iron/dark/textured_half,
 /area/station/commons/fitness)
 "aBE" = (
@@ -7468,7 +7671,12 @@
 /area/station/maintenance/port/fore)
 "aBM" = (
 /obj/effect/landmark/start/assistant,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
 /area/station/service/hydroponics/garden)
 "aBO" = (
 /obj/machinery/requests_console/directional/west{
@@ -7539,11 +7747,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "aCc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible,
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
 "aCd" = (
@@ -7779,7 +7985,12 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/arrivals)
 "aDa" = (
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
 /area/station/service/hydroponics/garden)
 "aDb" = (
 /obj/structure/table,
@@ -7789,7 +8000,8 @@
 	pixel_y = 5
 	},
 /obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/large,
 /area/station/commons/storage/primary)
 "aDc" = (
 /obj/structure/cable,
@@ -7806,6 +8018,9 @@
 /area/station/security/checkpoint/arrivals)
 "aDd" = (
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "aDf" = (
@@ -7824,7 +8039,8 @@
 /area/station/service/hydroponics/garden)
 "aDh" = (
 /obj/machinery/vending/assist,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/large,
 /area/station/commons/storage/primary)
 "aDi" = (
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -7859,28 +8075,33 @@
 	name = "Tool Storage Requests Console";
 	department = "Primary Tool Storage"
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/large,
 /area/station/commons/storage/primary)
 "aDl" = (
 /obj/structure/table,
 /obj/item/t_scanner,
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/large,
 /area/station/commons/storage/primary)
 "aDm" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/machinery/light_switch/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/large,
 /area/station/commons/storage/primary)
 "aDn" = (
 /obj/structure/table,
 /obj/item/assembly/signaler,
 /obj/item/assembly/signaler,
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/large,
 /area/station/commons/storage/primary)
 "aDo" = (
+/obj/effect/turf_decal/siding/thinplating_new,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "aDp" = (
@@ -7889,11 +8110,13 @@
 	pixel_x = -2;
 	pixel_y = -1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/large,
 /area/station/commons/storage/primary)
 "aDq" = (
 /obj/machinery/vending/tool,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/large,
 /area/station/commons/storage/primary)
 "aDs" = (
 /obj/effect/turf_decal/bot_white/right,
@@ -7925,7 +8148,7 @@
 	c_tag = "Security - Gear Room North"
 	},
 /obj/structure/closet/wardrobe/red,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/lockers)
 "aDE" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
@@ -8118,6 +8341,7 @@
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/neutral/diagonal_edge,
 /obj/effect/turf_decal/tile/bar/diagonal_centre,
+/obj/item/flashlight/lantern,
 /turf/open/floor/iron/dark/diagonal,
 /area/station/service/chapel/funeral)
 "aEp" = (
@@ -8200,7 +8424,13 @@
 	name = "Garden"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
+/turf/open/floor/iron/textured,
 /area/station/service/hydroponics/garden)
 "aEM" = (
 /turf/open/floor/circuit/green,
@@ -8264,7 +8494,9 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/gateway)
 "aEX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 5
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
@@ -8373,7 +8605,10 @@
 /obj/machinery/computer/records/medical/laptop{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "aFA" = (
 /obj/effect/turf_decal/siding/wood{
@@ -8470,7 +8705,17 @@
 	},
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/structure/table/glass,
+/obj/effect/turf_decal/tile/green/anticorner{
+	dir = 1
+	},
+/obj/item/food/grown/watermelon,
+/obj/item/food/grown/grapes,
+/obj/item/food/grown/citrus/orange,
+/obj/item/food/grown/apple,
+/obj/item/food/grown/banana,
+/obj/item/food/grown/wheat,
+/turf/open/floor/iron/corner,
 /area/station/service/hydroponics/garden)
 "aFQ" = (
 /obj/structure/table,
@@ -8487,7 +8732,8 @@
 	pixel_x = 0
 	},
 /obj/machinery/light/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/large,
 /area/station/commons/storage/primary)
 "aFU" = (
 /obj/effect/landmark/start/assistant,
@@ -8512,7 +8758,8 @@
 	pixel_y = -1
 	},
 /obj/machinery/light/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/large,
 /area/station/commons/storage/primary)
 "aGa" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
@@ -8825,12 +9072,11 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "aHd" = (
-/obj/machinery/disposal/bin/tagger,
-/obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/siding/wood/corner,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
 	},
+/obj/machinery/skill_station,
 /turf/open/floor/wood,
 /area/station/service/library)
 "aHe" = (
@@ -8839,7 +9085,8 @@
 	pixel_x = 1;
 	pixel_y = -1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/large,
 /area/station/commons/storage/primary)
 "aHf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
@@ -8878,7 +9125,8 @@
 /area/station/security/prison/rec)
 "aHp" = (
 /obj/structure/filingcabinet/chestdrawer,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/dark_red/diagonal_centre,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/security/warden)
 "aHq" = (
 /obj/machinery/door/poddoor/incinerator_atmos_main,
@@ -8922,15 +9170,18 @@
 	},
 /obj/structure/table/glass,
 /obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/green/anticorner{
-	dir = 1
+/obj/effect/turf_decal/tile/green/half{
+	dir = 8
 	},
-/turf/open/floor/iron/corner,
+/turf/open/floor/iron/edge{
+	dir = 8
+	},
 /area/station/service/hydroponics/garden)
 "aHD" = (
 /obj/structure/chair/stool/directional/south,
 /obj/effect/landmark/start/assistant,
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/thinplating_new,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "aHE" = (
@@ -8941,7 +9192,8 @@
 /obj/item/stack/package_wrap,
 /obj/item/stack/package_wrap,
 /obj/item/stack/package_wrap,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/large,
 /area/station/commons/storage/primary)
 "aHF" = (
 /turf/closed/wall/r_wall,
@@ -9003,9 +9255,6 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/gateway)
 "aHN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -9180,8 +9429,11 @@
 /turf/closed/wall,
 /area/station/service/hydroponics)
 "aIr" = (
-/obj/structure/filingcabinet,
 /obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/disposal/bin/tagger,
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -9193,6 +9445,9 @@
 	},
 /obj/structure/cable,
 /obj/item/radio/intercom/directional/north,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/carpet/green,
 /area/station/service/library)
 "aIu" = (
@@ -9200,9 +9455,6 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "aIv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/carpet/green,
@@ -9210,16 +9462,13 @@
 "aIw" = (
 /obj/structure/chair/office,
 /obj/structure/disposalpipe/segment{
-	dir = 6
+	dir = 10
 	},
 /obj/effect/landmark/start/assistant,
 /obj/structure/cable,
 /turf/open/floor/carpet/green,
 /area/station/service/library)
 "aIx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -9316,7 +9565,8 @@
 /obj/structure/table,
 /obj/item/wrench,
 /obj/item/analyzer,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/large,
 /area/station/commons/storage/primary)
 "aIO" = (
 /obj/machinery/light/directional/north,
@@ -9395,6 +9645,9 @@
 	codes_txt = "delivery;dir=8";
 	location = "Tool Storage"
 	},
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 4
+	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
@@ -9413,22 +9666,26 @@
 	pixel_y = 4
 	},
 /obj/item/clothing/gloves/color/fyellow,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/large,
 /area/station/commons/storage/primary)
 "aIX" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/large,
 /area/station/commons/storage/primary)
 "aIY" = (
 /obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/large,
 /area/station/commons/storage/primary)
 "aIZ" = (
 /obj/structure/table,
 /obj/item/storage/belt/utility,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/large,
 /area/station/commons/storage/primary)
 "aJa" = (
 /obj/structure/cable,
@@ -9438,15 +9695,19 @@
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "aJb" = (
-/obj/effect/turf_decal/delivery,
 /obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "aJc" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin/tagger,
 /obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/large,
 /area/station/commons/storage/primary)
 "aJd" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -9609,7 +9870,7 @@
 /area/station/engineering/atmos)
 "aJA" = (
 /obj/machinery/door/airlock/freezer{
-	name = "Kitchen Backroom"
+	name = "Kitchen Coldroom"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -9644,6 +9905,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/service/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured_half,
 /area/station/hallway/secondary/service)
 "aJE" = (
@@ -9726,6 +9990,7 @@
 "aJS" = (
 /obj/structure/table/wood,
 /obj/structure/disposalpipe/segment,
+/obj/item/pai_card,
 /turf/open/floor/carpet/green,
 /area/station/service/library)
 "aJT" = (
@@ -9772,14 +10037,22 @@
 	},
 /obj/structure/cable,
 /obj/effect/landmark/navigate_destination/tools,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new,
+/turf/open/floor/iron/textured,
 /area/station/commons/storage/primary)
 "aKa" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
 	name = "Primary Tool Storage"
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new,
+/turf/open/floor/iron/textured,
 /area/station/commons/storage/primary)
 "aKc" = (
 /obj/machinery/door/firedoor,
@@ -9835,7 +10108,11 @@
 	},
 /obj/structure/cable,
 /obj/machinery/duct,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 1
+	},
+/turf/open/floor/iron/textured,
 /area/station/service/hydroponics/garden)
 "aKn" = (
 /obj/effect/spawner/structure/window,
@@ -9908,6 +10185,11 @@
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/obj/effect/turf_decal/weather/snow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "aKD" = (
@@ -9935,14 +10217,16 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "aKH" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/effect/landmark/start/botanist,
+/obj/machinery/light_switch/directional/north,
+/obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
-/obj/effect/landmark/start/botanist,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "aKI" = (
 /obj/structure/closet/secure_closet/hydroponics,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "aKJ" = (
@@ -10000,31 +10284,44 @@
 /area/station/service/bar/backroom)
 "aKT" = (
 /obj/structure/closet/secure_closet/freezer/meat,
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/station/service/kitchen/coldroom)
-"aKV" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/machinery/door/window/right/directional/south{
-	req_access = list("kitchen");
-	name = "Kitchen Deliveries"
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
 	},
-/turf/open/floor/iron/dark,
-/area/station/service/kitchen/coldroom)
-"aKW" = (
-/obj/machinery/light_switch/directional/north,
-/obj/effect/turf_decal/loading_area{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/white{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
-"aKX" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/weather/snow,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 9
+	},
+/turf/open/floor/iron/kitchen_coldroom,
+/area/station/service/kitchen/coldroom)
+"aKV" = (
+/obj/structure/reagent_dispensers/cooking_oil,
+/obj/item/toy/figure/chef{
+	pixel_x = 2;
+	pixel_y = 14
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 6
+	},
+/obj/effect/turf_decal/weather/snow,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 5
+	},
+/turf/open/floor/iron/kitchen_coldroom,
+/area/station/service/kitchen/coldroom)
+"aKW" = (
 /obj/machinery/door/window/right/directional/east{
 	req_access = list("hydroponics");
 	name = "Hydroponics Deliveries"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "aKZ" = (
@@ -10061,6 +10358,7 @@
 	pixel_y = 5
 	},
 /obj/item/watertank,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "aLe" = (
@@ -10256,9 +10554,9 @@
 /area/station/hallway/primary/port)
 "aLL" = (
 /obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/bot_white,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/full,
+/obj/effect/turf_decal/tile/dark_red/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/lockers)
 "aLM" = (
@@ -10331,6 +10629,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "aLY" = (
@@ -10417,23 +10716,24 @@
 /area/station/ai_monitored/turret_protected/ai)
 "aMj" = (
 /mob/living/basic/goat/pete,
-/obj/effect/turf_decal/box/white{
-	color = "#9FED58"
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
 	},
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/weather/snow,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "aMk" = (
-/obj/machinery/chem_master/condimaster{
-	name = "CondiMaster Neo"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
+/obj/effect/turf_decal/weather/snow,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "aMl" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
 	},
+/obj/effect/turf_decal/weather/snow,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "aMm" = (
@@ -10518,7 +10818,9 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "aMz" = (
@@ -10545,7 +10847,16 @@
 /area/station/service/bar/backroom)
 "aMD" = (
 /obj/machinery/icecream_vat,
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/snow,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/kitchen_coldroom,
 /area/station/service/kitchen/coldroom)
 "aME" = (
 /obj/structure/disposalpipe/segment{
@@ -10558,16 +10869,19 @@
 "aMF" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
-/obj/effect/landmark/start/cook,
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/obj/structure/kitchenspike,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Coldroom Intake Pump"
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 5
+	},
+/obj/effect/turf_decal/bot_red,
+/obj/effect/turf_decal/weather/snow,
+/obj/effect/turf_decal/weather/snow/corner,
+/turf/open/floor/iron/kitchen_coldroom,
 /area/station/service/kitchen/coldroom)
-"aMG" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/shovel/spade,
-/obj/item/wrench,
-/obj/item/wirecutters,
-/turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
 "aMH" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -10577,7 +10891,10 @@
 /area/station/service/library)
 "aMI" = (
 /obj/machinery/light/small/directional/south,
-/obj/machinery/vending/wardrobe/hydro_wardrobe,
+/obj/structure/closet/crate/hydroponics,
+/obj/item/shovel/spade,
+/obj/item/wrench,
+/obj/item/wirecutters,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "aMJ" = (
@@ -10820,9 +11137,19 @@
 /turf/open/floor/wood/tile,
 /area/station/service/theater)
 "aNM" = (
-/obj/structure/kitchenspike,
 /obj/machinery/light/small/directional/west,
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/obj/machinery/food_cart,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/snow,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/kitchen_coldroom,
 /area/station/service/kitchen/coldroom)
 "aNN" = (
 /obj/machinery/door/firedoor,
@@ -10836,10 +11163,10 @@
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "aNO" = (
-/obj/machinery/light/small/directional/east,
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/vending/wardrobe/chef_wardrobe,
-/obj/effect/mapping_helpers/airalarm/tlv_cold_room,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/snow,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "aNP" = (
@@ -10938,10 +11265,6 @@
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 8
 	},
-/area/station/hallway/secondary/exit/departure_lounge)
-"aOd" = (
-/obj/structure/chair,
-/turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/secondary/exit/departure_lounge)
 "aOe" = (
 /obj/machinery/camera/directional/north{
@@ -11067,12 +11390,18 @@
 /obj/machinery/light/directional/south,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral/half,
+/obj/structure/sign/nanotrasen{
+	pixel_y = -32
+	},
 /turf/open/floor/iron/edge,
 /area/station/hallway/primary/central)
 "aOG" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral/half,
+/obj/structure/sign/nanotrasen{
+	pixel_y = -32
+	},
 /turf/open/floor/iron/edge,
 /area/station/hallway/primary/central)
 "aOH" = (
@@ -11088,8 +11417,20 @@
 /turf/open/floor/wood/large,
 /area/station/service/theater)
 "aOI" = (
-/obj/structure/kitchenspike,
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/obj/machinery/chem_master/condimaster{
+	name = "CondiMaster Neo"
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/snow,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 10
+	},
+/turf/open/floor/iron/kitchen_coldroom,
 /area/station/service/kitchen/coldroom)
 "aOJ" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/east,
@@ -11110,11 +11451,15 @@
 /area/station/service/theater)
 "aOM" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/structure/kitchenspike,
+/obj/effect/turf_decal/siding/white{
+	dir = 9
 	},
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/obj/effect/turf_decal/bot_red,
+/obj/effect/turf_decal/weather/snow,
+/obj/effect/turf_decal/weather/snow/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron/kitchen_coldroom,
 /area/station/service/kitchen/coldroom)
 "aOO" = (
 /obj/machinery/door/airlock/wood{
@@ -11167,8 +11512,10 @@
 /turf/open/floor/carpet,
 /area/station/service/library)
 "aOT" = (
-/obj/machinery/gibber,
 /obj/item/radio/intercom/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold/dark/visible,
+/obj/effect/turf_decal/weather/snow,
+/obj/effect/turf_decal/weather/snow/corner,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "aOV" = (
@@ -11335,12 +11682,8 @@
 /area/station/hallway/secondary/entry)
 "aPw" = (
 /obj/machinery/airalarm/directional/west,
-/obj/machinery/button/door/directional/north{
-	id = "shutters-bar";
-	name = "Bar Shutters Control";
-	req_access = list("bar")
-	},
 /obj/machinery/vending/boozeomat,
+/obj/structure/fish_mount/bar/directional/north,
 /turf/open/floor/wood/large,
 /area/station/service/bar)
 "aPx" = (
@@ -11384,12 +11727,20 @@
 /obj/effect/landmark/navigate_destination{
 	location = "Locker Room"
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new,
+/turf/open/floor/iron/textured,
 /area/station/commons/locker)
 "aPD" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new,
+/turf/open/floor/iron/textured,
 /area/station/commons/locker)
 "aPE" = (
 /obj/machinery/status_display/evac,
@@ -11509,13 +11860,14 @@
 /area/station/science/research/abandoned)
 "aQk" = (
 /obj/machinery/door/airlock/freezer{
-	name = "Kitchen Backroom"
+	name = "Kitchen Coldroom"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/duct,
 /obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured_half,
 /area/station/service/kitchen)
 "aQm" = (
@@ -11571,7 +11923,11 @@
 /area/station/service/library/private)
 "aQw" = (
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark_red/corner,
+/turf/open/floor/iron/dark/textured,
 /area/station/security/lockers)
 "aQz" = (
 /obj/item/radio/intercom/chapel/directional/east,
@@ -11606,20 +11962,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aQE" = (
-/turf/open/floor/plating,
-/area/station/hallway/secondary/exit/departure_lounge)
-"aQF" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	name = "Departures Security Dock"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/table,
+/obj/effect/spawner/random/entertainment/musical_instrument,
+/turf/open/floor/iron/white,
 /area/station/hallway/secondary/exit/departure_lounge)
 "aQG" = (
 /obj/structure/sign/warning/vacuum/external{
@@ -11656,20 +12002,36 @@
 /area/station/commons/locker)
 "aQO" = (
 /obj/effect/spawner/random/clothing/wardrobe_closet_colored,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/large,
 /area/station/commons/locker)
 "aQP" = (
-/obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/light_switch/directional/north,
-/turf/open/floor/iron,
+/obj/machinery/vending/clothing,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/large,
 /area/station/commons/locker)
 "aQQ" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/iron,
+/obj/machinery/vending/autodrobe,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/large,
 /area/station/commons/locker)
 "aQS" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/iron,
+/obj/structure/rack,
+/obj/item/chair/plastic{
+	pixel_x = 0;
+	pixel_y = 5
+	},
+/obj/item/chair/plastic{
+	pixel_x = 0;
+	pixel_y = 8
+	},
+/obj/item/chair/plastic{
+	pixel_x = 0;
+	pixel_y = 11
+	},
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/large,
 /area/station/commons/locker)
 "aQT" = (
 /obj/effect/turf_decal/tile/blue{
@@ -11681,19 +12043,27 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/hallway/secondary/entry)
 "aQU" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/iron,
+/obj/machinery/vending/coffee,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/large,
 /area/station/commons/locker)
 "aQV" = (
-/obj/machinery/vending/clothing,
-/turf/open/floor/iron,
+/obj/machinery/vending/cigarette,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/large,
 /area/station/commons/locker)
 "aQW" = (
 /obj/structure/closet/secure_closet/personal,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/large,
 /area/station/commons/locker)
 "aQX" = (
-/obj/machinery/vending/modularpc,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "aQY" = (
@@ -11930,7 +12300,6 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/lounge)
 "aRB" = (
-/obj/item/radio/intercom/directional/north,
 /obj/machinery/camera/directional/north{
 	c_tag = "SRV - Kitchen"
 	},
@@ -11939,6 +12308,7 @@
 /obj/item/book/manual/chef_recipes,
 /obj/effect/turf_decal/siding/dark,
 /obj/effect/turf_decal/tile/bar/full,
+/obj/structure/sign/warning/cold_temp/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/kitchen)
 "aRC" = (
@@ -11985,10 +12355,9 @@
 	},
 /area/station/security/prison)
 "aRL" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Departures Holding Area"
+/obj/machinery/door/airlock/public/glass{
+	name = "Arcade"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
@@ -12102,7 +12471,8 @@
 /obj/structure/closet/wardrobe/white,
 /obj/item/radio/intercom/directional/west,
 /obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/large,
 /area/station/commons/locker)
 "aSk" = (
 /obj/structure/table,
@@ -12407,9 +12777,6 @@
 /area/station/service/chapel)
 "aTl" = (
 /obj/machinery/status_display/evac/directional/north,
-/obj/effect/spawner/random/entertainment/arcade{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red/opposingcorners{
 	dir = 1
 	},
@@ -12443,7 +12810,8 @@
 /obj/structure/closet/wardrobe/grey,
 /obj/machinery/light/directional/west,
 /obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/large,
 /area/station/commons/locker)
 "aTx" = (
 /obj/effect/landmark/start/assistant,
@@ -12465,7 +12833,8 @@
 	c_tag = "Locker Room - East"
 	},
 /obj/machinery/light/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/large,
 /area/station/commons/locker)
 "aTE" = (
 /obj/structure/table,
@@ -12822,9 +13191,6 @@
 	},
 /area/station/service/chapel)
 "aUL" = (
-/obj/effect/spawner/random/entertainment/arcade{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
@@ -12885,7 +13251,8 @@
 	department = "Locker Room";
 	name = "Locker Room Requests Console"
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/large,
 /area/station/commons/locker)
 "aUW" = (
 /obj/structure/table/wood,
@@ -13174,9 +13541,16 @@
 /area/station/hallway/primary/starboard)
 "aVP" = (
 /obj/structure/table/wood,
-/obj/item/paper,
+/obj/item/paper{
+	pixel_x = 6;
+	pixel_y = 0
+	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
+	},
+/obj/item/flashlight/lamp/green{
+	pixel_x = -8;
+	pixel_y = 9
 	},
 /turf/open/floor/wood,
 /area/station/service/library)
@@ -13318,7 +13692,8 @@
 /obj/structure/closet/wardrobe/black,
 /obj/item/clothing/shoes/jackboots,
 /obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/large,
 /area/station/commons/locker)
 "aWo" = (
 /obj/machinery/camera/directional/south{
@@ -13328,6 +13703,10 @@
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/thinplating_new/corner,
+/obj/effect/turf_decal/siding/thinplating_new/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "aWr" = (
@@ -13654,6 +14033,9 @@
 	dir = 4
 	},
 /obj/machinery/duct,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "aXs" = (
@@ -13661,11 +14043,15 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/large,
 /area/station/commons/locker)
 "aXv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
@@ -14047,6 +14433,7 @@
 "aYS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/stone,
 /area/station/commons/dorms)
 "aYT" = (
@@ -14582,6 +14969,9 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 5
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "baB" = (
@@ -14591,6 +14981,7 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
 	},
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "baD" = (
@@ -14860,6 +15251,17 @@
 	dir = 6
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1;
+	color = "#D381C9"
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#D381C9"
+	},
 /turf/open/floor/iron/dark/textured_half,
 /area/station/science/ordnance)
 "bbL" = (
@@ -14886,7 +15288,7 @@
 /obj/item/razor{
 	pixel_x = 6
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/commons/locker)
 "bbO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -15197,6 +15599,7 @@
 "bcK" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "bcL" = (
@@ -15368,17 +15771,10 @@
 /turf/open/floor/iron/white,
 /area/station/hallway/secondary/exit/departure_lounge)
 "bdA" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/structure/chair{
 	dir = 4
 	},
-/obj/machinery/door/airlock/external{
-	name = "Departures Shuttle Dock";
-	space_dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/white,
 /area/station/hallway/secondary/exit/departure_lounge)
 "bdB" = (
 /obj/structure/cable,
@@ -15424,7 +15820,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "bdJ" = (
@@ -15775,6 +16170,7 @@
 	id = "garbage"
 	},
 /obj/machinery/light/small/directional/north,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "beU" = (
@@ -15795,6 +16191,9 @@
 /obj/item/stack/package_wrap{
 	pixel_x = -1;
 	pixel_y = -1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
@@ -15837,6 +16236,9 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
 "bfm" = (
@@ -15849,6 +16251,9 @@
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
@@ -15890,11 +16295,18 @@
 /area/station/command/heads_quarters/captain)
 "bfA" = (
 /obj/structure/table/wood,
-/obj/item/hand_tele,
+/obj/item/hand_tele{
+	pixel_x = 9;
+	pixel_y = -2
+	},
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
+	},
+/obj/item/pai_card{
+	pixel_x = -7;
+	pixel_y = -1
 	},
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/captain)
@@ -15988,8 +16400,11 @@
 /obj/structure/bodycontainer/morgue{
 	dir = 8
 	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
 /obj/effect/turf_decal/bot_white,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "bfT" = (
 /turf/closed/wall,
@@ -16025,41 +16440,24 @@
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/hallway/primary/starboard)
 "bga" = (
-/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/trimline/purple/line,
 /obj/effect/turf_decal/trimline/purple/mid_joiner,
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/effect/turf_decal/trimline/neutral/filled/mid_joiner,
+/obj/structure/sign/departments/science/directional/south,
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/hallway/primary/starboard)
 "bgb" = (
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen,
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/trimline/purple/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/smooth_corner{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/purple/line,
+/obj/effect/turf_decal/trimline/purple/mid_joiner,
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/mid_joiner,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark/smooth_half,
 /area/station/hallway/primary/starboard)
 "bgc" = (
 /turf/closed/wall/r_wall,
 /area/station/science/lab)
-"bgd" = (
-/obj/machinery/airalarm/directional/south,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/closet/firecloset,
-/turf/open/floor/iron/white/corner,
-/area/station/hallway/secondary/exit/departure_lounge)
 "bgf" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/tile/red/opposingcorners{
@@ -16069,11 +16467,10 @@
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/exit/departure_lounge)
 "bgg" = (
-/obj/structure/closet/emcloset,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/effect/landmark/start/hangover/closet,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/exit/departure_lounge)
 "bgh" = (
@@ -16137,6 +16534,9 @@
 	},
 /obj/effect/mapping_helpers/requests_console/supplies,
 /obj/structure/window/reinforced/spawner/directional/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "bgE" = (
@@ -16425,7 +16825,7 @@
 "bhm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "bhn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -16449,7 +16849,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/bed/medical/emergency,
 /obj/machinery/iv_drip,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 6
+	},
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "bhp" = (
 /obj/machinery/computer/operating,
@@ -16457,13 +16860,15 @@
 	pixel_x = -8;
 	pixel_y = 17
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "bhq" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/table/reinforced,
 /obj/effect/spawner/surgery_tray/full/morgue,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "bhr" = (
 /obj/machinery/door/firedoor,
@@ -16601,27 +17006,26 @@
 /turf/open/floor/plating,
 /area/station/science/lab)
 "bhD" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "rnd";
-	name = "Research Desk Shutters";
+/obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/right/directional/south{
-	pixel_y = 3;
-	req_access = list("research");
-	name = "Research Desk"
+/obj/effect/turf_decal/delivery/white{
+	color = "#D381C9"
 	},
-/obj/structure/desk_bell{
-	pixel_x = 7
-	},
-/obj/item/folder{
-	pixel_x = -6
-	},
-/turf/open/floor/plating,
-/area/station/science/lab)
+/turf/open/floor/iron/dark/textured_large,
+/area/station/hallway/primary/starboard)
 "bhE" = (
+/obj/effect/turf_decal/tile/purple/anticorner{
+	dir = 1
+	},
+/obj/machinery/vending/wardrobe/science_wardrobe,
+/turf/open/floor/iron/white/smooth_corner,
+/area/station/science/lab)
+"bhF" = (
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
 /obj/structure/table,
 /obj/item/stack/sheet/glass/fifty{
 	pixel_x = 3;
@@ -16644,24 +17048,8 @@
 	pixel_x = -4;
 	pixel_y = -7
 	},
-/obj/effect/turf_decal/tile/purple/anticorner{
+/turf/open/floor/iron/white/smooth_edge{
 	dir = 1
-	},
-/turf/open/floor/iron/white/smooth_corner,
-/area/station/science/lab)
-"bhF" = (
-/obj/structure/table,
-/obj/machinery/light/directional/north,
-/obj/machinery/cell_charger{
-	pixel_y = 5
-	},
-/obj/item/stock_parts/power_store/cell/high,
-/obj/item/stock_parts/power_store/cell/high,
-/obj/effect/turf_decal/tile/purple/anticorner{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_corner{
-	dir = 8
 	},
 /area/station/science/lab)
 "bhH" = (
@@ -16783,7 +17171,6 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/item/radio/intercom/directional/east,
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 4
 	},
@@ -16796,6 +17183,7 @@
 /obj/effect/turf_decal/tile/neutral/half{
 	dir = 4
 	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/edge{
 	dir = 4
 	},
@@ -16892,6 +17280,7 @@
 /area/station/medical/pharmacy)
 "bit" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/office)
 "biu" = (
@@ -16948,19 +17337,22 @@
 /area/station/security/checkpoint/medical)
 "biz" = (
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "biB" = (
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "biD" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/bodycontainer/morgue,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
 /obj/effect/turf_decal/bot_white,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "biF" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -17009,6 +17401,7 @@
 	name = "Robotics Desk Shutters Control";
 	req_access = list("robotics")
 	},
+/obj/structure/closet/crate/mod,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
@@ -17089,43 +17482,31 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
-"biU" = (
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 1
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/science/lab)
 "biV" = (
-/obj/structure/chair/stool/directional/north,
-/obj/effect/landmark/start/scientist,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 1
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/science/lab)
-"biX" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Science - Research Lab";
-	network = list("ss13","rd")
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/button/door/directional/north{
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
 	id = "rnd";
+	name = "Research Desk Shutters";
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/right/directional/south{
+	pixel_y = 3;
 	req_access = list("research");
-	name = "Research Desk Shutters Control"
+	name = "Research Desk"
 	},
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 1
+/obj/structure/desk_bell{
+	pixel_x = 7
 	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
+/obj/item/folder{
+	pixel_x = -6
 	},
+/obj/item/paper_bin{
+	pixel_x = -6;
+	pixel_y = 7
+	},
+/obj/item/pen,
+/turf/open/floor/plating,
 /area/station/science/lab)
 "biY" = (
 /obj/effect/turf_decal/stripes/line{
@@ -17200,11 +17581,15 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
 /obj/effect/landmark/navigate_destination/disposals,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/access/any/service/janitor,
+/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "bjg" = (
@@ -17277,6 +17662,7 @@
 "bjq" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/light/directional/north,
+/obj/machinery/suit_storage_unit/industrial/loader,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "bjr" = (
@@ -17316,8 +17702,13 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/central/greater)
 "bjA" = (
-/obj/machinery/light/small/directional/east,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "bjC" = (
@@ -17482,7 +17873,6 @@
 	},
 /area/station/science/research)
 "bka" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/siding/purple{
 	dir = 8
 	},
@@ -17510,8 +17900,11 @@
 /obj/structure/bodycontainer/morgue{
 	dir = 8
 	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
 /obj/effect/turf_decal/bot_white,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "bkh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -17558,6 +17951,22 @@
 /obj/effect/turf_decal/stripes/white/line{
 	color = "#D381C9"
 	},
+/obj/structure/closet/crate/medical{
+	name = "stolen medical kit crate";
+	desc = "A crate previously carried by a derelict freighter, before being stolen."
+	},
+/obj/item/storage/medkit/regular{
+	empty = 1;
+	desc = "An empty medkit. Looks like whoever recovered it needed the supplies."
+	},
+/obj/item/storage/medkit/regular{
+	empty = 1;
+	desc = "An empty medkit. Looks like whoever recovered it needed the supplies."
+	},
+/obj/item/storage/medkit/regular{
+	empty = 1;
+	desc = "An empty medkit. Looks like whoever recovered it needed the supplies."
+	},
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/science/robotics/lab)
 "bkq" = (
@@ -17601,11 +18010,12 @@
 /obj/effect/turf_decal/siding/purple,
 /obj/effect/mapping_helpers/requests_console/assistance,
 /obj/effect/turf_decal/tile/purple/half,
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/science/lab)
 "bkv" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 6
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -17733,28 +18143,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"bkT" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Bridge Maintenance"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/command/maintenance,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
-"bkW" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "bkX" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
@@ -17771,6 +18159,7 @@
 /obj/machinery/camera/directional/south{
 	c_tag = "Bridge - Council Chamber South"
 	},
+/obj/structure/sign/poster/official/random/directional/west,
 /turf/open/floor/carpet/blue,
 /area/station/command/meeting_room/council)
 "bkZ" = (
@@ -17801,6 +18190,17 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/captain,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#52B4E9"
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1;
+	color = "#52B4E9"
+	},
 /turf/open/floor/iron/dark/textured_half,
 /area/station/maintenance/central/lesser)
 "ble" = (
@@ -17962,8 +18362,14 @@
 "blE" = (
 /obj/structure/table,
 /obj/item/healthanalyzer,
-/obj/item/healthanalyzer,
-/obj/item/healthanalyzer,
+/obj/item/healthanalyzer{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/healthanalyzer{
+	pixel_x = -4;
+	pixel_y = -4
+	},
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
@@ -18009,6 +18415,7 @@
 	color = "#D381C9"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "blO" = (
@@ -18063,6 +18470,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "blW" = (
@@ -18103,12 +18511,12 @@
 	pixel_y = 3
 	},
 /obj/item/stack/cable_coil,
-/obj/machinery/firealarm/directional/east,
 /obj/item/stock_parts/servo,
 /obj/item/stock_parts/servo,
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
 	},
@@ -18160,13 +18568,13 @@
 /area/station/maintenance/starboard/fore)
 "bmn" = (
 /obj/machinery/light/directional/west,
-/obj/machinery/status_display/evac/directional/west,
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/structure/sign/departments/cargo/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bmo" = (
@@ -18228,7 +18636,13 @@
 	name = "Bathroom"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/captain,
-/turf/open/floor/iron/freezer,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/iron/sepia,
 /area/station/command/heads_quarters/captain/private)
 "bmB" = (
 /obj/machinery/light_switch/directional/north,
@@ -18407,7 +18821,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "bnk" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/siding/purple/corner{
 	dir = 1
 	},
@@ -18436,8 +18849,13 @@
 	codes_txt = "delivery;dir=8";
 	location = "Research Division"
 	},
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/window/left/directional/west{
+	name = "Science Deliveries";
+	req_access = list("science")
+	},
 /turf/open/floor/iron/dark,
-/area/station/maintenance/starboard/central)
+/area/station/science/lab)
 "bns" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -18550,7 +18968,8 @@
 	id = "hopqueue";
 	req_access = list("hop");
 	name = "Queue Shutters Control";
-	pixel_x = -8
+	pixel_x = -11;
+	pixel_y = 24
 	},
 /obj/machinery/button/flasher{
 	pixel_x = -24;
@@ -18563,7 +18982,8 @@
 	id = "hop";
 	req_access = list("hop");
 	name = "Blast Door Control";
-	pixel_x = 8
+	pixel_x = 11;
+	pixel_y = 24
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -18576,6 +18996,10 @@
 /obj/item/toy/figure/ian{
 	pixel_x = 2;
 	pixel_y = 9
+	},
+/obj/machinery/button/photobooth{
+	pixel_x = 0;
+	pixel_y = 24
 	},
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/hop)
@@ -18793,6 +19217,10 @@
 /obj/item/radio/headset/headset_sci{
 	pixel_x = -3
 	},
+/obj/machinery/ecto_sniffer{
+	pixel_x = 5;
+	pixel_y = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "box" = (
@@ -18806,6 +19234,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "boz" = (
@@ -18883,6 +19314,7 @@
 /area/station/cargo/storage)
 "boL" = (
 /obj/structure/table,
+/obj/item/clothing/mask/muzzle/breath,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "boM" = (
@@ -18966,15 +19398,17 @@
 	pixel_x = -3;
 	pixel_y = 10
 	},
+/obj/machinery/flasher/directional/north{
+	id = "hopflash";
+	pixel_x = -7;
+	pixel_y = 24
+	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/hop)
 "bpa" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment{
 	dir = 6
-	},
-/obj/machinery/flasher/directional/north{
-	id = "hopflash"
 	},
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -19027,7 +19461,6 @@
 	},
 /area/station/hallway/primary/central)
 "bpo" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/table,
 /obj/item/flatpack/flatpacker{
@@ -19300,6 +19733,9 @@
 /obj/structure/table/reinforced,
 /obj/item/dest_tagger,
 /obj/item/dest_tagger,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "bqq" = (
@@ -19387,6 +19823,17 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/teleporter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#52B4E9"
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1;
+	color = "#52B4E9"
+	},
 /turf/open/floor/iron/dark/textured_half,
 /area/station/maintenance/central/lesser)
 "bqL" = (
@@ -20261,7 +20708,23 @@
 /obj/effect/landmark/navigate_destination/teleporter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8;
+	color = "#52B4E9"
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4;
+	color = "#52B4E9"
+	},
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
 /area/station/command/teleporter)
 "btO" = (
 /obj/structure/disposalpipe/junction/flip{
@@ -20298,6 +20761,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
 	dir = 1
 	},
+/obj/machinery/recharge_station,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
@@ -20356,6 +20820,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
 	dir = 8
 	},
+/obj/structure/sign/poster/official/help_others/directional/west,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
@@ -20637,6 +21102,10 @@
 	pixel_y = -1
 	},
 /obj/item/hand_labeler,
+/obj/item/pai_card{
+	pixel_x = -9;
+	pixel_y = 15
+	},
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/hop)
 "buT" = (
@@ -20757,9 +21226,6 @@
 /area/station/science/research)
 "bvg" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/table,
@@ -20856,7 +21322,6 @@
 	dir = 6
 	},
 /obj/item/kirbyplants/random,
-/obj/structure/extinguisher_cabinet/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -20916,9 +21381,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/command/heads_quarters/rd)
-"bvK" = (
-/turf/closed/wall,
 /area/station/command/heads_quarters/rd)
 "bvL" = (
 /obj/structure/table,
@@ -21228,14 +21690,12 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/shaft_miner,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bwW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning{
 	dir = 8
 	},
@@ -21279,6 +21739,7 @@
 /area/station/medical/chemistry)
 "bxd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/project)
 "bxg" = (
@@ -21334,6 +21795,9 @@
 /area/station/command/heads_quarters/rd)
 "bxk" = (
 /obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "bxl" = (
@@ -21348,7 +21812,6 @@
 /turf/open/floor/iron/smooth_corner,
 /area/station/command/heads_quarters/rd)
 "bxm" = (
-/obj/effect/spawner/xmastree/rdrod,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
@@ -21365,7 +21828,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "bxu" = (
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/qm)
 "bxv" = (
 /obj/structure/chair/office{
@@ -21394,6 +21857,7 @@
 	name = "Quartermaster's Office Blast Doors";
 	id = "qm_blast"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/qm)
 "bxy" = (
@@ -21575,6 +22039,10 @@
 /obj/structure/table,
 /obj/item/clipboard,
 /obj/item/coin/silver,
+/obj/item/pai_card{
+	pixel_x = -16;
+	pixel_y = 1
+	},
 /turf/open/floor/carpet/orange,
 /area/station/command/heads_quarters/qm)
 "byh" = (
@@ -21615,6 +22083,7 @@
 	},
 /obj/item/pen/red,
 /obj/item/stamp/head/qm,
+/obj/structure/cable,
 /turf/open/floor/carpet/orange,
 /area/station/command/heads_quarters/qm)
 "byn" = (
@@ -21736,6 +22205,7 @@
 /obj/effect/turf_decal/box/white{
 	color = "#486091"
 	},
+/obj/structure/cable,
 /turf/open/floor/carpet/orange,
 /area/station/command/heads_quarters/qm)
 "byD" = (
@@ -22081,6 +22551,10 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
+	},
+/obj/item/pai_card{
+	pixel_x = 4;
+	pixel_y = 0
 	},
 /turf/open/floor/iron/smooth_corner{
 	dir = 4
@@ -22532,10 +23006,14 @@
 "bAV" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/window/left/directional/west{
-	name = "Janitorial Delivery";
+	name = "Janitorial Deliveries";
 	req_access = list("janitor")
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=8";
+	location = "Janitor"
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/maintenance/starboard/greater)
 "bAX" = (
@@ -23247,8 +23725,8 @@
 	},
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/item/storage/medkit/brute{
-	pixel_x = 3;
-	pixel_y = 3
+	pixel_x = 2;
+	pixel_y = 1
 	},
 /obj/item/storage/medkit/regular,
 /obj/item/storage/medkit/brute{
@@ -23371,7 +23849,9 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/service/janitor)
 "bDr" = (
-/obj/structure/mop_bucket/janitorialcart,
+/obj/structure/mop_bucket/janitorialcart{
+	dir = 8
+	},
 /obj/effect/turf_decal/tile/green/anticorner{
 	dir = 8
 	},
@@ -23381,8 +23861,8 @@
 	},
 /area/station/service/janitor)
 "bDs" = (
-/obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/tile/green/anticorner,
+/obj/structure/closet/jcloset,
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 1
 	},
@@ -23405,7 +23885,8 @@
 "bDw" = (
 /obj/structure/table,
 /obj/item/screwdriver{
-	pixel_y = 16
+	pixel_y = 9;
+	pixel_x = 0
 	},
 /obj/item/wirecutters,
 /turf/open/floor/iron/dark,
@@ -23459,7 +23940,6 @@
 /turf/open/floor/iron/dark/smooth_corner,
 /area/station/service/janitor)
 "bDJ" = (
-/obj/machinery/light_switch/directional/north,
 /obj/machinery/camera/directional/north{
 	c_tag = "Service - Custodial Closet"
 	},
@@ -23516,10 +23996,6 @@
 	},
 /area/station/service/janitor)
 "bDP" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=8";
-	location = "Janitor"
-	},
 /obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/smooth_large,
@@ -23665,26 +24141,9 @@
 	},
 /area/station/medical/storage)
 "bEj" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/machinery/disposal/bin/tagger,
-/obj/machinery/light/directional/south,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
-	dir = 1
-	},
-/obj/machinery/light_switch/directional/south{
-	pixel_x = -10;
-	pixel_y = -24
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/blue/full,
+/obj/machinery/vending/drugs,
+/turf/open/floor/iron/white/smooth_large,
 /area/station/medical/storage)
 "bEk" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
@@ -23699,8 +24158,8 @@
 /obj/structure/table/glass,
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/item/storage/medkit/o2{
-	pixel_x = 3;
-	pixel_y = 3
+	pixel_x = 2;
+	pixel_y = 1
 	},
 /obj/item/storage/medkit/regular,
 /obj/item/storage/medkit/o2{
@@ -23767,6 +24226,9 @@
 /area/station/science/ordnance)
 "bED" = (
 /obj/structure/railing,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/wood/tile,
 /area/station/service/chapel)
 "bEE" = (
@@ -23799,7 +24261,10 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/white/end{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
 /area/station/science/ordnance)
 "bEO" = (
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -23903,6 +24368,7 @@
 	},
 /obj/machinery/light/directional/east,
 /obj/machinery/newscaster/directional/east,
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 4
 	},
@@ -23973,7 +24439,15 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
 /area/station/security/interrogation)
 "bFB" = (
 /obj/effect/turf_decal/tile/yellow/anticorner{
@@ -24166,7 +24640,7 @@
 	id = "brm";
 	dir = 10
 	},
-/obj/machinery/bouldertech/refinery/smelter,
+/obj/machinery/bouldertech/refinery,
 /turf/open/floor/plating,
 /area/station/cargo/miningdock)
 "bGo" = (
@@ -24228,7 +24702,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/catwalk_floor/iron_dark,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "bGB" = (
 /obj/structure/table,
@@ -24273,6 +24747,7 @@
 /obj/effect/turf_decal/siding/purple{
 	dir = 1
 	},
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/service/janitor)
 "bGF" = (
@@ -24282,11 +24757,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/components/binary/pump/on/supply/hidden/layer4{
-	dir = 8;
-	name = "Distro to Ordnance Air"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "bGG" = (
 /obj/structure/cable,
@@ -24309,7 +24780,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/door/airlock/research{
-	name = "Ordnance Launch Room"
+	name = "Ordnance Launch Room Access"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "sci-toxins-passthrough"
@@ -24318,6 +24789,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -24368,6 +24840,9 @@
 	network = list("ss13","medbay")
 	},
 /obj/machinery/light_switch/directional/west,
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
 /turf/open/floor/iron/white/herringbone,
 /area/station/medical/break_room)
 "bHa" = (
@@ -24379,8 +24854,9 @@
 /obj/structure/table/glass,
 /obj/machinery/light/small/directional/north,
 /obj/effect/spawner/random/food_or_drink/donkpockets,
-/obj/structure/sign/painting/library{
-	pixel_y = 32
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 14;
+	pixel_y = 3
 	},
 /turf/open/floor/iron/white/herringbone,
 /area/station/medical/break_room)
@@ -25024,9 +25500,13 @@
 /area/station/engineering/storage/tech)
 "bJk" = (
 /obj/structure/table/wood,
-/obj/item/storage/fancy/candle_box,
 /obj/effect/turf_decal/tile/neutral/diagonal_edge,
 /obj/effect/turf_decal/tile/bar/diagonal_centre,
+/obj/item/storage/fancy/candle_box{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/fancy/candle_box,
 /turf/open/floor/iron/dark/diagonal,
 /area/station/service/chapel/funeral)
 "bJl" = (
@@ -25183,7 +25663,6 @@
 /turf/open/floor/iron,
 /area/station/science/research)
 "bJZ" = (
-/obj/effect/turf_decal/delivery,
 /obj/structure/closet/crate/internals{
 	name = "disaster survival crate";
 	desc = "A crate full of equipment to help oneself survive what is commonly referred to as a 'toxins moment'. Both radiation and fire protection included!"
@@ -25200,10 +25679,13 @@
 /obj/item/clothing/head/utility/hardhat/red,
 /obj/item/clothing/mask/gas,
 /obj/item/storage/medkit/fire,
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/delivery/white{
+	color = "#D381C9"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "bKa" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
@@ -25477,6 +25959,17 @@
 	},
 /obj/effect/mapping_helpers/airalarm/mixingchamber_access,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1;
+	color = "#D381C9"
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#D381C9"
+	},
 /turf/open/floor/iron/dark/textured_half,
 /area/station/science/ordnance)
 "bLj" = (
@@ -25501,6 +25994,9 @@
 /area/station/science/ordnance/testlab)
 "bLm" = (
 /obj/machinery/door/poddoor/incinerator_ordmix,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/burnchamber)
 "bLn" = (
@@ -25704,7 +26200,9 @@
 /obj/effect/turf_decal/tile/yellow/half{
 	dir = 1
 	},
-/obj/effect/landmark/navigate_destination/chemfactory,
+/obj/effect/landmark/navigate_destination/chemfactory{
+	location = "Chemistry Lab"
+	},
 /turf/open/floor/iron/white/textured_half,
 /area/station/medical/chemistry)
 "bMe" = (
@@ -25873,9 +26371,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "bMz" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
@@ -25889,18 +26384,17 @@
 	dir = 8;
 	name = "Burn Chamber Output Port"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
 /obj/machinery/portable_atmospherics/canister,
 /obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/siding/white{
+	dir = 9
+	},
 /turf/open/floor/iron/smooth,
 /area/station/science/ordnance)
 "bMB" = (
 /obj/effect/spawner/random/engineering/tank,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/east,
-/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "bMC" = (
@@ -26064,6 +26558,20 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor/heavy,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8;
+	color = "#D381C9"
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4;
+	color = "#D381C9"
+	},
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -26100,12 +26608,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"bNy" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
 "bNz" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Science - Ordnance Lab Central";
@@ -26113,10 +26615,10 @@
 	},
 /obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/smooth,
 /area/station/science/ordnance)
 "bNB" = (
@@ -26206,11 +26708,17 @@
 	},
 /obj/item/radio/intercom/directional/west,
 /obj/structure/window/reinforced/spawner/directional/south,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
 "bNQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
@@ -26228,6 +26736,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
 /turf/open/floor/iron/checker,
 /area/station/engineering/atmos/storage/gas)
 "bNT" = (
@@ -26400,9 +26911,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "bOH" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
 /obj/machinery/button/door/incinerator_vent_ordmix{
 	pixel_x = -25;
 	pixel_y = 7
@@ -26424,10 +26932,10 @@
 	dir = 1;
 	name = "Manual Temperature Adjustment Port"
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/siding/white{
 	dir = 10
 	},
-/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/smooth,
 /area/station/science/ordnance)
 "bOJ" = (
@@ -26455,6 +26963,7 @@
 	name = "Detective's Privacy Shutters";
 	id = "detective_shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/detectives_office)
 "bOO" = (
@@ -26915,6 +27424,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
+/obj/effect/turf_decal/siding/yellow,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured_half,
 /area/station/tcommsat/computer)
 "bQL" = (
@@ -27003,7 +27516,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "bQS" = (
-/obj/effect/spawner/random/trash/moisture_trap,
+/obj/structure/moisture_trap,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
@@ -27205,6 +27718,12 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -27615,6 +28134,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/yellow,
 /turf/open/floor/iron/dark/textured_half,
 /area/station/engineering/atmos/storage/gas)
 "bTS" = (
@@ -27694,7 +28217,8 @@
 	dir = 4;
 	name = "External Gas Mixer B"
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured,
 /area/station/science/ordnance)
 "bUo" = (
 /obj/structure/chair/office/light{
@@ -27778,6 +28302,12 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -27843,12 +28373,23 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
 /area/station/maintenance/starboard/greater)
 "bVb" = (
-/obj/machinery/light_switch/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
@@ -27867,6 +28408,7 @@
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 1
 	},
+/obj/structure/sign/departments/telecomms/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "bVf" = (
@@ -27922,7 +28464,15 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 4;
+	pixel_y = -1
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/security/mechbay)
 "bVo" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -27935,7 +28485,10 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
 /area/station/science/ordnance)
 "bVx" = (
 /obj/machinery/atmospherics/components/unary/passive_vent,
@@ -28023,6 +28576,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "bVJ" = (
@@ -28166,6 +28720,9 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
 /obj/effect/landmark/navigate_destination/tcomms,
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -28358,7 +28915,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/obj/effect/landmark/navigate_destination/engineering,
+/obj/effect/landmark/navigate_destination{
+	location = "Engineering and Atmospherics"
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -28388,6 +28953,9 @@
 "bXx" = (
 /obj/effect/landmark/blobstart,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
 "bXz" = (
@@ -28464,7 +29032,10 @@
 	name = "Atmospherics"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/effect/landmark/navigate_destination/atmos,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/yellow,
 /turf/open/floor/iron/dark/textured_half,
 /area/station/engineering/break_room)
 "bXO" = (
@@ -28613,10 +29184,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "bYv" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Mix to Space"
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/hangover,
@@ -28677,6 +29244,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
+/obj/structure/sign/departments/engineering/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "bYH" = (
@@ -28967,9 +29535,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "bZO" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/spawner/random/engineering/atmospherics_portable,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/plumbing/synthesizer{
+	reagent_id = /datum/reagent/water;
+	dir = 8
+	},
+/obj/machinery/door/window/left/directional/west{
+	name = "Med/Sci Water Supply";
+	req_one_access = list("medical","science")
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "bZP" = (
@@ -29038,7 +29611,7 @@
 /turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "cai" = (
-/obj/machinery/power/smes/engineering,
+/obj/machinery/power/smes/full,
 /obj/structure/cable,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
@@ -29153,7 +29726,7 @@
 /area/station/maintenance/starboard/greater)
 "caQ" = (
 /obj/machinery/atmospherics/components/tank/air/layer4,
-/obj/machinery/light/small/blacklight/directional/north,
+/obj/machinery/light/blacklight/directional/north,
 /obj/machinery/duct,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/virology)
@@ -29329,7 +29902,7 @@
 /obj/machinery/light/directional/north,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/station/security/prison/work)
 "cbB" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
@@ -29778,6 +30351,21 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
+"cdJ" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/effect/turf_decal/tile/bar/diagonal_centre,
+/obj/item/food/grown/harebell,
+/obj/item/food/grown/harebell{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/food/grown/harebell{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/open/floor/iron/dark/diagonal,
+/area/station/service/chapel/funeral)
 "cdM" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Brig Control"
@@ -29786,7 +30374,11 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/armory,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/dark_red,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_half,
 /area/station/security/warden)
 "cdN" = (
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -29876,17 +30468,9 @@
 	pixel_y = -1
 	},
 /obj/machinery/firealarm/directional/east,
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
-"cek" = (
-/obj/machinery/duct,
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/service)
 "cen" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -29950,7 +30534,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "ceQ" = (
-/obj/effect/landmark/blobstart,
 /obj/structure/training_machine,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
@@ -29964,6 +30547,7 @@
 /obj/item/stack/sheet/cardboard,
 /obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "ceT" = (
@@ -30162,6 +30746,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/navigate_destination/incinerator,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "cfY" = (
@@ -30178,10 +30763,7 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
 "cga" = (
-/obj/machinery/power/smes{
-	capacity = 9e+006;
-	charge = 10000
-	},
+/obj/machinery/power/smes/engineering,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
@@ -30839,6 +31421,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/full,
+/obj/item/pai_card,
 /turf/open/floor/iron/large,
 /area/station/command/heads_quarters/ce)
 "cka" = (
@@ -31027,13 +31610,19 @@
 /area/station/maintenance/disposal/incinerator)
 "clj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/hidden,
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "clp" = (
 /obj/effect/landmark/start/assistant,
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
 /area/station/service/hydroponics/garden)
 "clq" = (
 /obj/structure/disposalpipe/segment,
@@ -31146,7 +31735,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "clS" = (
-/obj/structure/filingcabinet,
+/obj/structure/filingcabinet/security,
 /obj/effect/turf_decal/siding/dark_red{
 	dir = 4
 	},
@@ -31209,11 +31798,11 @@
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/closet/firecloset/full,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 1
 	},
 /obj/machinery/light/directional/west,
+/obj/structure/closet/firecloset/full,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cmN" = (
@@ -31273,6 +31862,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
+"cnm" = (
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/right/directional/south{
+	req_access = list("kitchen");
+	name = "Kitchen Deliveries"
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
+/area/station/service/kitchen/coldroom)
 "cnq" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/neutral/diagonal_edge,
@@ -31376,11 +31977,11 @@
 /obj/machinery/camera/motion/directional/west{
 	c_tag = "AI Upload - Access Airlock"
 	},
-/obj/machinery/firealarm/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/south,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload_foyer)
 "col" = (
@@ -31462,6 +32063,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/structure/closet/firecloset/full,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "coS" = (
@@ -31501,7 +32103,7 @@
 "cpg" = (
 /obj/structure/table,
 /obj/effect/spawner/random/armory/barrier_grenades,
-/obj/effect/turf_decal/tile/red/full,
+/obj/effect/turf_decal/tile/dark_red/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/security/armory)
 "cpi" = (
@@ -31566,9 +32168,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
-	},
 /obj/effect/landmark/start/warden,
 /turf/open/floor/iron/smooth_large,
 /area/station/ai_monitored/security/armory)
@@ -31605,9 +32204,14 @@
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
 "cpT" = (
-/obj/effect/turf_decal/delivery,
 /obj/structure/closet/bombcloset,
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/siding/white{
+	dir = 10
+	},
+/obj/effect/turf_decal/delivery/white{
+	color = "#D381C9"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "cpV" = (
@@ -31725,7 +32329,9 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "cqm" = (
-/obj/machinery/meter,
+/obj/machinery/meter{
+	name = "Atmospheric Coolant Pipe"
+	},
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 10
 	},
@@ -31828,7 +32434,6 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter)
 "cqE" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/engineering/glass/critical{
 	name = "Supermatter Engine"
 	},
@@ -31839,7 +32444,7 @@
 "cqG" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/armory/rubbershot,
-/obj/effect/turf_decal/tile/red/full,
+/obj/effect/turf_decal/tile/dark_red/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/security/armory)
 "cqH" = (
@@ -31978,6 +32583,10 @@
 "crp" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/storage)
+"crr" = (
+/obj/structure/chair/sofa/left/maroon,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "crt" = (
 /obj/machinery/door/airlock/engineering/glass/critical{
 	name = "Supermatter Engine"
@@ -32297,6 +32906,10 @@
 /obj/effect/spawner/random/aimodule/neutral,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"cvJ" = (
+/obj/machinery/light/floor,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/hallway/secondary/exit/departure_lounge)
 "cvK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -32319,18 +32932,20 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"cvW" = (
+/obj/effect/turf_decal/tile/blue/half,
+/obj/structure/sign/departments/aiupload/directional/south,
+/turf/open/floor/iron/edge,
+/area/station/command/bridge)
 "cwp" = (
+/obj/item/radio/intercom/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/dark_red{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/dark_red,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron/dark/smooth_edge{
+/obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 1
 	},
+/turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
 "cwu" = (
 /obj/machinery/ai_slipper{
@@ -32360,7 +32975,7 @@
 	pixel_x = -3;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/tile/red/full,
+/obj/effect/turf_decal/tile/dark_red/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/security/armory)
 "cwT" = (
@@ -32526,16 +33141,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark/textured_half,
 /area/station/ai_monitored/command/storage/eva)
-"cyh" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	name = "Departures Security Dock"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/turf/open/floor/plating,
-/area/station/hallway/secondary/exit/departure_lounge)
 "cyi" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
@@ -32564,14 +33169,8 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "cyr" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	name = "Departures Shuttle Dock";
-	space_dir = 4
-	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/secondary/exit/departure_lounge)
 "cyt" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -33011,6 +33610,8 @@
 /obj/structure/closet,
 /obj/machinery/airalarm/directional/east,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "cAK" = (
@@ -33059,6 +33660,7 @@
 /area/station/engineering/storage)
 "cBa" = (
 /obj/machinery/light/directional/south,
+/obj/structure/sign/departments/aisat/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "cBg" = (
@@ -33153,6 +33755,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/effect/spawner/xmastree/rdrod,
 /turf/open/floor/iron/smooth_edge{
 	dir = 1
 	},
@@ -33178,7 +33781,6 @@
 	name = "Custodial Closet"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/event_spawn,
 /obj/effect/mapping_helpers/airlock/access/all/service/janitor,
 /obj/effect/turf_decal/tile/purple/half,
 /obj/effect/landmark/navigate_destination/janitor,
@@ -33383,9 +33985,7 @@
 /area/station/construction)
 "cCh" = (
 /obj/item/bedsheet/red,
-/mob/living/simple_animal/bot/secbot/beepsky{
-	name = "Officer Beepsky"
-	},
+/mob/living/simple_animal/bot/secbot/beepsky/officer,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
@@ -33573,17 +34173,6 @@
 	dir = 1;
 	name = "External Gas to Loop"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/engineering/supermatter/room)
-"cDF" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "External Gas to Loop"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/supermatter/room)
@@ -33919,6 +34508,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/structure/closet/firecloset/full,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "cFO" = (
@@ -34645,12 +35235,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
-"cPd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
 "cPl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -34724,6 +35308,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/textured,
 /area/station/maintenance/department/eva/abandoned)
+"cQs" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/herringbone,
+/area/station/security/warden)
 "cQZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -34991,8 +35581,11 @@
 /obj/structure/bodycontainer/morgue{
 	dir = 8
 	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 10
+	},
 /obj/effect/turf_decal/bot_white,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "cTQ" = (
 /obj/machinery/duct,
@@ -35169,10 +35762,6 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/virology)
 "cYY" = (
-/obj/machinery/door/window/right/directional/east{
-	name = "Monkey Pen";
-	req_access = list("genetics")
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -35219,6 +35808,15 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
 /turf/closed/wall,
 /area/station/medical/treatment_center)
+"daX" = (
+/obj/machinery/duct,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/station/service/hydroponics/garden)
 "dba" = (
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/wood/tile,
@@ -35344,6 +35942,12 @@
 /obj/effect/turf_decal/tile/bar/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/kitchen)
+"dei" = (
+/obj/structure/table,
+/obj/structure/cable,
+/obj/effect/spawner/random/entertainment/dice,
+/turf/open/floor/iron/white,
+/area/station/hallway/secondary/exit/departure_lounge)
 "deV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -35361,6 +35965,11 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"dfB" = (
+/obj/structure/closet/mini_fridge/grimy,
+/obj/item/reagent_containers/condiment/milk,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "dfK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35368,10 +35977,26 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"dfM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/moisture_trap,
+/turf/open/floor/plating,
+/area/station/maintenance/fore/greater)
 "dgb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
 /area/station/service/hydroponics/garden)
+"dgu" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/processing)
 "dgQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -35383,10 +36008,10 @@
 /obj/effect/turf_decal/siding/purple{
 	dir = 1
 	},
-/obj/machinery/vending/wardrobe/science_wardrobe,
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 1
 	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
@@ -35517,7 +36142,7 @@
 /area/station/science/lab)
 "dlP" = (
 /obj/structure/cable,
-/obj/item/kirbyplants/random,
+/obj/structure/sign/departments/genetics/directional/east,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
 	},
@@ -35560,6 +36185,17 @@
 	dir = 4
 	},
 /area/station/medical/medbay/aft)
+"dmB" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "Departures Shuttle Dock";
+	space_dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/hallway/secondary/exit/departure_lounge)
 "dmJ" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -35607,6 +36243,11 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
+"doz" = (
+/obj/structure/moisture_trap,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "doQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
@@ -35693,11 +36334,17 @@
 	},
 /obj/machinery/airalarm/directional/east,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/easel,
 /turf/open/floor/iron,
 /area/station/security/prison/rec)
 "drs" = (
 /obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 8
+	},
+/turf/open/floor/iron/edge{
+	dir = 8
+	},
 /area/station/service/hydroponics/garden)
 "drH" = (
 /obj/structure/disposalpipe/segment,
@@ -35725,7 +36372,7 @@
 	pixel_y = 11
 	},
 /obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/lockers)
 "dsF" = (
 /obj/structure/cable,
@@ -36112,7 +36759,8 @@
 	name = "Visitation Shutters"
 	},
 /obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/dark_red/full,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/security/prison/visit)
 "dCG" = (
 /obj/structure/sign/warning/vacuum/external{
@@ -36179,7 +36827,8 @@
 	dir = 4;
 	name = "External Gas Mixer A"
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured,
 /area/station/science/ordnance)
 "dDW" = (
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -36189,7 +36838,10 @@
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/pushbroom,
 /obj/item/storage/box/bodybags,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 10
+	},
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "dEz" = (
 /obj/effect/decal/cleanable/dirt,
@@ -36204,12 +36856,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"dFb" = (
+/obj/machinery/vending/wardrobe/hydro_wardrobe,
+/turf/open/floor/iron/dark,
+/area/station/service/hydroponics)
 "dFe" = (
 /obj/effect/landmark/start/coroner,
 /obj/structure/chair/office/tactical{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "dFi" = (
 /turf/closed/wall/r_wall,
@@ -36234,7 +36890,7 @@
 "dGz" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/plate_press,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/station/security/prison/work)
 "dGZ" = (
 /obj/structure/showcase/cyborg/old{
@@ -36249,9 +36905,9 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/mob/living/simple_animal/hostile/retaliate/goose/vomit,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
+/mob/living/basic/goose/vomit,
 /turf/open/floor/wood,
 /area/station/maintenance/port/aft)
 "dHQ" = (
@@ -36269,7 +36925,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/dark_red,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/prison/visit)
 "dIs" = (
 /obj/effect/turf_decal/tile/blue/half{
@@ -36319,6 +36976,15 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"dJl" = (
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/security/lockers)
 "dJt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36415,6 +37081,11 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/iron/diagonal,
 /area/station/engineering/storage_shared)
+"dLZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "dMb" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -36423,6 +37094,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "dME" = (
@@ -36469,11 +37141,6 @@
 /obj/structure/marker_beacon/burgundy,
 /turf/open/space,
 /area/space/nearstation)
-"dNQ" = (
-/obj/structure/cable,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "dNU" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -36492,10 +37159,20 @@
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/iron/showroomfloor,
 /area/station/engineering/atmos)
+"dOR" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/white/corner,
+/area/station/hallway/secondary/exit/departure_lounge)
 "dPl" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/east,
 /obj/structure/chair/stool/directional/north,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/prison/visit)
 "dPQ" = (
 /obj/machinery/airalarm/directional/south,
@@ -36550,7 +37227,12 @@
 /area/station/maintenance/radshelter)
 "dSK" = (
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
 /area/station/service/hydroponics/garden)
 "dSP" = (
 /obj/machinery/camera/directional/south{
@@ -36967,7 +37649,7 @@
 /area/station/science/explab)
 "eby" = (
 /obj/machinery/flasher/portable,
-/obj/effect/turf_decal/tile/red/full,
+/obj/effect/turf_decal/tile/dark_red/full,
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/security/armory)
@@ -36988,6 +37670,9 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
 /obj/machinery/airlock_controller/incinerator_ordmix{
 	pixel_y = 28
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/station/science/ordnance/burnchamber)
@@ -37014,8 +37699,16 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 10
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
+"edt" = (
+/obj/structure/moisture_trap,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/greater)
 "edy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
@@ -37043,6 +37736,13 @@
 	},
 /turf/open/floor/iron/white/herringbone,
 /area/station/medical/abandoned)
+"eeh" = (
+/obj/machinery/atmospherics/components/tank,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/iron/smooth_large,
+/area/station/science/ordnance)
 "eei" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37092,7 +37792,7 @@
 "eer" = (
 /obj/structure/table,
 /obj/effect/spawner/random/food_or_drink/donkpockets,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/lockers)
 "eev" = (
 /obj/effect/landmark/start/hangover,
@@ -37106,6 +37806,13 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
+"eeM" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/white,
+/area/station/hallway/secondary/exit/departure_lounge)
 "efs" = (
 /obj/structure/cable,
 /obj/structure/table,
@@ -37261,7 +37968,11 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/caution/white,
+/turf/open/floor/iron/dark/textured,
 /area/station/security/mechbay)
 "ekp" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -37287,6 +37998,10 @@
 "ekJ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/window/brigdoor/right/directional/south{
+	req_access = list("atmospherics");
+	name = "Turbine Access"
+	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
 "ele" = (
@@ -37371,15 +38086,20 @@
 	name = "Security Mech Bay Shutters";
 	dir = 4
 	},
-/obj/effect/turf_decal/box,
 /obj/effect/turf_decal/caution/stand_clear{
 	dir = 4
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/side{
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
 	},
 /area/station/security/mechbay)
 "eoW" = (
@@ -37532,7 +38252,7 @@
 /obj/effect/turf_decal/box/white{
 	color = "#52B4E9"
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "etH" = (
 /obj/structure/cable,
@@ -37583,6 +38303,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"evI" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/fore/greater)
 "ewz" = (
 /turf/closed/wall,
 /area/station/service/kitchen)
@@ -37738,6 +38463,10 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark_red,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured_half,
 /area/station/security/interrogation)
 "eAa" = (
@@ -37787,6 +38516,9 @@
 	dir = 1
 	},
 /obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/siding/thinplating_new/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "eAG" = (
@@ -37839,7 +38571,12 @@
 "eCD" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/structure/closet/l3closet/scientist,
-/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery/white{
+	color = "#D381C9"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "eCN" = (
@@ -37905,6 +38642,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/security/prison/safe)
+"eFu" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/cafeteria,
+/area/station/hallway/secondary/exit/departure_lounge)
 "eFD" = (
 /obj/machinery/light/directional/south,
 /obj/structure/closet/secure_closet/personal/patient{
@@ -38003,7 +38747,7 @@
 	},
 /obj/item/storage/box/bandages{
 	pixel_x = 0;
-	pixel_y = 9
+	pixel_y = 10
 	},
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 4
@@ -38174,7 +38918,10 @@
 /obj/structure/cable,
 /obj/structure/bed/dogbed/mcgriff,
 /mob/living/basic/pet/dog/pug/mcgriff,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/warden)
 "eMB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -38204,6 +38951,9 @@
 	dir = 8
 	},
 /obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/trimline/neutral/mid_joiner{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 8
 	},
@@ -38251,6 +39001,9 @@
 /area/station/hallway/primary/aft)
 "eOo" = (
 /obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "eOv" = (
@@ -38553,6 +39306,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "eVN" = (
@@ -38600,14 +39354,25 @@
 "eWO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "eWV" = (
-/obj/effect/turf_decal/stripes/red/line{
+/obj/effect/turf_decal/siding/dark_red,
+/turf/open/floor/iron/dark/textured,
+/area/station/security/lockers)
+"eXJ" = (
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/siding/thinplating_new{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/station/security/lockers)
+/obj/effect/turf_decal/siding/thinplating_new/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/commons/locker)
 "eXK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -38677,21 +39442,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
-"eZw" = (
-/obj/machinery/plumbing/synthesizer{
-	reagent_id = /datum/reagent/water;
-	dir = 4
-	},
-/obj/machinery/door/window/right/directional/east{
-	name = "Med/Sci Water Supply";
-	req_one_access = list("medical","science")
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/greater)
 "eZH" = (
 /obj/effect/mapping_helpers/dead_body_placer,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "eZK" = (
 /obj/effect/turf_decal/stripes/line,
@@ -38750,6 +39503,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor/heavy,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8;
+	color = "#D381C9"
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4;
+	color = "#D381C9"
+	},
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -38850,6 +39617,15 @@
 	},
 /turf/open/floor/engine/n2,
 /area/station/engineering/atmos)
+"fdL" = (
+/obj/effect/landmark/start/assistant,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 8
+	},
+/turf/open/floor/iron/edge{
+	dir = 8
+	},
+/area/station/service/hydroponics/garden)
 "feg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38994,6 +39770,9 @@
 "fhF" = (
 /obj/machinery/rnd/production/techfab/department/medical,
 /obj/effect/turf_decal/tile/blue/full,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/storage)
 "fhK" = (
@@ -39006,7 +39785,9 @@
 	id = "visitation";
 	name = "Visitation Shutters"
 	},
-/turf/open/floor/iron/dark,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/effect/turf_decal/tile/dark_red/full,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/security/prison/visit)
 "fif" = (
 /obj/structure/cable,
@@ -39031,6 +39812,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/heads_quarters/cmo)
+"fiD" = (
+/obj/structure/cable,
+/obj/structure/bodycontainer/morgue{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "fiT" = (
 /obj/machinery/plumbing/synthesizer{
 	reagent_id = /datum/reagent/water
@@ -39090,7 +39882,6 @@
 /area/station/medical/medbay/central)
 "flc" = (
 /obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "flw" = (
@@ -39117,6 +39908,15 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/freezerchamber)
+"fmb" = (
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/security/lockers)
 "fmj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39166,6 +39966,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
+"fmQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/tank/air{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "fmV" = (
 /obj/structure/table,
 /obj/machinery/airalarm/directional/north,
@@ -39346,6 +40154,10 @@
 "fqW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Mix to Space"
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
 "frd" = (
@@ -39400,7 +40212,10 @@
 	pixel_x = 3;
 	pixel_y = 26
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "fsA" = (
 /obj/structure/disposalpipe/segment,
@@ -39462,21 +40277,31 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
+"fwZ" = (
+/obj/structure/closet/secure_closet/engineering_personal,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "fxf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "fxq" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/blue/anticorner{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron/white/smooth_corner{
-	dir = 8
+/obj/effect/turf_decal/tile/blue/full,
+/obj/structure/table/reinforced/rglass,
+/obj/machinery/cell_charger,
+/obj/item/stack/package_wrap{
+	pixel_x = 7;
+	pixel_y = 7
 	},
+/obj/item/hand_labeler{
+	pixel_x = 5;
+	pixel_y = 8
+	},
+/turf/open/floor/iron/white/smooth_large,
 /area/station/medical/storage)
 "fxA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -39527,17 +40352,20 @@
 /obj/structure/bodycontainer/morgue/beeper_off{
 	dir = 8
 	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
 /obj/effect/turf_decal/delivery/white,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "fyS" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
 /obj/structure/table,
 /obj/item/clothing/gloves/color/orange,
 /obj/item/restraints/handcuffs,
 /obj/item/reagent_containers/spray/pepper,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "fzB" = (
@@ -39557,6 +40385,9 @@
 "fAd" = (
 /obj/machinery/duct,
 /obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/effect/turf_decal/siding/thinplating_new/corner{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "fBm" = (
@@ -39636,6 +40467,16 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"fDz" = (
+/obj/machinery/camera/directional/east{
+	c_tag = "Departure Lounge"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron/white/corner,
+/area/station/hallway/secondary/exit/departure_lounge)
 "fDJ" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -39792,6 +40633,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured,
 /area/station/command/heads_quarters/ce)
+"fIW" = (
+/obj/structure/lattice,
+/obj/structure/grille/broken,
+/turf/open/space,
+/area/space/nearstation)
 "fJa" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
@@ -39814,6 +40660,7 @@
 /obj/machinery/computer/rdconsole{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
 "fLt" = (
@@ -39840,6 +40687,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "fMD" = (
@@ -39898,7 +40746,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/security_officer,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/lockers)
 "fOp" = (
 /obj/machinery/door/firedoor/heavy,
@@ -39999,19 +40847,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/medical/break_room)
-"fRR" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/station/medical/storage)
 "fSe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/engineering/atmospherics_portable,
@@ -40141,7 +40976,7 @@
 "fVK" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/prison/visit)
 "fVQ" = (
 /obj/structure/table/glass,
@@ -40209,7 +41044,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/lockers)
 "fXM" = (
 /obj/structure/disposalpipe/segment{
@@ -40469,12 +41304,13 @@
 	pixel_x = -3;
 	pixel_y = 5
 	},
+/obj/structure/sign/departments/court/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/fore)
 "gje" = (
 /obj/structure/table/glass,
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/coffeemaker,
 /turf/open/floor/iron/white/herringbone,
 /area/station/medical/break_room)
 "gjl" = (
@@ -40502,7 +41338,7 @@
 	name = "Security Mech Garage Door Controls";
 	req_access = list("security")
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/lockers)
 "gjM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -40521,11 +41357,26 @@
 	dir = 8;
 	color = "#52B4E9"
 	},
-/obj/structure/sign/poster/official/random/directional/north,
+/obj/structure/sign/nanotrasen{
+	pixel_y = 32
+	},
 /turf/open/floor/iron/edge{
 	dir = 1
 	},
 /area/station/command/bridge)
+"gjX" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "Departures Shuttle Dock";
+	space_dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit/departure_lounge)
 "gkr" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
@@ -40744,6 +41595,15 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/station/service/lawoffice)
+"gpO" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white/corner,
+/area/station/hallway/secondary/exit/departure_lounge)
 "gqb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
@@ -40759,7 +41619,7 @@
 /obj/machinery/mech_bay_recharge_port,
 /obj/structure/cable,
 /obj/machinery/light/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/security/mechbay)
 "gqP" = (
 /obj/structure/tank_holder/anesthetic,
@@ -40770,6 +41630,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"gsw" = (
+/obj/effect/decal/cleanable/ash{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/item/cigbutt{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "gsA" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 8
@@ -40788,6 +41659,7 @@
 "gsJ" = (
 /obj/machinery/light/directional/west,
 /obj/structure/closet/lasertag/blue,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness)
 "gsN" = (
@@ -40840,6 +41712,9 @@
 "guB" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
@@ -41033,7 +41908,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
-/obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/trimline/red/filled/mid_joiner,
 /obj/effect/turf_decal/trimline/red/filled/mid_joiner{
 	dir = 8
@@ -41303,6 +42177,13 @@
 	},
 /turf/open/floor/iron/white/textured_half,
 /area/station/medical/patients_rooms/room_a)
+"gGd" = (
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/commons/locker)
 "gGJ" = (
 /obj/machinery/camera/directional/west{
 	network = list("ss13","rd","xeno");
@@ -41310,6 +42191,17 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"gGM" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
+/area/station/hallway/secondary/exit/departure_lounge)
 "gGP" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -41403,6 +42295,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "gIu" = (
@@ -41434,7 +42327,15 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
 /area/station/security/prison/visit)
 "gJk" = (
 /obj/structure/disposalpipe/segment,
@@ -41454,6 +42355,7 @@
 /area/station/security/prison/safe)
 "gKE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "gKO" = (
@@ -41503,6 +42405,7 @@
 	dir = 4
 	},
 /obj/machinery/duct,
+/obj/structure/sign/departments/rndserver/directional/south,
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
@@ -41521,6 +42424,29 @@
 /obj/item/pillow/random,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/security/prison/safe)
+"gNC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/cardboard{
+	name = "artistic supplies box";
+	desc = "A box with paint, crayons, and a variety of blank canvases."
+	},
+/obj/item/canvas/fortyfive_twentyseven,
+/obj/item/canvas/fortyfive_twentyseven,
+/obj/item/canvas/nineteen_nineteen,
+/obj/item/canvas/nineteen_nineteen,
+/obj/item/canvas/thirtysix_twentyfour,
+/obj/item/canvas/thirtysix_twentyfour,
+/obj/item/canvas/twentyfour_twentyfour,
+/obj/item/canvas/twentyfour_twentyfour,
+/obj/item/canvas/twentythree_nineteen,
+/obj/item/canvas/twentythree_nineteen,
+/obj/item/canvas/twentythree_twentythree,
+/obj/item/canvas/twentythree_twentythree,
+/obj/item/paint_palette,
+/obj/item/paint_palette,
+/obj/item/storage/crayons,
+/turf/open/floor/iron,
+/area/station/security/prison/rec)
 "gNQ" = (
 /obj/item/stack/sheet/glass,
 /obj/structure/table/glass,
@@ -41576,7 +42502,7 @@
 	name = "Coroner's Office";
 	req_access = list("morgue_secure")
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "gPi" = (
 /obj/structure/cable,
@@ -41585,6 +42511,10 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"gPr" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white,
+/area/station/hallway/secondary/exit/departure_lounge)
 "gPv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -41599,6 +42529,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/hangover,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "gPS" = (
@@ -41643,6 +42574,24 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
+"gSF" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Bridge Maintenance"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/command/maintenance,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "gSI" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
@@ -41717,6 +42666,12 @@
 /area/station/hallway/primary/starboard)
 "gVD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating_new/corner{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "gVL" = (
@@ -41834,6 +42789,19 @@
 /obj/effect/turf_decal/tile/bar/diagonal_centre,
 /turf/open/floor/iron/kitchen/diagonal,
 /area/station/service/kitchen)
+"gYm" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
+/obj/effect/landmark/start/cook,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/obj/effect/turf_decal/weather/snow,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/station/service/kitchen/coldroom)
 "gYt" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral/half{
@@ -41913,6 +42881,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/door/firedoor/heavy,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8;
+	color = "#D381C9"
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4;
+	color = "#D381C9"
+	},
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -41936,6 +42918,10 @@
 /area/station/engineering/atmos/hfr_room)
 "hby" = (
 /obj/effect/landmark/event_spawn,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/box/white,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "hbB" = (
@@ -42186,6 +43172,17 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/heads_quarters/cmo)
+"hhu" = (
+/obj/effect/turf_decal/tile/dark_red/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/hallway/secondary/exit/departure_lounge)
 "hhN" = (
 /turf/closed/wall/r_wall,
 /area/station/medical/break_room)
@@ -42213,6 +43210,15 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/dark,
 /area/station/medical/office)
+"hjn" = (
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/security/lockers)
 "hjM" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Laundry Room"
@@ -42246,6 +43252,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"hlf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/binary/pump/on/supply/hidden/layer4{
+	dir = 4;
+	name = "Distro to Ordnance Air"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "hlu" = (
 /obj/effect/turf_decal/siding/purple,
 /obj/effect/landmark/start/hangover,
@@ -42286,8 +43300,8 @@
 	req_access = list("medical")
 	},
 /obj/item/storage/medkit/toxin{
-	pixel_x = 3;
-	pixel_y = 3
+	pixel_x = 2;
+	pixel_y = 1
 	},
 /obj/item/storage/medkit/regular,
 /obj/item/storage/medkit/toxin{
@@ -42374,6 +43388,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/security/prison/mess)
+"hqp" = (
+/obj/structure/table,
+/obj/item/radio/off,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/hallway/secondary/exit/departure_lounge)
 "hqx" = (
 /obj/structure/cable,
 /obj/machinery/vending/wardrobe/sec_wardrobe,
@@ -42402,7 +43422,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "hrz" = (
 /obj/structure/closet/secure_closet/injection{
@@ -42559,6 +43579,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating_new/corner{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -42935,6 +43958,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -43059,6 +44083,13 @@
 "hMs" = (
 /turf/closed/wall,
 /area/station/medical/medbay/aft)
+"hMC" = (
+/obj/machinery/atmospherics/components/tank,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/iron/smooth_large,
+/area/station/science/ordnance)
 "hMM" = (
 /obj/structure/hoop{
 	dir = 8
@@ -43105,7 +44136,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
-/obj/structure/sign/poster/random/directional/north,
+/obj/structure/sign/departments/botany/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -43223,6 +44254,13 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/edge,
 /area/station/commons/storage/tools)
+"hSH" = (
+/obj/machinery/atmospherics/components/tank,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_large,
+/area/station/science/ordnance)
 "hSO" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/turf_decal/bot,
@@ -43232,6 +44270,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/stairs,
 /area/station/commons/fitness)
 "hTa" = (
@@ -43322,12 +44361,14 @@
 /obj/effect/turf_decal/siding/dark_red{
 	dir = 1
 	},
+/obj/structure/chair,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "hWx" = (
 /obj/structure/table,
 /obj/machinery/microwave,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/lockers)
 "hWy" = (
 /obj/machinery/incident_display/delam,
@@ -43397,6 +44438,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/hos)
+"iaE" = (
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/commons/locker)
 "ics" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -43407,7 +44454,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "icW" = (
@@ -43559,6 +44605,19 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"ifK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/blue/anticorner{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white/smooth_corner{
+	dir = 8
+	},
+/area/station/medical/storage)
 "igl" = (
 /obj/machinery/light/directional/north,
 /obj/effect/decal/cleanable/dirt,
@@ -43690,12 +44749,13 @@
 "iiW" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 6
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/mid_joiner,
+/obj/structure/cable,
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/medbay/central)
 "ijc" = (
@@ -43755,6 +44815,21 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/project)
+"ilC" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/filingcabinet,
+/turf/open/floor/wood,
+/area/station/service/library)
+"ilT" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "imc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43786,7 +44861,7 @@
 /area/station/commons/vacant_room/office)
 "imW" = (
 /obj/machinery/door/airlock/security/glass{
-	id_tag = "permaouter";
+	id_tag = "permainner";
 	name = "Permabrig Transfer"
 	},
 /obj/structure/cable,
@@ -43794,6 +44869,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured_half,
 /area/station/security/execution/transfer)
 "inh" = (
@@ -43804,8 +44882,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "ink" = (
-/obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/engine,
 /area/station/science/genetics)
 "ioR" = (
@@ -43852,8 +44931,16 @@
 /area/station/medical/medbay/aft)
 "irG" = (
 /obj/structure/railing/corner,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/wood/tile,
 /area/station/service/chapel)
+"irK" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit/departure_lounge)
 "isa" = (
 /obj/effect/decal/cleanable/blood/drip{
 	pixel_x = 13;
@@ -43882,6 +44969,12 @@
 	dir = 8
 	},
 /area/station/security/range)
+"isC" = (
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/commons/storage/primary)
 "isN" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Auxiliary EVA Prep Room"
@@ -43973,6 +45066,11 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"ium" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet,
+/area/station/service/chapel)
 "iun" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -44002,6 +45100,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
+"ivN" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "ivR" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -44088,11 +45196,25 @@
 /area/station/hallway/primary/central)
 "izj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/window/right/directional/west{
+	req_access = list("genetics");
+	name = "Monkey Pen"
+	},
 /turf/open/floor/engine,
 /area/station/science/genetics)
+"izv" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/hallway/secondary/exit/departure_lounge)
 "izD" = (
 /obj/effect/turf_decal/siding/thinplating_new/light{
 	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
@@ -44263,7 +45385,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/small,
 /area/station/security/evidence)
 "iEJ" = (
 /obj/machinery/door/airlock/external{
@@ -44337,6 +45462,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/station/science/explab)
+"iGC" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on/coldroom{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/snow,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 6
+	},
+/turf/open/floor/iron/kitchen_coldroom,
+/area/station/service/kitchen/coldroom)
 "iGJ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
 	dir = 4
@@ -44381,7 +45519,10 @@
 "iIT" = (
 /obj/structure/chair/stool/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/prison/visit)
 "iIU" = (
 /obj/structure/cable,
@@ -44465,12 +45606,19 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "SRV - Kitchen Backroom"
 	},
-/obj/structure/reagent_dispensers/cooking_oil,
-/obj/item/toy/figure/chef{
-	pixel_x = 2;
-	pixel_y = 14
+/obj/machinery/vending/wardrobe/chef_wardrobe,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
 	},
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/siding/white{
+	dir = 10
+	},
+/obj/effect/turf_decal/weather/snow,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/kitchen_coldroom,
 /area/station/service/kitchen/coldroom)
 "iNG" = (
 /obj/machinery/light/small/directional/east,
@@ -44484,6 +45632,7 @@
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
@@ -44505,11 +45654,11 @@
 /obj/item/storage/medkit/emergency,
 /obj/item/storage/medkit/emergency{
 	pixel_x = 0;
-	pixel_y = 3
+	pixel_y = 6
 	},
 /obj/item/storage/medkit/emergency{
 	pixel_x = 0;
-	pixel_y = 6
+	pixel_y = 12
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -44633,6 +45782,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/arrivals)
 "iRz" = (
+/obj/machinery/vending/coffee,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
 "iSc" = (
@@ -44664,6 +45814,10 @@
 /area/station/service/chapel/office)
 "iTd" = (
 /obj/effect/landmark/start/assistant,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new/corner,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "iTt" = (
@@ -44673,6 +45827,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 6
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
@@ -44705,7 +45862,12 @@
 /area/station/medical/abandoned)
 "iUR" = (
 /obj/machinery/duct,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 8
+	},
+/turf/open/floor/iron/edge{
+	dir = 8
+	},
 /area/station/service/hydroponics/garden)
 "iVq" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
@@ -44720,6 +45882,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
+"iVD" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/random/directional/east,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/white/corner,
+/area/station/hallway/secondary/exit/departure_lounge)
 "iWa" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44805,9 +45975,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"iZd" = (
-/turf/open/space/basic,
-/area/space/nearstation)
 "iZn" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/air_input{
 	dir = 1
@@ -44871,7 +46038,6 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "jbH" = (
@@ -44943,6 +46109,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/atmos/pumproom)
+"jfp" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/hallway/secondary/exit/departure_lounge)
 "jft" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44989,6 +46161,7 @@
 /obj/effect/turf_decal/delivery/white,
 /obj/effect/turf_decal/siding/dark,
 /obj/effect/turf_decal/tile/bar/full,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/kitchen)
 "jhd" = (
@@ -45081,7 +46254,9 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/range)
 "jlp" = (
-/obj/machinery/meter,
+/obj/machinery/meter{
+	name = "External Pump Ports"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
@@ -45135,13 +46310,6 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
-"jnw" = (
-/obj/effect/turf_decal/tile/neutral/diagonal_centre,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/diagonal,
-/area/station/commons/vacant_room/commissary)
 "jnH" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -45167,6 +46335,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"joN" = (
+/obj/structure/chair,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/hallway/secondary/exit/departure_lounge)
 "jpk" = (
 /obj/effect/turf_decal/tile/neutral/half{
 	dir = 1
@@ -45347,6 +46520,13 @@
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/pharmacy)
+"jtW" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/status_display/evac/directional/east,
+/turf/open/floor/iron/white/corner,
+/area/station/hallway/secondary/exit/departure_lounge)
 "jux" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
@@ -45379,6 +46559,21 @@
 	},
 /turf/open/floor/iron/white/smooth_corner,
 /area/station/medical/treatment_center)
+"juO" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/effect/turf_decal/tile/bar/diagonal_centre,
+/obj/item/food/grown/poppy{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/food/grown/poppy{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/food/grown/poppy,
+/turf/open/floor/iron/dark/diagonal,
+/area/station/service/chapel/funeral)
 "juP" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/white/line{
@@ -45408,7 +46603,9 @@
 	dir = 4;
 	color = "#52B4E9"
 	},
-/obj/structure/sign/poster/official/random/directional/north,
+/obj/structure/sign/nanotrasen{
+	pixel_y = 32
+	},
 /turf/open/floor/iron/edge{
 	dir = 1
 	},
@@ -45456,11 +46653,28 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/security/lockers)
 "jwp" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#D381C9"
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1;
+	color = "#D381C9"
+	},
 /turf/open/floor/iron/dark/textured_half,
 /area/station/science/ordnance)
 "jwt" = (
@@ -45651,7 +46865,10 @@
 /area/station/engineering/atmos/project)
 "jBh" = (
 /obj/structure/mannequin/skeleton,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "jBj" = (
 /obj/structure/disposalpipe/segment,
@@ -46039,7 +47256,7 @@
 "jMP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/commons/locker)
 "jMU" = (
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -46126,6 +47343,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"jPv" = (
+/obj/structure/cable,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/thinplating_new,
+/turf/open/floor/iron,
+/area/station/commons/locker)
 "jPw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/visible{
 	dir = 1
@@ -46133,6 +47358,15 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
+"jPI" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
+/area/station/hallway/secondary/exit/departure_lounge)
 "jPL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -46177,6 +47411,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
+"jQN" = (
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/commons/storage/primary)
 "jQU" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46198,9 +47438,19 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/checker,
 /area/station/hallway/primary/central)
+"jQY" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/turf/open/floor/iron/dark/herringbone,
+/area/station/security/lockers)
 "jRR" = (
 /turf/closed/wall,
 /area/station/service/theater)
+"jSi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "jSE" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 1
@@ -46236,10 +47486,17 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"jTt" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/hallway/secondary/exit/departure_lounge)
 "jTz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 1
 	},
@@ -46322,7 +47579,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/warden)
 "jVB" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -46331,6 +47591,7 @@
 	name = "Detective's Privacy Shutters";
 	id = "detective_shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/detectives_office)
 "jVG" = (
@@ -46338,6 +47599,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
 "jVL" = (
@@ -46359,6 +47623,15 @@
 	dir = 1
 	},
 /area/station/cargo/miningdock)
+"jWy" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/hallway/secondary/exit/departure_lounge)
 "jWM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -46378,6 +47651,7 @@
 /area/station/command/heads_quarters/cmo)
 "jWX" = (
 /obj/item/radio/intercom/directional/west,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/carpet,
 /area/station/service/library)
 "jXj" = (
@@ -46449,7 +47723,7 @@
 /area/station/security/range)
 "jYJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash/moisture_trap,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "jYM" = (
@@ -46499,6 +47773,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"jZy" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/hallway/secondary/exit/departure_lounge)
 "jZD" = (
 /obj/structure/disposalpipe/broken{
 	dir = 4;
@@ -46514,10 +47794,13 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"jZN" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
+"jZL" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron/white,
+/area/station/hallway/secondary/exit/departure_lounge)
 "kap" = (
 /obj/machinery/door/airlock/medical{
 	name = "Clinic Storage"
@@ -46805,6 +48088,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "kjv" = (
@@ -46831,6 +48115,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
+/obj/structure/sign/departments/morgue/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/starboard)
 "kjO" = (
@@ -46867,12 +48152,18 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/service/library/artgallery)
+"kkY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "klg" = (
 /obj/machinery/airalarm/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/security/detectives_office)
 "kmc" = (
@@ -47144,6 +48435,15 @@
 /obj/effect/turf_decal/tile/yellow/half,
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/pharmacy)
+"kwg" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot_white{
+	color = "#D381C9"
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/station/hallway/primary/starboard)
 "kwi" = (
 /obj/effect/turf_decal/tile/dark_red{
 	dir = 1
@@ -47181,6 +48481,9 @@
 /area/station/cargo/warehouse)
 "kwK" = (
 /obj/machinery/atmospherics/components/tank,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/open/floor/iron/smooth_large,
 /area/station/science/ordnance)
 "kwP" = (
@@ -47198,6 +48501,7 @@
 	dir = 6
 	},
 /obj/effect/spawner/random/vending/colavend,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness)
 "kxB" = (
@@ -47208,6 +48512,9 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/railing/corner{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -47357,7 +48664,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
 /area/station/service/hydroponics/garden)
 "kDZ" = (
 /obj/structure/disposalpipe/segment,
@@ -47453,8 +48765,8 @@
 	},
 /area/station/medical/pharmacy)
 "kGI" = (
-/obj/structure/weightmachine,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/punching_bag,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison/workout)
 "kGS" = (
@@ -47559,7 +48871,10 @@
 "kJc" = (
 /obj/machinery/vending/wardrobe/coroner_wardrobe,
 /obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "kJq" = (
 /obj/effect/decal/cleanable/dirt,
@@ -47644,7 +48959,7 @@
 "kLJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/prison/visit)
 "kLQ" = (
 /obj/machinery/light/small/directional/east,
@@ -47696,10 +49011,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
-"kMR" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/closed/wall/r_wall,
-/area/station/security/prison/visit)
 "kMS" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/mid_joiner,
 /obj/effect/turf_decal/trimline/dark_green/filled/line,
@@ -47730,7 +49041,14 @@
 /obj/effect/turf_decal/tile/blue/full{
 	color = "#5EB8B8"
 	},
-/obj/item/storage/briefcase/secure,
+/obj/item/storage/briefcase/secure{
+	pixel_x = 5;
+	pixel_y = 2
+	},
+/obj/item/pai_card{
+	pixel_x = -11;
+	pixel_y = 0
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/heads_quarters/cmo)
 "kNm" = (
@@ -48127,12 +49445,15 @@
 /area/station/command/heads_quarters/cmo)
 "kZw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "kZO" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/prison/visit)
 "lax" = (
 /obj/machinery/light/small/directional/north,
@@ -48340,10 +49661,17 @@
 	},
 /turf/open/floor/iron/white/smooth_corner,
 /area/station/medical/storage)
+"ljI" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/white/corner,
+/area/station/hallway/secondary/exit/departure_lounge)
 "ljZ" = (
 /obj/vehicle/sealed/mecha/ripley/paddy/preset,
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron/recharge_floor,
+/turf/open/floor/circuit/red,
 /area/station/security/mechbay)
 "lkp" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner{
@@ -48357,6 +49685,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
+"lkQ" = (
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/commons/locker)
 "llp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -48487,6 +49821,15 @@
 	},
 /turf/open/floor/iron/white/herringbone,
 /area/station/medical/break_room)
+"lph" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/station/medical/storage)
 "lpo" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -48584,6 +49927,14 @@
 /obj/structure/sign/warning/radiation/directional/south,
 /turf/open/space/basic,
 /area/space/nearstation)
+"lsF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/thinplating_new,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/commons/storage/primary)
 "lto" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 4
@@ -48604,6 +49955,11 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/service/chapel)
+"ltM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/plating,
+/area/station/maintenance/port/central)
 "lue" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -48756,6 +50112,11 @@
 	},
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"lxN" = (
+/obj/structure/chair/stool/directional/north,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/station/security/prison/rec)
 "lxO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
@@ -48816,6 +50177,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/work)
+"lAu" = (
+/obj/structure/table,
+/obj/item/pai_card,
+/turf/open/floor/iron,
+/area/station/commons/locker)
 "lAP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -48912,6 +50278,18 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron/checker,
 /area/station/service/kitchen/abandoned)
+"lCT" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/snow,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/station/service/kitchen/coldroom)
 "lCV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/landmark/start/mime,
@@ -49027,7 +50405,7 @@
 /area/station/maintenance/department/electrical)
 "lHh" = (
 /obj/effect/landmark/start/coroner,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "lHi" = (
 /obj/structure/extinguisher_cabinet/directional/east,
@@ -49153,6 +50531,16 @@
 "lJI" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos/storage/gas)
+"lJR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
+"lJY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "lKe" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
@@ -49169,6 +50557,7 @@
 "lKg" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/mapping_helpers/apc/cell_10k,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "lKL" = (
@@ -49272,7 +50661,12 @@
 "lOH" = (
 /obj/structure/sink/directional/south,
 /obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
 /area/station/service/hydroponics/garden)
 "lOL" = (
 /obj/machinery/door/firedoor,
@@ -49370,6 +50764,13 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
+"lRN" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/hallway/secondary/exit/departure_lounge)
 "lRO" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/button/door/directional/east{
@@ -49537,6 +50938,17 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"lWm" = (
+/obj/item/reagent_containers/cup/glass/bottle/beer/almost_empty{
+	pixel_x = -11;
+	pixel_y = 14
+	},
+/obj/item/reagent_containers/cup/glass/bottle/beer/almost_empty{
+	pixel_x = -8;
+	pixel_y = 7
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "lWA" = (
 /obj/machinery/door/airlock/external{
 	name = "Exterior Access";
@@ -49573,6 +50985,11 @@
 /obj/effect/spawner/random/maintenance/five,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"lXQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "lYb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 10
@@ -49635,6 +51052,10 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/eva/abandoned)
+"maC" = (
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/hallway/secondary/exit/departure_lounge)
 "maH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -49667,6 +51088,7 @@
 /area/station/maintenance/disposal/incinerator)
 "mbr" = (
 /obj/structure/table/wood/fancy/red,
+/obj/machinery/recharger,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "mbu" = (
@@ -50115,6 +51537,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"mrb" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "mrj" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -50244,7 +51673,7 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/aft)
 "mug" = (
-/obj/structure/weightmachine/weightlifter,
+/obj/structure/weightmachine,
 /obj/structure/sign/gym/right{
 	pixel_y = 32
 	},
@@ -50348,6 +51777,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/security/prison)
+"myh" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/security/execution/transfer)
 "mzb" = (
 /obj/structure/table,
 /obj/item/electropack,
@@ -50394,10 +51828,9 @@
 	},
 /area/station/security/range)
 "mzW" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/hallway/secondary/exit/departure_lounge)
 "mzY" = (
@@ -50471,9 +51904,7 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
+/obj/machinery/vending/cigarette,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "mCJ" = (
@@ -50524,7 +51955,8 @@
 /area/station/hallway/primary/central)
 "mFY" = (
 /obj/machinery/vending/modularpc,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/large,
 /area/station/commons/storage/primary)
 "mGj" = (
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
@@ -50534,15 +51966,20 @@
 	dir = 4
 	},
 /area/station/security/range)
-"mGB" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/generic_maintenance_landmark,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
+"mGq" = (
+/obj/structure/table,
+/obj/machinery/cell_charger{
+	pixel_y = 5
+	},
+/obj/item/stock_parts/power_store/cell/high,
+/obj/item/stock_parts/power_store/cell/high,
+/obj/effect/turf_decal/tile/purple/anticorner{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_corner{
+	dir = 8
+	},
+/area/station/science/lab)
 "mGD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
@@ -50628,7 +52065,7 @@
 /area/station/engineering/atmos)
 "mIv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "mIy" = (
 /obj/structure/disposalpipe/segment{
@@ -50737,6 +52174,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/siding/thinplating_new/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating_new/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "mLs" = (
@@ -50746,7 +52192,7 @@
 	name = "barber's apron";
 	desc = "Useful for keeping blood off your clothes. Or hair, if you're just a regular barber."
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/commons/locker)
 "mLy" = (
 /turf/open/floor/iron/dark,
@@ -50758,6 +52204,17 @@
 /area/station/maintenance/port/fore)
 "mMk" = (
 /obj/machinery/door/firedoor/heavy,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#D381C9"
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1;
+	color = "#D381C9"
+	},
 /turf/open/floor/iron/dark/textured_half,
 /area/station/science/ordnance)
 "mMA" = (
@@ -50807,7 +52264,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "mOV" = (
-/obj/machinery/light/directional/east,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -50825,7 +52281,7 @@
 	name = "barber's apron";
 	desc = "Useful for keeping blood off your clothes. Or hair, if you're just a regular barber."
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/commons/locker)
 "mPh" = (
 /obj/structure/disposalpipe/segment{
@@ -50920,6 +52376,13 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
+/area/station/service/chapel)
+"mQW" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/tile,
 /area/station/service/chapel)
 "mRb" = (
 /obj/structure/lattice/catwalk,
@@ -51076,9 +52539,12 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/station/security/prison/safe)
 "mUY" = (
-/obj/structure/table,
-/obj/item/electropack,
 /obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/table,
+/obj/item/storage/box/prisoner{
+	pixel_y = 8
+	},
+/obj/item/storage/box/prisoner,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "mVj" = (
@@ -51096,6 +52562,9 @@
 /obj/effect/turf_decal/siding/thinplating_new/light/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/thinplating_new/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "mVv" = (
@@ -51135,16 +52604,11 @@
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"mWn" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/sign/poster/official/random/directional/east,
-/turf/open/floor/iron/white/corner,
-/area/station/hallway/secondary/exit/departure_lounge)
 "mWx" = (
 /obj/structure/rack,
 /obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/clothing/mask/breath,
 /obj/item/clothing/mask/breath,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -51173,6 +52637,7 @@
 /obj/effect/turf_decal/siding/green{
 	dir = 5
 	},
+/obj/structure/sign/warning/cold_temp/directional/south,
 /turf/open/floor/iron/large,
 /area/station/hallway/secondary/service)
 "mYz" = (
@@ -51187,6 +52652,16 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/command/storage/eva)
+"mYG" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Departures Holding Area"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/hallway/secondary/exit/departure_lounge)
 "mYY" = (
 /obj/structure/closet/secure_closet/medical2,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -51225,7 +52700,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "nbG" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
@@ -51291,16 +52766,11 @@
 /turf/open/floor/carpet/blue,
 /area/station/command/meeting_room/council)
 "neP" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/bodybags{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/rxglasses,
-/obj/item/hand_labeler,
-/obj/item/gun/syringe,
-/obj/item/gun/syringe,
 /obj/effect/turf_decal/tile/blue/full,
+/obj/machinery/disposal/bin/tagger,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/storage)
 "neQ" = (
@@ -51340,7 +52810,7 @@
 "nfK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/prison/visit)
 "nfN" = (
 /obj/effect/turf_decal/siding/dark{
@@ -51507,6 +52977,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/project)
+"nkO" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "Departures Security Dock"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit/departure_lounge)
 "nkQ" = (
 /obj/machinery/door/airlock/security{
 	name = "Permabrig Visitation"
@@ -51514,8 +52997,11 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/dark_red,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_half,
 /area/station/security/prison/visit)
 "nle" = (
 /obj/machinery/light/directional/west,
@@ -51541,13 +53027,21 @@
 /turf/open/floor/iron/smooth,
 /area/station/engineering/storage/tech)
 "nlq" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/siding/purple/corner{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Science - Research Lab";
+	network = list("ss13","rd")
+	},
+/obj/machinery/button/door/directional/north{
+	id = "rnd";
+	req_access = list("research");
+	name = "Research Desk Shutters Control"
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lab)
@@ -51575,6 +53069,10 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/entry)
+"nmf" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/hallway/secondary/exit/departure_lounge)
 "nmn" = (
 /obj/structure/chair{
 	dir = 4
@@ -51631,9 +53129,9 @@
 /turf/open/floor/iron/white/smooth_corner,
 /area/station/medical/patients_rooms/room_a)
 "npF" = (
-/obj/structure/window/reinforced/spawner/directional/north,
 /mob/living/carbon/human/species/monkey,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/engine,
 /area/station/science/genetics)
 "npP" = (
@@ -51710,6 +53208,7 @@
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /obj/item/kirbyplants/random,
+/obj/structure/sign/departments/security/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/fore)
 "nsU" = (
@@ -51761,6 +53260,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/checker,
 /area/station/security/interrogation)
 "nud" = (
@@ -51817,6 +53317,10 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark_red,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured_half,
 /area/station/security/range)
 "nxM" = (
@@ -51932,15 +53436,6 @@
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron/white/herringbone,
 /area/station/hallway/secondary/entry)
-"nBa" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Departure Lounge"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron/white/corner,
-/area/station/hallway/secondary/exit/departure_lounge)
 "nBr" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -52079,8 +53574,33 @@
 /obj/structure/table,
 /obj/effect/turf_decal/tile/green/full,
 /obj/structure/sign/poster/random/directional/west,
+/obj/item/seeds/apple{
+	pixel_x = 3;
+	pixel_y = 6
+	},
+/obj/item/seeds/wheat{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/seeds/tomato{
+	pixel_x = 3;
+	pixel_y = 0
+	},
+/obj/item/seeds/potato{
+	pixel_x = 3;
+	pixel_y = -3
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/hydroponics)
+"nFl" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/station/service/hydroponics/garden)
 "nGb" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
@@ -52142,7 +53662,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/warden)
 "nHw" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/brown/visible,
@@ -52170,7 +53693,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/small,
 /area/station/security/evidence)
 "nIP" = (
 /obj/machinery/doppler_array{
@@ -52557,7 +54083,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "nUV" = (
 /obj/machinery/duct,
@@ -52580,6 +54106,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
+"nVH" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/herringbone,
+/area/station/security/lockers)
 "nVN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
@@ -52628,7 +54160,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "nWm" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -52695,6 +54226,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/landmark/blobstart,
 /turf/open/floor/iron/checker,
 /area/station/service/kitchen/abandoned)
 "nYN" = (
@@ -52789,7 +54321,7 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/trash/moisture_trap,
+/obj/structure/moisture_trap,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "obu" = (
@@ -52804,6 +54336,14 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/hallway/primary/fore)
+"obK" = (
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating_new/corner,
+/turf/open/floor/iron,
+/area/station/commons/locker)
 "obO" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -52874,7 +54414,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/effect/landmark/navigate_destination/incinerator,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -52917,12 +54456,17 @@
 	name = "Security Mech Bay Shutters";
 	dir = 4
 	},
-/obj/effect/turf_decal/box,
 /obj/effect/turf_decal/caution/stand_clear{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/side{
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
 	},
 /area/station/security/mechbay)
 "ofw" = (
@@ -53013,6 +54557,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/command/storage/eva)
+"ohV" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/thinplating_new,
+/turf/open/floor/iron,
+/area/station/commons/storage/primary)
 "ohW" = (
 /obj/machinery/camera/directional/east{
 	network = list("ss13","rd","xeno");
@@ -53045,7 +54594,6 @@
 /area/station/maintenance/disposal/incinerator)
 "oiI" = (
 /obj/structure/chair,
-/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "oiT" = (
@@ -53152,9 +54700,9 @@
 /area/station/hallway/primary/central)
 "olq" = (
 /obj/structure/table/wood,
-/obj/item/food/grown/poppy,
 /obj/effect/turf_decal/tile/neutral/diagonal_edge,
 /obj/effect/turf_decal/tile/bar/diagonal_centre,
+/obj/item/book/bible,
 /turf/open/floor/iron/dark/diagonal,
 /area/station/service/chapel/funeral)
 "olH" = (
@@ -53624,8 +55172,21 @@
 /area/station/maintenance/starboard/greater)
 "ozG" = (
 /obj/machinery/computer/records/security,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/warden)
+"ozW" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/station/medical/storage)
 "oAc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53645,6 +55206,17 @@
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1;
+	color = "#D381C9"
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#D381C9"
 	},
 /turf/open/floor/iron/dark/textured_half,
 /area/station/science/ordnance)
@@ -53696,7 +55268,10 @@
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/security/mechbay)
 "oDF" = (
 /obj/machinery/light/directional/south,
@@ -53769,15 +55344,15 @@
 	dir = 4
 	},
 /area/station/hallway/primary/central)
+"oHy" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/status_display/ai/directional/south,
+/turf/open/floor/iron/white/corner,
+/area/station/hallway/secondary/exit/departure_lounge)
 "oHz" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
+/turf/open/floor/iron/white,
 /area/station/medical/storage)
 "oHH" = (
 /obj/structure/cable,
@@ -53792,10 +55367,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/prison/visit)
 "oIT" = (
-/obj/effect/spawner/random/trash/moisture_trap,
+/obj/structure/moisture_trap,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
@@ -53872,6 +55447,10 @@
 	dir = 8
 	},
 /area/station/security/prison)
+"oLV" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark/herringbone,
+/area/station/security/lockers)
 "oMe" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/red/opposingcorners,
@@ -53926,7 +55505,11 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/dark_red,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_half,
 /area/station/security/prison/visit)
 "oNw" = (
 /obj/structure/lattice,
@@ -54069,6 +55652,7 @@
 "oTy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/stairs,
 /area/station/security/courtroom)
 "oTN" = (
@@ -54385,10 +55969,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "pay" = (
-/obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/engine,
 /area/station/science/genetics)
 "paM" = (
@@ -54500,9 +56084,7 @@
 /area/station/medical/storage)
 "peu" = (
 /obj/structure/railing/corner,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/tile,
 /area/station/service/chapel)
 "peD" = (
@@ -54613,18 +56195,9 @@
 /obj/structure/sign/painting/library{
 	pixel_y = -32
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
-"pgT" = (
-/obj/effect/turf_decal/tile/dark_red/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/dark_red{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron/dark,
-/area/station/hallway/secondary/exit/departure_lounge)
 "pgV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/wood{
@@ -54819,7 +56392,7 @@
 /area/station/maintenance/department/eva/abandoned)
 "pkK" = (
 /obj/effect/turf_decal/arrows,
-/mob/living/basic/sloth/citrus,
+/mob/living/basic/sloth/paperwork,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "plu" = (
@@ -54908,6 +56481,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/project)
+"poc" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "pog" = (
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/structure/window/spawner/directional/south,
@@ -54942,6 +56524,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
+"poz" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red/half,
+/obj/structure/sign/departments/lawyer/directional/south,
+/turf/open/floor/iron/dark/smooth_half,
+/area/station/hallway/primary/fore)
 "poH" = (
 /obj/structure/table/optable,
 /obj/machinery/light/directional/north,
@@ -54956,6 +56546,9 @@
 /area/station/medical/patients_rooms/room_a)
 "poM" = (
 /obj/machinery/holopad,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 4
+	},
 /obj/effect/turf_decal/box/white,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
@@ -55059,6 +56652,9 @@
 /obj/machinery/atmospherics/components/tank/oxygen{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron/smooth_large,
 /area/station/science/ordnance)
 "ptN" = (
@@ -55080,6 +56676,7 @@
 "pvj" = (
 /obj/structure/chair/office,
 /obj/effect/turf_decal/siding/wood,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
 "pvI" = (
@@ -55112,11 +56709,12 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/holopad/secure,
+/obj/effect/turf_decal/siding/thinplating_new/dark,
 /obj/effect/turf_decal/box/white{
 	color = "#DE3A3A"
 	},
-/obj/machinery/holopad/secure,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/lockers)
 "pwu" = (
 /obj/machinery/door/airlock/medical{
@@ -55246,6 +56844,11 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/armory,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/effect/turf_decal/siding/dark_red,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured_half,
 /area/station/security/execution/education)
 "pzA" = (
@@ -55313,6 +56916,7 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/pharmacy)
 "pAZ" = (
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/wood/large,
 /area/station/service/bar/backroom)
 "pBj" = (
@@ -55476,7 +57080,7 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/station/commons/dorms)
 "pGM" = (
-/obj/machinery/power/smes/engineering,
+/obj/machinery/power/smes/full,
 /obj/structure/cable,
 /obj/item/toy/figure/borg{
 	pixel_x = -5;
@@ -55507,16 +57111,14 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/structure/closet/l3closet,
 /obj/machinery/light/directional/south,
 /obj/effect/mapping_helpers/requests_console/assistance,
 /obj/effect/mapping_helpers/requests_console/supplies,
 /obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
 	dir = 1
 	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
+/obj/structure/closet/l3closet,
+/turf/open/floor/iron/white/textured,
 /area/station/medical/storage)
 "pID" = (
 /obj/structure/cable,
@@ -55590,6 +57192,12 @@
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/engine,
 /area/station/cargo/warehouse)
+"pKd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
+/obj/effect/spawner/random/engineering/atmospherics_portable,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "pKm" = (
 /obj/machinery/requests_console/directional/east{
 	name = "Circuits Lab Requests Console";
@@ -55605,8 +57213,15 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
+"pKQ" = (
+/obj/effect/spawner/random/entertainment/arcade,
+/turf/open/floor/eighties/red,
+/area/station/hallway/secondary/exit/departure_lounge)
 "pLn" = (
 /obj/machinery/conveyor/inverted{
 	dir = 5;
@@ -55738,6 +57353,7 @@
 /obj/structure/table/glass,
 /obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/tile/blue/full,
+/obj/item/storage/box/rxglasses,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/treatment_center)
 "pOr" = (
@@ -55777,6 +57393,23 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/science/genetics)
+"pPi" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
+	dir = 1
+	},
+/obj/machinery/light_switch/directional/south{
+	pixel_x = -10;
+	pixel_y = -24
+	},
+/obj/machinery/suit_storage_unit/medical,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/storage)
 "pPs" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -55865,6 +57498,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"pSo" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "pSr" = (
 /obj/effect/turf_decal/tile/blue/half,
 /obj/effect/landmark/start/hangover,
@@ -55917,7 +57556,7 @@
 /turf/open/floor/wood/large,
 /area/station/service/lawoffice)
 "pUD" = (
-/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "pUK" = (
@@ -55978,7 +57617,7 @@
 	dir = 4;
 	id = "brm"
 	},
-/obj/machinery/bouldertech/refinery,
+/obj/machinery/bouldertech/refinery/smelter,
 /turf/open/floor/plating,
 /area/station/cargo/miningdock)
 "pZa" = (
@@ -56031,8 +57670,12 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "qas" = (
-/obj/machinery/atmospherics/components/tank/air{
+/obj/effect/turf_decal/siding/white{
 	dir = 1
+	},
+/obj/structure/closet/l3closet/scientist,
+/obj/effect/turf_decal/delivery/white{
+	color = "#D381C9"
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
@@ -56162,6 +57805,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Departures Lounge"
 	},
+/obj/structure/sign/departments/evac/directional/south,
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/primary/starboard)
 "qdQ" = (
@@ -56212,6 +57856,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
+"qfC" = (
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/security/lockers)
 "qgg" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral/half,
@@ -56227,7 +57877,12 @@
 /area/space/nearstation)
 "qgD" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 8
+	},
+/turf/open/floor/iron/edge{
+	dir = 8
+	},
 /area/station/service/hydroponics/garden)
 "qgW" = (
 /obj/effect/turf_decal/tile/yellow/half{
@@ -56285,6 +57940,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/chem_storage)
+"qil" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/hallway/secondary/exit/departure_lounge)
 "qiw" = (
 /obj/effect/turf_decal/tile/neutral/half{
 	dir = 4
@@ -56409,7 +58072,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/commons/locker)
 "qnT" = (
 /obj/vehicle/ridden/wheelchair{
@@ -56428,6 +58091,7 @@
 /area/station/medical/medbay/central)
 "qod" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/station/security/prison/safe)
 "qoe" = (
@@ -56481,7 +58145,7 @@
 "qpJ" = (
 /obj/structure/chair,
 /obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/commons/locker)
 "qqe" = (
 /obj/structure/cable,
@@ -56595,7 +58259,7 @@
 /obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/lockers)
 "quW" = (
 /obj/structure/cable,
@@ -56648,14 +58312,14 @@
 /turf/open/floor/plating,
 /area/station/science/ordnance/testlab)
 "qwi" = (
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/commons/locker)
 "qwy" = (
 /obj/structure/chair/plastic{
 	dir = 8
 	},
 /obj/effect/landmark/start/security_officer,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/lockers)
 "qwX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -56674,6 +58338,9 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "qya" = (
@@ -56750,6 +58417,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/side,
 /area/station/science/research)
+"qzC" = (
+/obj/machinery/destructive_scanner,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/box/white{
+	color = "#D381C9"
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/station/hallway/primary/starboard)
 "qzD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/effect/mapping_helpers/damaged_window,
@@ -56901,6 +58578,7 @@
 	pixel_y = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/security/detectives_office)
 "qHi" = (
@@ -57340,12 +59018,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
-"qXy" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/station/service/chapel)
 "qYD" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
@@ -57392,6 +59064,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/structure/closet/radiation,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "raz" = (
@@ -57462,6 +59135,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/mid_joiner{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/smooth_corner,
 /area/station/commons/fitness)
 "rdP" = (
@@ -57479,6 +59155,10 @@
 	pixel_x = 4;
 	pixel_y = 3
 	},
+/obj/item/flashlight/lamp{
+	pixel_x = -7;
+	pixel_y = 7
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "reh" = (
@@ -57492,6 +59172,17 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/service/bar)
+"reE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "reI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -57741,6 +59432,13 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"roC" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark_red,
+/turf/open/floor/iron/dark/textured,
+/area/station/security/lockers)
 "rps" = (
 /obj/structure/table,
 /obj/item/folder,
@@ -57805,6 +59503,19 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"rrO" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark_red/corner,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/security/lockers)
 "rsb" = (
 /obj/machinery/atmospherics/components/binary/pressure_valve/on{
 	name = "Waste Release"
@@ -57812,8 +59523,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "rsD" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/hallway/secondary/exit/departure_lounge)
 "rsE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -57900,6 +59614,11 @@
 	dir = 1
 	},
 /area/station/maintenance/department/eva/abandoned)
+"ruL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/station/security/prison)
 "ruS" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -57982,10 +59701,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white,
@@ -57993,7 +59708,7 @@
 "rxj" = (
 /obj/structure/chair,
 /obj/effect/landmark/start/assistant,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/commons/locker)
 "rxB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -58114,6 +59829,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/edge,
 /area/station/security/prison)
+"rCT" = (
+/obj/structure/reagent_dispensers/plumbed{
+	dir = 8;
+	name = "med/sci reservoir"
+	},
+/obj/structure/window/reinforced/spawner/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/greater)
 "rDK" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
@@ -58216,7 +59939,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/security/mechbay)
 "rGI" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -58286,6 +60009,16 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/explab)
+"rJE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/table,
+/obj/effect/spawner/random/entertainment/lighter{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/obj/effect/spawner/random/entertainment/cigarette_pack,
+/turf/open/floor/iron/white,
+/area/station/hallway/secondary/exit/departure_lounge)
 "rJU" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -58326,15 +60059,8 @@
 	},
 /area/station/security/prison/workout)
 "rKc" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/window/left/directional/west{
-	name = "Science Deliveries";
-	req_access = list("science")
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/starboard/central)
+/turf/open/floor/iron/white,
+/area/station/science/lab)
 "rKo" = (
 /obj/structure/showcase/machinery{
 	icon = 'icons/obj/machines/bci_implanter.dmi';
@@ -58391,6 +60117,9 @@
 /obj/item/restraints/handcuffs,
 /obj/item/restraints/handcuffs,
 /obj/item/restraints/handcuffs,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 5
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
 "rMm" = (
@@ -58493,6 +60222,9 @@
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "rQS" = (
@@ -58503,7 +60235,12 @@
 "rQW" = (
 /obj/structure/cable,
 /obj/machinery/duct,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 8
+	},
+/turf/open/floor/iron/edge{
+	dir = 8
+	},
 /area/station/service/hydroponics/garden)
 "rRn" = (
 /obj/structure/disposalpipe/segment,
@@ -58515,6 +60252,36 @@
 	dir = 8
 	},
 /area/station/hallway/primary/central)
+"rRB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/firedoor/heavy,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8;
+	color = "#D381C9"
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4;
+	color = "#D381C9"
+	},
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/station/science/research)
+"rRN" = (
+/obj/machinery/washing_machine,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron/white,
+/area/station/commons/locker)
 "rRQ" = (
 /obj/structure/chair{
 	dir = 4
@@ -59041,6 +60808,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/effect/turf_decal/siding/dark_red,
 /turf/open/floor/iron/dark/textured_half,
 /area/station/security/execution/transfer)
 "sjk" = (
@@ -59160,7 +60928,7 @@
 /obj/item/storage/fancy/donut_box,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/lockers)
 "soA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -59175,7 +60943,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/commons/locker)
 "spw" = (
 /obj/structure/cable,
@@ -59243,6 +61011,7 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 8
 	},
+/obj/structure/sign/departments/exodrone/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "srA" = (
@@ -59402,7 +61171,8 @@
 	name = "Visitation Shutters"
 	},
 /obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/dark_red/full,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/security/prison/visit)
 "svp" = (
 /obj/effect/landmark/event_spawn,
@@ -59413,7 +61183,7 @@
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/lockers)
 "svS" = (
 /obj/structure/cable,
@@ -59469,6 +61239,12 @@
 	id = "commissary";
 	name = "Commissary Shutters"
 	},
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "swW" = (
@@ -59490,6 +61266,10 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
+"sxu" = (
+/obj/structure/chair/sofa/right/maroon,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "sxD" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
@@ -59585,7 +61365,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/catwalk_floor/iron_dark,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "szE" = (
 /obj/structure/closet/l3closet/virology,
@@ -59608,6 +61388,13 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"sAm" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/security/execution/transfer)
 "sAF" = (
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron/dark,
@@ -59895,6 +61682,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
+"sLg" = (
+/obj/effect/turf_decal/trimline/purple/line,
+/obj/effect/turf_decal/trimline/purple/mid_joiner,
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/mid_joiner,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/smooth_half,
+/area/station/hallway/primary/starboard)
 "sLN" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/highsecurity{
@@ -59902,7 +61697,9 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/landmark/navigate_destination/aiupload,
+/obj/effect/landmark/navigate_destination/aiupload{
+	location = "AI Upload and Chamber"
+	},
 /obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -59972,7 +61769,10 @@
 	dir = 8;
 	name = "Coolant Supply Port"
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
 /area/station/science/ordnance)
 "sOt" = (
 /obj/structure/disposalpipe/segment{
@@ -60032,6 +61832,15 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/wood/large,
 /area/station/hallway/secondary/exit/departure_lounge)
+"sPQ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/processing)
 "sRe" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -60101,7 +61910,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/commons/locker)
 "sUg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -60125,7 +61934,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/hydroponics/constructable,
+/obj/machinery/hydroponics/constructable{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "sUE" = (
@@ -60152,6 +61963,10 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness)
+"sVx" = (
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "sWC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60171,7 +61986,7 @@
 /obj/machinery/light/small/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "sWP" = (
 /obj/structure/cable,
@@ -60269,6 +62084,9 @@
 /area/station/cargo/storage)
 "sYJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "sYV" = (
@@ -60350,6 +62168,7 @@
 /obj/effect/turf_decal/siding/green{
 	dir = 5
 	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
 "tav" = (
@@ -60461,6 +62280,11 @@
 	},
 /turf/open/floor/wood,
 /area/station/maintenance/port/aft)
+"tcQ" = (
+/obj/structure/table,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/hallway/secondary/exit/departure_lounge)
 "tcU" = (
 /obj/structure/chair/pew/right{
 	dir = 1
@@ -60556,6 +62380,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/carpet/green,
 /area/station/service/library)
 "tfr" = (
@@ -60654,6 +62481,7 @@
 /obj/effect/turf_decal/siding/dark_red{
 	dir = 1
 	},
+/obj/structure/chair,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "tiY" = (
@@ -60685,6 +62513,7 @@
 	dir = 5
 	},
 /obj/effect/landmark/start/scientist,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white/herringbone,
 /area/station/science/lab)
 "tkm" = (
@@ -60738,7 +62567,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
 /area/station/service/hydroponics/garden)
 "tlW" = (
 /obj/structure/disposalpipe/segment,
@@ -60765,6 +62599,15 @@
 /obj/item/storage/box/drinkingglasses,
 /turf/open/floor/wood/large,
 /area/station/hallway/secondary/exit/departure_lounge)
+"tmu" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "tmG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -60793,6 +62636,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
+"tnQ" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "Departures Security Dock"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/hallway/secondary/exit/departure_lounge)
 "tnV" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/light/directional/south,
@@ -60813,20 +62667,13 @@
 /obj/item/modular_computer/laptop/preset/civilian,
 /turf/open/floor/iron/white,
 /area/station/hallway/secondary/exit/departure_lounge)
+"tos" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/hallway/secondary/exit/departure_lounge)
 "toC" = (
 /obj/structure/table/wood,
-/obj/item/coffee_cartridge/fancy{
-	pixel_x = 1;
-	pixel_y = 8
-	},
-/obj/item/storage/fancy/coffee_cart_rack{
-	pixel_x = -9;
-	pixel_y = 7
-	},
-/obj/item/coffee_cartridge/decaf{
-	pixel_x = 1;
-	pixel_y = 4
-	},
 /obj/item/reagent_containers/cup/glass/mug/nanotrasen{
 	pixel_x = -7;
 	pixel_y = -2
@@ -60835,7 +62682,14 @@
 	pixel_x = -1;
 	pixel_y = -7
 	},
-/obj/structure/sign/poster/official/random/directional/west,
+/obj/item/storage/box/coffeepack/robusta{
+	pixel_x = 4;
+	pixel_y = 10
+	},
+/obj/item/storage/box/coffeepack{
+	pixel_x = 8;
+	pixel_y = 7
+	},
 /turf/open/floor/carpet/blue,
 /area/station/command/meeting_room/council)
 "toK" = (
@@ -60850,6 +62704,7 @@
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/turf_decal/trimline/red/filled/mid_joiner,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/edge,
 /area/station/security/prison)
 "tpe" = (
@@ -61221,6 +63076,37 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/medical/virology)
+"txy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/duct,
+/obj/machinery/door/firedoor/heavy,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8;
+	color = "#D381C9"
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4;
+	color = "#D381C9"
+	},
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/station/science/research)
+"txz" = (
+/turf/closed/wall/r_wall,
+/area/station/science/robotics/mechbay)
+"txG" = (
+/obj/structure/chair/stool/directional/north,
+/turf/open/floor/eighties/red,
+/area/station/hallway/secondary/exit/departure_lounge)
 "txS" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -61318,6 +63204,12 @@
 /obj/effect/turf_decal/tile/neutral/half,
 /turf/open/floor/iron/edge,
 /area/station/hallway/primary/port)
+"tzX" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
 "tAs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -61400,7 +63292,8 @@
 /area/station/medical/psychology)
 "tGy" = (
 /obj/effect/landmark/start/warden,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/dark_red/diagonal_centre,
+/turf/open/floor/iron/dark/diagonal,
 /area/station/security/warden)
 "tHz" = (
 /obj/structure/disposalpipe/segment,
@@ -61481,6 +63374,7 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
 	},
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "tKG" = (
@@ -61520,16 +63414,18 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "tMl" = (
-/obj/effect/turf_decal/loading_area,
-/obj/machinery/food_cart,
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/snow,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "tMn" = (
 /obj/structure/table/glass,
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/item/storage/medkit/fire{
-	pixel_x = 3;
-	pixel_y = 3
+	pixel_x = 2;
+	pixel_y = 1
 	},
 /obj/item/storage/medkit/regular,
 /obj/item/storage/medkit/fire{
@@ -61573,12 +63469,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
+/obj/machinery/atmospherics/pipe/bridge_pipe/purple/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/catwalk_floor/iron_dark,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "tNr" = (
 /obj/effect/landmark/start/hangover,
@@ -61603,7 +63498,9 @@
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "tNE" = (
-/obj/machinery/meter,
+/obj/machinery/meter{
+	name = "External Scrubber Ports"
+	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 9
 	},
@@ -61639,6 +63536,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"tPY" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white/corner,
+/area/station/hallway/secondary/exit/departure_lounge)
 "tQg" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -61799,6 +63704,14 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"tWf" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/closet/emcloset,
+/obj/effect/landmark/start/hangover/closet,
+/turf/open/floor/iron/white/corner,
+/area/station/hallway/secondary/exit/departure_lounge)
 "tWh" = (
 /obj/machinery/power/shieldwallgen,
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -61979,6 +63892,12 @@
 	},
 /turf/open/floor/iron/white/herringbone,
 /area/station/medical/abandoned)
+"tZR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/hallway/secondary/exit/departure_lounge)
 "uaL" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/bronze,
@@ -62080,6 +63999,12 @@
 /area/station/hallway/primary/central)
 "uea" = (
 /obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "ued" = (
@@ -62176,6 +64101,7 @@
 "uhQ" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
 "uiV" = (
@@ -62356,10 +64282,11 @@
 /area/station/service/library)
 "uot" = (
 /obj/structure/table/optable,
+/obj/effect/turf_decal/siding/wideplating_new/dark,
 /obj/effect/turf_decal/box/white{
 	color = "#52B4E9"
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "uoy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -62422,6 +64349,12 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "usk" = (
@@ -62435,6 +64368,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
+"utr" = (
+/turf/open/floor/iron/dark/herringbone,
+/area/station/security/lockers)
 "uty" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -62448,6 +64384,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
+"utD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/plating,
+/area/station/maintenance/fore/greater)
 "utI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -62519,7 +64461,8 @@
 "uuU" = (
 /obj/structure/closet{
 	icon_door = "sec_wardrobe";
-	name = "security wardrobe"
+	name = "security wardrobe";
+	desc = "It's a storage unit for additional Nanotrasen attire."
 	},
 /obj/item/clothing/under/rank/security/officer/blueshirt,
 /obj/item/clothing/under/rank/security/officer/blueshirt,
@@ -62544,7 +64487,7 @@
 /obj/item/clothing/head/hats/warden/police{
 	armor_type = /datum/armor/cosmetic_sec
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/lockers)
 "uvv" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -62642,6 +64585,12 @@
 	dir = 4
 	},
 /area/station/service/hydroponics)
+"uAc" = (
+/obj/structure/cable,
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/siding/dark_red,
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "uAz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -62650,7 +64599,7 @@
 /area/station/maintenance/starboard/fore)
 "uAM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "uBB" = (
 /obj/structure/disposalpipe/segment,
@@ -62673,7 +64622,11 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/iron/cafeteria,
+/obj/machinery/newscaster/directional/north,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
 /area/station/hallway/secondary/exit/departure_lounge)
 "uEq" = (
 /obj/structure/cable,
@@ -62684,7 +64637,6 @@
 /area/station/maintenance/disposal/incinerator)
 "uFd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "uGz" = (
@@ -62695,6 +64647,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/sepia,
 /area/station/service/library)
+"uGM" = (
+/obj/structure/chair,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "uGR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -62705,6 +64661,7 @@
 "uHg" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/siding/thinplating_new/corner,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "uHp" = (
@@ -62799,6 +64756,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
+"uIQ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/sign/departments/vault/directional/north,
+/turf/open/floor/plating,
+/area/station/hallway/primary/port)
 "uJo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -62918,12 +64881,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/security/prison)
-"uMP" = (
-/obj/effect/turf_decal/siding/purple,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/purple/half,
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/science/lab)
 "uNg" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -63206,8 +65163,11 @@
 /obj/structure/marker_beacon/cerulean,
 /turf/open/space,
 /area/space/nearstation)
+"uVt" = (
+/turf/closed/wall/r_wall,
+/area/station/cargo/office)
 "uVB" = (
-/obj/machinery/door/window/right/directional/south{
+/obj/machinery/door/window/right/directional/north{
 	req_access = list("ordnance");
 	name = "Freezer Chamber Access"
 	},
@@ -63256,6 +65216,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airalarm/unlocked,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "uWR" = (
@@ -63270,6 +65231,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"uXI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/lab)
 "uXT" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 4
@@ -63331,16 +65298,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"vac" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 1
-	},
-/obj/structure/sign/poster/official/random/directional/west,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/science/lab)
 "vad" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -63354,7 +65311,7 @@
 /area/station/engineering/atmos)
 "vao" = (
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/lockers)
 "vap" = (
 /obj/structure/chair{
@@ -63454,7 +65411,7 @@
 "vdl" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 5
 	},
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -63631,6 +65588,7 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -63802,6 +65760,17 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#D381C9"
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1;
+	color = "#D381C9"
+	},
 /turf/open/floor/iron/dark/textured_half,
 /area/station/science/ordnance)
 "vnk" = (
@@ -63843,6 +65812,15 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/iron,
 /area/station/maintenance/department/eva/abandoned)
+"voV" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "voZ" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -63941,6 +65919,7 @@
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 1
 	},
+/obj/structure/sign/departments/custodian/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
 "vsa" = (
@@ -63958,7 +65937,12 @@
 /obj/structure/cable,
 /obj/machinery/duct,
 /obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 8
+	},
+/turf/open/floor/iron/edge{
+	dir = 8
+	},
 /area/station/service/hydroponics/garden)
 "vsX" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
@@ -64013,6 +65997,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"vuP" = (
+/obj/effect/spawner/random/entertainment/arcade,
+/obj/machinery/light/directional/north,
+/turf/open/floor/eighties/red,
+/area/station/hallway/secondary/exit/departure_lounge)
 "vvb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -64027,6 +66016,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/project)
+"vvU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/greater)
 "vvV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -64078,6 +66072,7 @@
 /area/station/commons/vacant_room/commissary)
 "vxl" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/greater)
 "vxN" = (
@@ -64209,7 +66204,7 @@
 	req_access = list("morgue_secure");
 	name = "Smartfridge Access"
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "vBd" = (
 /obj/item/radio/intercom/directional/west,
@@ -64228,7 +66223,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "vBP" = (
@@ -64253,7 +66247,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
 "vCq" = (
@@ -64266,9 +66259,6 @@
 	},
 /obj/machinery/meter{
 	name = "Gas Mixers In"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
@@ -64375,6 +66365,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark_red,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/security/armory)
 "vGL" = (
@@ -64613,6 +66607,7 @@
 /obj/structure/flora/bush/sparsegrass/style_random,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/station/medical/virology)
 "vNi" = (
@@ -64682,8 +66677,11 @@
 "vPs" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/bodycontainer/morgue,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
 /obj/effect/turf_decal/bot_white,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "vPt" = (
 /obj/machinery/camera/preset/ordnance{
@@ -64698,6 +66696,9 @@
 "vPE" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/components/tank,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/open/floor/iron/smooth_large,
 /area/station/science/ordnance)
 "vPN" = (
@@ -64732,7 +66733,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/large,
 /area/station/commons/locker)
 "vRW" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
@@ -64894,7 +66896,10 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/court,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark_red{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured_half{
@@ -64925,12 +66930,15 @@
 /turf/open/floor/wood,
 /area/station/maintenance/port/aft)
 "vXq" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
 /obj/structure/closet/bombcloset,
-/obj/effect/turf_decal/delivery,
 /obj/machinery/airalarm/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/white{
+	dir = 9
+	},
+/obj/effect/turf_decal/delivery/white{
+	color = "#D381C9"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "vYa" = (
@@ -65152,7 +67160,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
 	dir = 1
 	},
-/obj/structure/sign/poster/official/help_others/directional/north,
+/obj/structure/sign/departments/morgue/directional/north,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
@@ -65226,6 +67234,13 @@
 /obj/structure/broken_flooring/pile,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"wko" = (
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/siding/thinplating_new/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/commons/locker)
 "wkp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/event_spawn,
@@ -65487,8 +67502,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "wqU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "wro" = (
@@ -65642,6 +67658,13 @@
 	dir = 8
 	},
 /area/station/commons/fitness)
+"wvG" = (
+/obj/effect/turf_decal/siding/thinplating_new,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/commons/storage/primary)
 "wvN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
@@ -65769,6 +67792,17 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white,
 /area/station/hallway/secondary/exit/departure_lounge)
+"wAG" = (
+/obj/item/storage/fancy/cigarettes{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/effect/spawner/random/entertainment/lighter{
+	pixel_x = 3;
+	pixel_y = -7
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "wAO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/plasma_output{
 	dir = 8
@@ -66048,6 +68082,21 @@
 /obj/machinery/component_printer,
 /turf/open/floor/iron/dark,
 /area/station/science/circuits)
+"wKA" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/dark_red{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark_red,
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
+/area/station/hallway/secondary/exit/departure_lounge)
 "wLT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -66093,7 +68142,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/prison/visit)
 "wMO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -66135,6 +68184,13 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"wOj" = (
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/hallway/secondary/exit/departure_lounge)
 "wOn" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/table,
@@ -66219,7 +68275,6 @@
 	},
 /area/station/security/prison/shower)
 "wQO" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/siding/purple{
 	dir = 8
 	},
@@ -66252,6 +68307,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"wRI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/port/aft)
 "wRL" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/item/paper/guides/jobs/hydroponics,
@@ -66311,6 +68373,7 @@
 /obj/item/book/bible,
 /obj/structure/railing,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/tile,
 /area/station/service/chapel)
 "wUs" = (
@@ -66365,7 +68428,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "wVT" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
@@ -66375,6 +68437,13 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
+"wWk" = (
+/obj/effect/turf_decal/siding/purple,
+/obj/effect/turf_decal/tile/purple/half,
+/obj/structure/chair/stool/directional/north,
+/obj/effect/landmark/start/scientist,
+/turf/open/floor/iron/white/smooth_edge,
+/area/station/science/lab)
 "wWq" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
@@ -66487,9 +68556,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "wYV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
@@ -66508,6 +68574,7 @@
 "wZl" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/structure/sign/poster/random/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "wZo" = (
@@ -66872,11 +68939,25 @@
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
+"xkE" = (
+/obj/machinery/light/small/directional/east,
+/obj/machinery/airalarm/directional/east,
+/obj/effect/mapping_helpers/airalarm/tlv_kitchen,
+/obj/machinery/gibber,
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery/red,
+/obj/effect/turf_decal/weather/snow,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 5
+	},
+/turf/open/floor/iron/kitchen_coldroom,
+/area/station/service/kitchen/coldroom)
 "xkH" = (
 /turf/closed/wall,
 /area/station/medical/coldroom)
 "xkP" = (
-/obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -67171,6 +69252,11 @@
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"xws" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/table,
+/turf/open/floor/iron/white,
+/area/station/hallway/secondary/exit/departure_lounge)
 "xwv" = (
 /obj/item/toy/plush/moth{
 	pixel_x = 11;
@@ -67217,10 +69303,7 @@
 /area/station/hallway/primary/port)
 "xwK" = (
 /obj/structure/table,
-/obj/machinery/processor{
-	pixel_y = 7;
-	pixel_x = 0
-	},
+/obj/machinery/processor,
 /obj/effect/turf_decal/bot_white,
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
@@ -67309,11 +69392,10 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/dock)
 "xzW" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
+/obj/structure/closet/secure_closet/brig,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "xAm" = (
@@ -67321,6 +69403,7 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
 "xAq" = (
@@ -67352,6 +69435,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"xAW" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/white,
+/area/station/hallway/secondary/exit/departure_lounge)
 "xBk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -67495,6 +69585,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod,
 /area/station/maintenance/radshelter)
+"xGk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet,
+/area/station/service/chapel)
 "xGF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -67506,7 +69600,13 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/security/lockers)
 "xHM" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -67567,6 +69667,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/general,
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/iron/dark/textured_half,
 /area/station/commons/fitness)
 "xJh" = (
@@ -67745,7 +69846,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/lockers)
 "xSw" = (
 /obj/machinery/camera/directional/west{
@@ -67806,7 +69908,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/dark_red,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/prison/visit)
 "xVQ" = (
 /obj/structure/cable,
@@ -67815,7 +69918,7 @@
 /area/station/command/heads_quarters/hos)
 "xWc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/security/prison/visit)
 "xWG" = (
 /obj/effect/turf_decal/tile/neutral/half{
@@ -67900,6 +70003,7 @@
 /area/station/engineering/atmos)
 "yay" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
 "yaA" = (
@@ -67964,6 +70068,15 @@
 	},
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
+"ycE" = (
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/security/lockers)
 "ycJ" = (
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
@@ -68103,6 +70216,7 @@
 	fax_name = "Law Office";
 	name = "Law Office Fax Machine"
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/wood/large,
 /area/station/service/lawoffice)
 "yib" = (
@@ -68160,6 +70274,17 @@
 	dir = 4
 	},
 /area/station/commons/fitness)
+"yje" = (
+/obj/effect/turf_decal/loading_area,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/effect/turf_decal/weather/snow,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/station/service/kitchen/coldroom)
 "yjr" = (
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
@@ -68188,6 +70313,13 @@
 "ykN" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/storage_shared)
+"ykO" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/closet/firecloset,
+/turf/open/floor/iron/white/corner,
+/area/station/hallway/secondary/exit/departure_lounge)
 "ylC" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio6";
@@ -83480,7 +85612,7 @@ mqW
 arP
 aAU
 iUR
-aBM
+fdL
 qgD
 drs
 azF
@@ -83738,7 +85870,7 @@ azi
 dgb
 clp
 tlh
-qgD
+nFl
 aDa
 azF
 azF
@@ -84507,7 +86639,7 @@ arP
 mqW
 arP
 lOH
-iUR
+daX
 dSK
 aDa
 kDX
@@ -85280,7 +87412,7 @@ mqW
 uuS
 arP
 aDh
-nwl
+lsF
 aFQ
 aHe
 aIN
@@ -85290,10 +87422,10 @@ xVy
 xwI
 aPA
 uea
-nYZ
-aQN
-aQN
-nYZ
+eXJ
+iaE
+iaE
+obK
 aXQ
 aYe
 eNq
@@ -85550,7 +87682,7 @@ aQQ
 sYJ
 leC
 hsd
-rQh
+jPv
 aXp
 baO
 qCz
@@ -85804,7 +87936,7 @@ xVy
 lde
 aPA
 aQP
-aQN
+lkQ
 tXH
 aTB
 aWo
@@ -86053,7 +88185,7 @@ arP
 aDl
 bxk
 aFU
-aDd
+ohV
 aIX
 aBQ
 sFZ
@@ -86061,10 +88193,10 @@ xVy
 aOp
 aPA
 aXs
-nYZ
+gGd
 aTz
 aTz
-rQh
+jPv
 awH
 qnP
 rxj
@@ -86308,9 +88440,9 @@ arP
 kUh
 arP
 aDk
-aDo
+isC
 nwl
-aDd
+ohV
 aIW
 aBQ
 cTL
@@ -86321,7 +88453,7 @@ aXr
 fAd
 iiR
 aUp
-rQh
+jPv
 ayW
 jMP
 qwi
@@ -86565,7 +88697,7 @@ mLC
 uuS
 arP
 aDn
-aDo
+isC
 rYv
 aHD
 aIZ
@@ -86575,10 +88707,10 @@ xVy
 aOq
 aPD
 aXv
-nYZ
+wko
+lAu
 aTz
-aTz
-rQh
+jPv
 soP
 sTZ
 qpJ
@@ -86832,7 +88964,7 @@ xVy
 vjg
 aPA
 aQS
-aQN
+lkQ
 obu
 aTx
 mVu
@@ -87079,7 +89211,7 @@ arP
 mqW
 arP
 aDp
-aDo
+isC
 aFU
 eAB
 aJb
@@ -87089,13 +89221,13 @@ xVy
 xwI
 aPE
 aQV
-aQN
+lkQ
 aQN
 aQN
 yeu
 tCj
 wOn
-aZB
+rRN
 aZB
 aXA
 aPz
@@ -87337,8 +89469,8 @@ mqW
 arP
 mFY
 iTd
-aDo
-aDo
+jQN
+jQN
 aIU
 aKa
 jpk
@@ -87346,7 +89478,7 @@ ara
 xwI
 aPA
 aQU
-aQN
+lkQ
 nYZ
 nYZ
 yeu
@@ -87369,7 +89501,7 @@ bjr
 iDv
 ydD
 srf
-mQr
+fxJ
 xpo
 asO
 wlV
@@ -87593,7 +89725,7 @@ cyi
 atJ
 arP
 aDq
-aDo
+wvG
 aFZ
 aHE
 aJc
@@ -88127,7 +90259,7 @@ aPz
 aPz
 aPz
 aPz
-cuk
+ltM
 sws
 aPz
 bjp
@@ -88335,7 +90467,7 @@ aaa
 aaa
 aaa
 aaa
-iZd
+aaa
 gXs
 gXs
 gXs
@@ -88420,7 +90552,7 @@ amJ
 bVA
 aDB
 aEX
-aiQ
+soA
 aDE
 amJ
 tNX
@@ -89190,7 +91322,7 @@ anr
 amJ
 bVF
 bWA
-aEX
+wRI
 aCc
 aDF
 amJ
@@ -89395,7 +91527,7 @@ lVB
 aEO
 aGc
 aHF
-aJd
+uIQ
 aJd
 aLN
 jlZ
@@ -89682,7 +91814,7 @@ aZE
 aZE
 aZE
 aZE
-aZE
+uVt
 byD
 bwU
 byn
@@ -89939,7 +92071,7 @@ brO
 btt
 buE
 bvZ
-aZE
+uVt
 bxx
 bwT
 bxx
@@ -90116,7 +92248,7 @@ aaB
 aaB
 aaa
 bqu
-jzm
+ruL
 aWy
 eiP
 hHS
@@ -90906,12 +93038,12 @@ kga
 gSI
 fyS
 clZ
-gXs
+sxu
+lWm
 gXs
 aaa
 aaa
-aaa
-gXs
+eRz
 aaa
 aaa
 aaa
@@ -91134,7 +93266,7 @@ aaa
 aaa
 aaa
 aaB
-iZd
+aaa
 aai
 aai
 aai
@@ -91162,13 +93294,13 @@ kCk
 xzW
 qSI
 aft
-abz
-gXs
+clZ
+crr
+aaH
 gXs
 aaa
 aaa
-aaa
-gXs
+eRz
 aaa
 aaa
 aaa
@@ -91394,7 +93526,7 @@ aaB
 gXs
 aaN
 aaV
-gyq
+lxN
 afG
 bBG
 dGz
@@ -91416,16 +93548,16 @@ lHy
 eGJ
 dWm
 kCk
-kga
+xzW
 qSI
 aft
-abz
+clZ
+dfB
+gXs
 gXs
 aaa
 aaa
-aaa
-aaa
-gXs
+eRz
 aaa
 aiU
 aln
@@ -91469,7 +93601,7 @@ wuU
 bdE
 tav
 mId
-cNG
+tzX
 vLS
 jEG
 xkv
@@ -91673,16 +93805,16 @@ gJY
 mST
 rlH
 kCk
-kga
+xzW
 qSI
-aft
-abz
+myh
+clZ
 gXs
 gXs
 gXs
-aaf
-aaf
-aaf
+gXs
+gXs
+aaT
 aaf
 aiU
 alp
@@ -91726,7 +93858,7 @@ jIq
 vwS
 tav
 aZH
-cNG
+tzX
 tVK
 nBP
 grF
@@ -91911,7 +94043,7 @@ aaX
 fZR
 pfZ
 nle
-bEc
+gNC
 aHk
 gIQ
 gzX
@@ -91932,14 +94064,14 @@ bNt
 kCk
 aeb
 qSI
-afv
+aft
 clZ
 gXs
 aaa
+gXs
 aaa
-aaa
-aiT
-aiT
+aiV
+aiV
 aiV
 akG
 lVn
@@ -91976,7 +94108,7 @@ aSa
 aSr
 aPQ
 wbV
-jnw
+gES
 gES
 uTi
 bcG
@@ -92187,23 +94319,23 @@ acc
 eGJ
 dWm
 kCk
-kga
+xzW
 qSI
 aft
-abz
+clZ
 gXs
 gXs
 gXs
-aaf
-aiT
+aaa
+aiV
 ajs
 akb
-aor
-aor
+dgu
+dgu
 amc
 aiT
 ant
-aor
+dgu
 aos
 aiT
 apR
@@ -92444,15 +94576,15 @@ gJY
 kLQ
 rlH
 kCk
-kga
+xzW
 qSI
 aft
-abz
+clZ
+wAG
+aaH
 gXs
-aaa
-aaa
-aaa
-aiU
+gXs
+aiV
 ajr
 aka
 tAs
@@ -92701,17 +94833,17 @@ bNt
 bNt
 bNt
 kCk
-aeg
+xzW
 qSI
 aft
-abz
-gXs
-gXs
-gXs
-aaa
-aiU
+clZ
+uGM
+gsw
+aaH
+aaH
+aiV
 aju
-akK
+sPQ
 akK
 akK
 akK
@@ -92958,9 +95090,9 @@ pwe
 ahE
 ada
 clZ
-kga
+sAm
 qSI
-afz
+aft
 bBi
 bBi
 bBi
@@ -92968,7 +95100,7 @@ bBi
 bBi
 bBi
 ajt
-akK
+sPQ
 akJ
 alr
 aor
@@ -92988,7 +95120,7 @@ mqW
 odn
 kIo
 aBh
-fbR
+doz
 awc
 aCW
 aGg
@@ -93191,7 +95323,7 @@ aaa
 aaa
 aaB
 aaB
-iZd
+aaa
 aai
 aai
 cpW
@@ -93271,7 +95403,7 @@ svg
 bgG
 bid
 aLX
-dNQ
+xgM
 ycJ
 bnN
 boY
@@ -93489,7 +95621,7 @@ iDT
 ahU
 aiX
 rbi
-xYY
+poz
 aph
 air
 aqY
@@ -93527,10 +95659,10 @@ bcX
 aZM
 bjz
 bjz
+gSF
 bjz
-bkT
 bjz
-bjz
+jXq
 boX
 sZY
 mOe
@@ -93785,9 +95917,9 @@ cvv
 bgH
 bie
 bjA
-bkW
 bmp
 bjz
+afv
 bpa
 bHC
 cBr
@@ -94044,7 +96176,7 @@ bmo
 bmo
 bmo
 bmo
-bjz
+bmr
 boZ
 brU
 brU
@@ -94769,8 +96901,8 @@ cGM
 auj
 wQn
 akO
-xdu
-alx
+poc
+uAc
 amQ
 ewL
 rbi
@@ -95013,7 +97145,7 @@ abC
 svk
 acH
 adc
-kMR
+aaZ
 aeo
 fBu
 lhi
@@ -95026,7 +97158,7 @@ cGM
 iAi
 akp
 vad
-alw
+tmu
 amg
 amQ
 vvW
@@ -95797,8 +97929,8 @@ aiz
 tRe
 wQn
 akR
-xdu
-alx
+poc
+uAc
 amQ
 ewL
 ymh
@@ -96023,7 +98155,7 @@ aaa
 aaa
 gXs
 gXs
-gXs
+eRz
 gXs
 aCa
 ffT
@@ -96054,7 +98186,7 @@ aiy
 nnG
 akp
 vad
-alw
+tmu
 ami
 amQ
 oCj
@@ -96146,7 +98278,7 @@ cCY
 cnA
 rdP
 cmN
-pWb
+mrb
 aPU
 cFL
 lbe
@@ -96279,8 +98411,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+gXs
+eRz
 gXs
 aCa
 mPt
@@ -96536,8 +98668,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+gXs
+eRz
 gXs
 aCa
 lrr
@@ -96793,8 +98925,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+gXs
+eRz
 gXs
 aCa
 aCa
@@ -96826,7 +98958,7 @@ xdu
 wQn
 akT
 aww
-alx
+uAc
 amQ
 ewL
 ymh
@@ -96857,7 +98989,7 @@ aPS
 aRn
 aSz
 aTY
-bQV
+cvW
 alv
 coc
 bfv
@@ -97051,11 +99183,11 @@ nXv
 gXs
 gXs
 gXs
+eRz
 gXs
 gXs
 gXs
-gXs
-gXs
+eRz
 gXs
 gXs
 gXs
@@ -97082,7 +99214,7 @@ aiH
 xdu
 igO
 vad
-alw
+tmu
 amk
 amQ
 oCj
@@ -97307,13 +99439,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+gXs
+eRz
 gXs
 aaa
-aaa
-aaa
-aaa
+gXs
+eRz
+gXs
 aaa
 aaa
 gXs
@@ -97564,13 +99696,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+gXs
+eRz
 gXs
 aaa
-aaa
-aaa
-aaa
+gXs
+eRz
+gXs
 aaa
 aaa
 gXs
@@ -97587,7 +99719,7 @@ coS
 aet
 cxA
 aeY
-agS
+cQs
 agS
 jVl
 aie
@@ -97628,7 +99760,7 @@ aPS
 aRo
 aSA
 aVo
-ajo
+bQV
 aPR
 aPR
 bfv
@@ -97821,13 +99953,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+gXs
+eRz
 gXs
 aaa
-aaa
-aaa
-aaa
+gXs
+eRz
+gXs
 aaa
 bRz
 bRz
@@ -98078,13 +100210,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+gXs
+eRz
 gXs
 aaa
-aaa
-aaa
-aaa
+gXs
+eRz
+gXs
 aaa
 bRz
 gqK
@@ -98202,12 +100334,12 @@ cSZ
 cfc
 cmF
 lMe
-cWh
+pSo
 aPU
 cFL
 cSK
 mHP
-cDF
+cDE
 cEa
 cEg
 cFj
@@ -98858,9 +100990,9 @@ kYg
 fpW
 rvL
 nxG
-xHo
-xHo
-aew
+nVH
+nVH
+utr
 gjI
 eer
 hWx
@@ -98868,7 +101000,7 @@ aLL
 aco
 acO
 abl
-eWV
+qfC
 eWV
 afc
 abo
@@ -99116,16 +101248,16 @@ hso
 gWM
 abp
 dsq
-xHo
-aew
+nVH
+utr
 fOe
 vao
-aew
+jQY
 aQw
-aew
+hjn
 jwk
-aew
-aew
+hjn
+dJl
 aew
 afb
 abo
@@ -99231,7 +101363,7 @@ ahB
 ray
 lMe
 cWh
-cWh
+fwZ
 aPU
 cpu
 sit
@@ -99378,12 +101510,12 @@ fXC
 svD
 soy
 pwm
-xHo
+roC
 acq
 acq
 acq
 acq
-xHo
+rrO
 xHo
 afS
 aik
@@ -99630,16 +101762,16 @@ aaa
 aaa
 aJW
 uuU
-aew
-aQw
+utr
+oLV
 qwy
 qwy
 xSq
-aew
-aew
-aew
-aew
-aew
+ycE
+fmb
+fmb
+fmb
+fmb
 aev
 afd
 abo
@@ -99970,7 +102102,7 @@ bzs
 bDP
 bzs
 fSe
-cdE
+vvU
 twm
 bZN
 cmd
@@ -100229,7 +102361,7 @@ bKD
 bKD
 omj
 wky
-dbm
+edt
 cmd
 emX
 kQy
@@ -103242,7 +105374,7 @@ aaa
 afp
 aaa
 qmj
-nVN
+utD
 axz
 ahk
 vqt
@@ -103489,9 +105621,9 @@ aaa
 aaa
 aaa
 aaa
+gXs
 aaa
-aaa
-aaf
+aba
 aaa
 aaa
 qmj
@@ -103507,7 +105639,7 @@ nVN
 rUX
 xji
 axz
-aiA
+dfM
 qmj
 anG
 qmj
@@ -103746,9 +105878,9 @@ aaa
 aaa
 aaa
 aaa
+bhT
 aaa
-aaa
-aaa
+bhT
 aaa
 aaa
 adR
@@ -103763,7 +105895,7 @@ aiA
 vlD
 qGp
 cKy
-aiA
+evI
 aiA
 qmj
 khB
@@ -104003,9 +106135,9 @@ aaa
 aaa
 aaa
 aaa
+bhT
 aaa
-aaa
-aaa
+eRz
 aaa
 aaa
 aaa
@@ -104260,9 +106392,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+bhT
+gXs
+eRz
 aaa
 aaa
 aaa
@@ -104517,9 +106649,9 @@ aaa
 aaa
 aaa
 aaa
+bhT
 aaa
-aaa
-aaa
+eRz
 aaa
 aaa
 aaa
@@ -104533,7 +106665,7 @@ aaa
 aaa
 gXs
 aaa
-bhT
+eRz
 aaa
 aaa
 aaa
@@ -104774,9 +106906,9 @@ aaa
 aaa
 aaa
 aaa
+bhT
 aaa
-aaa
-aaa
+bhT
 aaa
 aaa
 aaa
@@ -104788,9 +106920,9 @@ aaa
 aaa
 aaa
 aaa
-gXs
+eRz
 aaa
-bhT
+eRz
 aaa
 aaa
 aaa
@@ -105031,23 +107163,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 bhT
 aaa
 bhT
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+eRz
+aaa
+eRz
 aaa
 aaa
 aaa
@@ -105288,23 +107420,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 bhT
 aaa
 bhT
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+eRz
+aaa
+eRz
 aaa
 aoV
 aaa
@@ -105545,23 +107677,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bhT
 aaa
 bhT
 aaa
-gXs
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+eRz
+aaa
+eRz
 aaa
 aaa
 aaa
@@ -105802,23 +107934,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 bhT
 aaa
 bhT
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+eRz
+aaa
+eRz
 aaa
 aaa
 aaa
@@ -105893,7 +108025,7 @@ ctA
 bzs
 tBe
 oQU
-cdE
+vvU
 cdE
 fSe
 oRL
@@ -106059,23 +108191,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 bhT
 aaa
 bhT
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+eRz
+aaa
+eRz
 aaa
 aaa
 aaa
@@ -106316,23 +108448,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-gXs
-aaa
 bhT
+gXs
+bhT
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+eRz
+aaa
+eRz
 aaa
 aaa
 aaa
@@ -106573,23 +108705,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 bhT
 aaa
-bhT
+eRz
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+eRz
+aaa
+eRz
 aaa
 aaa
 aaa
@@ -106615,9 +108747,9 @@ aCz
 aGB
 vGm
 aJA
+lCT
 azV
-azV
-aKC
+gYm
 aKC
 aQk
 eam
@@ -106830,9 +108962,9 @@ aaa
 aaa
 aaa
 aaa
+bhT
 aaa
-aaa
-aaa
+eRz
 aaa
 aaa
 aaa
@@ -106844,7 +108976,7 @@ aaa
 aaa
 aaw
 aaa
-bhT
+eRz
 aaa
 gXs
 aaa
@@ -106937,7 +109069,7 @@ chm
 akD
 dWo
 clf
-lcA
+lJR
 cdz
 aHf
 hwN
@@ -107087,9 +109219,9 @@ aaa
 aaa
 aaa
 aaa
+bhT
 aaa
-aaa
-aaa
+eRz
 aaa
 aaa
 aaa
@@ -107128,7 +109260,7 @@ wrp
 rFV
 wDZ
 pSw
-aJK
+aJI
 aKV
 tMl
 aMl
@@ -107384,10 +109516,10 @@ tsg
 lxO
 rFV
 jCS
-cek
-aJI
-aJI
-aJI
+pSw
+aJK
+cnm
+yje
 aNO
 aOT
 ewz
@@ -107454,12 +109586,12 @@ wry
 oou
 pCs
 siO
+gXs
+eRz
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+gXs
 aaa
 aoV
 aaa
@@ -107642,11 +109774,11 @@ tTL
 rFV
 jCS
 gPA
-aJL
-aKX
 aJI
 aJI
 aJI
+xkE
+iGC
 ewz
 ddJ
 gjH
@@ -107716,9 +109848,9 @@ bzs
 aaa
 aaa
 aaa
+eRz
 aaa
-aaa
-aaa
+bhT
 aaa
 aaa
 aaa
@@ -107899,9 +110031,9 @@ rnD
 rFV
 pVD
 aIk
-aIp
+aJL
 aKW
-aMG
+aIp
 aIp
 aIp
 aIp
@@ -107973,9 +110105,9 @@ bzs
 bzs
 aaa
 aaa
+eRz
 aaa
-aaa
-aaa
+eRz
 aaa
 aaa
 aaa
@@ -108228,11 +110360,11 @@ bxL
 xjn
 kJq
 bPn
-aaa
-aaa
-aaa
-aaa
-aaa
+gXs
+gXs
+eRz
+gXs
+eRz
 aaa
 aaa
 aaa
@@ -108487,9 +110619,9 @@ vxl
 bPn
 aaa
 aaa
+eRz
 aaa
-aaa
-aoV
+aaT
 aaa
 aaa
 aaa
@@ -108744,9 +110876,9 @@ oSI
 bPn
 aaa
 aaa
+eRz
 aaa
-aaa
-aaa
+eRz
 aaa
 aaa
 aaa
@@ -108958,9 +111090,9 @@ gVb
 qMq
 gHL
 rwY
-bvs
+bzm
 fxq
-fRR
+oHz
 oHz
 bEj
 bye
@@ -109001,9 +111133,9 @@ nWE
 bzs
 aaa
 aaa
+eRz
 aaa
-aaa
-aaa
+eRz
 aaa
 aaa
 aaa
@@ -109203,7 +111335,7 @@ eei
 jre
 kjH
 bfL
-cTO
+fiD
 bkf
 bfS
 cTO
@@ -109215,11 +111347,11 @@ wZo
 nQp
 buq
 iiW
-bzm
-brx
-bBQ
-hnE
-bEl
+bvs
+ifK
+ozW
+lph
+pPi
 bye
 bHb
 loQ
@@ -109258,9 +111390,9 @@ bzs
 bzs
 nXv
 aaa
+eRz
 aaa
-aaa
-aaa
+eRz
 aaa
 aaa
 aaa
@@ -109472,12 +111604,12 @@ wIs
 qMq
 bux
 bvy
-bzs
-cmd
-cmd
-cmd
-cmd
-bzs
+bzm
+brx
+bBQ
+hnE
+bEl
+bye
 bHa
 gje
 jUr
@@ -109515,9 +111647,9 @@ cdE
 cqu
 nXv
 aaa
+gXs
 aaa
-aaa
-aaa
+eRz
 aaa
 aaa
 aaa
@@ -109684,7 +111816,7 @@ aoO
 apB
 aof
 art
-jrS
+kkY
 jrS
 xcS
 apC
@@ -109692,7 +111824,7 @@ alP
 sXl
 alP
 aAr
-uPY
+jSi
 alP
 aaa
 aaf
@@ -109730,10 +111862,10 @@ sfJ
 buG
 bvA
 bzs
-eZw
-ank
-pCs
-dbm
+cmd
+cmd
+cmd
+cmd
 bzs
 bzs
 bzs
@@ -109771,10 +111903,10 @@ bzs
 bPn
 bPn
 nXv
+gXs
+bhT
 aaa
-aaa
-aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -109957,7 +112089,7 @@ aGV
 alP
 aJN
 aLd
-anM
+dFb
 aNQ
 aOZ
 eoW
@@ -110029,9 +112161,9 @@ aaa
 aaa
 aaa
 aaa
+eRz
 aaa
-aaa
-aaa
+eRz
 aaa
 aaa
 aaa
@@ -110245,7 +112377,7 @@ buL
 bvB
 bzs
 bZO
-bZN
+rCT
 cmd
 cmd
 cmd
@@ -110286,9 +112418,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+eRz
+gXs
+eRz
 aaa
 aaa
 aaa
@@ -110492,7 +112624,7 @@ biG
 jmP
 blu
 bnb
-aWr
+txz
 bor
 bpS
 bsO
@@ -110543,9 +112675,9 @@ aaa
 aaa
 aaa
 aaa
+eRz
 aaa
-aaa
-aaa
+eRz
 aaa
 aaa
 aaa
@@ -110749,7 +112881,7 @@ dDf
 bkh
 gZQ
 cHQ
-aWr
+txz
 boE
 ele
 gqP
@@ -110800,9 +112932,9 @@ aaa
 aaa
 aaa
 aaa
+eRz
 aaa
-aaa
-aaa
+eRz
 aaa
 aaa
 aaa
@@ -110985,7 +113117,7 @@ alP
 aIr
 jhM
 aLf
-jhM
+ilC
 aNS
 aPb
 aQp
@@ -111006,7 +113138,7 @@ biH
 jwP
 blv
 bls
-aWr
+txz
 boD
 fXm
 bsP
@@ -111057,9 +113189,9 @@ aaa
 aaa
 aaa
 aaa
+eRz
 aaa
-aaa
-aaa
+eRz
 aaa
 aaa
 aaa
@@ -111263,7 +113395,7 @@ eRa
 cvK
 fER
 blx
-aWr
+txz
 boL
 jAx
 bsR
@@ -111314,9 +113446,9 @@ aaa
 aaa
 aaa
 aaa
+eRz
 aaa
-aaa
-aaa
+eRz
 aaa
 aaa
 aaa
@@ -111520,7 +113652,7 @@ biG
 blw
 bjP
 bnb
-aWr
+txz
 boG
 suU
 cIe
@@ -111571,9 +113703,9 @@ aaa
 aaa
 aaa
 aaa
+eRz
 aaa
-aaa
-aaa
+bhT
 aaa
 aaa
 aaa
@@ -111726,7 +113858,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+bhT
 aaa
 aaa
 aaf
@@ -111776,8 +113908,8 @@ cHK
 blA
 blA
 blA
-box
-box
+biq
+biq
 cHU
 cHZ
 cIf
@@ -111828,9 +113960,9 @@ aaa
 aaa
 aaa
 aaa
+eRz
 aaa
-aaa
-aaa
+eRz
 aaa
 aaa
 aaa
@@ -111983,7 +114115,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+bhT
 aaa
 aaa
 aaa
@@ -112085,9 +114217,9 @@ aaa
 aaa
 aaa
 aaa
+gXs
 aaa
-aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -112240,7 +114372,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+eRz
 aaa
 aaa
 aaa
@@ -112316,7 +114448,7 @@ vRW
 bQN
 fNn
 qVI
-yjr
+sVx
 bVk
 yjr
 yjr
@@ -112497,7 +114629,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+eRz
 aaa
 aaa
 aaa
@@ -112754,7 +114886,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+eRz
 aaa
 aaa
 aaa
@@ -112774,7 +114906,7 @@ sfR
 apC
 awL
 jrS
-jrS
+lJY
 apE
 llX
 llX
@@ -113011,7 +115143,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+eRz
 aaa
 aaa
 aaa
@@ -113268,7 +115400,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+eRz
 aaa
 aaa
 aaa
@@ -113525,7 +115657,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+eRz
 aaa
 aaa
 aaa
@@ -113782,7 +115914,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+eRz
 aaf
 aaf
 aaf
@@ -113827,7 +115959,7 @@ aFu
 bcs
 idZ
 axs
-imy
+sLg
 bvx
 bvx
 bvx
@@ -113838,8 +115970,8 @@ bpW
 brs
 box
 box
-fbX
-mVj
+rRB
+txy
 byk
 byk
 byk
@@ -114039,7 +116171,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+eRz
 aaa
 aaa
 aaa
@@ -114126,7 +116258,7 @@ rHZ
 mtK
 xaZ
 vPR
-ovI
+dLZ
 ovI
 rrN
 aXg
@@ -114335,7 +116467,7 @@ aUJ
 bFR
 xPn
 aZf
-aZf
+njA
 baz
 bbF
 ioR
@@ -114592,7 +116724,7 @@ nKd
 ozk
 tcU
 aZf
-aZf
+njA
 tNr
 bbF
 sFP
@@ -114842,21 +116974,21 @@ aFw
 aMM
 aMM
 pdE
-ltC
+mQW
 lqJ
 oYB
 aZf
 aZf
 aZf
-qXy
 aZf
+njA
 aZf
 bbF
 sFP
 byy
 ybA
 bga
-bvx
+bhA
 bvx
 bvx
 bvx
@@ -114872,13 +117004,13 @@ wkN
 wkN
 wkN
 aiG
-bvK
+kuX
 bvJ
 bvJ
 bvJ
 bxW
-bvK
-bvK
+kuX
+kuX
 bMs
 bMs
 bMs
@@ -115102,10 +117234,10 @@ fgl
 dQh
 wTy
 fMC
-njA
+ium
 wqU
-njA
-njA
+ium
+ium
 hby
 aZf
 bbF
@@ -115113,8 +117245,8 @@ sFP
 jJv
 hlu
 imy
+kwg
 bhC
-vac
 bks
 blI
 fLf
@@ -115129,13 +117261,13 @@ pBj
 hmi
 pDu
 lQm
-bvK
+kuX
 bCk
 byo
 aDH
 bxP
 bCf
-bvK
+kuX
 aaf
 aaf
 aaf
@@ -115363,16 +117495,16 @@ aZf
 aZf
 aZf
 gRe
-aZf
+xGk
 aZf
 bbF
 sFP
 byy
 ybA
-vxX
+imy
 bhD
 biV
-pUK
+wWk
 vbJ
 vhd
 gCG
@@ -115386,7 +117518,7 @@ tuC
 olf
 glA
 ubw
-bvK
+kuX
 bxj
 byq
 bwR
@@ -115620,16 +117752,16 @@ aTi
 gsA
 omd
 aZf
-aZf
+xGk
 sCP
 bbF
 sFP
 bdv
 ybA
 bgb
+qzC
 bhC
-biU
-uMP
+pUK
 blJ
 bno
 gCG
@@ -115643,7 +117775,7 @@ koR
 olf
 tuC
 uCO
-bvK
+kuX
 bxi
 byp
 bzJ
@@ -115877,7 +118009,7 @@ gte
 vMP
 vSA
 aZf
-aZf
+xGk
 guB
 bbF
 pRY
@@ -115885,7 +118017,7 @@ byy
 gVx
 bgc
 bgc
-biX
+bgc
 nlq
 bka
 wQO
@@ -115900,7 +118032,7 @@ pfu
 olf
 bDA
 bUq
-bvK
+kuX
 bxl
 bys
 bzM
@@ -116157,7 +118289,7 @@ tuC
 olf
 nRn
 hAK
-bvK
+kuX
 cBu
 byr
 bzL
@@ -116399,10 +118531,10 @@ bdy
 beI
 bgc
 bhF
-bib
-bki
-bma
-gNQ
+uXI
+rKc
+rKc
+bth
 bth
 dlP
 sXi
@@ -116414,7 +118546,7 @@ gXZ
 kAw
 pKm
 fYq
-bvK
+kuX
 bxm
 byu
 bzN
@@ -116655,13 +118787,13 @@ ukW
 tpB
 beH
 bgc
-bgc
-caI
-caI
-caI
-caI
+mGq
+bib
+bki
+bma
+gNQ
 rKc
-caI
+bgc
 vGb
 bpE
 bpE
@@ -116897,9 +119029,9 @@ ntc
 tEl
 aEn
 aMZ
-aOb
-aPr
-wXs
+pKQ
+txG
+jWy
 aNa
 gEo
 wzg
@@ -116910,15 +119042,15 @@ mgT
 bcA
 rUt
 bdz
-beJ
-jYX
-bhH
-brj
-bEI
-bmd
+gpO
+bgc
+caI
+caI
+caI
+caI
 caI
 bnr
-caI
+bgc
 pOJ
 jxy
 buu
@@ -116936,7 +119068,7 @@ jBs
 bKa
 bLi
 bMz
-bNy
+mLy
 bOH
 jwp
 vup
@@ -117154,25 +119286,25 @@ gUh
 gUh
 bOJ
 aMZ
-aOa
-jCN
-lZJ
+vuP
+txG
+qil
 aRL
 pUm
 jnf
 tKe
-env
+tcQ
 aZk
-opl
+vZD
 jys
 env
 tod
-tWn
-bgd
-bky
-bky
-bky
-blO
+beJ
+jYX
+bhH
+brj
+bEI
+bmd
 caI
 bnq
 caI
@@ -117406,28 +119538,28 @@ ccz
 aIz
 ccz
 cnq
-aEn
+juO
 olq
-aEn
+cdJ
 bJk
 aMZ
-aOd
-wjL
+pKQ
+txG
 cwp
 aNa
 gEo
 mzW
 kJA
-kJA
+lRN
 ukq
 vZD
 kJA
 ukq
 cBl
-iDi
+tos
 bgg
-aNa
-aaa
+bky
+bky
 bky
 bqh
 bEI
@@ -117455,7 +119587,7 @@ bOI
 mMk
 mLy
 uFd
-cPd
+mLy
 vCt
 wYV
 bEC
@@ -117668,22 +119800,22 @@ aJM
 aJM
 aJM
 aMZ
-aOc
-aPs
-pgT
-aNa
+aMZ
+aMZ
+aMZ
+aMZ
 uDz
-gFD
-hBf
-gFD
-gFD
-nBa
-hBf
-mWn
-gFD
-gFD
-bgf
-aNa
+jnf
+jZy
+maC
+vZD
+opl
+vZD
+vZD
+gPr
+tos
+oHy
+aMZ
 aaf
 bky
 nHd
@@ -117701,7 +119833,7 @@ bon
 nYQ
 sat
 nYQ
-jZN
+mLy
 mLy
 bGF
 vXq
@@ -117712,7 +119844,7 @@ mtK
 mtK
 cpT
 icS
-kwK
+hMC
 ptw
 kwK
 bEC
@@ -117924,23 +120056,23 @@ aaf
 aaf
 aaf
 aaf
-aNa
-aNa
 aMZ
-aQF
-aMZ
+aOb
+aPr
+wXs
+irK
+gEo
+jnf
 bdA
-aMZ
-bcz
-seC
-sPO
-aMZ
+izv
+xAW
+vZD
+jZL
+xAW
 bdA
+tWn
+dOR
 aMZ
-bdA
-aMZ
-aNa
-aNa
 aaa
 bky
 blP
@@ -117970,8 +120102,8 @@ mtK
 bJZ
 flc
 vPE
-kwK
-kwK
+hSH
+eeh
 bEC
 ebv
 ebv
@@ -118181,23 +120313,23 @@ aaa
 aaa
 aaa
 aaf
-aaf
-aaf
-aNa
+aMZ
+aOa
+jCN
+lZJ
+mYG
+gGM
+tZR
+hqp
+dei
+env
+vZD
+xws
+rJE
 aQE
+tWn
+ykO
 aNa
-aQE
-aNa
-fVD
-eSW
-rOc
-aNa
-aQE
-aNa
-aQE
-aNa
-aaf
-aaf
 aaf
 bky
 blR
@@ -118431,30 +120563,30 @@ aoV
 aoV
 aoV
 aaf
-aoV
 aaf
-aoV
-aaa
-aaa
-aaa
-aaf
-aaf
-aaa
-aNa
-aQE
-aNa
-aQE
-aNa
-rum
-rgf
-rum
-aNa
-aQE
-aNa
+fIW
+aaT
+eRz
+eRz
+eRz
+aaT
+irK
+joN
+nmf
+wKA
+irK
+jPI
+jfp
+kJA
+eeM
+ukq
+vZD
 rsD
+eeM
+rsD
+iDi
+tWf
 aNa
-aaa
-aaf
 aaa
 bky
 cyC
@@ -118493,7 +120625,7 @@ bNC
 bNC
 bNC
 bNC
-mGB
+bNC
 bNC
 uYY
 bNC
@@ -118694,24 +120826,24 @@ aoV
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aNa
+gXs
+irK
+aOc
+aPs
+hhu
+irK
+eFu
+ljI
+hBf
+gFD
+gFD
+fDz
+tPY
+iVD
 afE
+jtW
+bgf
 aNa
-afE
-aNa
-jZb
-tmn
-kyJ
-aNa
-afE
-aNa
-afE
-aNa
-aaa
-aaa
 aaa
 aaf
 aaa
@@ -118739,7 +120871,7 @@ ovI
 ccp
 kRQ
 wvN
-ovI
+hlf
 ovI
 ovI
 ovI
@@ -118939,36 +121071,36 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-aaa
-aaf
-aoV
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eRz
+eRz
+eRz
+eRz
+eRz
+aaT
+wwP
+aaT
+aaT
+eRz
+eRz
+eRz
+eRz
+irK
+irK
+aMZ
+tnQ
+aMZ
+dmB
+aMZ
+bcz
+seC
+sPO
+aMZ
+dmB
+aMZ
+dmB
+aMZ
 aNa
-aQE
 aNa
-aQE
-aNa
-aNa
-aNa
-aNa
-aNa
-aQE
-aNa
-aQE
-aNa
-aaa
-aaa
 aaa
 aaf
 aaf
@@ -118989,14 +121121,14 @@ brj
 kXf
 fKX
 gIh
-fKX
+ilT
 bVI
-hDZ
-bNC
-cct
-ovI
-ovI
-vPR
+ivN
+voV
+reE
+lXQ
+pKd
+fmQ
 raz
 fFQ
 sgS
@@ -119208,24 +121340,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aMZ
-cyh
-aMZ
-cyr
-aMZ
 gXs
 aaf
-gXs
-aMZ
+aaf
+aNa
 cyr
-aMZ
+aNa
 cyr
-aMZ
-aaa
-aaa
+aNa
+fVD
+eSW
+rOc
+aNa
+cyr
+aNa
+cyr
+aNa
+aaf
+aaf
 aaf
 aaf
 aaf
@@ -119466,23 +121598,23 @@ aaa
 aaa
 aaa
 aaa
+aaf
 aaa
+aNa
+jTt
+aNa
+jTt
+aNa
+rum
+rgf
+rum
+aNa
+jTt
+aNa
+wOj
+aNa
 aaa
-aaa
-aaa
-aaa
-afa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaf
 aaa
 aaa
 aaa
@@ -119725,19 +121857,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aNa
+cvJ
+aNa
+cvJ
+aNa
+jZb
+tmn
+kyJ
+aNa
+cvJ
+aNa
+cvJ
+aNa
 aaa
 aaa
 aaa
@@ -119982,19 +122114,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aNa
+wjL
+aNa
+wjL
+aNa
+aNa
+aNa
+aNa
+aNa
+wjL
+aNa
+wjL
+aNa
 aaa
 aaa
 aaa
@@ -120239,19 +122371,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aMZ
+nkO
+aMZ
+gjX
+aMZ
+gXs
+aaf
+gXs
+aMZ
+gjX
+aMZ
+gjX
+aMZ
 aaa
 aaa
 aaa
@@ -120499,7 +122631,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+afa
 aaa
 aaa
 aaa
@@ -120538,11 +122670,11 @@ aaa
 aaa
 aaa
 aaf
-aaa
-aaa
-aaa
-aaa
-aaa
+eRz
+eRz
+eRz
+eRz
+eRz
 aaf
 aaf
 aaa
@@ -121315,13 +123447,13 @@ aaa
 aaa
 aaa
 aaf
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eRz
+eRz
+eRz
+eRz
+eRz
+eRz
+gXs
 aaf
 aaa
 aaa
@@ -122583,11 +124715,11 @@ aaa
 aaa
 aaa
 aag
-aaa
-aaa
-aaa
-aaa
-aaf
+eRz
+eRz
+eRz
+eRz
+aaT
 aaa
 aaf
 aaa


### PR DESCRIPTION
I had initially wanted to wait for the Torment Nexus to release, as I had setup all the infrastructure for that. Seeing that it's indefinitely delayed, I figured I'd push all the other changes and updates since the initial PR so that admins who run the map can do it on a more updated version. There have been several changes, so I might forget to mention some.

The departures lounge has been doubled in size, and given an arcade. Fewer shuttles will crash into the station now.
All heads of staff now start with a pAI card in their office.
Cargo now has the loader MODsuit; medical now has a medical MODsuit.
Medical now has a NanoDrug Plus in their storage room.
Most of aft Medical is no longer lit with blacklights. The break room's bathroom, the freezer room, and Virology are the exceptions.
Robotics now has a MOD crate, as well as empty medkits to make medibots.
The research lab's layout has been changed slightly, and an experimental destructive scanner has been added outside the front desk.
Ordnance's floors have been changed slightly.
The warden's office floors have been changed.
The security locker room, mech bay floors have been changed.
The kitchen freezer room has been updated with a cooling loop per #89245, and its floors have been changed.
The library now has a skillchip station.
PACMAN generators have been added to maintenance areas.
The fitness area above the holodeck now has substantially more dust shielding, as well as firelocks to prevent it from causing the rest of dorms to depressurize.
Courtroom shutters are now properly linked.
Beepsky now uses the correct path-- was previously a varedited securitron.
The prison now has art supplies.
The armoury now has a grenade launcher.
Photobooths have been added to the prison transfer room and the HOPline.
I also removed several moisture trap spawners near maintenance doors, so fewer axolotls and frogs should appear in the hallways.

Among other minor changes.

![StrongDMM-2025-02-05 19 22 55](https://github.com/user-attachments/assets/3d56110b-7147-4c19-9a5e-5250f1a8fcaa)
