### PR TITLE
Gigabump Playable Stations through PR 91053

### DIFF
--- a/StationMaps/KiloStation/KiloStation.dmm
+++ b/StationMaps/KiloStation/KiloStation.dmm
@@ -1716,8 +1716,8 @@
 /area/station/engineering/atmos)
 "aBB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/robot_debris,
-/obj/effect/decal/cleanable/oil/streak,
+/obj/effect/decal/cleanable/blood/gibs/robot_debris,
+/obj/effect/decal/cleanable/blood/splatter/oil,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
@@ -2753,7 +2753,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -5457,7 +5457,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/misc/asteroid/airless,
 /area/station/hallway/secondary/entry)
@@ -7242,7 +7242,7 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/ai_monitored/security/armory)
 "ctu" = (
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /turf/open/misc/asteroid/airless,
 /area/station/hallway/secondary/entry)
 "ctv" = (
@@ -12516,7 +12516,7 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/fore)
 "eji" = (
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/effect/turf_decal/siding/purple{
 	dir = 8
 	},
@@ -13851,7 +13851,7 @@
 	location = "QM #1"
 	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/contraband/the_griffin/directional/north,
 /mob/living/simple_animal/bot/mulebot,
@@ -24464,7 +24464,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/oil/slippery,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
@@ -25780,7 +25779,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "ipg" = (
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
@@ -35026,7 +35025,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -35337,7 +35336,7 @@
 /area/station/service/kitchen)
 "luk" = (
 /obj/machinery/light/small/directional/south,
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
@@ -35934,7 +35933,7 @@
 /area/station/maintenance/aft)
 "lDK" = (
 /obj/effect/decal/remains/robot,
-/obj/effect/decal/cleanable/oil/streak,
+/obj/effect/decal/cleanable/blood/splatter/oil,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/storage)
 "lDS" = (
@@ -37707,7 +37706,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse/upper)
@@ -49086,7 +49085,7 @@
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/hos)
 "qbE" = (
-/obj/structure/altar_of_gods,
+/obj/structure/altar/of_gods,
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
@@ -50349,7 +50348,7 @@
 /area/station/medical/chemistry)
 "qyn" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -52425,10 +52424,8 @@
 /turf/open/floor/carpet/royalblue,
 /area/station/service/chapel/office)
 "riX" = (
-/obj/effect/decal/cleanable/robot_debris/limb,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil/streak,
-/obj/effect/decal/cleanable/robot_debris/old,
+/obj/effect/decal/cleanable/blood/splatter/oil,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
@@ -65525,7 +65522,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "vqe" = (
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -66361,7 +66358,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/mapping_helpers/broken_floor,
@@ -66602,7 +66599,7 @@
 /obj/item/flashlight/flare,
 /obj/item/flashlight/flare,
 /obj/item/stock_parts/power_store/cell/high,
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
@@ -67786,7 +67783,7 @@
 /area/station/service/bar)
 "vVq" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},

--- a/StationMaps/KosmicStation/kosmicstation.dmm
+++ b/StationMaps/KosmicStation/kosmicstation.dmm
@@ -10137,7 +10137,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "Oi" = (
-/obj/structure/altar_of_gods,
+/obj/structure/altar/of_gods,
 /turf/open/floor/iron/chapel{
 	dir = 8
 	},

--- a/StationMaps/NorthStar/north_star.dmm
+++ b/StationMaps/NorthStar/north_star.dmm
@@ -8625,7 +8625,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "cgw" = (
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod,
 /area/station/maintenance/floor4/starboard/aft)
@@ -9820,7 +9820,7 @@
 	pixel_x = -7;
 	pixel_y = 4
 	},
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/item/weldingtool{
 	pixel_x = 4;
 	pixel_y = 6
@@ -11199,7 +11199,7 @@
 	dir = 4
 	},
 /obj/item/radio/intercom/directional/south,
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/iron/half{
 	dir = 1
 	},
@@ -14308,7 +14308,7 @@
 /area/station/maintenance/floor1/starboard/fore)
 "dGa" = (
 /obj/effect/turf_decal/stripes,
-/obj/effect/decal/cleanable/xenoblood,
+/obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/engine,
 /area/station/science/cytology)
 "dGe" = (
@@ -18149,7 +18149,7 @@
 /turf/open/floor/engine,
 /area/station/science/cytology)
 "eHk" = (
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/effect/turf_decal/stripes{
 	dir = 1
 	},
@@ -19922,7 +19922,7 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor2/port/fore)
 "fiO" = (
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/secondary/exit)
 "fiT" = (
@@ -21012,7 +21012,7 @@
 /turf/open/floor/plating,
 /area/station/engineering/lobby)
 "fxm" = (
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/iron,
 /area/station/maintenance/floor2/starboard/aft)
 "fxo" = (
@@ -21511,12 +21511,6 @@
 	},
 /turf/open/floor/mineral/silver,
 /area/station/service/chapel)
-"fEr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/robot_debris/down,
-/turf/open/floor/engine,
-/area/station/maintenance/floor4/starboard/aft)
 "fEv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22200,10 +22194,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
-"fNY" = (
-/obj/effect/decal/cleanable/robot_debris/up,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat_interior)
 "fOg" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 4
@@ -25655,7 +25645,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "gHV" = (
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/engineering/lobby)
@@ -33013,7 +33003,7 @@
 "iCP" = (
 /obj/structure/sign/poster/random/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 8
 	},
@@ -34961,13 +34951,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/hallway/floor2/aft)
-"jdC" = (
-/obj/effect/decal/cleanable/xenoblood/xgibs/larva/body,
-/obj/effect/turf_decal/stripes{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/station/science/cytology)
 "jdD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -36561,7 +36544,7 @@
 /turf/open/floor/bamboo/tatami/black,
 /area/station/commons/storage/art)
 "jzB" = (
-/obj/effect/decal/cleanable/oil/streak,
+/obj/effect/decal/cleanable/blood/splatter/oil,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36704,7 +36687,7 @@
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
 "jBa" = (
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/starboard/fore)
 "jBf" = (
@@ -36967,7 +36950,7 @@
 /area/station/science/lobby)
 "jFB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil/streak,
+/obj/effect/decal/cleanable/blood/splatter/oil,
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/iron,
 /area/station/maintenance/floor2/starboard/aft)
@@ -39361,7 +39344,7 @@
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/oil/streak,
+/obj/effect/decal/cleanable/blood/splatter/oil,
 /turf/open/floor/iron/textured_large,
 /area/station/engineering/lobby)
 "kjW" = (
@@ -42759,7 +42742,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
 "lcg" = (
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/item/mop,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port/fore)
@@ -44124,7 +44107,7 @@
 	dir = 4
 	},
 /obj/structure/railing,
-/obj/effect/decal/cleanable/robot_debris,
+/obj/effect/decal/cleanable/blood/gibs/robot_debris,
 /obj/effect/landmark/start/bitrunner,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/cargo/bitrunning/den)
@@ -46787,7 +46770,7 @@
 /area/station/science/ordnance/testlab)
 "mcu" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/pod/light,
@@ -52232,7 +52215,7 @@
 	},
 /area/station/science/genetics)
 "ntW" = (
-/obj/structure/altar_of_gods,
+/obj/structure/altar/of_gods,
 /obj/effect/turf_decal/siding/white,
 /obj/item/book/bible,
 /turf/open/floor/mineral/silver,
@@ -58150,7 +58133,7 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/fitness)
 "oVB" = (
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/iron/textured_large,
 /area/station/hallway/secondary/exit/departure_lounge)
 "oVH" = (
@@ -60055,11 +60038,6 @@
 	dir = 4
 	},
 /area/station/hallway/floor1/fore)
-"pxw" = (
-/obj/effect/turf_decal/stripes,
-/obj/effect/decal/cleanable/robot_debris/down,
-/turf/open/floor/iron,
-/area/station/maintenance/floor2/starboard/aft)
 "pxy" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 1
@@ -61517,7 +61495,7 @@
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
 "pPP" = (
-/obj/effect/decal/cleanable/oil/streak,
+/obj/effect/decal/cleanable/blood/splatter/oil,
 /turf/open/floor/iron/smooth,
 /area/station/construction)
 "pPQ" = (
@@ -62444,7 +62422,7 @@
 /area/station/service/bar)
 "qcD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/iron/smooth,
 /area/station/construction)
 "qcH" = (
@@ -64063,7 +64041,7 @@
 "qxN" = (
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/light/directional/south,
-/obj/effect/decal/cleanable/oil/streak,
+/obj/effect/decal/cleanable/blood/splatter/oil,
 /obj/machinery/byteforge,
 /obj/effect/turf_decal/box,
 /obj/structure/disposalpipe/segment{
@@ -66961,7 +66939,7 @@
 /turf/open/floor/engine/hull/reinforced,
 /area/space/nearstation)
 "rif" = (
-/obj/effect/decal/cleanable/robot_debris,
+/obj/effect/decal/cleanable/blood/gibs/robot_debris,
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor2/starboard/aft)
 "rim" = (
@@ -75885,7 +75863,7 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port)
 "tCC" = (
-/obj/effect/decal/cleanable/oil/streak,
+/obj/effect/decal/cleanable/blood/splatter/oil,
 /turf/open/floor/plating,
 /area/station/engineering/lobby)
 "tCF" = (
@@ -76678,7 +76656,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "tNC" = (
@@ -82745,7 +82723,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/floor2/starboard/aft)
 "vqS" = (
-/obj/effect/decal/cleanable/oil/streak,
+/obj/effect/decal/cleanable/blood/splatter/oil,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/marker_beacon/burgundy,
 /turf/open/floor/pod/light,
@@ -84269,7 +84247,7 @@
 /obj/effect/turf_decal/stripes{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/xenoblood,
+/obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/engine,
 /area/station/science/cytology)
 "vLv" = (
@@ -85585,7 +85563,7 @@
 /area/station/hallway/floor4/fore)
 "wbx" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/iron,
 /area/station/maintenance/floor2/starboard/aft)
@@ -87666,7 +87644,6 @@
 /area/station/service/theater)
 "wBg" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/robot_debris/up,
 /obj/item/assembly/prox_sensor,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron,
@@ -88950,7 +88927,7 @@
 /area/station/engineering/lobby)
 "wRn" = (
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "wRp" = (
@@ -90848,7 +90825,7 @@
 	id = "survshop";
 	name = "Workshop Shutters"
 	},
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod,
 /area/station/maintenance/floor4/starboard/aft)
@@ -91139,7 +91116,7 @@
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "xvO" = (
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -92466,7 +92443,7 @@
 /area/station/maintenance/floor1/port/fore)
 "xMd" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port/fore)
@@ -92575,7 +92552,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "xNE" = (
@@ -92756,7 +92733,7 @@
 "xPX" = (
 /obj/machinery/light/red/dim/directional/south,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil/streak,
+/obj/effect/decal/cleanable/blood/splatter/oil,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/starboard/aft)
 "xPZ" = (
@@ -192064,7 +192041,7 @@ sUj
 rkM
 rXg
 dtm
-jdC
+bID
 bID
 tRU
 rkM
@@ -203379,7 +203356,7 @@ spr
 aOa
 deK
 spr
-pxw
+kgY
 edO
 awA
 jBf
@@ -323649,7 +323626,7 @@ sOB
 nNk
 nSC
 dtv
-fEr
+dtv
 sLe
 psc
 daY
@@ -337551,7 +337528,7 @@ aFj
 mWh
 oiP
 nEI
-fNY
+oiP
 mWh
 vyR
 imS

--- a/StationMaps/OmegaStation/Modernized+Heads of Staff (2024)/OmegaStation.dmm
+++ b/StationMaps/OmegaStation/Modernized+Heads of Staff (2024)/OmegaStation.dmm
@@ -6329,7 +6329,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "aqv" = (
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/structure/closet/crate,
 /obj/item/flashlight,
 /obj/item/flashlight,
@@ -6523,7 +6523,7 @@
 /area/station/commons/storage/primary)
 "aqW" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
@@ -7091,7 +7091,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard)
 "ast" = (
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -7838,7 +7838,7 @@
 /area/station/engineering/atmos)
 "auE" = (
 /obj/machinery/space_heater,
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -8909,7 +8909,7 @@
 /turf/open/misc/asteroid,
 /area/station/asteroid)
 "ayh" = (
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -15316,7 +15316,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/iron/dark/corner,
 /area/station/engineering/atmos)
 "aPX" = (
@@ -19016,7 +19016,7 @@
 /area/station/science/robotics/mechbay)
 "aZX" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/mechbay)
@@ -19622,7 +19622,7 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "bbM" = (
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/effect/turf_decal/bot,
 /obj/item/bot_assembly/cleanbot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -21726,7 +21726,7 @@
 /obj/item/book/bible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/altar_of_gods,
+/obj/structure/altar/of_gods,
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel)
@@ -25823,7 +25823,7 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security)
 "fDG" = (
@@ -26630,7 +26630,7 @@
 /turf/closed/wall,
 /area/station/maintenance/starboard/aft)
 "hrd" = (
-/obj/effect/decal/cleanable/oil/streak,
+/obj/effect/decal/cleanable/blood/splatter/oil,
 /turf/open/misc/asteroid,
 /area/station/asteroid)
 "hsj" = (
@@ -30960,7 +30960,7 @@
 	pixel_x = 24;
 	pixel_y = 24
 	},
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow{
@@ -33630,7 +33630,7 @@
 	dir = 4
 	},
 /obj/structure/closet/firecloset,
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/iron,
 /area/station/maintenance/department/cargo)
 "sLD" = (
@@ -34866,7 +34866,7 @@
 	id = "engsm";
 	name = "Radiation Chamber Shutters"
 	},
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter)
 "tpH" = (
@@ -35256,7 +35256,7 @@
 /turf/open/misc/asteroid/airless,
 /area/centcom/asteroid/nearstation/bomb_site)
 "ueC" = (
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -35713,7 +35713,7 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos/office)
 "uVJ" = (
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "uVL" = (
@@ -37203,12 +37203,6 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
-"xCP" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "xDo" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -61219,7 +61213,7 @@ xYx
 aqo
 aqo
 aqo
-xCP
+aME
 aUi
 aLv
 rKO

--- a/StationMaps/PhobosStation/PhobosIV.dmm
+++ b/StationMaps/PhobosStation/PhobosIV.dmm
@@ -8336,7 +8336,7 @@
 /area/station/maintenance/solars/port/fore)
 "joX" = (
 /obj/effect/turf_decal/sand/plating,
-/obj/structure/altar_of_gods,
+/obj/structure/altar/of_gods,
 /obj/item/book/bible,
 /obj/item/reagent_containers/cup/glass/bottle/holywater,
 /turf/open/floor/plating,
@@ -21366,7 +21366,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/mineral/titanium/airless,
 /area/station/science/ordnance/bomb)
 "yfk" = (

--- a/StationMaps/PubbyStation/PubbyStation.dmm
+++ b/StationMaps/PubbyStation/PubbyStation.dmm
@@ -2619,7 +2619,7 @@
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
 "akh" = (
-/obj/effect/decal/cleanable/oil{
+/obj/effect/decal/cleanable/blood/oil{
 	icon_state = "floor5"
 	},
 /turf/open/floor/plating,
@@ -3405,7 +3405,7 @@
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
 "amG" = (
-/obj/effect/decal/cleanable/oil{
+/obj/effect/decal/cleanable/blood/oil{
 	icon_state = "floor6"
 	},
 /obj/effect/mapping_helpers/broken_floor,
@@ -3581,7 +3581,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "anp" = (
-/obj/effect/decal/cleanable/robot_debris{
+/obj/effect/decal/cleanable/blood/gibs/robot_debris{
 	icon_state = "gib6"
 	},
 /obj/structure/cable,
@@ -9627,7 +9627,7 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Dormitory Cyborg Recharging Station"
 	},
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
@@ -14725,8 +14725,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "bgE" = (
-/obj/effect/decal/cleanable/oil,
-/obj/effect/decal/cleanable/robot_debris{
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/blood/gibs/robot_debris{
 	icon_state = "gib3"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -15177,7 +15177,7 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/mechbay)
 "bix" = (
-/obj/effect/decal/cleanable/robot_debris{
+/obj/effect/decal/cleanable/blood/gibs/robot_debris{
 	icon_state = "gib3"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -21312,10 +21312,9 @@
 /turf/open/space,
 /area/space/nearstation)
 "bLt" = (
-/obj/effect/decal/cleanable/oil{
+/obj/effect/decal/cleanable/blood/oil{
 	icon_state = "floor6"
 	},
-/obj/effect/decal/cleanable/robot_debris/old,
 /turf/open/floor/iron/dark,
 /area/station/service/abandoned_gambling_den/gaming)
 "bLu" = (
@@ -21594,7 +21593,7 @@
 /turf/open/floor/iron/dark,
 /area/station/service/abandoned_gambling_den/gaming)
 "bMD" = (
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/iron/dark,
 /area/station/service/abandoned_gambling_den/gaming)
 "bME" = (
@@ -29155,7 +29154,7 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/abandoned)
 "cIt" = (
-/obj/effect/decal/cleanable/oil{
+/obj/effect/decal/cleanable/blood/oil{
 	icon_state = "floor6"
 	},
 /obj/item/radio/intercom/directional/west,
@@ -36621,7 +36620,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
@@ -38692,7 +38691,7 @@
 /area/station/ai_monitored/turret_protected/ai_sat_ext_as)
 "lqc" = (
 /obj/item/toy/gun,
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
@@ -40022,7 +40021,7 @@
 /area/station/science/breakroom)
 "mBu" = (
 /obj/item/book/bible,
-/obj/structure/altar_of_gods,
+/obj/structure/altar/of_gods,
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "mBz" = (
@@ -42949,7 +42948,7 @@
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
 "pdq" = (
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/plating,
 /area/station/security/range)
 "pds" = (
@@ -46866,7 +46865,7 @@
 	dir = 8
 	},
 /obj/structure/sign/poster/contraband/random/directional/east,
-/obj/effect/decal/cleanable/oil{
+/obj/effect/decal/cleanable/blood/oil{
 	icon_state = "floor6"
 	},
 /turf/open/floor/iron/dark,
@@ -49080,7 +49079,7 @@
 /turf/open/floor/carpet,
 /area/station/service/abandoned_gambling_den)
 "uaE" = (
-/obj/effect/decal/cleanable/oil{
+/obj/effect/decal/cleanable/blood/oil{
 	icon_state = "floor6"
 	},
 /turf/open/floor/plating,
@@ -50702,7 +50701,7 @@
 /area/station/engineering/main)
 "vlF" = (
 /obj/item/coin/silver,
-/obj/effect/decal/cleanable/oil{
+/obj/effect/decal/cleanable/blood/oil{
 	icon_state = "floor5"
 	},
 /obj/structure/light_construct/small{

--- a/StationMaps/SokobanStation/Sokoban.dmm
+++ b/StationMaps/SokobanStation/Sokoban.dmm
@@ -860,7 +860,7 @@
 	},
 /area/space/nearstation)
 "dX" = (
-/obj/structure/altar_of_gods,
+/obj/structure/altar/of_gods,
 /obj/item/storage/book/bible,
 /obj/item/flashlight/lantern{
 	pixel_y = 7


### PR DESCRIPTION
Update here:
* Kilostation
* Pubbystation
* PhobosIV
* Omegastation
* NorthStar
* Kosmic
* Sokoban

All update paths applied through 91053_update_blood_decals.txt