### PR TITLE
UpdatePath rags on 6 maps

### DIFF
--- a/StationMaps/BoxStation/BoxStation 2024/BoxStation.dmm
+++ b/StationMaps/BoxStation/BoxStation 2024/BoxStation.dmm
@@ -12950,7 +12950,7 @@
 /obj/structure/table,
 /obj/effect/turf_decal/tile/bar/diagonal_centre,
 /obj/item/reagent_containers/cup/beaker/large,
-/obj/item/reagent_containers/cup/rag{
+/obj/item/rag{
 	pixel_x = -4
 	},
 /obj/item/reagent_containers/cup/beaker{
@@ -38109,7 +38109,7 @@
 	pixel_x = -6;
 	pixel_y = 6
 	},
-/obj/item/reagent_containers/cup/rag{
+/obj/item/rag{
 	pixel_x = 5;
 	pixel_y = 3
 	},
@@ -55588,7 +55588,7 @@
 	pixel_x = 8;
 	pixel_y = -4
 	},
-/obj/item/reagent_containers/cup/rag{
+/obj/item/rag{
 	pixel_x = 11;
 	pixel_y = 13
 	},
@@ -60241,7 +60241,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/item/reagent_containers/cup/rag,
+/obj/item/rag,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/wood/large,
 /area/station/service/bar)

--- a/StationMaps/KiloStation/KiloStation.dmm
+++ b/StationMaps/KiloStation/KiloStation.dmm
@@ -12638,7 +12638,7 @@
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/obj/item/reagent_containers/cup/rag,
+/obj/item/rag,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -64090,7 +64090,7 @@
 	pixel_y = 6
 	},
 /obj/item/knife/kitchen,
-/obj/item/reagent_containers/cup/rag,
+/obj/item/rag,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/service/kitchen)

--- a/StationMaps/KosmicStation/kosmicstation.dmm
+++ b/StationMaps/KosmicStation/kosmicstation.dmm
@@ -9421,7 +9421,7 @@
 /area/station/security/prison)
 "LH" = (
 /obj/structure/table,
-/obj/item/reagent_containers/cup/rag,
+/obj/item/rag,
 /obj/item/reagent_containers/cup/glass/shaker{
 	pixel_x = -6
 	},

--- a/StationMaps/NorthStar/north_star.dmm
+++ b/StationMaps/NorthStar/north_star.dmm
@@ -8161,7 +8161,7 @@
 	},
 /obj/effect/mapping_helpers/requests_console/supplies,
 /obj/item/storage/bag/tray,
-/obj/item/reagent_containers/cup/rag,
+/obj/item/rag,
 /turf/open/floor/wood/large,
 /area/station/service/kitchen/kitchen_backroom)
 "cbm" = (
@@ -19759,7 +19759,7 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/spray/cleaner,
-/obj/item/reagent_containers/cup/rag,
+/obj/item/rag,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/virology/isolation)
 "fgB" = (
@@ -47060,7 +47060,7 @@
 /obj/effect/turf_decal/tile/green/opposingcorners,
 /obj/structure/table/reinforced,
 /obj/item/storage/bag/tray,
-/obj/item/reagent_containers/cup/rag,
+/obj/item/rag,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/bar)
 "mfI" = (
@@ -62183,7 +62183,7 @@
 	},
 /obj/machinery/newscaster/directional/south,
 /obj/structure/table/reinforced,
-/obj/item/reagent_containers/cup/rag,
+/obj/item/rag,
 /turf/open/floor/iron/kitchen/herringbone,
 /area/station/service/kitchen)
 "pZB" = (
@@ -92011,7 +92011,7 @@
 /obj/item/reagent_containers/cup/bottle/syrup_bottle/caramel{
 	pixel_y = 16
 	},
-/obj/item/reagent_containers/cup/rag,
+/obj/item/rag,
 /obj/item/reagent_containers/cup/glass/coffee{
 	pixel_x = -3;
 	pixel_y = 9

--- a/StationMaps/PhobosStation/PhobosIV.dmm
+++ b/StationMaps/PhobosStation/PhobosIV.dmm
@@ -9941,7 +9941,7 @@
 /obj/item/reagent_containers/cup/glass/shaker{
 	pixel_x = -6
 	},
-/obj/item/reagent_containers/cup/rag,
+/obj/item/rag,
 /obj/effect/spawner/random/food_or_drink/cake_ingredients,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)

--- a/StationMaps/PubbyStation/PubbyStation.dmm
+++ b/StationMaps/PubbyStation/PubbyStation.dmm
@@ -12785,7 +12785,7 @@
 "aYf" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/cup/rag,
+/obj/item/rag,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
@@ -47197,7 +47197,7 @@
 /area/station/engineering/atmos)
 "sBW" = (
 /obj/structure/closet/crate/bin,
-/obj/item/reagent_containers/cup/rag,
+/obj/item/rag,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)


### PR DESCRIPTION
This runs update paths for the damp rag repath on the following stations:

* Kilostation
* Pubbystation
* Kosmistation
* North Star
* Boxstation
* Phobos