### PR TITLE
Updated paths for Box & Sokoban

### DIFF
--- a/StationMaps/BoxStation/BoxStation 2024/BoxStation.dmm
+++ b/StationMaps/BoxStation/BoxStation 2024/BoxStation.dmm
@@ -52,18 +52,6 @@
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/wood,
 /area/station/maintenance/port/aft)
-"aae" = (
-/obj/effect/landmark/carpspawn,
-/turf/open/space,
-/area/space)
-"aaf" = (
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
-"aag" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/space/nearstation)
 "aai" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison/rec)
@@ -221,12 +209,7 @@
 "aaS" = (
 /obj/effect/spawner/random/structure/grille,
 /obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
-"aaT" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "aaV" = (
 /obj/structure/table,
@@ -243,11 +226,6 @@
 "aaZ" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison/visit)
-"aba" = (
-/obj/structure/lattice,
-/obj/effect/spawner/random/structure/grille,
-/turf/open/space,
-/area/space/nearstation)
 "abc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -312,14 +290,14 @@
 /obj/item/key/security,
 /obj/effect/turf_decal/tile/dark_red/full,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "abn" = (
 /obj/structure/rack,
 /obj/machinery/firealarm/directional/north,
 /obj/effect/spawner/random/armory/dragnet,
 /obj/effect/turf_decal/tile/dark_red/full,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "abo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -383,7 +361,7 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/station/security/prison/visit)
 "abE" = (
-/obj/structure/chair/stool/directional/north,
+/obj/structure/chair/stool/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/siding/dark_red{
 	dir = 1
@@ -407,7 +385,7 @@
 /obj/item/storage/lockbox/loyalty,
 /obj/effect/turf_decal/tile/dark_red/full,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "abI" = (
 /obj/structure/rack,
 /obj/machinery/light/directional/north,
@@ -415,7 +393,7 @@
 /obj/effect/spawner/random/armory/bulletproof_helmet,
 /obj/effect/turf_decal/tile/dark_red/full,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "abJ" = (
 /obj/structure/rack,
 /obj/machinery/camera/motion/directional/north{
@@ -426,7 +404,7 @@
 /obj/effect/spawner/random/armory/riot_shield,
 /obj/effect/turf_decal/tile/dark_red/full,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "abN" = (
 /obj/structure/rack,
 /obj/item/flashlight/seclite{
@@ -451,7 +429,7 @@
 /obj/effect/turf_decal/tile/dark_red/full,
 /obj/item/gun/grenadelauncher,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "abO" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 10
@@ -473,7 +451,7 @@
 /obj/effect/turf_decal/tile/dark_red/full,
 /obj/item/gun/ballistic/automatic/battle_rifle,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "abR" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/machinery/light/directional/east,
@@ -535,13 +513,8 @@
 /area/station/solars/starboard/fore)
 "abY" = (
 /obj/effect/spawner/random/structure/grille,
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
-"abZ" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/turf/open/space,
-/area/station/solars/port/fore)
 "acc" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Cell 1"
@@ -588,7 +561,7 @@
 /obj/item/clothing/head/beret/sec/navywarden,
 /obj/item/clothing/head/hats/hos/beret/navyhos,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "acj" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/suit_storage_unit/hos,
@@ -603,7 +576,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "acl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -613,7 +586,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "acm" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -624,7 +597,7 @@
 	},
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "acn" = (
 /obj/structure/closet/secure_closet/hos,
 /turf/open/floor/wood/large,
@@ -637,9 +610,7 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/lockers)
 "acp" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
-	},
+/obj/structure/sign/warning/vacuum/external/directional/north,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/dock)
@@ -684,16 +655,11 @@
 /obj/effect/spawner/random/contraband/armory,
 /obj/effect/turf_decal/delivery/red,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
-"acx" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/turf/open/space,
-/area/station/solars/starboard/fore)
+/area/station/security/armory)
 "acy" = (
 /obj/structure/lattice,
 /obj/item/stack/cable_coil,
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "acA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -728,7 +694,7 @@
 /area/station/security/prison/rec)
 "acH" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/west,
-/obj/structure/chair/stool/directional/north,
+/obj/structure/chair/stool/directional/south,
 /obj/effect/turf_decal/siding/dark_red{
 	dir = 1
 	},
@@ -748,16 +714,16 @@
 	dir = 4
 	},
 /turf/open/floor/iron/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "acM" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot_red,
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/spawner/random/armory/e_gun,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "acN" = (
-/obj/structure/chair/stool/bar/directional/east,
+/obj/structure/chair/stool/bar/directional/west,
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
@@ -837,7 +803,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "acU" = (
 /obj/machinery/door/airlock/external{
 	name = "Security Exterior Access"
@@ -937,7 +903,7 @@
 	},
 /obj/effect/turf_decal/siding/dark_red,
 /turf/open/floor/iron/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "adh" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -948,7 +914,7 @@
 /obj/machinery/flasher/portable,
 /obj/effect/turf_decal/tile/dark_red/full,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "adj" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot_red,
@@ -956,7 +922,7 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/spawner/random/armory/laser_gun,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "adk" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot_red,
@@ -964,7 +930,7 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/effect/spawner/random/armory/disablers,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "adl" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "armory";
@@ -979,7 +945,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "adm" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/structure/window/reinforced,
@@ -1001,9 +967,7 @@
 /turf/open/floor/wood/tile,
 /area/station/service/theater)
 "adr" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = -32
-	},
+/obj/structure/sign/warning/vacuum/external/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
 "ads" = (
@@ -1048,7 +1012,7 @@
 /area/station/engineering/break_room)
 "ady" = (
 /obj/structure/lattice/catwalk,
-/turf/open/space,
+/turf/open/space/basic,
 /area/station/solars/port/fore)
 "adz" = (
 /obj/structure/closet/firecloset,
@@ -1148,7 +1112,7 @@
 /obj/effect/turf_decal/stripes/red/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "adR" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/fore/greater)
@@ -1174,7 +1138,7 @@
 /area/station/solars/starboard/fore)
 "adU" = (
 /obj/structure/lattice/catwalk,
-/turf/open/space,
+/turf/open/space/basic,
 /area/station/solars/starboard/fore)
 "adW" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -1295,20 +1259,20 @@
 "aes" = (
 /obj/machinery/suit_storage_unit/security,
 /turf/open/floor/iron/freezer,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "aet" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/siding/dark_blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/red/corner{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "aeu" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Engineering - Decontamination Chamber"
@@ -1405,7 +1369,7 @@
 	control_area = "/area/station/ai_monitored/turret_protected/ai"
 	},
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "aeQ" = (
 /obj/machinery/light/directional/east,
 /obj/structure/closet/radiation,
@@ -1463,7 +1427,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "afa" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -1567,7 +1531,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "afr" = (
 /obj/machinery/flasher{
 	id = "AI";
@@ -1581,7 +1545,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "afs" = (
 /obj/machinery/shower/directional/west,
 /obj/structure/fluff/shower_drain,
@@ -1717,7 +1681,7 @@
 	},
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "afP" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -1729,7 +1693,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "afS" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Gear Room"
@@ -1823,7 +1787,7 @@
 /obj/item/kirbyplants/random,
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "agn" = (
 /turf/closed/wall/r_wall,
 /area/station/security/warden)
@@ -1879,7 +1843,7 @@
 /area/station/cargo/miningdock)
 "agx" = (
 /obj/effect/turf_decal/tile/dark_red/diagonal_centre,
-/obj/machinery/photocopier,
+/obj/machinery/photocopier/prebuilt,
 /turf/open/floor/iron/dark/diagonal,
 /area/station/security/office)
 "agz" = (
@@ -2524,7 +2488,7 @@
 "aio" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "aip" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/computer/records/security{
@@ -2624,7 +2588,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/glass,
-/obj/effect/decal/cleanable/robot_debris/up,
+/obj/effect/decal/cleanable/blood/gibs/robot_debris/up,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
@@ -2718,7 +2682,7 @@
 "aiS" = (
 /obj/item/stack/rods,
 /obj/structure/lattice,
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "aiT" = (
 /turf/closed/wall,
@@ -3111,9 +3075,7 @@
 /area/station/medical/morgue)
 "ajZ" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
-	},
+/obj/structure/sign/warning/vacuum/external/directional/north,
 /turf/open/floor/plating,
 /area/station/construction/mining/aux_base)
 "aka" = (
@@ -3327,9 +3289,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "akG" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
-	},
+/obj/structure/sign/warning/vacuum/external/directional/north,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/security/processing)
@@ -3551,15 +3511,15 @@
 /area/station/maintenance/port/aft)
 "alt" = (
 /turf/closed/wall/r_wall,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "alu" = (
 /obj/machinery/nuclearbomb/selfdestruct,
 /obj/effect/turf_decal/delivery/red,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/nuke_storage)
+/area/station/command/vault)
 "alv" = (
 /turf/closed/wall/r_wall,
-/area/station/ai_monitored/turret_protected/ai_upload_foyer)
+/area/station/ai/upload/foyer)
 "alx" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -3708,9 +3668,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "alS" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = 32
-	},
+/obj/structure/sign/warning/vacuum/external/directional/east,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -3923,7 +3881,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "amy" = (
-/obj/structure/chair/stool/directional/north,
+/obj/structure/chair/stool/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
@@ -4075,13 +4033,13 @@
 "amR" = (
 /obj/structure/light_construct/directional/south,
 /obj/structure/sign/poster/contraband/random/directional/south,
-/obj/structure/chair/stool/bar/directional/north,
+/obj/structure/chair/stool/bar/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/station/maintenance/port/aft)
 "amS" = (
-/obj/structure/chair/stool/bar/directional/north,
+/obj/structure/chair/stool/bar/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
@@ -4186,7 +4144,7 @@
 /area/station/maintenance/solars/port/fore)
 "ani" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/south,
-/obj/structure/chair/stool/bar/directional/north,
+/obj/structure/chair/stool/bar/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/random/maintenance{
@@ -4483,9 +4441,7 @@
 "aoi" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/gas,
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
-	},
+/obj/structure/sign/warning/vacuum/external/directional/north,
 /obj/item/multitool,
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -4513,9 +4469,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aoq" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = -32
-	},
+/obj/structure/sign/warning/vacuum/external/directional/south,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/security/processing)
@@ -4680,7 +4634,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
 "aoN" = (
-/obj/structure/chair/stool/directional/north,
+/obj/structure/chair/stool/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
@@ -4703,9 +4657,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"aoV" = (
-/turf/open/space,
-/area/space)
 "aoW" = (
 /obj/structure/table,
 /obj/item/stamp,
@@ -5180,7 +5131,7 @@
 /obj/effect/turf_decal/tile/neutral/diagonal_centre,
 /obj/effect/turf_decal/siding/thinplating_new,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/effect/mapping_helpers/turn_off_lights_with_lightswitch,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/diagonal,
@@ -5263,7 +5214,7 @@
 "arn" = (
 /obj/structure/closet/athletic_mixed,
 /obj/structure/sign/poster/random/directional/north,
-/obj/effect/landmark/start/hangover/closet,
+/obj/effect/landmark/start/hangover,
 /obj/item/clothing/shoes/jackboots,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
@@ -5273,9 +5224,7 @@
 	},
 /area/station/holodeck/rec_center)
 "arp" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
-	},
+/obj/structure/sign/warning/vacuum/external/directional/north,
 /turf/closed/wall,
 /area/station/maintenance/starboard/fore)
 "arq" = (
@@ -5299,7 +5248,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "aru" = (
-/obj/structure/chair/stool/directional/north,
+/obj/structure/chair/stool/directional/south,
 /obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/maintenance,
@@ -5483,7 +5432,7 @@
 	c_tag = "Dormitories - Fitness Room North"
 	},
 /obj/structure/closet/masks,
-/obj/effect/landmark/start/hangover/closet,
+/obj/effect/landmark/start/hangover,
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
@@ -5534,12 +5483,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "asB" = (
-/obj/structure/filingcabinet/filingcabinet,
-/obj/structure/filingcabinet/filingcabinet{
+/obj/structure/filingcabinet/white,
+/obj/structure/filingcabinet/white{
 	pixel_x = -10;
 	pixel_y = 0
 	},
-/obj/structure/filingcabinet/filingcabinet{
+/obj/structure/filingcabinet/white{
 	pixel_x = 10;
 	pixel_y = 0
 	},
@@ -5815,7 +5764,7 @@
 "atR" = (
 /obj/effect/landmark/carpspawn,
 /obj/structure/lattice,
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "atS" = (
 /turf/closed/wall,
@@ -5824,7 +5773,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/decal/cleanable/robot_debris,
+/obj/effect/decal/cleanable/blood/gibs/robot_debris,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "atV" = (
@@ -6034,7 +5983,7 @@
 /area/station/maintenance/department/electrical)
 "auO" = (
 /obj/structure/closet/emcloset,
-/obj/effect/landmark/start/hangover/closet,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
 "auP" = (
@@ -6121,9 +6070,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "ave" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
-	},
+/obj/structure/sign/warning/vacuum/external/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
@@ -6243,7 +6190,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "avC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -6317,7 +6264,7 @@
 /obj/docking_port/stationary/syndicate/northeast{
 	dir = 8
 	},
-/turf/open/space,
+/turf/open/space/basic,
 /area/space)
 "avU" = (
 /obj/item/paper/crumpled,
@@ -6939,7 +6886,7 @@
 	},
 /obj/effect/turf_decal/siding/dark,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "ayx" = (
 /obj/structure/bed{
 	dir = 4
@@ -6980,7 +6927,7 @@
 	},
 /obj/effect/turf_decal/siding/dark,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "ayL" = (
 /turf/closed/wall/r_wall,
 /area/station/science/server)
@@ -7003,7 +6950,7 @@
 	},
 /obj/effect/turf_decal/siding/dark,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "ayN" = (
 /obj/machinery/door/airlock/command{
 	name = "EVA Storage"
@@ -7013,14 +6960,14 @@
 /obj/effect/landmark/navigate_destination/eva,
 /obj/effect/mapping_helpers/airlock/red_alert_access,
 /turf/open/floor/iron/dark/textured_half,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "ayP" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /obj/structure/tank_dispenser/oxygen,
 /obj/effect/turf_decal/siding/dark/end,
 /turf/open/floor/iron/dark/textured_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "ayQ" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
@@ -7028,7 +6975,7 @@
 	c_tag = "Engineering - Cooling Loop South";
 	network = list("ss13","engine")
 	},
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "ayR" = (
 /obj/structure/chair,
@@ -7197,7 +7144,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "azF" = (
 /turf/closed/wall,
 /area/station/service/hydroponics/garden)
@@ -7253,7 +7200,7 @@
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "azV" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -7461,9 +7408,7 @@
 /turf/closed/wall/r_wall,
 /area/station/hallway/secondary/entry)
 "aAD" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
-	},
+/obj/structure/sign/warning/vacuum/external/directional/north,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
@@ -7582,7 +7527,7 @@
 /obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
@@ -7722,7 +7667,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/mid_joiner,
 /obj/effect/mapping_helpers/requests_console/supplies,
 /turf/open/floor/iron/edge,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "aBQ" = (
 /turf/closed/wall,
 /area/station/commons/storage/primary)
@@ -7732,30 +7677,30 @@
 "aBS" = (
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/circuit/green,
-/area/station/ai_monitored/command/nuke_storage)
+/area/station/command/vault)
 "aBT" = (
 /obj/machinery/computer/bank_machine,
 /obj/effect/turf_decal/bot_white,
 /obj/effect/turf_decal/tile/neutral/full,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/nuke_storage)
+/area/station/command/vault)
 "aBU" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/circuit/green,
-/area/station/ai_monitored/command/nuke_storage)
+/area/station/command/vault)
 "aBV" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/light/directional/north,
 /turf/open/floor/circuit/green,
-/area/station/ai_monitored/command/nuke_storage)
+/area/station/command/vault)
 "aBW" = (
 /obj/structure/filingcabinet,
 /obj/item/folder/documents,
 /obj/effect/turf_decal/bot_white,
 /obj/effect/turf_decal/tile/neutral/full,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/nuke_storage)
+/area/station/command/vault)
 "aBZ" = (
 /obj/effect/turf_decal/bot_white,
 /obj/structure/cable,
@@ -7829,7 +7774,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "aCj" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
@@ -7840,7 +7785,7 @@
 	},
 /obj/item/radio/intercom/command,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "aCl" = (
 /turf/closed/wall/r_wall,
 /area/station/security/office)
@@ -8162,12 +8107,12 @@
 /obj/effect/turf_decal/bot_white/right,
 /obj/effect/turf_decal/tile/neutral/full,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/nuke_storage)
+/area/station/command/vault)
 "aDv" = (
 /obj/effect/turf_decal/bot_white/left,
 /obj/effect/turf_decal/tile/neutral/full,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/nuke_storage)
+/area/station/command/vault)
 "aDx" = (
 /obj/machinery/door/window/left/directional/south{
 	name = "Gateway Chamber";
@@ -8475,24 +8420,24 @@
 /area/station/service/hydroponics/garden)
 "aEM" = (
 /turf/open/floor/circuit/green,
-/area/station/ai_monitored/command/nuke_storage)
+/area/station/command/vault)
 "aEN" = (
 /obj/effect/turf_decal/bot_white/right,
 /obj/structure/closet/crate/goldcrate,
 /obj/effect/turf_decal/tile/neutral/full,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/nuke_storage)
+/area/station/command/vault)
 "aEO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/circuit/green,
-/area/station/ai_monitored/command/nuke_storage)
+/area/station/command/vault)
 "aEP" = (
 /obj/effect/turf_decal/bot_white/left,
 /obj/structure/closet/crate/silvercrate,
 /obj/effect/turf_decal/tile/neutral/full,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/nuke_storage)
+/area/station/command/vault)
 "aEQ" = (
 /obj/machinery/computer/gateway_control,
 /turf/open/floor/iron/dark/smooth_large,
@@ -8550,10 +8495,10 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "aFc" = (
 /turf/closed/wall/r_wall,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "aFe" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Dormitories - Entrance"
@@ -8807,13 +8752,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark/smooth_corner,
-/area/station/ai_monitored/command/nuke_storage)
+/area/station/command/vault)
 "aGb" = (
 /obj/effect/turf_decal/bot_white/right,
 /obj/machinery/ore_silo,
 /obj/effect/turf_decal/tile/neutral/full,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/nuke_storage)
+/area/station/command/vault)
 "aGc" = (
 /obj/machinery/camera/motion/directional/south{
 	network = list("vault");
@@ -8827,7 +8772,7 @@
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 8
 	},
-/area/station/ai_monitored/command/nuke_storage)
+/area/station/command/vault)
 "aGd" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/neutral/filled/warning,
@@ -8836,7 +8781,7 @@
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 1
 	},
-/area/station/ai_monitored/command/nuke_storage)
+/area/station/command/vault)
 "aGe" = (
 /obj/structure/safe/vault,
 /obj/effect/turf_decal/bot_white/left,
@@ -8848,7 +8793,7 @@
 /obj/item/storage/briefcase/secure/riches,
 /obj/item/clothing/neck/stethoscope,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/nuke_storage)
+/area/station/command/vault)
 "aGf" = (
 /obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/stripes/line{
@@ -8867,7 +8812,7 @@
 /area/station/maintenance/port/fore)
 "aGj" = (
 /turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "aGk" = (
 /obj/structure/sink/directional/east,
 /turf/open/floor/iron/freezer,
@@ -9067,7 +9012,7 @@
 	dir = 8;
 	color = "#9FED58"
 	},
-/obj/effect/landmark/start/hangover/closet,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/secondary/service)
 "aGX" = (
@@ -9075,7 +9020,7 @@
 	dir = 4
 	},
 /obj/structure/lattice,
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "aGY" = (
 /obj/structure/table/wood/fancy/blue,
@@ -9238,7 +9183,7 @@
 /area/station/commons/storage/primary)
 "aHF" = (
 /turf/closed/wall/r_wall,
-/area/station/ai_monitored/command/nuke_storage)
+/area/station/command/vault)
 "aHG" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/vault{
@@ -9253,7 +9198,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/navigate_destination/vault,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/command/nuke_storage)
+/area/station/command/vault)
 "aHH" = (
 /obj/structure/curtain/cloth/fancy{
 	name = "Dormitory Curtains"
@@ -9777,7 +9722,7 @@
 /turf/open/floor/iron/corner{
 	dir = 1
 	},
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "aJg" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/machinery/light/directional/east,
@@ -9824,7 +9769,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "aJm" = (
 /obj/structure/sink/kitchen/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -10115,7 +10060,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "aKi" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -10453,7 +10398,7 @@
 /area/station/hallway/secondary/entry)
 "aLl" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -10463,7 +10408,7 @@
 "aLm" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -10755,7 +10700,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "aMj" = (
 /mob/living/basic/goat/pete,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -11245,7 +11190,7 @@
 /turf/open/floor/iron/edge,
 /area/station/hallway/primary/port)
 "aNV" = (
-/obj/machinery/photocopier,
+/obj/machinery/photocopier/prebuilt,
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
@@ -11379,7 +11324,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/half,
-/obj/machinery/bluespace_vendor/directional/south,
 /turf/open/floor/iron/edge,
 /area/station/hallway/primary/port)
 "aOs" = (
@@ -11829,7 +11773,7 @@
 /area/station/commons/storage/emergency/port)
 "aPL" = (
 /obj/structure/closet/firecloset,
-/obj/effect/landmark/start/hangover/closet,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/port)
 "aPN" = (
@@ -12014,9 +11958,7 @@
 /turf/open/floor/iron/white,
 /area/station/hallway/secondary/exit/departure_lounge)
 "aQG" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
-	},
+/obj/structure/sign/warning/vacuum/external/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "aQI" = (
@@ -12516,7 +12458,7 @@
 "aSh" = (
 /obj/structure/closet/wardrobe/white,
 /obj/item/radio/intercom/directional/west,
-/obj/effect/landmark/start/hangover/closet,
+/obj/effect/landmark/start/hangover,
 /obj/effect/turf_decal/tile/neutral/full,
 /turf/open/floor/iron/large,
 /area/station/commons/locker)
@@ -12752,7 +12694,7 @@
 /obj/effect/turf_decal/tile/yellow/anticorner{
 	dir = 8
 	},
-/obj/effect/landmark/start/hangover/closet,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/corner{
 	dir = 4
 	},
@@ -12855,7 +12797,7 @@
 "aTw" = (
 /obj/structure/closet/wardrobe/grey,
 /obj/machinery/light/directional/west,
-/obj/effect/landmark/start/hangover/closet,
+/obj/effect/landmark/start/hangover,
 /obj/effect/turf_decal/tile/neutral/full,
 /turf/open/floor/iron/large,
 /area/station/commons/locker)
@@ -12866,10 +12808,6 @@
 /area/station/commons/locker)
 "aTz" = (
 /obj/structure/table,
-/turf/open/floor/iron,
-/area/station/commons/locker)
-"aTB" = (
-/obj/structure/chair/stool/directional/east,
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "aTD" = (
@@ -13714,7 +13652,7 @@
 /obj/structure/grille,
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "aWl" = (
 /obj/effect/turf_decal/siding/dark_green{
@@ -14127,7 +14065,7 @@
 /obj/effect/spawner/random/clothing/funny_hats,
 /obj/effect/spawner/random/clothing/costume,
 /obj/effect/spawner/random/clothing/funny_hats,
-/obj/effect/landmark/start/hangover/closet,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white,
 /area/station/commons/locker)
 "aXB" = (
@@ -14334,7 +14272,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai_upload_foyer)
+/area/station/ai/upload/foyer)
 "aYB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/wood{
@@ -14345,7 +14283,7 @@
 /area/station/service/lawoffice)
 "aYC" = (
 /obj/machinery/firealarm/directional/south,
-/obj/structure/filingcabinet/filingcabinet,
+/obj/structure/filingcabinet/white,
 /obj/effect/turf_decal/tile/blue/anticorner{
 	dir = 8
 	},
@@ -14745,7 +14683,7 @@
 /obj/structure/table,
 /obj/item/ai_module/supplied/freeform,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "aZT" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Upload Access"
@@ -14758,7 +14696,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "aZU" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -15436,7 +15374,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "bch" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
@@ -15448,7 +15386,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "bcj" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8
@@ -15635,7 +15573,7 @@
 "bcI" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/hangover/closet,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "bcJ" = (
@@ -15734,7 +15672,7 @@
 /obj/machinery/airalarm/directional/west,
 /obj/effect/landmark/start/cyborg,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "bdg" = (
 /obj/structure/cable,
 /obj/machinery/holopad/secure,
@@ -15743,7 +15681,7 @@
 	color = "#486091"
 	},
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "bdi" = (
 /obj/effect/spawner/random/entertainment/arcade{
 	dir = 4
@@ -15933,9 +15871,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "bdT" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
-	},
+/obj/structure/sign/warning/vacuum/external/directional/north,
 /obj/effect/landmark/navigate_destination/dockescpod1,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
@@ -15965,16 +15901,16 @@
 /area/station/command/meeting_room/council)
 "bec" = (
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "bee" = (
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "bef" = (
 /obj/effect/turf_decal/bot_white,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "bei" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/wood,
@@ -16326,7 +16262,7 @@
 /area/station/command/meeting_room/council)
 "bfv" = (
 /turf/closed/wall/r_wall,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "bfy" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -16429,7 +16365,7 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/closet/emcloset,
 /obj/structure/cable,
-/obj/effect/landmark/start/hangover/closet,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/starboard)
 "bfR" = (
@@ -16514,7 +16450,7 @@
 /obj/effect/turf_decal/tile/red/opposingcorners{
 	dir = 1
 	},
-/obj/effect/landmark/start/hangover/closet,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/exit/departure_lounge)
 "bgg" = (
@@ -16654,7 +16590,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "bgP" = (
 /obj/machinery/disposal/bin/tagger,
 /obj/effect/turf_decal/trimline/yellow/end{
@@ -17257,7 +17193,7 @@
 /obj/effect/landmark/start/cyborg,
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "bik" = (
 /obj/item/radio/intercom/command/directional/west,
 /obj/machinery/suit_storage_unit/captain,
@@ -17485,7 +17421,7 @@
 /obj/effect/turf_decal/tile/red/half{
 	dir = 1
 	},
-/obj/structure/chair/stool/directional/north,
+/obj/structure/chair/stool/directional/south,
 /obj/effect/landmark/start/roboticist,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
@@ -17578,9 +17514,7 @@
 /obj/machinery/conveyor{
 	id = "garbage"
 	},
-/obj/structure/sign/warning/vacuum{
-	pixel_x = -32
-	},
+/obj/structure/sign/warning/vacuum/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "bjc" = (
@@ -17618,7 +17552,7 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17732,7 +17666,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "bju" = (
-/obj/machinery/photocopier,
+/obj/machinery/photocopier/prebuilt,
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/office)
@@ -18108,7 +18042,7 @@
 /obj/vehicle/ridden/secway,
 /mob/living/simple_animal/bot/secbot/beepsky/armsky,
 /turf/open/floor/iron/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "bkB" = (
 /obj/machinery/computer/pod/old/mass_driver_controller/trash{
 	pixel_x = -24;
@@ -18218,7 +18152,7 @@
 /obj/machinery/power/terminal,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "blb" = (
 /obj/machinery/door/airlock/command{
 	name = "Captain's Quarters"
@@ -18493,9 +18427,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "blR" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
-	},
+/obj/structure/sign/warning/vacuum/external/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
@@ -18516,7 +18448,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "blV" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/cable,
@@ -19366,7 +19298,7 @@
 /area/station/cargo/storage)
 "boL" = (
 /obj/structure/table,
-/obj/item/clothing/mask/muzzle/breath,
+/obj/item/clothing/mask/breath/muzzle,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "boM" = (
@@ -20133,10 +20065,10 @@
 "bru" = (
 /obj/effect/turf_decal/siding/dark/corner,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
@@ -20238,10 +20170,7 @@
 	location = "QM #1"
 	},
 /obj/effect/turf_decal/bot,
-/mob/living/simple_animal/bot/mulebot{
-	home_destination = "QM #1";
-	suffix = "#1"
-	},
+/mob/living/simple_animal/bot/mulebot,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "brN" = (
@@ -20314,7 +20243,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "bsh" = (
 /turf/closed/wall,
 /area/station/command/teleporter)
@@ -20627,10 +20556,7 @@
 	location = "QM #2"
 	},
 /obj/effect/turf_decal/bot,
-/mob/living/simple_animal/bot/mulebot{
-	home_destination = "QM #2";
-	suffix = "#2"
-	},
+/mob/living/simple_animal/bot/mulebot,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "btt" = (
@@ -21206,10 +21132,10 @@
 /area/station/science/research)
 "buV" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/white/corner{
-	dir = 8;
+	dir = 4;
 	color = "#52B4E9"
 	},
 /turf/open/floor/iron/dark,
@@ -21254,7 +21180,7 @@
 /turf/open/floor/iron/corner{
 	dir = 4
 	},
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "bve" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21941,7 +21867,7 @@
 "bxE" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "bxG" = (
 /obj/machinery/door/airlock/command{
 	name = "Head of Personnel's Office"
@@ -22624,7 +22550,7 @@
 	},
 /area/station/command/heads_quarters/rd)
 "bzO" = (
-/obj/machinery/computer/scan_consolenew{
+/obj/machinery/computer/dna_console{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -23840,10 +23766,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
-"bDi" = (
-/obj/structure/sign/warning/docking/directional/north,
-/turf/open/space,
-/area/space/nearstation)
 "bDk" = (
 /obj/structure/table,
 /obj/item/folder/yellow,
@@ -23978,7 +23900,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer1{
 	dir = 8
 	},
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "bDG" = (
 /obj/machinery/door/firedoor,
@@ -25342,7 +25264,7 @@
 "bIH" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "bIL" = (
 /obj/machinery/door/firedoor,
@@ -26146,7 +26068,7 @@
 /turf/open/floor/plating,
 /area/station/construction)
 "bLF" = (
-/obj/structure/filingcabinet/filingcabinet,
+/obj/structure/filingcabinet/white,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -26172,7 +26094,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/effect/landmark/start/hangover/closet,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/primary/aft)
 "bLI" = (
@@ -26271,7 +26193,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "bMg" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
@@ -26551,7 +26473,7 @@
 /obj/item/airlock_painter,
 /obj/structure/lattice,
 /obj/structure/closet,
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "bNd" = (
 /turf/closed/wall/r_wall,
@@ -26589,18 +26511,18 @@
 	req_one_access = list("maint_tunnels","command","eva")
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/white/corner{
+	color = "#52B4E9";
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/white/corner{
 	color = "#52B4E9";
 	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/corner{
-	color = "#52B4E9";
-	dir = 4
 	},
 /obj/machinery/light/directional/north,
 /obj/effect/decal/cleanable/dirt,
@@ -27355,7 +27277,7 @@
 "bPP" = (
 /obj/structure/closet/wardrobe/grey,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/hangover/closet,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "bPX" = (
@@ -28026,7 +27948,7 @@
 "bSH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/structure/lattice,
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "bSK" = (
 /obj/structure/disposalpipe/segment{
@@ -28675,9 +28597,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bVU" = (
-/obj/machinery/atmospherics/components/unary/bluespace_sender{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
@@ -29053,7 +28972,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
@@ -29244,9 +29163,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "bYu" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = -32
-	},
+/obj/structure/sign/warning/vacuum/external/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
@@ -29327,7 +29244,7 @@
 	dir = 4
 	},
 /obj/structure/closet/firecloset,
-/obj/effect/landmark/start/hangover/closet,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -29498,7 +29415,7 @@
 /obj/structure/noticeboard/ce{
 	pixel_y = -32
 	},
-/obj/machinery/photocopier,
+/obj/machinery/photocopier/prebuilt,
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
@@ -29964,7 +29881,7 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
 	dir = 4
 	},
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "cbA" = (
 /obj/machinery/light/directional/north,
@@ -30255,11 +30172,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"ccX" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/turf/open/space,
-/area/station/solars/port/aft)
 "ccY" = (
 /obj/structure/table,
 /obj/item/food/flatdough,
@@ -30344,7 +30256,7 @@
 "cdu" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/hangover/closet,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "cdv" = (
@@ -30633,9 +30545,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "ceU" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = -32
-	},
+/obj/structure/sign/warning/vacuum/external/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
@@ -30728,9 +30638,7 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Engineering Maintenance"
 	},
-/obj/structure/sign/warning/radiation/rad_area{
-	pixel_x = -32
-	},
+/obj/structure/sign/warning/radiation/rad_area/directional/west,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/engine_equipment,
 /obj/effect/turf_decal/stripes/line,
@@ -30904,9 +30812,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "cgA" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = -32
-	},
+/obj/structure/sign/warning/vacuum/external/directional/west,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -31126,7 +31032,7 @@
 "chH" = (
 /obj/structure/closet/firecloset,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/hangover/closet,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "chJ" = (
@@ -31136,7 +31042,7 @@
 /area/station/solars/port/aft)
 "chL" = (
 /obj/structure/lattice/catwalk,
-/turf/open/space,
+/turf/open/space/basic,
 /area/station/solars/port/aft)
 "chN" = (
 /obj/structure/cable,
@@ -31318,7 +31224,7 @@
 "ciT" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/hangover/closet,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "ciW" = (
@@ -31849,9 +31755,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
 "cmx" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = -32
-	},
+/obj/structure/sign/warning/vacuum/external/directional/south,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -32062,7 +31966,7 @@
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai_upload_foyer)
+/area/station/ai/upload/foyer)
 "col" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -32151,7 +32055,7 @@
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/spawner/random/armory/shotgun,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "coZ" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
 /obj/effect/turf_decal/siding/yellow,
@@ -32185,12 +32089,7 @@
 /obj/effect/spawner/random/armory/barrier_grenades,
 /obj/effect/turf_decal/tile/dark_red/full,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
-"cpi" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/turf/open/space,
-/area/station/solars/starboard/aft)
+/area/station/security/armory)
 "cpq" = (
 /obj/effect/turf_decal/siding/yellow,
 /obj/effect/turf_decal/siding/yellow{
@@ -32221,7 +32120,7 @@
 /area/station/engineering/supermatter/room)
 "cpv" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 9
@@ -32242,7 +32141,7 @@
 	},
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai_upload_foyer)
+/area/station/ai/upload/foyer)
 "cpA" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -32250,7 +32149,7 @@
 /obj/structure/cable,
 /obj/effect/landmark/start/warden,
 /turf/open/floor/iron/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "cpC" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
@@ -32295,9 +32194,7 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "cpV" = (
-/obj/structure/sign/warning/radiation/rad_area{
-	pixel_x = -32
-	},
+/obj/structure/sign/warning/radiation/rad_area/directional/west,
 /obj/effect/turf_decal/siding/yellow{
 	dir = 4
 	},
@@ -32400,7 +32297,7 @@
 /area/station/engineering/supermatter/room)
 "cql" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
@@ -32463,7 +32360,7 @@
 "cqw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "cqx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32526,7 +32423,7 @@
 /obj/effect/spawner/random/armory/rubbershot,
 /obj/effect/turf_decal/tile/dark_red/full,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "cqH" = (
 /obj/machinery/door/airlock/external{
 	name = "Exterior Access";
@@ -32602,7 +32499,7 @@
 /area/station/engineering/supermatter/room)
 "crk" = (
 /obj/structure/lattice/catwalk,
-/turf/open/space,
+/turf/open/space/basic,
 /area/station/solars/starboard/aft)
 "crl" = (
 /obj/machinery/shower/directional/north,
@@ -32626,10 +32523,9 @@
 /area/station/engineering/gravity_generator)
 "crm" = (
 /obj/machinery/shower/directional/north,
-/obj/structure/sign/warning/radiation/rad_area{
+/obj/structure/sign/warning/radiation/rad_area/directional/south{
 	desc = "A warning sign which reads 'RADIOACTIVE DECONTAMINATION SECTION'.";
-	name = "RADIOACTIVE DECONTAMINATION SECTION";
-	pixel_y = -32
+	name = "RADIOACTIVE DECONTAMINATION SECTION"
 	},
 /obj/structure/fluff/shower_drain,
 /obj/effect/turf_decal/siding/yellow{
@@ -32698,14 +32594,14 @@
 	c_tag = "Engineering - Cooling Loop North";
 	network = list("ss13","engine")
 	},
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "crJ" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "crK" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
@@ -32738,14 +32634,14 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "crU" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
 	},
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "crW" = (
 /obj/machinery/light/small/directional/west,
@@ -32764,14 +32660,14 @@
 	dir = 4
 	},
 /obj/structure/lattice,
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "csb" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
 	},
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "cse" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
@@ -32798,7 +32694,7 @@
 "css" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "csu" = (
 /obj/structure/closet/firecloset,
@@ -32807,7 +32703,7 @@
 "csx" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "csy" = (
 /obj/structure/disposalpipe/segment,
@@ -32961,13 +32857,13 @@
 	},
 /obj/effect/landmark/start/cyborg,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "cvk" = (
 /turf/closed/wall,
 /area/station/security/courtroom)
 "cvl" = (
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "cvv" = (
 /turf/open/floor/wood/large,
 /area/station/command/meeting_room/council)
@@ -32985,7 +32881,7 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/effect/spawner/random/aimodule/neutral,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "cvJ" = (
 /obj/machinery/light/floor,
 /turf/open/floor/iron/dark/smooth_large,
@@ -33033,7 +32929,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "cwK" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 1
@@ -33057,7 +32953,7 @@
 	},
 /obj/effect/turf_decal/tile/dark_red/full,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "cwT" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Escape Pod Two Dock"
@@ -33070,7 +32966,7 @@
 	dir = 8;
 	name = "lavaland"
 	},
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "cxj" = (
 /obj/machinery/air_sensor/nitrogen_tank,
@@ -33091,7 +32987,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "cxE" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -33221,11 +33117,11 @@
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/red_alert_access,
 /turf/open/floor/iron/dark/textured_half,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "cyi" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/hangover/closet,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "cyl" = (
@@ -33410,7 +33306,7 @@
 	dir = 4;
 	name = "lavaland"
 	},
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "czO" = (
 /obj/effect/landmark/event_spawn,
@@ -33501,7 +33397,7 @@
 /area/station/engineering/supermatter)
 "cAo" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/engine,
@@ -33692,7 +33588,7 @@
 /obj/machinery/airalarm/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/maintenance,
-/obj/effect/landmark/start/hangover/closet,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "cAK" = (
@@ -33732,7 +33628,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "cAV" = (
 /obj/effect/turf_decal/siding/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33743,7 +33639,7 @@
 /obj/machinery/light/directional/south,
 /obj/structure/sign/departments/aisat/directional/south,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "cBg" = (
 /obj/machinery/smartfridge/food,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -34197,7 +34093,7 @@
 	id = "AI"
 	},
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "cDt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -34361,7 +34257,7 @@
 	dir = 6
 	},
 /obj/structure/lattice,
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "cEr" = (
 /obj/effect/turf_decal/stripes/line{
@@ -34422,7 +34318,7 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
 	},
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "cEL" = (
 /obj/effect/turf_decal/stripes/line{
@@ -34527,21 +34423,21 @@
 "cFm" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/structure/lattice,
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "cFn" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
 	},
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "cFo" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
 	},
 /obj/structure/lattice,
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "cFu" = (
 /obj/effect/turf_decal/stripes/line{
@@ -34564,7 +34460,7 @@
 /area/station/maintenance/port/aft)
 "cFJ" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/engine,
@@ -34750,7 +34646,7 @@
 "cHr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -34782,7 +34678,7 @@
 /area/station/maintenance/starboard/lesser)
 "cHF" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -34811,7 +34707,7 @@
 /area/station/science/robotics/mechbay)
 "cHJ" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35087,7 +34983,7 @@
 /obj/structure/table,
 /obj/effect/spawner/random/aimodule/harmless,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "cLd" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 5
@@ -35157,7 +35053,7 @@
 	name = "Goes-On-Adventures"
 	},
 /turf/open/floor/wood,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "cMq" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
@@ -35685,7 +35581,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
@@ -35723,7 +35619,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -35747,7 +35643,7 @@
 	dir = 8;
 	color = "#9FED58"
 	},
-/obj/effect/landmark/start/hangover/closet,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/secondary/service)
 "cVT" = (
@@ -35879,7 +35775,7 @@
 	name = "Private Channel"
 	},
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "daG" = (
 /obj/effect/landmark/generic_maintenance_landmark,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -36002,7 +35898,7 @@
 	pixel_y = 11
 	},
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "ddD" = (
 /obj/machinery/monkey_recycler,
 /obj/effect/turf_decal/stripes/line{
@@ -36161,7 +36057,7 @@
 "diw" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "diB" = (
 /obj/structure/cable,
@@ -36189,7 +36085,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "djf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -36350,7 +36246,7 @@
 "dpm" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "dpy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -36406,7 +36302,7 @@
 /area/station/medical/medbay/aft)
 "dqY" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /turf/open/floor/engine,
@@ -36477,7 +36373,7 @@
 /turf/open/floor/pod/dark,
 /area/station/maintenance/radshelter)
 "dtc" = (
-/obj/machinery/photocopier,
+/obj/machinery/photocopier/prebuilt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/toy/figure/lawyer{
 	pixel_x = 3;
@@ -36527,7 +36423,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "duk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
@@ -36568,7 +36464,7 @@
 "duC" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "duG" = (
 /obj/structure/cable,
 /obj/machinery/duct,
@@ -36807,16 +36703,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
-"dAB" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/bluespace_vendor/directional/west,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "dBs" = (
 /obj/machinery/light/directional/east,
 /obj/effect/landmark/start/hangover,
@@ -36850,9 +36736,7 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/prison/visit)
 "dCG" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = -32
-	},
+/obj/structure/sign/warning/vacuum/external/directional/west,
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
@@ -36987,7 +36871,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "dHE" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -37193,7 +37077,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "dMQ" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/siding/wideplating_new/dark{
@@ -37223,11 +37107,6 @@
 /obj/effect/mapping_helpers/requests_console/ore_update,
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/chemistry)
-"dNI" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/marker_beacon/burgundy,
-/turf/open/space,
-/area/space/nearstation)
 "dNU" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -37255,7 +37134,7 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "dPl" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/east,
-/obj/structure/chair/stool/directional/north,
+/obj/structure/chair/stool/directional/south,
 /obj/effect/turf_decal/siding/dark_red{
 	dir = 1
 	},
@@ -37268,7 +37147,7 @@
 	},
 /obj/effect/landmark/start/cyborg,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "dQh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37362,7 +37241,7 @@
 	},
 /obj/effect/landmark/start/cyborg,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "dTf" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner{
 	dir = 4
@@ -37441,7 +37320,7 @@
 	dir = 4
 	},
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "dWd" = (
 /obj/structure/closet/crate/secure/engineering/atmos{
 	name = "atmospherics emergency crate";
@@ -37484,7 +37363,7 @@
 	dir = 8
 	},
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "dWm" = (
 /obj/structure/sink/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37510,7 +37389,7 @@
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "dWT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37535,7 +37414,7 @@
 "dYf" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/indigo,
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "dYq" = (
 /turf/closed/wall,
@@ -37676,7 +37555,7 @@
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "eai" = (
 /obj/structure/weightmachine/weightlifter,
 /obj/effect/decal/cleanable/dirt,
@@ -37740,7 +37619,7 @@
 /obj/effect/turf_decal/tile/dark_red/full,
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "eco" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -37856,7 +37735,7 @@
 	name = "Private Channel"
 	},
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "eel" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 9
@@ -37918,7 +37797,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 9
 	},
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "efM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38032,7 +37911,7 @@
 /area/station/security/prison/workout)
 "ejQ" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
@@ -38050,7 +37929,7 @@
 "ekd" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/bronze,
-/turf/open/space,
+/turf/open/space/basic,
 /area/station/solars/starboard/fore)
 "ekm" = (
 /obj/structure/cable,
@@ -38075,7 +37954,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 9
 	},
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "eky" = (
 /obj/structure/cable,
@@ -38318,7 +38197,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "esP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/structure/chair{
@@ -38462,7 +38341,7 @@
 /area/station/engineering/atmos/pumproom)
 "eyq" = (
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "eyz" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
@@ -38493,7 +38372,7 @@
 	name = "Private Channel"
 	},
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "ezj" = (
 /obj/structure/cable,
 /obj/machinery/camera/directional/west{
@@ -38757,7 +38636,7 @@
 "eGo" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "eGJ" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -38806,13 +38685,13 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "eIs" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "eIE" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable,
@@ -38882,7 +38761,7 @@
 "eKq" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "eKw" = (
 /obj/structure/cable,
@@ -39002,7 +38881,7 @@
 "eMu" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "eMA" = (
 /obj/structure/cable,
 /obj/structure/bed/dogbed/mcgriff,
@@ -39028,7 +38907,7 @@
 /obj/machinery/recharge_station,
 /obj/effect/landmark/start/cyborg,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "eNl" = (
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 5
@@ -39158,7 +39037,7 @@
 	},
 /mob/living/basic/bot/cleanbot,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "eRg" = (
 /turf/closed/wall/r_wall,
 /area/station/security/brig)
@@ -39240,7 +39119,7 @@
 /obj/machinery/recharge_station,
 /obj/effect/landmark/start/cyborg,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "eSG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -39483,7 +39362,7 @@
 	pixel_y = 16
 	},
 /turf/open/floor/iron/freezer,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "eYn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39570,7 +39449,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
@@ -40271,7 +40150,7 @@
 /area/station/engineering/atmos)
 "frE" = (
 /obj/structure/closet/emcloset,
-/obj/effect/landmark/start/hangover/closet,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white/herringbone,
 /area/station/hallway/secondary/dock)
 "frJ" = (
@@ -40591,7 +40470,7 @@
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/wood,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "fFF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -40604,7 +40483,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "fFM" = (
 /obj/machinery/exodrone_launcher,
 /obj/item/exodrone,
@@ -40723,11 +40602,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured,
 /area/station/command/heads_quarters/ce)
-"fIW" = (
-/obj/structure/lattice,
-/obj/structure/grille/broken,
-/turf/open/space,
-/area/space/nearstation)
 "fJa" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
@@ -40806,7 +40680,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/airalarm/directional/east,
@@ -40887,7 +40761,7 @@
 	},
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "fQu" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 4
@@ -41200,7 +41074,7 @@
 /turf/open/floor/pod/dark,
 /area/station/maintenance/radshelter)
 "fZR" = (
-/obj/structure/chair/stool/directional/east,
+/obj/structure/chair/stool/directional/west,
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron,
 /area/station/security/prison/rec)
@@ -41353,11 +41227,6 @@
 	dir = 4
 	},
 /area/station/commons/dorms)
-"ghr" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/marker_beacon/yellow,
-/turf/open/space,
-/area/space/nearstation)
 "ghK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/structure/cable,
@@ -41470,7 +41339,7 @@
 "gkr" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "gkF" = (
 /obj/structure/cable,
@@ -41548,7 +41417,7 @@
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "gny" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
@@ -41926,7 +41795,7 @@
 /turf/open/floor/wood/tile,
 /area/station/service/chapel)
 "gyq" = (
-/obj/structure/chair/stool/directional/north,
+/obj/structure/chair/stool/directional/south,
 /turf/open/floor/iron,
 /area/station/security/prison/rec)
 "gyy" = (
@@ -42211,7 +42080,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "gFd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -42237,7 +42106,7 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "gFP" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
@@ -42362,7 +42231,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "gIa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42627,7 +42496,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "gQw" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -42675,7 +42544,7 @@
 /area/station/security/execution/transfer)
 "gSN" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
@@ -43176,9 +43045,7 @@
 /area/station/command/meeting_room/council)
 "hfA" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/radiation/rad_area{
-	pixel_x = 32
-	},
+/obj/structure/sign/warning/radiation/rad_area/directional/east,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/gravity_generator)
@@ -43536,7 +43403,7 @@
 "hsB" = (
 /obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
@@ -43591,7 +43458,7 @@
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer1,
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "huh" = (
 /obj/structure/window/spawner/directional/south,
@@ -43811,7 +43678,7 @@
 /area/station/command/heads_quarters/cmo)
 "hCb" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
@@ -43841,7 +43708,6 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 1
 	},
-/obj/machinery/bluespace_vendor/directional/south,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/primary/fore)
@@ -44092,7 +43958,7 @@
 /turf/open/floor/iron/edge{
 	dir = 1
 	},
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "hII" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/small/directional/east,
@@ -44138,11 +44004,6 @@
 	dir = 8
 	},
 /area/station/commons/fitness)
-"hKO" = (
-/obj/effect/turf_decal/tile/neutral/half,
-/obj/machinery/bluespace_vendor/directional/south,
-/turf/open/floor/iron/edge,
-/area/station/hallway/primary/starboard)
 "hLs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
@@ -44224,7 +44085,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "hOY" = (
 /obj/effect/turf_decal/tile/blue/anticorner,
 /turf/open/floor/iron/white/smooth_corner{
@@ -44237,7 +44098,7 @@
 /area/station/commons/dorms)
 "hPk" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
@@ -44980,7 +44841,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/moisture_trap,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
@@ -45195,7 +45056,7 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
@@ -45454,7 +45315,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "iDS" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -45604,7 +45465,7 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
 "iIT" = (
-/obj/structure/chair/stool/directional/north,
+/obj/structure/chair/stool/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/siding/dark_red{
 	dir = 1
@@ -45626,7 +45487,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "iIY" = (
 /obj/effect/turf_decal/tile/neutral/half{
 	dir = 4
@@ -45652,7 +45513,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "iKa" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/camera/directional/west{
@@ -45679,7 +45540,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 4
 	},
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "iMl" = (
 /obj/effect/turf_decal/tile/blue{
@@ -45841,7 +45702,6 @@
 /obj/effect/turf_decal/tile/neutral/half{
 	dir = 1
 	},
-/obj/machinery/bluespace_vendor/directional/north,
 /turf/open/floor/iron/edge{
 	dir = 1
 	},
@@ -46300,7 +46160,7 @@
 "jiK" = (
 /obj/structure/closet/toolcloset,
 /obj/effect/turf_decal/tile/yellow/half,
-/obj/effect/landmark/start/hangover/closet,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/edge,
 /area/station/commons/storage/tools)
 "jiV" = (
@@ -46390,9 +46250,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "jnk" = (
-/obj/structure/sign/warning/radiation/rad_area{
-	pixel_x = -32
-	},
+/obj/structure/sign/warning/radiation/rad_area/directional/west,
 /obj/effect/turf_decal/siding/yellow/corner,
 /obj/effect/turf_decal/siding/yellow/corner{
 	dir = 4
@@ -46774,7 +46632,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer1{
 	dir = 5
 	},
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "jwE" = (
 /obj/structure/disposalpipe/segment{
@@ -46859,7 +46717,7 @@
 /obj/machinery/newscaster/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "jzb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -47784,7 +47642,7 @@
 /turf/open/floor/iron/edge{
 	dir = 4
 	},
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "jXC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/monitored/air_output{
 	dir = 1
@@ -47972,7 +47830,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/structure/chair/stool/directional/east,
+/obj/structure/chair/stool/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing{
 	dir = 1
@@ -48133,7 +47991,7 @@
 /turf/open/floor/iron/checker,
 /area/station/service/kitchen/abandoned)
 "khb" = (
-/obj/machinery/photocopier,
+/obj/machinery/photocopier/prebuilt,
 /obj/effect/turf_decal/tile/green/opposingcorners{
 	dir = 1
 	},
@@ -48459,7 +48317,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "ksU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48498,7 +48356,7 @@
 	dir = 4
 	},
 /obj/structure/closet/emcloset,
-/obj/effect/landmark/start/hangover/closet,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/aft)
 "kux" = (
@@ -48514,7 +48372,7 @@
 /area/station/command/heads_quarters/rd)
 "kvj" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
@@ -48617,15 +48475,15 @@
 /obj/structure/table,
 /obj/item/ai_module/reset,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "kxR" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "kxU" = (
-/obj/machinery/photocopier,
+/obj/machinery/photocopier/prebuilt,
 /obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/carpet/blue,
 /area/station/command/meeting_room/council)
@@ -48692,7 +48550,7 @@
 "kzm" = (
 /obj/structure/cable,
 /turf/closed/wall,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "kAw" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -48884,7 +48742,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
@@ -48927,7 +48785,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "kIg" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -49082,7 +48940,7 @@
 "kMe" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -49306,17 +49164,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
-"kTd" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/bluespace_vendor/directional/west,
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
 "kTf" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/structure/window/reinforced/spawner/directional/east{
@@ -49738,7 +49585,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "liQ" = (
 /turf/open/floor/iron/white/side{
 	dir = 4
@@ -50208,9 +50055,9 @@
 	dir = 8
 	},
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "lxN" = (
-/obj/structure/chair/stool/directional/north,
+/obj/structure/chair/stool/directional/south,
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/station/security/prison/rec)
@@ -50664,7 +50511,7 @@
 	req_access = list("ai_upload")
 	},
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "lLk" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -50718,7 +50565,7 @@
 /area/station/engineering/main)
 "lME" = (
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "lNg" = (
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 1;
@@ -50861,7 +50708,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer1{
 	dir = 10
 	},
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "lRN" = (
 /obj/structure/chair{
@@ -50942,7 +50789,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "lTK" = (
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/light/directional/east,
@@ -51023,7 +50870,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/circuit/green,
-/area/station/ai_monitored/command/nuke_storage)
+/area/station/command/vault)
 "lVC" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -51065,7 +50912,7 @@
 /obj/structure/cable,
 /obj/effect/landmark/start/cyborg,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "lWK" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/carbon_input{
 	dir = 8
@@ -51189,7 +51036,7 @@
 "mbq" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/status_display/evac/directional/south,
@@ -51646,7 +51493,7 @@
 "mqi" = (
 /mob/living/basic/bot/repairbot,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "mqT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -51682,7 +51529,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
@@ -51976,7 +51823,7 @@
 "mAN" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "mAV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -52039,7 +51886,7 @@
 /obj/item/stock_parts/power_store/cell/high,
 /obj/effect/turf_decal/siding/dark/end,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "mDa" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -52243,7 +52090,7 @@
 	network = list("ss13","rd")
 	},
 /obj/structure/cable,
-/obj/machinery/computer/scan_consolenew,
+/obj/machinery/computer/dna_console,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
@@ -52434,7 +52281,7 @@
 "mPs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "mPt" = (
 /obj/structure/sink/kitchen/directional/south,
 /obj/effect/turf_decal/tile/red/opposingcorners,
@@ -52779,7 +52626,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "mYG" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Departures Holding Area"
@@ -52874,7 +52721,7 @@
 /turf/open/floor/iron/checker,
 /area/station/security/interrogation)
 "ndR" = (
-/obj/machinery/photocopier,
+/obj/machinery/photocopier/prebuilt,
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/hop)
 "ndX" = (
@@ -52953,7 +52800,7 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -53374,7 +53221,7 @@
 	},
 /obj/effect/turf_decal/siding/dark,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "ntw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/holopad,
@@ -53567,7 +53414,7 @@
 /area/station/service/janitor)
 "nAT" = (
 /obj/structure/closet/emcloset,
-/obj/effect/landmark/start/hangover/closet,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white/herringbone,
 /area/station/hallway/secondary/entry)
 "nBr" = (
@@ -53762,7 +53609,7 @@
 /turf/open/floor/iron/edge{
 	dir = 4
 	},
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "nGv" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4
@@ -53950,7 +53797,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "nMP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -53973,7 +53820,7 @@
 	c_tag = "EVA Storage - Planning Room"
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "nNx" = (
 /obj/structure/closet/crate/secure/engineering/atmos{
 	name = "atmospherics tool crate";
@@ -53993,7 +53840,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
 	},
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "nPd" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
@@ -54443,13 +54290,13 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "oaw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "oaV" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -54690,7 +54537,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "ohV" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/thinplating_new,
@@ -55650,7 +55497,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer1{
 	dir = 10
 	},
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "oNR" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
@@ -55715,7 +55562,7 @@
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 1
 	},
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "oQU" = (
 /obj/effect/decal/cleanable/dirt,
@@ -55872,7 +55719,7 @@
 /area/station/maintenance/port/fore)
 "oUU" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -55915,7 +55762,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "oWS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -56042,7 +55889,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -56272,7 +56119,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "pfZ" = (
-/obj/structure/chair/stool/directional/east,
+/obj/structure/chair/stool/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/prison/rec)
@@ -56345,7 +56192,7 @@
 "phB" = (
 /obj/machinery/digital_clock/directional/east,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "pib" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -56442,7 +56289,7 @@
 /obj/machinery/status_display/ai/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "pjw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
@@ -56765,7 +56612,7 @@
 "ptf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "pts" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -57161,7 +57008,7 @@
 	},
 /obj/structure/cable,
 /obj/structure/broken_flooring/singular/directional/east,
-/obj/effect/decal/cleanable/robot_debris/down,
+/obj/effect/decal/cleanable/blood/gibs/robot_debris/down,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "pFb" = (
@@ -57176,7 +57023,7 @@
 	},
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "pFU" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/sign/warning/vacuum/external/directional/west,
@@ -57218,7 +57065,7 @@
 	pixel_y = 12
 	},
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "pHl" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 5
@@ -57435,7 +57282,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "pNh" = (
 /obj/structure/table,
 /obj/machinery/firealarm/directional/north,
@@ -57767,7 +57614,7 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/mid_joiner,
 /turf/open/floor/iron/edge,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "pZX" = (
 /obj/structure/railing,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -57793,13 +57640,13 @@
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "qaq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "qas" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -57879,7 +57726,7 @@
 "qcg" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/violet,
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "qcy" = (
 /obj/machinery/door/airlock/public{
@@ -58004,7 +57851,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "qgD" = (
 /obj/structure/cable,
@@ -58079,15 +57926,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
-"qiw" = (
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 4
-	},
-/obj/machinery/bluespace_vendor/directional/east,
-/turf/open/floor/iron/edge{
-	dir = 4
-	},
-/area/station/hallway/primary/central)
 "qix" = (
 /obj/machinery/shower/directional/east,
 /obj/structure/window/reinforced/tinted/spawner/directional/south,
@@ -58282,7 +58120,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "qrE" = (
 /obj/structure/chair/sofa/corner/maroon{
 	dir = 8
@@ -58328,7 +58166,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -58372,7 +58210,7 @@
 "qug" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/purple,
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "quw" = (
 /obj/effect/turf_decal/stripes/line{
@@ -58929,7 +58767,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -59107,7 +58945,7 @@
 /turf/open/floor/iron/kitchen_coldroom,
 /area/station/medical/coldroom)
 "qUQ" = (
-/obj/structure/chair/stool/directional/east,
+/obj/structure/chair/stool/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
@@ -59250,7 +59088,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -59533,7 +59371,7 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/station/service/chapel/funeral)
 "rmY" = (
-/obj/structure/chair/stool/bar/directional/east,
+/obj/structure/chair/stool/bar/directional/west,
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
@@ -59696,7 +59534,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "rtM" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light/directional/north,
@@ -59731,7 +59569,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "rum" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/wood/large,
@@ -59784,7 +59622,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "rvI" = (
 /obj/effect/turf_decal/tile/neutral/half{
 	dir = 1
@@ -60280,7 +60118,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 4
 	},
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "rNg" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -60348,7 +60186,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "rPX" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
@@ -60481,7 +60319,7 @@
 	},
 /obj/item/paper_bin/carbon,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "rUp" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
@@ -60772,7 +60610,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/mid_joiner,
 /turf/open/floor/iron/edge,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "sdc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -60801,7 +60639,7 @@
 /turf/open/floor/iron/white/small,
 /area/station/service/hydroponics)
 "seC" = (
-/obj/structure/chair/stool/bar/directional/east,
+/obj/structure/chair/stool/bar/directional/west,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
@@ -61124,7 +60962,7 @@
 /turf/open/floor/iron/edge{
 	dir = 4
 	},
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "sqq" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/white,
@@ -61344,7 +61182,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "svW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -61447,7 +61285,7 @@
 /turf/open/floor/plating,
 /area/station/science/ordnance/testlab)
 "syg" = (
-/obj/structure/chair/stool/directional/north,
+/obj/structure/chair/stool/directional/south,
 /obj/machinery/light/directional/east,
 /obj/effect/landmark/start/prisoner,
 /obj/effect/decal/cleanable/dirt,
@@ -61562,7 +61400,7 @@
 "sCe" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/circuit/green,
-/area/station/ai_monitored/command/nuke_storage)
+/area/station/command/vault)
 "sCr" = (
 /obj/machinery/button/flasher{
 	id = "execution_flash";
@@ -61677,7 +61515,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "sFZ" = (
 /obj/machinery/duct,
 /obj/effect/turf_decal/tile/neutral/half{
@@ -61747,7 +61585,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
@@ -61869,7 +61707,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai_upload_foyer)
+/area/station/ai/upload/foyer)
 "sMp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -61929,7 +61767,7 @@
 /obj/effect/turf_decal/siding/dark,
 /obj/effect/mapping_helpers/airlock/red_alert_access,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "sOs" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2{
 	dir = 8;
@@ -61970,7 +61808,7 @@
 	req_access = list("ai_upload")
 	},
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "sOX" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -61990,7 +61828,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "sPO" = (
-/obj/structure/chair/stool/bar/directional/east,
+/obj/structure/chair/stool/bar/directional/west,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
@@ -62013,20 +61851,20 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/white/line{
 	color = "#ff8300"
 	},
 /obj/effect/turf_decal/stripes/white/corner{
-	dir = 1;
+	dir = 8;
 	color = "#ff8300"
 	},
 /obj/effect/turf_decal/stripes/white/corner{
-	dir = 4;
+	dir = 1;
 	color = "#ff8300"
 	},
 /turf/open/floor/iron,
@@ -62125,7 +61963,7 @@
 /area/station/engineering/storage_shared)
 "sVk" = (
 /obj/structure/closet/lasertag/red,
-/obj/effect/landmark/start/hangover/closet,
+/obj/effect/landmark/start/hangover,
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness)
@@ -62627,10 +62465,10 @@
 	network = list("ss13","prison")
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/white/corner{
-	dir = 4;
+	dir = 1;
 	color = "#ff8300"
 	},
 /turf/open/floor/iron,
@@ -62954,7 +62792,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 10
 	},
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "tqY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -63031,7 +62869,7 @@
 "tsq" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/fuchsia,
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "tsw" = (
 /obj/structure/table,
@@ -63063,7 +62901,7 @@
 /area/station/maintenance/starboard/aft)
 "tsX" = (
 /turf/closed/wall,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "ttc" = (
 /obj/structure/table,
 /obj/item/raw_anomaly_core/random{
@@ -63277,7 +63115,7 @@
 /turf/closed/wall/r_wall,
 /area/station/science/robotics/mechbay)
 "txG" = (
-/obj/structure/chair/stool/directional/north,
+/obj/structure/chair/stool/directional/south,
 /turf/open/floor/eighties/red,
 /area/station/hallway/secondary/exit/departure_lounge)
 "txS" = (
@@ -63331,10 +63169,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/white/corner{
-	dir = 4;
+	dir = 1;
 	color = "#D381C9"
 	},
 /obj/structure/sign/poster/official/random/directional/south,
@@ -63479,7 +63317,7 @@
 /obj/machinery/light/directional/north,
 /obj/effect/landmark/start/cyborg,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "tHL" = (
 /obj/structure/reagent_dispensers/plumbed{
 	name = "service reservoir"
@@ -63514,7 +63352,7 @@
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "tIL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -63533,7 +63371,7 @@
 "tJT" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/bronze,
-/turf/open/space,
+/turf/open/space/basic,
 /area/station/solars/port/aft)
 "tKe" = (
 /obj/structure/table,
@@ -63883,7 +63721,7 @@
 	dir = 8
 	},
 /obj/structure/closet/emcloset,
-/obj/effect/landmark/start/hangover/closet,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/exit/departure_lounge)
 "tWh" = (
@@ -63937,7 +63775,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
@@ -63948,11 +63786,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/security/prison)
-"tXH" = (
-/obj/effect/landmark/start/assistant,
-/obj/structure/chair/stool/directional/east,
-/turf/open/floor/iron,
-/area/station/commons/locker)
 "tXL" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/disposal/incinerator)
@@ -64075,7 +63908,7 @@
 "uaL" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/bronze,
-/turf/open/space,
+/turf/open/space/basic,
 /area/station/solars/starboard/aft)
 "uaM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
@@ -64140,7 +63973,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "ucR" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -64161,7 +63994,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "udK" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -64213,7 +64046,7 @@
 "ugk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "ugl" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -64282,10 +64115,10 @@
 /area/station/security/detectives_office)
 "uiV" = (
 /turf/closed/wall/r_wall,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "ujh" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /obj/structure/closet/secure_closet/cytology,
 /turf/open/floor/iron/dark,
@@ -64332,7 +64165,7 @@
 "ulc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "ulf" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchenhydro";
@@ -64438,7 +64271,7 @@
 /obj/effect/turf_decal/siding/dark,
 /obj/effect/mapping_helpers/airlock/red_alert_access,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "uob" = (
 /obj/structure/cable,
 /obj/machinery/duct,
@@ -64951,7 +64784,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
@@ -64980,20 +64813,20 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/white/line{
 	color = "#ff8300"
 	},
 /obj/effect/turf_decal/stripes/white/corner{
-	dir = 1;
+	dir = 8;
 	color = "#ff8300"
 	},
 /obj/effect/turf_decal/stripes/white/corner{
-	dir = 4;
+	dir = 1;
 	color = "#ff8300"
 	},
 /turf/open/floor/iron,
@@ -65287,7 +65120,7 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "uTR" = (
-/obj/structure/chair/stool/bar/directional/east,
+/obj/structure/chair/stool/bar/directional/west,
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
@@ -65339,7 +65172,7 @@
 "uVs" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/cerulean,
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "uVt" = (
 /turf/closed/wall/r_wall,
@@ -65560,7 +65393,7 @@
 	color = "#52B4E9"
 	},
 /turf/open/floor/iron/dark/textured_half,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "vbJ" = (
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
@@ -65667,7 +65500,7 @@
 /turf/open/floor/iron/checker,
 /area/station/service/kitchen/abandoned)
 "vep" = (
-/obj/structure/chair/stool/directional/east,
+/obj/structure/chair/stool/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
@@ -65733,7 +65566,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "vgZ" = (
 /obj/structure/table/reinforced/rglass,
 /obj/machinery/firealarm/directional/north,
@@ -65927,14 +65760,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "vmR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
@@ -66028,7 +65861,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/mid_joiner,
 /turf/open/floor/iron/edge,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "vpT" = (
 /obj/structure/bookcase/random/reference,
 /obj/structure/cable,
@@ -66139,7 +65972,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "vtw" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -66422,7 +66255,7 @@
 "vBU" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/bronze,
-/turf/open/space,
+/turf/open/space/basic,
 /area/station/solars/port/fore)
 "vCb" = (
 /obj/machinery/rnd/production/techfab/department/service,
@@ -66542,7 +66375,7 @@
 /obj/structure/sign/flag/nanotrasen/directional/north,
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "vGB" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -66553,7 +66386,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "vGL" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 1
@@ -66909,7 +66742,7 @@
 "vRu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/circuit/green,
-/area/station/ai_monitored/command/nuke_storage)
+/area/station/command/vault)
 "vRw" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/duct,
@@ -67567,7 +67400,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
 	dir = 8
 	},
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "wot" = (
 /obj/effect/decal/cleanable/dirt,
@@ -67723,7 +67556,7 @@
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "wrQ" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -68050,7 +67883,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "wDV" = (
 /obj/effect/turf_decal/siding/blue/corner,
 /obj/effect/turf_decal/tile/neutral{
@@ -68074,7 +67907,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "wEY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -68237,7 +68070,7 @@
 	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
@@ -68404,14 +68237,14 @@
 /obj/effect/turf_decal/siding/dark_red,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/smooth_large,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "wPX" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -68524,10 +68357,10 @@
 	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/white/corner{
-	dir = 8;
+	dir = 4;
 	color = "#52B4E9"
 	},
 /obj/effect/turf_decal/stripes/white/corner{
@@ -68554,7 +68387,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "wTy" = (
-/obj/structure/altar_of_gods,
+/obj/structure/altar/of_gods,
 /obj/item/book/bible,
 /obj/structure/railing,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -68618,14 +68451,14 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "wWb" = (
-/obj/structure/chair/stool/directional/north,
+/obj/structure/chair/stool/directional/south,
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "wWk" = (
 /obj/effect/turf_decal/siding/purple,
 /obj/effect/turf_decal/tile/purple/half,
-/obj/structure/chair/stool/directional/north,
+/obj/structure/chair/stool/directional/south,
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/science/lab)
@@ -68865,7 +68698,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "xcK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -69152,7 +68985,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue/full,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -69201,7 +69034,7 @@
 /turf/open/floor/iron/edge{
 	dir = 1
 	},
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "xmh" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/structure/cable,
@@ -69221,7 +69054,7 @@
 	dir = 9
 	},
 /obj/structure/lattice,
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "xny" = (
 /obj/machinery/light/directional/north,
@@ -69263,7 +69096,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/hangover,
@@ -69304,7 +69137,7 @@
 "xqr" = (
 /obj/machinery/porta_turret/ai,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "xqs" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -69589,7 +69422,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "xAm" = (
-/obj/machinery/photocopier,
+/obj/machinery/photocopier/prebuilt,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
@@ -69779,13 +69612,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/station/service/chapel)
-"xGF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/bluespace_vendor/directional/east,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/dock)
 "xHo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -69807,7 +69633,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "xHZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -69878,7 +69704,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
 "xJH" = (
-/obj/structure/chair/stool/bar/directional/east,
+/obj/structure/chair/stool/bar/directional/west,
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
@@ -70122,7 +69948,7 @@
 /area/station/hallway/primary/central)
 "xXe" = (
 /obj/machinery/airalarm/directional/east,
-/obj/machinery/computer/scan_consolenew{
+/obj/machinery/computer/dna_console{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -70138,7 +69964,7 @@
 "xXI" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "xXU" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -70340,7 +70166,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "yff" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -77342,7 +77168,7 @@ aaa
 aaa
 aaa
 aaa
-aae
+aaw
 aaa
 aaa
 aaa
@@ -77868,7 +77694,7 @@ aaa
 aaa
 aaa
 aaa
-aae
+aaw
 aaa
 aaa
 aaa
@@ -78094,15 +77920,15 @@ aaa
 aaa
 aaa
 aaa
-aae
-aaf
+aaw
+gXs
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aae
+aaw
 aaa
 aaa
 aaa
@@ -78352,7 +78178,7 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 mRb
 aaa
 aaa
@@ -78609,7 +78435,7 @@ aaa
 aaa
 gXs
 gXs
-aaf
+gXs
 gXs
 aaa
 aaa
@@ -78634,7 +78460,7 @@ aaa
 aaa
 aaa
 aaa
-aoV
+aaa
 aaa
 aaa
 aaa
@@ -78861,12 +78687,12 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 gXs
 aaa
-aaf
+gXs
 aaa
 aaa
 cqq
@@ -78891,12 +78717,12 @@ aaa
 aaa
 aaa
 aaa
-aoV
+aaa
 aaa
 wCV
 aaa
 aaa
-aoV
+aaa
 aaa
 aaa
 aaa
@@ -79117,13 +78943,13 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
+gXs
+gXs
 aaa
-aaf
+gXs
 arB
 wyu
 aYH
@@ -79153,7 +78979,7 @@ asE
 xzN
 asE
 asE
-aoV
+aaa
 aaa
 aaa
 aaa
@@ -79405,12 +79231,12 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 bnX
 wIT
 bnX
-aaf
-aaf
+gXs
+gXs
 aaa
 aaa
 aaa
@@ -79667,7 +79493,7 @@ aEs
 sHE
 asE
 bIR
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -79884,7 +79710,7 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 apJ
 apN
 apN
@@ -80141,7 +79967,7 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 apJ
 apN
 apN
@@ -80398,7 +80224,7 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 apJ
 apN
 apN
@@ -81426,7 +81252,7 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 apJ
 apN
 apN
@@ -82199,7 +82025,7 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 apJ
 asH
 arE
@@ -82494,7 +82320,7 @@ brS
 bbb
 cZg
 bnX
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -82751,7 +82577,7 @@ aKo
 bbb
 beN
 aEs
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -83008,8 +82834,8 @@ leQ
 bbb
 wXa
 bIR
-aaf
-aoV
+gXs
+aaa
 aaa
 aaa
 aaa
@@ -83228,10 +83054,10 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
+gXs
 arP
 atJ
 jYJ
@@ -83256,7 +83082,7 @@ aPy
 kBz
 aTr
 aUM
-xGF
+wLT
 wLT
 fpq
 baG
@@ -83482,11 +83308,11 @@ aaa
 aaa
 aaa
 aaa
-aae
+aaw
 aaa
 aaa
 aaa
-aag
+nXv
 arP
 arP
 arP
@@ -83743,7 +83569,7 @@ aaa
 aaa
 aaa
 aaa
-aag
+nXv
 aqJ
 arK
 gLH
@@ -83831,7 +83657,7 @@ aaa
 aaa
 aaa
 aaa
-aae
+aaw
 aaa
 aaa
 aaa
@@ -84056,7 +83882,7 @@ aaa
 aaa
 aaa
 aaa
-aae
+aaw
 aaa
 aaa
 aaa
@@ -84512,7 +84338,7 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 arP
 arP
 apM
@@ -84594,7 +84420,7 @@ aaa
 aaa
 aaS
 aaa
-aaf
+gXs
 aaa
 aaS
 aaa
@@ -84761,12 +84587,12 @@ aaS
 aaS
 aaS
 aaS
-aba
+bhT
 aaS
 aaS
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
 aaa
 aaa
 aaa
@@ -84850,9 +84676,9 @@ aaa
 aaa
 aaa
 aaS
-aaf
+gXs
 chJ
-aaf
+gXs
 aaS
 aaa
 aaa
@@ -85008,15 +84834,15 @@ aaa
 aaa
 abY
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
 acy
 aaa
-aaf
+gXs
 aaa
 aiS
 aaa
@@ -85105,16 +84931,16 @@ aaS
 aaS
 aaS
 aaS
-aaf
-aaf
+gXs
+gXs
 aaa
-ccX
+cjH
 aaa
-aaf
-aaf
+gXs
+gXs
 aaS
 aaS
-aba
+bhT
 aaS
 aaS
 aaa
@@ -85278,9 +85104,9 @@ adu
 acV
 aaa
 aaS
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
 aaa
 aaa
 aaa
@@ -85350,7 +85176,7 @@ aaa
 aaa
 aaa
 aaa
-aae
+aaw
 aaa
 aaa
 aaa
@@ -85360,17 +85186,17 @@ aaa
 aaS
 aaa
 aaa
-aaf
+gXs
 aaa
-aaf
-aaa
-aaa
-ccX
+gXs
 aaa
 aaa
-aaf
+cjH
 aaa
-aaf
+aaa
+gXs
+aaa
+gXs
 aaa
 aaa
 aaS
@@ -85517,11 +85343,11 @@ aaa
 aaa
 aaa
 aaa
-aae
+aaw
 aaa
 aaa
 abY
-aaf
+gXs
 acV
 adu
 acV
@@ -85533,8 +85359,8 @@ aaa
 acV
 adu
 acV
-aaf
-aaf
+gXs
+gXs
 aaa
 aaa
 aaa
@@ -85615,7 +85441,7 @@ aaa
 aaa
 aaa
 aaS
-aaf
+gXs
 cca
 cca
 cca
@@ -85629,7 +85455,7 @@ cca
 cca
 cca
 cca
-aaf
+gXs
 aaS
 aaa
 aaa
@@ -85782,23 +85608,23 @@ aaa
 acV
 adu
 acV
-aaf
+gXs
 acV
 adu
 acV
-aaf
+gXs
 acV
 adu
 acV
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aqQ
 cyi
@@ -85873,14 +85699,14 @@ aaa
 aaa
 aaS
 aaa
-ccX
-ccX
-ccX
-ccX
-ccX
-ccX
+cjH
+cjH
+cjH
+cjH
+cjH
+cjH
 tJT
-ccX
+cjH
 cjH
 cjH
 cjH
@@ -85893,7 +85719,7 @@ aaa
 aaa
 aaa
 aaa
-aae
+aaw
 aaa
 aaa
 aaa
@@ -86034,8 +85860,8 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
+gXs
+gXs
 acV
 adu
 acV
@@ -86047,15 +85873,15 @@ aaa
 acV
 adu
 acV
-aaf
-aaf
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
+gXs
+gXs
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aqQ
 fbR
@@ -86127,9 +85953,9 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaS
-aaf
+gXs
 cca
 cca
 cca
@@ -86143,7 +85969,7 @@ cca
 cca
 cca
 cca
-aaf
+gXs
 aaS
 aaa
 aaa
@@ -86291,7 +86117,7 @@ aaa
 aaS
 aaS
 aaS
-aaf
+gXs
 aaa
 acV
 adu
@@ -86305,7 +86131,7 @@ acV
 adu
 acV
 aaa
-aaf
+gXs
 aaa
 ajV
 anH
@@ -86377,19 +86203,19 @@ aaa
 aaa
 aaa
 aaa
-aag
+nXv
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaS
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -86397,11 +86223,11 @@ chL
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
-aba
+bhT
 aaa
 aaa
 aaa
@@ -86547,7 +86373,7 @@ aaa
 aaa
 aaS
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -86634,16 +86460,16 @@ aaa
 aaa
 aaa
 aaa
-aag
+nXv
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaS
-aaf
+gXs
 cca
 cca
 cca
@@ -86657,7 +86483,7 @@ cca
 cca
 cca
 cca
-aaf
+gXs
 aaS
 aaa
 aaa
@@ -86803,10 +86629,10 @@ aaa
 aaa
 aaa
 aaS
-aaf
+gXs
 abs
-abZ
-abZ
+adu
+adu
 ady
 vBU
 ady
@@ -86818,7 +86644,7 @@ ady
 ady
 vBU
 ady
-abZ
+adu
 ajW
 kWJ
 alh
@@ -86891,24 +86717,24 @@ aaa
 aaa
 aaa
 aaa
-aag
+nXv
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaS
 aaa
-ccX
-ccX
-ccX
-ccX
-ccX
-ccX
+cjH
+cjH
+cjH
+cjH
+cjH
+cjH
 tJT
-ccX
+cjH
 cjH
 cjH
 cjH
@@ -87061,19 +86887,19 @@ aaa
 aaa
 aaS
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
-abZ
+adu
 aaa
 aaa
 aaa
-abZ
+adu
 aaa
 aaa
 aaa
-abZ
+adu
 aaa
 aaa
 ajV
@@ -87148,14 +86974,14 @@ aaa
 aaa
 aaa
 aaa
-aag
+nXv
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaS
 acy
 cca
@@ -87171,7 +86997,7 @@ cca
 cca
 cca
 cca
-aaf
+gXs
 aaS
 aaa
 aaa
@@ -87317,23 +87143,23 @@ aaa
 aaa
 aaa
 aaS
-aba
+bhT
 aaS
-aaf
+gXs
 aaa
 acV
-abZ
-acV
-aaa
-acV
-abZ
+adu
 acV
 aaa
 acV
-abZ
+adu
 acV
 aaa
-aaf
+acV
+adu
+acV
+aaa
+gXs
 aaa
 ajV
 anH
@@ -87405,19 +87231,19 @@ aaa
 aaa
 aaa
 aaa
-aag
+nXv
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aaf
-aba
+gXs
+bhT
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -87425,7 +87251,7 @@ chL
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -87576,21 +87402,21 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
+gXs
+gXs
 acV
-abZ
-acV
-aaa
-acV
-abZ
+adu
 acV
 aaa
 acV
-abZ
+adu
 acV
-aaf
-aaf
+aaa
+acV
+adu
+acV
+gXs
+gXs
 aaa
 aaa
 arP
@@ -87662,16 +87488,16 @@ aaa
 aaa
 aaa
 aaa
-aag
+nXv
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaS
-aaf
+gXs
 cca
 cca
 cca
@@ -87685,7 +87511,7 @@ cca
 cca
 cca
 cca
-aaf
+gXs
 aaS
 aaa
 aaa
@@ -87836,20 +87662,20 @@ aaa
 aaS
 aaa
 acV
-abZ
+adu
 acV
-aaf
+gXs
 acV
-abZ
+adu
 acV
-aaf
+gXs
 acV
-abZ
+adu
 acV
 aaa
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
 arP
 lpo
 ycZ
@@ -87919,24 +87745,24 @@ aaa
 aaa
 aaa
 aaa
-aag
+nXv
 aaa
-aoV
+aaa
 bZm
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
 aaa
 aaS
 aaa
-ccX
-ccX
-ccX
-ccX
-ccX
-ccX
+cjH
+cjH
+cjH
+cjH
+cjH
+cjH
 tJT
-ccX
+cjH
 cjH
 cjH
 cjH
@@ -88091,20 +87917,20 @@ aaa
 aaa
 aaa
 aaS
-aaf
+gXs
 acV
-abZ
-acV
-aaa
-acV
-abZ
+adu
 acV
 aaa
 acV
-abZ
+adu
 acV
-aaf
-aaf
+aaa
+acV
+adu
+acV
+gXs
+gXs
 aaa
 aaa
 arP
@@ -88112,7 +87938,7 @@ aoU
 hDA
 ycZ
 arP
-aoV
+aaa
 pbu
 pXv
 jvn
@@ -88137,8 +87963,8 @@ lde
 aPA
 aQP
 lkQ
-tXH
-aTB
+aTx
+obu
 aWo
 aXQ
 aXQ
@@ -88176,16 +88002,16 @@ aaa
 aaa
 aaa
 aaa
-aag
+nXv
 aaa
-aoV
+aaa
 bVz
-aaf
-aaf
-aoV
+gXs
+gXs
+aaa
 aaa
 aaS
-aaf
+gXs
 cca
 cca
 cca
@@ -88199,7 +88025,7 @@ cca
 cca
 cca
 cca
-aaf
+gXs
 aaS
 aaa
 aaa
@@ -88350,15 +88176,15 @@ aaa
 aaS
 aaa
 acV
-abZ
+adu
 acV
 aaa
 acV
-abZ
+adu
 acV
 aaa
 acV
-abZ
+adu
 acV
 aaa
 aaS
@@ -88369,7 +88195,7 @@ amD
 mUh
 xwm
 aqQ
-aoV
+aaa
 xOj
 dtO
 uyC
@@ -88433,28 +88259,28 @@ aaa
 aaa
 aaa
 aaa
-aag
+nXv
 aaa
-aag
+nXv
 bVz
-aag
-aag
-aoV
+nXv
+nXv
+aaa
 aaa
 aaS
 aaa
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
 aaa
 chL
 aaa
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
 aaa
 aaS
@@ -88606,27 +88432,27 @@ aaa
 aaa
 aaS
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
 aaS
-aaf
-aaf
+gXs
+gXs
 arP
 cCa
 daG
 omZ
 aqQ
-aaf
+gXs
 xOj
 dtO
 nWb
@@ -88690,28 +88516,28 @@ aaa
 aaa
 aaa
 aaa
-aag
+nXv
 aaa
-aaf
+gXs
 bVz
-aoV
-aag
-aoV
+aaa
+nXv
+aaa
 aaa
 aaS
 aaS
 aaS
-aaf
-aaf
-aaf
-aaf
-aaf
-ccX
-aaf
-aaf
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
+gXs
+gXs
+cjH
+gXs
+gXs
+gXs
+gXs
+gXs
 aaS
 aaS
 aaS
@@ -88866,7 +88692,7 @@ aaS
 aaS
 aaS
 aaS
-aba
+bhT
 aaS
 aaS
 aaS
@@ -88883,7 +88709,7 @@ nor
 coK
 mXM
 arP
-aoV
+aaa
 xOj
 sbo
 suI
@@ -88947,19 +88773,19 @@ aaa
 aaa
 aaa
 aaa
-aag
+nXv
 aaa
-aaf
+gXs
 bVz
-aaf
-aag
-aoV
+gXs
+nXv
 aaa
 aaa
-aaf
+aaa
+gXs
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 cfx
@@ -89140,7 +88966,7 @@ kmm
 kqw
 wye
 arP
-aoV
+aaa
 pbu
 tzc
 gwy
@@ -89199,24 +89025,24 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
 aaa
 aaa
-aag
+nXv
 aaa
 bVx
 azY
-aoV
-aag
-aaf
+aaa
+nXv
+gXs
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 cfx
@@ -89397,7 +89223,7 @@ amF
 xwv
 shR
 arP
-aaf
+gXs
 pbu
 mBT
 suI
@@ -89465,10 +89291,10 @@ bLv
 amJ
 amJ
 cbj
-aoV
-aag
-aaf
-aaf
+aaa
+nXv
+gXs
+gXs
 cAi
 cAi
 cAi
@@ -89654,7 +89480,7 @@ arP
 arP
 aQB
 arP
-aaf
+gXs
 pbu
 iyN
 arO
@@ -89725,7 +89551,7 @@ cbj
 bLv
 bXv
 bLv
-aaf
+gXs
 cAi
 cAy
 cAB
@@ -89982,7 +89808,7 @@ cbk
 bLv
 bWz
 bLv
-aaf
+gXs
 cAi
 cAA
 hxd
@@ -90169,8 +89995,8 @@ arP
 paM
 arP
 aaH
-aaf
-aaf
+gXs
+gXs
 aaH
 pbu
 xOj
@@ -90409,7 +90235,7 @@ aaa
 aaa
 aaa
 aaa
-aoV
+aaa
 aaa
 aaa
 gXs
@@ -90426,21 +90252,21 @@ aqQ
 wXE
 aqQ
 avb
-aaf
+gXs
 aaH
-aaf
-aoV
-aoV
-aaf
+gXs
+aaa
+aaa
+gXs
 aqQ
 vYM
 ayB
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
 aaa
 aJd
@@ -90477,7 +90303,7 @@ bxu
 bxu
 bxu
 bxu
-bDi
+pcS
 aaa
 aaa
 aaa
@@ -90678,28 +90504,28 @@ gXs
 gXs
 atR
 gXs
-aaf
+gXs
 aqQ
 wXE
 aqQ
 avb
 aaH
-aaf
-aoV
-aoV
-aoV
-aoV
+gXs
+aaa
+aaa
+aaa
+aaa
 aqQ
 eVz
 ayB
-aaf
+gXs
 aHF
 aHF
 aHF
 aHF
 aHF
 aHF
-aaf
+gXs
 aJd
 aLN
 bDe
@@ -90942,10 +90768,10 @@ arP
 arP
 arP
 aaH
-aaf
-aoV
-aaf
-aaf
+gXs
+aaa
+gXs
+gXs
 aqQ
 eVz
 ayB
@@ -91206,7 +91032,7 @@ aqQ
 arP
 eVz
 ayB
-aaf
+gXs
 aHF
 aBS
 sCe
@@ -91255,8 +91081,8 @@ bGi
 bJb
 bGi
 bGi
-aoV
-aoV
+aaa
+aaa
 amJ
 dHE
 cFx
@@ -91282,7 +91108,7 @@ kOP
 amJ
 amJ
 amJ
-aag
+nXv
 aaa
 aaa
 aaa
@@ -91505,15 +91331,15 @@ byC
 bzT
 byl
 bxx
-aaf
-aaf
+gXs
+gXs
 bGi
 bHz
 vzb
 bKk
 bGi
-aoV
-aoV
+aaa
+aaa
 amJ
 alg
 alN
@@ -91539,12 +91365,12 @@ soA
 cqH
 dCG
 lWA
-aag
+nXv
 aaa
 aaa
 eRz
 eRz
-aaT
+eRz
 eRz
 eRz
 eRz
@@ -91720,7 +91546,7 @@ aqQ
 arP
 eVz
 ayB
-aaf
+gXs
 aHF
 aBU
 lVB
@@ -91769,8 +91595,8 @@ bHy
 vzb
 bKj
 bGi
-aoV
-aoV
+aaa
+aaa
 amJ
 uGR
 onN
@@ -91796,7 +91622,7 @@ amJ
 amJ
 amJ
 amJ
-aag
+nXv
 aaa
 aaa
 gXs
@@ -91973,7 +91799,7 @@ aaa
 aaa
 aaa
 aaa
-aag
+nXv
 aqQ
 nQz
 ayB
@@ -92026,8 +91852,8 @@ bxy
 bJd
 bKm
 bxy
-aaf
-aaf
+gXs
+gXs
 amJ
 als
 cOw
@@ -92230,18 +92056,18 @@ aaa
 aaa
 aaa
 aaa
-aag
+nXv
 aqQ
 eVz
 ayB
-aaf
+gXs
 aHF
 aHF
 aHF
 aHF
 aHF
 aHF
-aaf
+gXs
 aJd
 mHc
 skg
@@ -92296,12 +92122,12 @@ boO
 oda
 boO
 bLv
-aaf
-aoV
-aoV
-aoV
-aoV
-aoV
+gXs
+aaa
+aaa
+aaa
+aaa
+aaa
 bLv
 qlI
 amJ
@@ -92320,7 +92146,7 @@ ccw
 aaa
 aaa
 aaa
-aaT
+eRz
 aaa
 aaa
 aaa
@@ -92487,16 +92313,16 @@ aaa
 aaa
 aaa
 aaa
-aag
+nXv
 aqQ
 qwZ
 ayB
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
 aaa
 aJd
@@ -92540,8 +92366,8 @@ mAL
 vKS
 nBr
 bGi
-aaf
-aaf
+gXs
+gXs
 bLv
 soA
 soA
@@ -92553,12 +92379,12 @@ bLv
 bLv
 bLv
 bLv
-aoV
-aoV
-aoV
-aoV
-aoV
-aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+gXs
 bLv
 eFF
 amJ
@@ -92742,7 +92568,7 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 arP
 avd
 arP
@@ -92797,8 +92623,8 @@ bEQ
 vKS
 jnH
 bGi
-aoV
-aoV
+aaa
+aaa
 bLv
 bPZ
 sEv
@@ -92806,16 +92632,16 @@ soA
 cTF
 ijL
 bLv
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 bLv
 qlI
 amJ
@@ -92999,7 +92825,7 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 arP
 ave
 arP
@@ -93054,8 +92880,8 @@ yeg
 eqq
 pXX
 bGi
-aaf
-aaf
+gXs
+gXs
 bLv
 lDX
 soA
@@ -93063,16 +92889,16 @@ pVs
 amJ
 boO
 bLv
-aoV
-aoV
-aoV
-aaf
-aaf
+aaa
+aaa
+aaa
+gXs
+gXs
 aaH
 aaH
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
 bLv
 rcg
 amJ
@@ -93320,16 +93146,16 @@ hEa
 amJ
 goS
 bLv
-aaf
-aaf
-aoV
-aoV
+gXs
+gXs
+aaa
+aaa
 aaH
 aaH
 aaH
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
 bLv
 eFF
 amJ
@@ -93568,8 +93394,8 @@ scp
 esV
 bGn
 bxy
-aaf
-aaf
+gXs
+gXs
 amJ
 bOK
 amJ
@@ -93577,16 +93403,16 @@ amJ
 amJ
 boO
 bLv
-aoV
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
+aaa
 cjn
 bSu
 aaH
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
 bLv
 eFF
 amJ
@@ -93834,16 +93660,16 @@ aaa
 bLv
 boO
 bLv
-aoV
-aoV
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
+aaa
+aaa
 aaH
-aaf
-aoV
-aoV
-aoV
+gXs
+aaa
+aaa
+aaa
 bLv
 kyE
 amJ
@@ -93872,8 +93698,8 @@ aaa
 aaa
 aaa
 aaa
-aaT
-aaT
+eRz
+eRz
 aaa
 aaa
 aaa
@@ -94014,8 +93840,8 @@ gXs
 gXs
 gXs
 gXs
-aaT
-aaf
+eRz
+gXs
 aiU
 alp
 aiU
@@ -94023,9 +93849,9 @@ aaa
 aiU
 alp
 aiU
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
 arP
 arP
 arP
@@ -94087,20 +93913,20 @@ soA
 soA
 soA
 bLv
-aaf
+gXs
 bLv
 oda
 bLv
-aaf
-aaf
-aoV
-aoV
-aoV
+gXs
+gXs
+aaa
+aaa
+aaa
 aaH
-aoV
-aoV
-aaf
-aaf
+aaa
+aaa
+gXs
+gXs
 amJ
 rcg
 amJ
@@ -94118,20 +93944,20 @@ crl
 ccw
 gXs
 gXs
-aaT
-aaT
-aaT
-aaT
-aaT
-aaT
-aaT
-aaT
-aaT
+eRz
+eRz
+eRz
+eRz
+eRz
+eRz
+eRz
+eRz
+eRz
 aaa
-aaf
+gXs
 ctv
-aaT
-aaT
+eRz
+eRz
 aaa
 aaa
 aaa
@@ -94348,16 +94174,16 @@ aaa
 bLv
 boO
 bLv
-aoV
-aoV
-aoV
-aoV
-aoV
-aaf
-aoV
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
+aaa
+aaa
+gXs
+aaa
+aaa
+aaa
+aaa
 amJ
 gav
 amJ
@@ -94375,7 +94201,7 @@ crm
 ccw
 aaa
 aaa
-aaT
+eRz
 ctv
 ctv
 ctv
@@ -94383,12 +94209,12 @@ ctv
 ctv
 ctv
 ctv
-aaT
+eRz
 aaa
-aaf
+gXs
 ctv
 ctv
-aaT
+eRz
 aaa
 aaa
 aaa
@@ -94596,7 +94422,7 @@ xmy
 bJf
 amJ
 aaa
-aaf
+gXs
 bLv
 soA
 bLv
@@ -94632,19 +94458,19 @@ crl
 ccw
 gXs
 gXs
-aaT
-aaT
-aaT
-aaT
-aaT
-aaT
-aaT
-aaT
-aaT
-aaf
-ghr
-aaf
-aaf
+eRz
+eRz
+eRz
+eRz
+eRz
+eRz
+eRz
+eRz
+eRz
+gXs
+mws
+gXs
+gXs
 aaa
 aaa
 aaa
@@ -94889,17 +94715,17 @@ ccw
 ccw
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -95084,7 +94910,7 @@ eRT
 eRT
 xWG
 eRT
-dAB
+aYF
 dMb
 bkS
 weY
@@ -95146,19 +94972,19 @@ jnk
 crp
 crp
 aaa
-aaf
+gXs
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
-aaT
-aaT
-aaT
+eRz
+eRz
+eRz
 aaa
 aaa
 aaa
@@ -95413,9 +95239,9 @@ csx
 cEE
 aaa
 aaa
-aaT
+eRz
 ctv
-aaT
+eRz
 aaa
 aaa
 aaa
@@ -95618,13 +95444,13 @@ pID
 aIK
 aJw
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -95668,11 +95494,11 @@ csx
 csx
 css
 csb
-aaf
-aaf
-aaT
+gXs
+gXs
+eRz
 ctv
-aaT
+eRz
 aaa
 aaa
 aaa
@@ -95881,11 +95707,11 @@ bEU
 bEU
 bEU
 aaa
-aaf
+gXs
 aaa
 aaa
-aaf
-aaf
+gXs
+gXs
 amJ
 oaV
 wTu
@@ -95927,9 +95753,9 @@ css
 cEE
 aaa
 aaa
-aaT
+eRz
 ctv
-aaT
+eRz
 aaa
 aaa
 aaa
@@ -96131,14 +95957,14 @@ kcr
 kBy
 aIK
 aJw
-aaf
+gXs
 bEU
 bGt
 bHG
 qlr
 bEU
-aaf
-aaf
+gXs
+gXs
 aaa
 aaa
 bLv
@@ -96182,11 +96008,11 @@ csx
 csx
 css
 csb
-aaf
-aaf
-aaT
+gXs
+gXs
+eRz
 ctv
-aaT
+eRz
 aaa
 aaa
 aaa
@@ -96395,9 +96221,9 @@ cBC
 bJg
 bEU
 aaa
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
 bLv
 cNH
 teJ
@@ -96441,9 +96267,9 @@ css
 cEE
 aaa
 aaa
-aaT
+eRz
 ctv
-aaT
+eRz
 aaa
 aaa
 aaa
@@ -96696,11 +96522,11 @@ csx
 csx
 css
 csb
-aaf
-aaf
-aaT
+gXs
+gXs
+eRz
 ctv
-aaT
+eRz
 aaa
 aaa
 aaa
@@ -96955,12 +96781,12 @@ css
 cEE
 aaa
 aaa
-aaT
+eRz
 ctv
-aaT
+eRz
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -97210,15 +97036,15 @@ csx
 ayQ
 css
 csb
-aaf
-aaf
-aaT
-aaT
-aaT
 gXs
-aaf
-aaf
-aaf
+gXs
+eRz
+eRz
+eRz
+gXs
+gXs
+gXs
+gXs
 aaa
 aaa
 aaa
@@ -97469,12 +97295,12 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -97731,7 +97557,7 @@ cGD
 cGD
 aaa
 eRz
-aaT
+eRz
 eRz
 aaa
 aaa
@@ -97987,9 +97813,9 @@ cGR
 uhH
 cGD
 aaa
-aaT
+eRz
 ctv
-aaT
+eRz
 aaa
 aaa
 aaa
@@ -98244,9 +98070,9 @@ cGR
 cGR
 cGD
 aaa
-aaT
+eRz
 ctv
-aaT
+eRz
 aaa
 aaa
 aaa
@@ -98500,11 +98326,11 @@ ciZ
 ciZ
 oDF
 cGD
-aaf
-aaT
+gXs
+eRz
 ctv
-aaT
-aaf
+eRz
+gXs
 aaa
 aaa
 aaa
@@ -98758,9 +98584,9 @@ cAu
 ciZ
 cGD
 aaa
-aaT
+eRz
 ctv
-aaT
+eRz
 aaa
 aaa
 aaa
@@ -98883,7 +98709,7 @@ mNg
 acZ
 aCa
 gXs
-aaf
+gXs
 alt
 abm
 cpg
@@ -99014,10 +98840,10 @@ cGR
 cGR
 cGR
 cGD
-aaf
-aaT
+gXs
+eRz
 ctv
-aaT
+eRz
 aaa
 aaa
 aaa
@@ -99220,7 +99046,7 @@ bSR
 tlW
 bFj
 bSR
-kTd
+bSR
 bHR
 bIe
 tlW
@@ -99272,12 +99098,12 @@ cHo
 cGR
 cGD
 aaa
-aaT
+eRz
 ctv
-aaT
+eRz
 aaa
 aaa
-aae
+aaw
 aaa
 aaa
 aaa
@@ -99392,10 +99218,10 @@ gXs
 gXs
 gXs
 gXs
-aaT
+eRz
 gXs
-aoV
-aaf
+aaa
+gXs
 aWj
 liK
 alt
@@ -99529,9 +99355,9 @@ noK
 cGR
 cGD
 aaa
-aaT
+eRz
 ctv
-aaT
+eRz
 aaa
 aaa
 aaa
@@ -99649,10 +99475,10 @@ gXs
 aaa
 aaa
 gXs
-aaT
+eRz
 gXs
-aoV
-aaf
+aaa
+gXs
 aWj
 aaa
 alt
@@ -99785,10 +99611,10 @@ cGR
 cHp
 cGR
 cGD
-aaf
-aaT
+gXs
+eRz
 ctv
-aaT
+eRz
 aaa
 aaa
 aaa
@@ -99906,10 +99732,10 @@ gXs
 aaa
 aaa
 gXs
-aaT
+eRz
 gXs
-aoV
-aaf
+aaa
+gXs
 aWj
 aaa
 alt
@@ -100042,10 +99868,10 @@ cGR
 cGR
 cGR
 cGD
-aaf
-aaT
+gXs
+eRz
 ctv
-aaT
+eRz
 aaa
 aaa
 aaa
@@ -100166,7 +99992,7 @@ bRz
 bRz
 bRz
 bRz
-aaf
+gXs
 aWj
 aaa
 alt
@@ -100300,9 +100126,9 @@ cGS
 lKg
 cGD
 aaa
-aaT
+eRz
 ctv
-aaT
+eRz
 aaa
 aaa
 aaa
@@ -100423,7 +100249,7 @@ gqK
 oDx
 bVl
 bRz
-aaf
+gXs
 aWj
 aaa
 alt
@@ -100556,11 +100382,11 @@ ciZ
 ciZ
 oDF
 cGD
-aaf
-aaT
+gXs
+eRz
 ctv
-aaT
-aaf
+eRz
+gXs
 aaa
 aaa
 aaa
@@ -100680,7 +100506,7 @@ ljZ
 ekm
 rGl
 bRz
-aaf
+gXs
 aWj
 diw
 alt
@@ -100813,10 +100639,10 @@ acA
 cGR
 cGR
 cGD
-aaf
-aaT
+gXs
+eRz
 ctv
-aaT
+eRz
 aaa
 aaa
 aaa
@@ -101070,10 +100896,10 @@ jKh
 cGR
 udp
 cGD
-aaf
-aaT
+gXs
+eRz
 ctv
-aaT
+eRz
 aaa
 aaa
 aaa
@@ -101328,9 +101154,9 @@ cGD
 cGD
 cGD
 aaa
-aaT
-aaT
-aaT
+eRz
+eRz
+eRz
 aaa
 aaa
 aaa
@@ -101579,14 +101405,14 @@ cGj
 qQq
 cGZ
 hOF
-aag
+nXv
 aaa
-aaf
-aaa
-aaa
+gXs
 aaa
 aaa
-aaf
+aaa
+aaa
+gXs
 aaa
 aaa
 aaa
@@ -101834,18 +101660,18 @@ gJC
 oYu
 cGk
 cGD
-aag
-aag
-aag
-aaf
-aaf
-aaf
-aaf
+nXv
+nXv
+nXv
 gXs
-aaf
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
 aaa
 aaa
 aaa
@@ -102093,14 +101919,14 @@ cGl
 cGD
 aaa
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 ctv
-aaT
+eRz
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -102348,16 +102174,16 @@ aPU
 aPU
 aPU
 cGD
-aaf
-aaf
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
+gXs
+gXs
 ctv
-aaT
+eRz
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -102475,11 +102301,11 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
+gXs
+gXs
 abq
 abq
 abq
@@ -102601,7 +102427,7 @@ jdP
 cjR
 crW
 dNU
-aag
+nXv
 aaa
 aaa
 aaa
@@ -102611,7 +102437,7 @@ aaa
 ctv
 ctv
 ctv
-aaT
+eRz
 aaa
 aaa
 aaa
@@ -102736,7 +102562,7 @@ aaa
 aaa
 eRz
 aaa
-aaf
+gXs
 abq
 abT
 acs
@@ -102858,21 +102684,21 @@ xuR
 ykN
 crX
 xxp
-ghr
+mws
 aaa
 aaa
 aaa
 aaa
 gXs
 aaa
-aaT
-aaT
-aaT
-aaT
+eRz
+eRz
+eRz
+eRz
 aaa
 aaa
 aaa
-aoV
+aaa
 aaa
 aaa
 aaa
@@ -102989,11 +102815,11 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
-aaT
-aaf
-aaf
+gXs
+gXs
+eRz
+gXs
+gXs
 abr
 tHT
 acr
@@ -103099,7 +102925,7 @@ bUL
 nLC
 cgV
 cCF
-aaf
+gXs
 bQA
 cxj
 clT
@@ -103115,7 +102941,7 @@ ykN
 ykN
 ykN
 xxp
-aag
+nXv
 aaa
 aaa
 aaa
@@ -103250,7 +103076,7 @@ aaa
 aaa
 eRz
 aaa
-aaf
+gXs
 abr
 abV
 xVQ
@@ -103497,17 +103323,17 @@ aaa
 aaa
 aaa
 aaa
-aae
+aaw
 aaa
 aaa
 aaa
-aag
-aaf
-aaf
-aaf
-aaT
-aaf
-aaf
+nXv
+gXs
+gXs
+gXs
+eRz
+gXs
+gXs
 abr
 jLe
 act
@@ -103764,7 +103590,7 @@ aaa
 aaa
 eRz
 aaa
-aaf
+gXs
 abq
 abW
 abk
@@ -103810,7 +103636,7 @@ ltr
 aAh
 puE
 iIY
-qiw
+iIY
 iIY
 lqU
 iIY
@@ -104127,7 +103953,7 @@ huj
 nLC
 cgZ
 cCF
-aaf
+gXs
 bQA
 kQb
 clV
@@ -104283,7 +104109,7 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 bit
 aeB
 afm
@@ -104538,9 +104364,9 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
 bit
 aeA
 afl
@@ -104795,7 +104621,7 @@ aaa
 aaa
 aaa
 aaa
-aag
+nXv
 qmj
 qmj
 adR
@@ -105049,10 +104875,10 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
-aaf
-aag
+gXs
+gXs
+gXs
+nXv
 acU
 adr
 sXy
@@ -105155,7 +104981,7 @@ fYl
 fcV
 chc
 cCF
-aaf
+gXs
 bQA
 bQo
 cBP
@@ -105302,14 +105128,14 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
-aag
-aag
-aag
+gXs
+gXs
+nXv
+nXv
+nXv
 aaa
 aaa
-aag
+nXv
 qmj
 qmj
 qmj
@@ -105563,12 +105389,12 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aag
-aaf
-aaf
-aaf
-aaf
+gXs
+nXv
+gXs
+gXs
+gXs
+gXs
 qmj
 aaa
 afp
@@ -105669,7 +105495,7 @@ cit
 cit
 che
 cit
-aaf
+gXs
 bOh
 bOh
 bOh
@@ -105823,7 +105649,7 @@ aaa
 aaa
 gXs
 aaa
-aba
+bhT
 aaa
 aaa
 qmj
@@ -105904,18 +105730,18 @@ dvY
 cmd
 twm
 bzs
-aaf
-aaf
+gXs
+gXs
 rNc
-aaf
+gXs
 nOP
-aaf
+gXs
 qgv
-aaf
+gXs
 nOP
-aaf
+gXs
 qgv
-aaf
+gXs
 nOP
 tqO
 cbz
@@ -106161,7 +105987,7 @@ cCp
 cmd
 twm
 bzs
-aaf
+gXs
 bOh
 bQr
 bQA
@@ -106183,17 +106009,17 @@ bDB
 cit
 jAU
 cit
-aoV
-aoV
-aoV
-aaf
-aaf
-aoV
-aoV
-aoV
-aoV
-aoV
-aaf
+aaa
+aaa
+aaa
+gXs
+gXs
+aaa
+aaa
+aaa
+aaa
+aaa
+gXs
 aaa
 aaa
 aaa
@@ -106418,7 +106244,7 @@ bIc
 cmd
 vLQ
 bzs
-aaf
+gXs
 bOh
 sqS
 niU
@@ -106442,15 +106268,15 @@ cCS
 byN
 byN
 byN
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
 gXs
 gXs
 gXs
@@ -106675,7 +106501,7 @@ dND
 cmd
 twm
 bzs
-aaf
+gXs
 bOh
 bPk
 bQB
@@ -106693,7 +106519,7 @@ ccC
 ccB
 ccC
 bOh
-aaf
+gXs
 cCF
 uIF
 qvf
@@ -106932,7 +106758,7 @@ cCp
 cmd
 twm
 bzs
-aaf
+gXs
 bOh
 bQB
 bQC
@@ -106950,21 +106776,21 @@ ccC
 ccD
 ccC
 bOh
-aaf
+gXs
 cCF
 rcn
 byN
 byN
 byN
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
 gXs
 gXs
 gXs
@@ -107112,7 +106938,7 @@ bhT
 aaa
 aaa
 aaa
-aae
+aaw
 aaa
 aaa
 aaa
@@ -107189,7 +107015,7 @@ bIi
 cmd
 twm
 bzs
-aaf
+gXs
 bOh
 bOh
 bOh
@@ -107207,21 +107033,21 @@ bOh
 bOh
 bOh
 bOh
-aaf
+gXs
 cit
 rcn
 cit
-aaf
-aaf
-aaf
-aaf
-aaf
-aoV
-aoV
-aoV
-aoV
-aoV
-aaf
+gXs
+gXs
+gXs
+gXs
+gXs
+aaa
+aaa
+aaa
+aaa
+aaa
+gXs
 aaa
 aaa
 aaa
@@ -107446,25 +107272,25 @@ scz
 cmd
 twm
 bzs
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
 tXL
 odw
 tXL
@@ -107472,13 +107298,13 @@ tXL
 dtD
 tXL
 tXL
-aaf
-aaf
-aaf
-aaf
 gXs
-aaf
-aaf
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
 gXs
 gXs
 gXs
@@ -107638,7 +107464,7 @@ eRz
 aaa
 eRz
 aaa
-aoV
+aaa
 aaa
 aaa
 aaa
@@ -107735,7 +107561,7 @@ lwx
 lwx
 lwx
 aJF
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -107990,10 +107816,10 @@ tXL
 tXL
 aHq
 tXL
-aaf
+gXs
 aaH
-aaf
-aoV
+gXs
+aaa
 aaa
 aaa
 aaa
@@ -108250,7 +108076,7 @@ tXL
 nXv
 nXv
 nXv
-aag
+nXv
 aaa
 aaa
 aaa
@@ -108507,7 +108333,7 @@ dtD
 aaH
 aaH
 aaa
-aag
+nXv
 aaa
 aaa
 aaa
@@ -108764,7 +108590,7 @@ tXL
 tXL
 aaH
 aaa
-aag
+nXv
 aaa
 aaa
 aaa
@@ -108926,7 +108752,7 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aCu
 orm
 kyl
@@ -109021,7 +108847,7 @@ aLb
 tXL
 aaH
 aaa
-aag
+nXv
 aaa
 aaa
 aaa
@@ -109182,8 +109008,8 @@ gXs
 aaa
 aaa
 aaa
-aaf
-aaf
+gXs
+gXs
 aCu
 aCu
 aCu
@@ -109278,7 +109104,7 @@ aIA
 cop
 nXv
 nXv
-aag
+nXv
 aaa
 aaa
 aaa
@@ -109438,8 +109264,8 @@ aaa
 gXs
 aaa
 aaa
-aaf
-aaf
+gXs
+gXs
 aaa
 aaa
 aaa
@@ -109679,7 +109505,7 @@ aaa
 aaa
 aaa
 aaS
-aba
+bhT
 aaS
 aaS
 aaS
@@ -109694,15 +109520,15 @@ aaS
 aaS
 aaS
 aaa
-aaf
-aaf
+gXs
+gXs
 aaa
 aaa
 aaa
 aaa
 aaa
-aaf
-aaf
+gXs
+gXs
 aCu
 hKB
 tuS
@@ -109793,7 +109619,7 @@ aaa
 aaa
 gXs
 aaa
-aoV
+aaa
 aaa
 aaa
 aaa
@@ -109937,27 +109763,27 @@ aaa
 aaa
 aaS
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
 aaS
-aaf
-aaf
+gXs
+gXs
 aaa
 aaa
 aaa
 aaa
 aaa
-aag
+nXv
 alP
 arp
 alP
@@ -110207,14 +110033,14 @@ adT
 ads
 aaa
 aaS
-aaf
+gXs
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aag
+nXv
 cxW
 jrS
 aqv
@@ -110445,12 +110271,12 @@ aaa
 aaa
 aaa
 aaa
-aae
+aaw
 aaa
 aaa
 aaa
 aaS
-aaf
+gXs
 ads
 adT
 ads
@@ -110462,8 +110288,8 @@ aaa
 ads
 adT
 ads
-aaf
-aaf
+gXs
+gXs
 aaa
 aaa
 aaa
@@ -110471,7 +110297,7 @@ aaa
 aaa
 aaa
 aaa
-aag
+nXv
 alP
 alP
 alP
@@ -110504,7 +110330,7 @@ bal
 bam
 sFP
 eei
-hKO
+sXH
 bfL
 bhq
 mIv
@@ -110711,16 +110537,16 @@ aaa
 ads
 adT
 ads
-aaf
+gXs
 ads
 adT
 ads
-aaf
+gXs
 ads
 adT
 ads
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -110821,7 +110647,7 @@ aaa
 aaa
 eRz
 aaa
-aaT
+eRz
 aaa
 aaa
 aaa
@@ -110963,8 +110789,8 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
+gXs
+gXs
 ads
 adT
 ads
@@ -110976,16 +110802,16 @@ aaa
 ads
 adT
 ads
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
 apC
 apC
 apC
@@ -111220,7 +111046,7 @@ aaa
 aaS
 aaS
 aaS
-aaf
+gXs
 aaa
 ads
 adT
@@ -111234,7 +111060,7 @@ ads
 adT
 ads
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -111476,7 +111302,7 @@ aaa
 aaa
 aaS
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -111491,7 +111317,7 @@ aaa
 adT
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 amw
@@ -111732,10 +111558,10 @@ aaa
 aaa
 aaa
 aaS
-aaf
+gXs
 abX
-acx
-acx
+adT
+adT
 adU
 ekd
 adU
@@ -111747,10 +111573,10 @@ adU
 adU
 ekd
 adU
-acx
-acx
-acx
-acx
+adT
+adT
+adT
+adT
 amv
 ane
 cxN
@@ -111990,22 +111816,22 @@ aaa
 aaa
 aaS
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
-acx
+adT
 aaa
 aaa
 aaa
-acx
+adT
 aaa
 aaa
 aaa
-acx
+adT
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 amw
@@ -112027,7 +111853,7 @@ aAr
 jSi
 alP
 aaa
-aaf
+gXs
 aGX
 alP
 anM
@@ -112246,23 +112072,23 @@ aaa
 aaa
 aaa
 aaS
-aba
+bhT
 aaS
 acy
 aaa
 ads
-acx
+adT
 ads
 aaa
 ads
-acx
+adT
 ads
 aaa
 ads
-acx
+adT
 ads
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -112505,28 +112331,28 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
+gXs
+gXs
 ads
-acx
-ads
-aaa
-ads
-acx
+adT
 ads
 aaa
 ads
-acx
+adT
 ads
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
+aaa
+ads
+adT
+ads
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
 apC
 aAs
 jrS
@@ -112765,22 +112591,22 @@ aaa
 aaS
 aaa
 ads
-acx
+adT
 ads
-aaf
+gXs
 ads
-acx
+adT
 ads
-aaf
+gXs
 ads
-acx
+adT
 ads
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -113020,24 +112846,24 @@ aaa
 aaa
 aaa
 aaS
-aaf
+gXs
 ads
-acx
-ads
-aaa
-ads
-acx
+adT
 ads
 aaa
 ads
-acx
+adT
 ads
-aaf
-aaf
+aaa
+ads
+adT
+ads
+gXs
+gXs
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -113279,25 +113105,25 @@ aaa
 aaS
 aaa
 ads
-acx
+adT
 ads
 aaa
 ads
-acx
+adT
 ads
 aaa
 ads
-acx
+adT
 ads
 aaa
 aaS
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
 apC
 aAs
 jrS
@@ -113535,15 +113361,15 @@ aaa
 aaa
 aaS
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
 aiS
 aaa
@@ -113802,16 +113628,16 @@ aaS
 aaS
 aaS
 aaS
-aba
+bhT
 aaS
 aaS
-aaf
+gXs
 aaa
 aaa
-aaf
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
+gXs
 alO
 aqz
 aru
@@ -114061,8 +113887,8 @@ aaa
 bhT
 aaa
 aaa
-aaf
-aaf
+gXs
+gXs
 aaa
 aaa
 aaa
@@ -114319,13 +114145,13 @@ bhT
 aaa
 aaa
 aaa
-aaf
-aaf
+gXs
+gXs
 aaa
 aaa
 aaa
-aaf
-aaf
+gXs
+gXs
 alO
 aqA
 lVw
@@ -114577,8 +114403,8 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
+gXs
+gXs
 aaa
 aaa
 aaa
@@ -114820,7 +114646,7 @@ aaa
 aaa
 aaa
 aaa
-aae
+aaw
 aaa
 aaa
 aaa
@@ -114835,8 +114661,8 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
+gXs
+gXs
 aaa
 aaa
 dZX
@@ -115093,8 +114919,8 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
+gXs
+gXs
 aaa
 dZX
 mVS
@@ -115351,8 +115177,8 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
+gXs
+gXs
 dZX
 xLt
 gPv
@@ -115451,7 +115277,7 @@ hYR
 uyk
 euE
 aMO
-aag
+nXv
 aaa
 aaa
 aaa
@@ -116115,10 +115941,10 @@ aaa
 aaa
 aaa
 eRz
-aaf
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
+gXs
 alP
 alP
 alP
@@ -116888,12 +116714,12 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
 alP
 ndX
 bmm
@@ -117150,7 +116976,7 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 alP
 unc
 spZ
@@ -117246,10 +117072,10 @@ fGh
 fQz
 qQr
 oxL
-aaf
-aaf
-aaT
-aaf
+gXs
+gXs
+eRz
+gXs
 aaa
 gXs
 gXs
@@ -117257,7 +117083,7 @@ eRz
 aaa
 aaa
 aaa
-aae
+aaw
 aaa
 aaa
 aaa
@@ -117405,9 +117231,9 @@ aaa
 aaa
 aaa
 aaa
-aaT
-aaf
-aaf
+eRz
+gXs
+gXs
 alP
 gtw
 jJd
@@ -117468,9 +117294,9 @@ aDH
 bxP
 bCf
 kuX
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
 bEs
 bEs
 eJx
@@ -117664,7 +117490,7 @@ aaa
 aaa
 eRz
 aaa
-aaf
+gXs
 alP
 exV
 yha
@@ -117920,8 +117746,8 @@ aaa
 aaa
 aaa
 eRz
-aaf
-aaf
+gXs
+gXs
 alP
 alP
 alP
@@ -118017,13 +117843,13 @@ wpI
 odI
 tnb
 sND
-aaf
-aaf
-aaT
-aaf
-aaf
-aaT
-aaf
+gXs
+gXs
+eRz
+gXs
+gXs
+eRz
+gXs
 aaa
 aaa
 aaa
@@ -118172,18 +117998,18 @@ aaa
 aaa
 aaa
 aaa
-aae
+aaw
 aaa
 aaa
 aaa
 eRz
 aaa
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
 aTe
 atH
 auM
@@ -118438,7 +118264,7 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 aTe
@@ -118537,7 +118363,7 @@ aaS
 aaS
 aaS
 aaS
-aba
+bhT
 aaS
 aaS
 aaS
@@ -118695,13 +118521,13 @@ eRz
 eRz
 eRz
 eRz
-aaT
+eRz
 eRz
 aaa
 atS
-aaf
-aoV
-aoV
+gXs
+aaa
+aaa
 bRE
 qAB
 hGQ
@@ -118780,24 +118606,24 @@ tKU
 cNW
 ttD
 cNW
-aaf
-aaf
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
+gXs
+gXs
 aaS
 aaa
-aaf
+gXs
 aaa
 acy
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
 aaS
 aaa
@@ -118956,9 +118782,9 @@ aaa
 aaa
 aaa
 atS
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
 bRE
 fbO
 nbZ
@@ -119213,9 +119039,9 @@ aaa
 aaa
 aaa
 atS
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
 bRE
 aBq
 sSG
@@ -119299,8 +119125,8 @@ aaa
 aaa
 aaa
 aaa
-aba
-aaf
+bhT
+gXs
 cMQ
 crC
 cMQ
@@ -119312,7 +119138,7 @@ aaa
 cMQ
 crC
 cMQ
-aaf
+gXs
 aaS
 aaa
 aaa
@@ -119470,9 +119296,9 @@ aaa
 aaa
 aaa
 atS
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
 bRE
 bXT
 bXT
@@ -119556,16 +119382,16 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 cMQ
 crC
 cMQ
-aaf
+gXs
 cMQ
 crC
 cMQ
-aaf
+gXs
 cMQ
 crC
 cMQ
@@ -119727,9 +119553,9 @@ aaa
 aaa
 aaa
 aaH
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
 bRE
 bRE
 bRE
@@ -119808,13 +119634,13 @@ cgu
 bMB
 clw
 cNW
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
 cMQ
 crC
 cMQ
@@ -119826,8 +119652,8 @@ aaa
 cMQ
 crC
 cMQ
-aaf
-aaf
+gXs
+gXs
 aaa
 aaa
 aaa
@@ -119984,13 +119810,13 @@ aaa
 aaa
 aaa
 atS
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
 atS
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
 ccz
 bUO
 ccz
@@ -120016,7 +119842,7 @@ gPr
 tos
 oHy
 aMZ
-aaf
+gXs
 bky
 nHd
 fpY
@@ -120070,7 +119896,7 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 cMQ
 crC
@@ -120084,7 +119910,7 @@ cMQ
 crC
 cMQ
 aaa
-aaf
+gXs
 aaS
 aaS
 aaS
@@ -120238,24 +120064,24 @@ aaa
 aaa
 aaa
 aaa
-aae
+aaw
 aaa
 atS
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
 atS
-aaf
-aoV
-aaf
-aaf
-aoV
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
+gXs
+aaa
+gXs
+gXs
+aaa
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
 aMZ
 aOb
 aPr
@@ -120327,7 +120153,7 @@ cnj
 cnj
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 crC
@@ -120342,7 +120168,7 @@ crC
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aaS
 aaa
@@ -120497,22 +120323,22 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aoV
-aoV
-aoV
+gXs
+aaa
+aaa
+aaa
 atS
-aoV
-aoV
-aaf
-aaf
-aoV
-aaf
-aoV
+aaa
+aaa
+gXs
+gXs
+aaa
+gXs
 aaa
 aaa
 aaa
-aaf
+aaa
+gXs
 aMZ
 aOa
 jCN
@@ -120530,7 +120356,7 @@ aQE
 tWn
 ykO
 aNa
-aaf
+gXs
 bky
 blR
 bky
@@ -120582,10 +120408,10 @@ cyG
 cnk
 cks
 cyU
-cpi
-cpi
-cpi
-cpi
+crC
+crC
+crC
+crC
 crk
 uaL
 crk
@@ -120597,10 +120423,10 @@ crk
 crk
 uaL
 crk
-cpi
-cpi
+crC
+crC
 ctB
-aaf
+gXs
 aaS
 aaa
 aaa
@@ -120754,22 +120580,22 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aoV
-aoV
-aoV
-aaf
-aoV
-aoV
-aoV
-aaf
-aaf
-fIW
-aaT
+gXs
+aaa
+aaa
+aaa
+gXs
+aaa
+aaa
+aaa
+gXs
+gXs
+wwP
 eRz
 eRz
 eRz
-aaT
+eRz
+eRz
 irK
 joN
 nmf
@@ -120841,22 +120667,22 @@ cnj
 cnj
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
-cpi
-aaa
-aaa
-aaa
-cpi
+crC
 aaa
 aaa
 aaa
-cpi
+crC
 aaa
 aaa
 aaa
-aaf
+crC
+aaa
+aaa
+aaa
+gXs
 aaa
 aaS
 aaa
@@ -121011,18 +120837,18 @@ aaa
 aaa
 aaa
 aaa
-aoV
-aoV
-aoV
-aoV
-aaf
-aoV
-aoV
-aoV
-aaf
 aaa
-aaf
-aoV
+aaa
+aaa
+aaa
+gXs
+aaa
+aaa
+aaa
+gXs
+aaa
+gXs
+aaa
 aaa
 aaa
 aaa
@@ -121045,7 +120871,7 @@ jtW
 bgf
 aNa
 aaa
-aaf
+gXs
 aaa
 bky
 blO
@@ -121098,21 +120924,21 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 cMQ
-cpi
-cMQ
-aaa
-cMQ
-cpi
+crC
 cMQ
 aaa
 cMQ
-cpi
+crC
 cMQ
 aaa
-aaf
+cMQ
+crC
+cMQ
+aaa
+gXs
 aaS
 aaS
 aaS
@@ -121276,10 +121102,10 @@ eRz
 eRz
 eRz
 eRz
-aaT
+eRz
 wwP
-aaT
-aaT
+eRz
+eRz
 eRz
 eRz
 eRz
@@ -121302,8 +121128,8 @@ aMZ
 aNa
 aNa
 aaa
-aaf
-aaf
+gXs
+gXs
 bky
 boH
 bEI
@@ -121348,28 +121174,28 @@ kYh
 cNW
 aaa
 aaa
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
 cMQ
-cpi
-cMQ
-aaa
-cMQ
-cpi
+crC
 cMQ
 aaa
 cMQ
-cpi
+crC
 cMQ
-aaf
-aaf
+aaa
+cMQ
+crC
+cMQ
+gXs
+gXs
 aaa
 aaa
 aaa
@@ -121541,8 +121367,8 @@ aaa
 aaa
 aaa
 gXs
-aaf
-aaf
+gXs
+gXs
 aNa
 cyr
 aNa
@@ -121556,11 +121382,11 @@ cyr
 aNa
 cyr
 aNa
-aaf
-aaf
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
+gXs
+gXs
 bky
 bky
 bky
@@ -121603,27 +121429,27 @@ cfv
 cBL
 wvN
 cNW
-aaf
+gXs
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 cMQ
-cpi
+crC
 cMQ
-aaf
+gXs
 cMQ
-cpi
+crC
 cMQ
-aaf
+gXs
 cMQ
-cpi
+crC
 cMQ
 aaa
 aaS
@@ -121635,7 +121461,7 @@ aaa
 aaa
 aaa
 aaa
-aae
+aaw
 aaa
 aaa
 aaa
@@ -121798,7 +121624,7 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aNa
 jTt
@@ -121814,7 +121640,7 @@ aNa
 wOj
 aNa
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -121844,9 +121670,9 @@ kYh
 cNW
 aaa
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 cNW
 bYs
 ovI
@@ -121860,29 +121686,29 @@ cNW
 ovI
 chH
 cNW
-aaf
-aaf
+gXs
+gXs
 aaa
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
 cMQ
-cpi
-cMQ
-aaa
-cMQ
-cpi
+crC
 cMQ
 aaa
 cMQ
-cpi
+crC
 cMQ
-aaf
+aaa
+cMQ
+crC
+cMQ
+gXs
 aaS
 aaa
 aaa
@@ -122101,9 +121927,9 @@ cOT
 cNW
 aaa
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 cNW
 cNW
 cOT
@@ -122117,27 +121943,27 @@ cNW
 cNW
 cNW
 cNW
-aaf
-aaf
+gXs
+gXs
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
 aaa
-aba
-aaa
-cMQ
-cpi
-cMQ
+bhT
 aaa
 cMQ
-cpi
+crC
 cMQ
 aaa
 cMQ
-cpi
+crC
+cMQ
+aaa
+cMQ
+crC
 cMQ
 aaa
 aaS
@@ -122304,7 +122130,7 @@ aaa
 aaa
 aaa
 aaa
-aae
+aaw
 aaa
 aaa
 aaa
@@ -122352,52 +122178,52 @@ dTr
 iuN
 kGx
 bHJ
-aaf
 gXs
 gXs
-aaf
+gXs
+gXs
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
-aag
-aaf
+nXv
+gXs
 aaa
 aaa
 aaa
-aaf
-aaf
+gXs
+gXs
 cNW
 ceU
 cNW
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
 aaa
 aaS
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
-aba
+bhT
 aaa
 aaa
 aaa
@@ -122577,7 +122403,7 @@ aMZ
 gjX
 aMZ
 gXs
-aaf
+gXs
 gXs
 aMZ
 gjX
@@ -122612,34 +122438,34 @@ bHJ
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
-aag
-aaf
+nXv
+gXs
 aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 cNW
 cPI
 cNW
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
 aaS
 aaS
 aaS
@@ -122851,14 +122677,14 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
+gXs
+gXs
 aaa
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
 aaa
-aaf
+gXs
 bHJ
 cxQ
 gyY
@@ -122869,30 +122695,30 @@ bHJ
 aaa
 aaa
 aaa
-aaf
+gXs
 eRz
 eRz
 eRz
 eRz
 eRz
-aaf
-aaf
+gXs
+gXs
 aaa
 aaa
 aaa
 aaa
-aaf
-aag
-aag
-aag
-aaf
+gXs
+nXv
+nXv
+nXv
+gXs
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -123108,14 +122934,14 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
-aaf
+gXs
 bHJ
 bLp
 oyF
@@ -123126,13 +122952,13 @@ bHJ
 aaa
 aaa
 aaa
-aag
+nXv
 aaa
 aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -123140,7 +122966,7 @@ aaa
 aaa
 aaa
 aaa
-aag
+nXv
 aaa
 aaa
 aaa
@@ -123365,14 +123191,14 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
-aaf
+gXs
 bHJ
 tPS
 oyF
@@ -123383,13 +123209,13 @@ bHJ
 aaa
 aaa
 aaa
-aag
+nXv
 aaa
 aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -123397,7 +123223,7 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -123622,31 +123448,31 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
-aaf
+gXs
 bHJ
 nIP
 bTL
 tbG
 bHJ
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
-aag
+nXv
 aaa
 aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 eRz
 eRz
 eRz
@@ -123654,7 +123480,7 @@ eRz
 eRz
 eRz
 gXs
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -123666,7 +123492,7 @@ aaa
 aaa
 aaa
 aaa
-aae
+aaw
 aaa
 aaa
 aaa
@@ -123879,43 +123705,39 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
-aaf
+gXs
 bHJ
 peD
 peD
 peD
 bHJ
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
-aag
-aaa
-aaa
-aaa
-aaa
+nXv
 aaa
 aaa
 aaa
 aaa
 aaa
-aae
-aaa
-aaa
-aaa
-aaf
 aaa
 aaa
 aaa
 aaa
+aaw
+aaa
+aaa
+aaa
+gXs
 aaa
 aaa
 aaa
@@ -123938,7 +123760,11 @@ aaa
 aaa
 aaa
 aaa
-aae
+aaa
+aaa
+aaa
+aaa
+aaw
 aaa
 aaa
 aaa
@@ -124136,28 +123962,25 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aaw
 aaa
 aaa
 aaa
 aaa
-aaf
 gXs
 gXs
 gXs
 gXs
-aaf
+gXs
+gXs
 aaa
-aaf
-aaa
-aaa
-aaa
-aag
+gXs
 aaa
 aaa
 aaa
+nXv
 aaa
 aaa
 aaa
@@ -124168,7 +123991,10 @@ aaa
 aaa
 aaa
 aaa
-aaf
+aaa
+aaa
+aaa
+gXs
 aaa
 aaa
 aaa
@@ -124393,14 +124219,14 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aag
+nXv
 aaa
 aaa
 aaa
@@ -124411,7 +124237,7 @@ dYf
 aaa
 aaa
 aaa
-aag
+nXv
 aaa
 aaa
 aaa
@@ -124650,25 +124476,25 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
 aaa
 aaa
 aaa
 aaa
-aag
+nXv
 aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
 aaw
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -124909,19 +124735,19 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
 aaa
-aag
+nXv
 eRz
 eRz
 eRz
 eRz
-aaT
+eRz
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -125165,20 +124991,20 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
+gXs
+gXs
 aaa
 aaa
 aaa
 aaa
-aag
+nXv
 aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -125428,15 +125254,15 @@ aaa
 aaa
 aaa
 aaa
-aag
+nXv
 aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
-aaf
-aoV
+gXs
+aaa
 aaa
 aaa
 aaa
@@ -125685,7 +125511,7 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -125942,14 +125768,14 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -126204,9 +126030,9 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -126427,7 +126253,7 @@ aaa
 aaa
 aaa
 aaa
-aae
+aaw
 aaa
 aaa
 aaa
@@ -126461,9 +126287,9 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -126718,9 +126544,9 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -127232,9 +127058,9 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -127485,17 +127311,17 @@ aaa
 aaa
 aaa
 aaa
-aoV
-aoV
-aoV
-aoV
-aaf
 aaa
-aaf
-aoV
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
+gXs
+aaa
+gXs
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -127742,17 +127568,17 @@ aaa
 aaa
 aaa
 aaa
-aoV
-aoV
-aoV
-aoV
-aaf
 aaa
-aaf
-aoV
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
+gXs
+aaa
+gXs
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -127999,17 +127825,17 @@ aaa
 aaa
 aaa
 aaa
-aoV
-aoV
 aaa
 aaa
-aaf
 aaa
-aaf
 aaa
-aoV
-aoV
-aoV
+gXs
+aaa
+gXs
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -128256,17 +128082,17 @@ aaa
 aaa
 aaa
 aaa
-aoV
 aaa
 aaa
-aoV
+aaa
+aaa
 tsq
 gXs
 tsq
-aoV
 aaa
-aoV
-aoV
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -128515,15 +128341,15 @@ aaa
 aaa
 aaa
 aaa
-aoV
-aoV
-aaf
 aaa
-aaf
-aoV
-aoV
-aoV
-aoV
+aaa
+gXs
+aaa
+gXs
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -128771,16 +128597,16 @@ aaa
 aaa
 aaa
 aaa
-aoV
-aoV
-aoV
-aaf
 aaa
-aaf
-aoV
-aoV
-aoV
-aoV
+aaa
+aaa
+gXs
+aaa
+gXs
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -129029,17 +128855,17 @@ aaa
 aaa
 aaa
 aaa
-aoV
-aoV
-aaf
-aaa
-aaf
-aoV
-aoV
-aoV
 aaa
 aaa
-aoV
+gXs
+aaa
+gXs
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -129285,16 +129111,16 @@ aaa
 aaa
 aaa
 aaa
-aoV
-aoV
 aaa
-aaf
 aaa
-aaf
 aaa
-aoV
-aoV
-aoV
+gXs
+aaa
+gXs
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -129542,15 +129368,15 @@ aaa
 aaa
 aaa
 aaa
-aoV
-aoV
-aoV
-dNI
+aaa
+aaa
+aaa
+mRb
 gXs
-dNI
-aoV
-aoV
-aoV
+mRb
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -129798,17 +129624,17 @@ aaa
 aaa
 aaa
 aaa
-aoV
-aoV
-aoV
-aoV
-aaf
 aaa
-aaf
-aoV
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
+gXs
+aaa
+gXs
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -130055,17 +129881,17 @@ aaa
 aaa
 aaa
 aaa
-aoV
-aoV
-aoV
-aaf
-aaf
 aaa
-aaf
-aaf
 aaa
-aoV
-aoV
+aaa
+gXs
+gXs
+aaa
+gXs
+gXs
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -130312,17 +130138,15 @@ aaa
 aaa
 aaa
 aaa
-aoV
-aoV
-aaf
-aaf
+aaa
+aaa
+gXs
+gXs
 bGf
 bLo
 bGf
-aaf
-aaf
-aoV
-aoV
+gXs
+gXs
 aaa
 aaa
 aaa
@@ -130406,7 +130230,9 @@ aaa
 aaa
 aaa
 aaa
-aae
+aaa
+aaa
+aaw
 aaa
 aaa
 aaa
@@ -130570,15 +130396,15 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
+gXs
+gXs
 fBm
 bGf
 bLn
 bGf
 fBm
-aaf
-aaf
+gXs
+gXs
 aaa
 aaa
 aaa
@@ -130826,8 +130652,8 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
+gXs
+gXs
 bGf
 bGf
 bKh
@@ -130835,8 +130661,8 @@ bLo
 bMD
 bGf
 bGf
-aaf
-aaf
+gXs
+gXs
 aaa
 aaa
 aaa
@@ -131083,7 +130909,7 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 bIX
 bIX
 bKd
@@ -131093,7 +130919,7 @@ hCb
 bND
 bIX
 bIX
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -131338,9 +131164,9 @@ aaa
 aaa
 aaa
 aaa
-dNI
-aaf
-aaf
+mRb
+gXs
+gXs
 bGf
 tNu
 bJa
@@ -131350,9 +131176,9 @@ bKg
 bNF
 eMc
 bGf
-aaf
-aaf
-dNI
+gXs
+gXs
+mRb
 aaa
 aaa
 aaa
@@ -131597,7 +131423,7 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 bIX
 bIX
 bHw
@@ -131607,7 +131433,7 @@ dyX
 bNE
 bIX
 bIX
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -131854,8 +131680,8 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
+gXs
+gXs
 bGf
 bGf
 bKi
@@ -131863,8 +131689,8 @@ vPt
 bME
 bGf
 bGf
-aaf
-aaf
+gXs
+gXs
 aaa
 aaa
 aaa
@@ -132081,7 +131907,6 @@ aaa
 aaa
 aaa
 aaa
-aoV
 aaa
 aaa
 aaa
@@ -132112,15 +131937,16 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
+aaa
+gXs
+gXs
 fBm
 bGf
 bLq
 bGf
 fBm
-aaf
-aaf
+gXs
+gXs
 aaa
 aaa
 aaa
@@ -132353,7 +132179,6 @@ aaa
 aaa
 aaa
 aaa
-aoV
 aaa
 aaa
 aaa
@@ -132370,13 +132195,14 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
+aaa
+gXs
+gXs
 bGf
 bIX
 bGf
-aaf
-aaf
+gXs
+gXs
 aaa
 aaa
 aaa
@@ -132628,11 +132454,11 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
+gXs
+gXs
 aaa
 aaa
 aaa
@@ -132643,7 +132469,7 @@ aaa
 aaa
 aaa
 aaa
-aoV
+aaa
 aaa
 aaa
 aaa
@@ -132886,9 +132712,9 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
 aaa
 aaa
 aaa
@@ -133144,7 +132970,7 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -133401,7 +133227,7 @@ aaa
 aaa
 aaa
 aaa
-dNI
+mRb
 aaa
 aaa
 aaa
@@ -133873,7 +133699,6 @@ aaa
 aaa
 aaa
 aaa
-aoV
 aaa
 aaa
 aaa
@@ -133906,7 +133731,8 @@ aaa
 aaa
 aaa
 aaa
-aoV
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -134198,7 +134024,7 @@ aaa
 aaa
 aaa
 aaa
-aoV
+aaa
 aaa
 aaa
 aaa

--- a/StationMaps/SokobanStation/Sokoban.dmm
+++ b/StationMaps/SokobanStation/Sokoban.dmm
@@ -81,13 +81,13 @@
 /obj/structure/cable,
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "ar" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/machinery/light/directional/west,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "au" = (
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
@@ -125,9 +125,9 @@
 /turf/open/floor/plating,
 /area/station/service/hydroponics)
 "aC" = (
-/obj/structure/industrial_lift/public,
+/obj/structure/transport/linear,
 /turf/open/openspace,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "aF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /turf/closed/wall/r_wall,
@@ -327,7 +327,7 @@
 "bD" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/openspace,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "bE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -453,7 +453,7 @@
 /area/space/nearstation)
 "cq" = (
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/machinery/photocopier,
+/obj/machinery/photocopier/prebuilt,
 /obj/item/paper_bin{
 	pixel_x = -3;
 	pixel_y = 7
@@ -467,7 +467,7 @@
 /obj/structure/window/reinforced/plasma/spawner/directional/east,
 /obj/structure/cable,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "ct" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 4
@@ -587,13 +587,13 @@
 "cV" = (
 /obj/machinery/suit_storage_unit/ce,
 /obj/machinery/light_switch/directional/west,
-/obj/machinery/keycard_auth/directional/west{
+/obj/machinery/keycard_auth/wall_mounted/directional/west{
 	pixel_x = -37
 	},
 /obj/effect/turf_decal/tile/yellow/diagonal_centre,
 /obj/effect/turf_decal/tile/dark_blue/diagonal_edge,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -663,7 +663,7 @@
 /area/station/service/kitchen)
 "dk" = (
 /obj/structure/ladder,
-/obj/machinery/keycard_auth/directional/east,
+/obj/machinery/keycard_auth/wall_mounted/directional/east,
 /turf/open/misc/asteroid,
 /area/station/command/heads_quarters/hop)
 "dm" = (
@@ -691,7 +691,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown/fourcorners,
-/obj/machinery/keycard_auth/directional/east,
+/obj/machinery/keycard_auth/wall_mounted/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "dp" = (
@@ -726,7 +726,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "dw" = (
 /obj/structure/railing,
 /mob/living/simple_animal/bot/mulebot,
@@ -765,7 +765,6 @@
 /obj/machinery/holopad,
 /obj/machinery/turretid{
 	control_area = "/area/station/ai_monitored/turret_protected/ai_upload";
-	icon_state = "control_stun";
 	name = "AI Upload Turret Control";
 	pixel_y = 28
 	},
@@ -786,7 +785,7 @@
 	},
 /obj/effect/landmark/start/cyborg,
 /turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "dC" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
@@ -861,7 +860,7 @@
 /area/space/nearstation)
 "dX" = (
 /obj/structure/altar/of_gods,
-/obj/item/storage/book/bible,
+/obj/item/book/bible,
 /obj/item/flashlight/lantern{
 	pixel_y = 7
 	},
@@ -912,7 +911,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "eo" = (
 /obj/machinery/hydroponics/constructable,
 /obj/item/wrench,
@@ -1041,7 +1040,7 @@
 "eK" = (
 /obj/effect/landmark/start/cyborg,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/area/station/ai/satellite/interior)
 "eM" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
 	dir = 4
@@ -1108,10 +1107,10 @@
 /obj/machinery/requests_console/directional/north{
 	department = "Janitorial";
 	name = "Janitorial Requests Console";
-	assistance_requestable = 1;
 	pixel_y = -30;
 	dir = 2
 	},
+/obj/effect/mapping_helpers/requests_console/assistance,
 /turf/open/floor/carpet/executive,
 /area/station/service/janitor)
 "eW" = (
@@ -1139,9 +1138,9 @@
 	linked_elevator_id = "test_vator"
 	},
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "fc" = (
-/obj/machinery/modular_computer/console/preset/engineering{
+/obj/machinery/modular_computer/preset/engineering{
 	dir = 4
 	},
 /obj/machinery/camera/autoname/directional/west,
@@ -1200,7 +1199,7 @@
 	},
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/area/station/ai/satellite/interior)
 "fn" = (
 /obj/structure/railing,
 /obj/machinery/airalarm/directional/west,
@@ -1225,9 +1224,7 @@
 /turf/open/floor/plating,
 /area/station/service/chapel/office)
 "fu" = (
-/obj/structure/sign/poster/official/moth_piping{
-	pixel_y = 32
-	},
+/obj/structure/sign/poster/official/moth_piping/directional/north,
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/item/pipe_dispenser,
@@ -1396,7 +1393,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "go" = (
 /obj/structure/window/spawner/directional/east,
 /obj/structure/chair/office/light{
@@ -1618,7 +1615,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "hi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1658,13 +1655,12 @@
 /area/station/cargo/storage)
 "ht" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor{
+/obj/machinery/door/window/brigdoor/left/directional/south{
 	name = "Weapon Distribution";
 	req_access = list("armory")
 	},
-/obj/machinery/door/window/left/directional/south{
-	name = "Requests Window";
-	dir = 1
+/obj/machinery/door/window/left/directional/north{
+	name = "Requests Window"
 	},
 /obj/item/storage/box/firingpins,
 /obj/item/storage/fancy/donut_box,
@@ -1710,7 +1706,7 @@
 	},
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/area/station/ai/satellite/interior)
 "hH" = (
 /obj/structure/table/reinforced,
 /obj/item/wheelchair{
@@ -1926,10 +1922,9 @@
 /area/station/hallway/primary/aft)
 "iB" = (
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/machinery/door/window/brigdoor/security/cell{
+/obj/machinery/door/window/brigdoor/security/cell/left/directional/west{
 	id = "Cell 2";
-	name = "Cell 2";
-	dir = 8
+	name = "Cell 2"
 	},
 /obj/structure/chair/office{
 	dir = 8
@@ -1963,10 +1958,8 @@
 /area/space/nearstation)
 "iM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/airalarm/mixingchamber{
-	dir = 8;
-	pixel_x = -26
-	},
+/obj/machinery/airalarm/directional/east,
+/obj/effect/mapping_helpers/airalarm/mixingchamber_access,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -1995,15 +1988,13 @@
 /area/station/security/prison)
 "iS" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor{
+/obj/machinery/door/window/brigdoor/left/directional/north{
 	base_state = "rightsecure";
-	dir = 1;
 	icon_state = "rightsecure";
 	name = "Head of Personnel's Desk";
 	req_access = list("hop")
 	},
-/obj/machinery/door/window/left/directional/north{
-	dir = 2;
+/obj/machinery/door/window/left/directional/south{
 	name = "Reception Window"
 	},
 /obj/structure/cable,
@@ -2218,7 +2209,7 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 4
 	},
-/obj/structure/chair/stool/bar/directional/north,
+/obj/structure/chair/stool/bar/directional/south,
 /obj/structure/sign/poster/random/directional/south,
 /obj/effect/landmark/start/assistant,
 /obj/effect/decal/cleanable/dirt,
@@ -2233,7 +2224,7 @@
 "kb" = (
 /obj/machinery/telecomms/relay/preset/station,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "kc" = (
 /obj/structure/closet/secure_closet/psychology,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -2260,7 +2251,6 @@
 /obj/item/bedsheet/medical{
 	dir = 4
 	},
-/obj/effect/landmark/start/virologist,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/camera/autoname/directional/east,
 /obj/structure/extinguisher_cabinet/directional/east,
@@ -2277,9 +2267,8 @@
 /turf/open/floor/engine,
 /area/station/engineering/gravity_generator)
 "kj" = (
-/obj/machinery/door/window/brigdoor{
+/obj/machinery/door/window/brigdoor/left/directional/north{
 	base_state = "rightsecure";
-	dir = 1;
 	icon_state = "rightsecure";
 	name = "Head of Personnel's Office";
 	req_access = list("hop")
@@ -2318,7 +2307,7 @@
 /turf/open/openspace,
 /area/station/hallway/primary/central)
 "ks" = (
-/mob/living/simple_animal/hostile/retaliate/goose/vomit,
+/mob/living/basic/goose/vomit,
 /obj/machinery/hydroponics/soil{
 	pixel_y = 8
 	},
@@ -2351,7 +2340,7 @@
 "kx" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/machinery/modular_computer/console/preset/research{
+/obj/machinery/modular_computer/preset/research{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/dark_blue/diagonal_edge,
@@ -2494,7 +2483,7 @@
 /obj/structure/chair/comfy/black{
 	dir = 8
 	},
-/mob/living/simple_animal/hostile/lizard/wags_his_tail,
+/mob/living/basic/lizard/wags_his_tail,
 /turf/open/floor/wood,
 /area/station/service/janitor)
 "ls" = (
@@ -2514,7 +2503,7 @@
 /obj/machinery/requests_console/directional/west,
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "lw" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -2606,7 +2595,7 @@
 	dir = 8
 	},
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/area/station/ai/satellite/interior)
 "lS" = (
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/burnchamber)
@@ -2663,7 +2652,7 @@
 /obj/item/clothing/suit/hooded/ablative,
 /obj/item/gun/energy/temperature/security,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "mu" = (
 /obj/structure/stairs/east,
 /obj/structure/railing{
@@ -2700,7 +2689,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "mE" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -2741,7 +2730,7 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 4
 	},
-/obj/structure/chair/stool/bar/directional/north,
+/obj/structure/chair/stool/bar/directional/south,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2832,7 +2821,6 @@
 /area/space)
 "nd" = (
 /obj/machinery/turretid{
-	icon_state = "control_stun";
 	name = "AI Chamber turret control";
 	pixel_x = 3;
 	pixel_y = -23
@@ -2840,7 +2828,7 @@
 /mob/living/simple_animal/bot/secbot/pingsky,
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "nf" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -2856,7 +2844,7 @@
 "ni" = (
 /obj/machinery/teleport/station,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/area/station/ai/satellite/interior)
 "nj" = (
 /turf/closed/wall,
 /area/station/science/server)
@@ -2879,7 +2867,7 @@
 /turf/open/floor/engine,
 /area/station/engineering/gravity_generator)
 "nl" = (
-/obj/item/storage/secure/safe/directional/east,
+/obj/structure/secure_safe/directional/east,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
@@ -2971,7 +2959,7 @@
 "nH" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "nJ" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/monkeycubes{
@@ -3025,10 +3013,7 @@
 /area/station/security/brig)
 "nN" = (
 /obj/structure/sink/directional/east,
-/obj/structure/sign/poster/official/cleanliness{
-	pixel_x = -32
-	},
-/obj/effect/landmark/start/virologist,
+/obj/structure/sign/poster/official/cleanliness/directional/west,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3124,7 +3109,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -3204,7 +3189,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/minisat,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "oI" = (
 /obj/structure/railing,
 /obj/machinery/light/dim/directional/north,
@@ -3290,7 +3275,7 @@
 /area/station/security/lockers)
 "oT" = (
 /obj/structure/cable,
-/obj/structure/sign/delamination_counter/directional/north,
+/obj/machinery/incident_display/delam/directional/north,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -3304,7 +3289,7 @@
 	dir = 1
 	},
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/area/station/ai/satellite/interior)
 "oV" = (
 /obj/effect/landmark/start/quartermaster,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3408,8 +3393,7 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/machinery/door/window/left/directional/west{
-	dir = 2;
+/obj/machinery/door/window/left/directional/south{
 	layer = 3.1;
 	name = "Cyborg Upload Console Window";
 	req_access = list("ai_upload")
@@ -3418,7 +3402,7 @@
 	id = "AI"
 	},
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "pu" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -3434,7 +3418,7 @@
 /area/station/command/heads_quarters/hos)
 "pB" = (
 /turf/closed/wall/r_wall,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "pC" = (
 /obj/machinery/computer/camera_advanced/xenobio,
 /obj/structure/sign/xenobio_guide/directional/north,
@@ -3483,7 +3467,7 @@
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/item/clothing/glasses/welding,
-/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/power_store/cell/high,
 /obj/effect/turf_decal/siding/purple{
 	dir = 1
 	},
@@ -3548,7 +3532,7 @@
 /obj/item/radio/intercom/directional/west,
 /obj/structure/table/wood,
 /obj/item/storage/lockbox/medal,
-/obj/item/stamp/captain,
+/obj/item/stamp/head/captain,
 /obj/item/disk/nuclear,
 /obj/item/hand_tele,
 /obj/item/reagent_containers/cup/glass/flask/gold,
@@ -3572,15 +3556,15 @@
 /obj/effect/turf_decal/tile/dark_blue/diagonal_edge,
 /obj/effect/turf_decal/tile/dark_red/diagonal_centre,
 /obj/machinery/requests_console/directional/north{
-	announcementConsole = 1;
 	department = "Head of Security's Desk";
 	name = "Head of Security Requests Console";
-	assistance_requestable = 1;
-	anon_tips_receiver = 1;
 	dir = 8;
 	pixel_x = -30;
 	pixel_y = 0
 	},
+/obj/effect/mapping_helpers/requests_console/announcement,
+/obj/effect/mapping_helpers/requests_console/information,
+/obj/effect/mapping_helpers/requests_console/assistance,
 /obj/machinery/light/directional/west,
 /obj/machinery/computer/records/security{
 	dir = 4
@@ -3630,7 +3614,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "qx" = (
-/obj/machinery/modular_computer/console/preset/id{
+/obj/machinery/modular_computer/preset/id{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow/diagonal_centre,
@@ -3658,28 +3642,27 @@
 "qz" = (
 /obj/machinery/turretid{
 	control_area = "/area/station/ai_monitored/turret_protected/ai_upload";
-	icon_state = "control_stun";
 	name = "AI Upload Turret Control";
 	pixel_y = 28
 	},
 /obj/effect/turf_decal/tile/dark_blue/diagonal_edge,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple/diagonal_centre,
 /obj/machinery/light/small/directional/west,
 /obj/machinery/requests_console/directional/east{
-	announcementConsole = 1;
 	department = "Research Director's Desk";
 	name = "Research Director's Requests Console";
-	assistance_requestable = 1;
-	anon_tips_receiver = 1;
 	pixel_x = -30
 	},
+/obj/effect/mapping_helpers/requests_console/announcement,
+/obj/effect/mapping_helpers/requests_console/information,
+/obj/effect/mapping_helpers/requests_console/assistance,
 /obj/structure/closet/secure_closet/research_director,
 /obj/item/aicard,
 /obj/item/circuitboard/aicore,
-/obj/item/stamp/rd,
+/obj/item/stamp/head/rd,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "qB" = (
@@ -3750,7 +3733,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "qL" = (
 /turf/closed/wall,
 /area/station/medical/virology)
@@ -3778,8 +3761,7 @@
 /area/station/security/lockers)
 "qT" = (
 /obj/structure/ladder,
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
+/obj/machinery/door/window/brigdoor/left/directional/north{
 	name = "Monkey Pen";
 	req_access = list("virology")
 	},
@@ -3939,7 +3921,7 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/telecomms/relay/preset/station,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/command/nuke_storage)
+/area/station/command/vault)
 "rC" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
@@ -3973,7 +3955,7 @@
 /area/station/medical/medbay/central)
 "rL" = (
 /turf/closed/wall/r_wall,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "rN" = (
 /obj/machinery/vending/wardrobe/viro_wardrobe,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -4003,12 +3985,12 @@
 "rQ" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/machinery/suit_storage_unit/rd,
-/obj/machinery/keycard_auth/directional/north{
+/obj/machinery/keycard_auth/wall_mounted/directional/north{
 	pixel_x = -5
 	},
 /obj/effect/turf_decal/tile/dark_blue/diagonal_edge,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple/diagonal_centre,
 /obj/machinery/light_switch/directional/north{
@@ -4022,7 +4004,7 @@
 	},
 /obj/machinery/camera/autoname/directional/east,
 /obj/machinery/firealarm/directional/north,
-/obj/machinery/keycard_auth/directional/south,
+/obj/machinery/keycard_auth/wall_mounted/directional/south,
 /turf/open/floor/carpet/orange,
 /area/station/command/heads_quarters/qm)
 "rT" = (
@@ -4110,7 +4092,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "sm" = (
-/obj/effect/spawner/random/structure/crate_empty,
+/obj/effect/spawner/random/structure/closet_empty/crate,
 /obj/effect/spawner/random/food_or_drink/donkpockets{
 	pixel_x = -9;
 	pixel_y = 3
@@ -4193,7 +4175,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "sB" = (
 /turf/open/floor/glass/reinforced/plasma/airless,
 /area/space)
@@ -4239,10 +4221,10 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "sQ" = (
 /obj/structure/table,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray/full,
 /obj/item/mmi,
 /obj/item/reagent_containers/spray/cleaner{
 	pixel_x = -10;
@@ -4291,13 +4273,12 @@
 /area/station/engineering/supermatter/room)
 "sW" = (
 /turf/open/floor/plating/elevatorshaft,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/area/station/ai/satellite/interior)
 "sX" = (
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/machinery/door/window/brigdoor/security/cell{
+/obj/machinery/door/window/brigdoor/security/cell/left/directional/west{
 	id = "Cell 1";
-	name = "Cell 1";
-	dir = 8
+	name = "Cell 1"
 	},
 /obj/structure/chair/office{
 	dir = 8
@@ -4442,7 +4423,7 @@
 /area/station/security/brig)
 "ts" = (
 /obj/machinery/mecha_part_fabricator{
-	dir = 1
+	drop_direction = 1
 	},
 /obj/structure/sign/poster/random/directional/east,
 /obj/effect/turf_decal/trimline/red/filled/warning{
@@ -4493,11 +4474,11 @@
 /obj/effect/turf_decal/tile/dark/half/contrasted{
 	dir = 1
 	},
-/obj/item/ammo_box/a357,
+/obj/item/ammo_box/speedloader/c357,
 /obj/item/card/id/advanced/silver/reaper,
-/obj/item/gun/ballistic/revolver/syndicate,
+/obj/item/gun/ballistic/revolver/badass,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/command/nuke_storage)
+/area/station/command/vault)
 "tC" = (
 /obj/structure/rack,
 /obj/machinery/airalarm/directional/south,
@@ -4527,7 +4508,7 @@
 	},
 /obj/item/gun/energy/laser,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "tF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4625,7 +4606,7 @@
 /turf/open/space/openspace,
 /area/space)
 "uf" = (
-/obj/effect/spawner/random/structure/crate_empty,
+/obj/effect/spawner/random/structure/closet_empty/crate,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/east,
 /obj/structure/extinguisher_cabinet/directional/east,
@@ -4681,10 +4662,10 @@
 /obj/effect/turf_decal/tile/blue/diagonal_centre,
 /obj/structure/table/glass,
 /obj/item/computer_disk/medical,
-/obj/machinery/keycard_auth/directional/south{
+/obj/machinery/keycard_auth/wall_mounted/directional/south{
 	pixel_x = 6
 	},
-/obj/item/stamp/cmo,
+/obj/item/stamp/head/cmo,
 /obj/item/radio/intercom/directional/south{
 	pixel_y = -40
 	},
@@ -4785,11 +4766,11 @@
 	pixel_x = 29
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /obj/effect/landmark/start/cyborg,
 /turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "uW" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/decal/cleanable/dirt,
@@ -4858,7 +4839,7 @@
 	pixel_x = -22
 	},
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/area/station/ai/satellite/interior)
 "vi" = (
 /obj/machinery/computer/robotics{
 	dir = 4
@@ -4898,7 +4879,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "vl" = (
 /obj/machinery/door/morgue{
 	name = "Private Study";
@@ -4991,7 +4972,7 @@
 "vE" = (
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/area/station/ai/satellite/interior)
 "vH" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge Access"
@@ -5010,7 +4991,7 @@
 "vL" = (
 /obj/effect/turf_decal/tile/dark_blue/diagonal_edge,
 /obj/effect/turf_decal/tile/dark_red/diagonal_centre,
-/mob/living/basic/giant_spider/sgt_araneus,
+/mob/living/basic/spider/giant/sgt_araneus,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "vN" = (
@@ -5021,10 +5002,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "vU" = (
-/obj/machinery/door/window/left/directional/south{
+/obj/machinery/door/window/left/directional/north{
 	name = "Medical Lathe";
-	req_access = list("medical");
-	dir = 1
+	req_access = list("medical")
 	},
 /obj/effect/landmark/start/paramedic,
 /obj/machinery/door/firedoor,
@@ -5183,7 +5163,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "wM" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Chamber"
@@ -5193,7 +5173,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/area/station/ai/satellite/interior)
 "wR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5288,7 +5268,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/machinery/keycard_auth/directional/north{
+/obj/machinery/keycard_auth/wall_mounted/directional/north{
 	pixel_x = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5324,15 +5304,15 @@
 /obj/effect/turf_decal/tile/dark_blue/diagonal_edge,
 /obj/effect/turf_decal/tile/blue/diagonal_centre,
 /obj/machinery/requests_console/directional/west{
-	announcementConsole = 1;
 	department = "Chief Medical Officer's Desk";
 	name = "Chief Medical Officer's Requests Console";
-	assistance_requestable = 1;
-	anon_tips_receiver = 1;
 	dir = 2;
 	pixel_y = -30;
 	pixel_x = 0
 	},
+/obj/effect/mapping_helpers/requests_console/announcement,
+/obj/effect/mapping_helpers/requests_console/information,
+/obj/effect/mapping_helpers/requests_console/assistance,
 /obj/effect/landmark/start/chief_medical_officer,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -5349,7 +5329,7 @@
 /turf/open/floor/circuit/green{
 	luminosity = 2
 	},
-/area/station/ai_monitored/command/nuke_storage)
+/area/station/command/vault)
 "xw" = (
 /obj/machinery/porta_turret/ai{
 	dir = 1
@@ -5357,7 +5337,7 @@
 /obj/effect/turf_decal/stripes/box,
 /obj/effect/turf_decal/stripes/red/box,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "xx" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/siding/purple{
@@ -5373,7 +5353,7 @@
 /obj/structure/cable,
 /obj/machinery/power/rtg/abductor,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "xE" = (
 /turf/open/misc/asteroid/airless,
 /area/space/nearstation)
@@ -5434,7 +5414,7 @@
 /area/station/science/lab)
 "xN" = (
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/machinery/modular_computer/console/preset/curator{
+/obj/machinery/modular_computer/preset/curator{
 	dir = 1
 	},
 /obj/machinery/newscaster/directional/east,
@@ -5550,7 +5530,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "yg" = (
 /obj/machinery/computer/station_alert{
 	dir = 8
@@ -5702,7 +5682,7 @@
 "yL" = (
 /obj/machinery/computer/rdservercontrol,
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/machinery/door/window/brigdoor{
+/obj/machinery/door/window/brigdoor/left/directional/south{
 	name = "Research Director Observation";
 	req_access = list("rd")
 	},
@@ -5713,9 +5693,7 @@
 	dir = 5
 	},
 /obj/machinery/light/directional/west,
-/obj/structure/sign/poster/official/safety_internals{
-	pixel_x = -32
-	},
+/obj/structure/sign/poster/official/safety_internals/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "yT" = (
@@ -5728,9 +5706,8 @@
 /obj/machinery/computer/upload/ai,
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/machinery/door/window/left/directional/west{
+/obj/machinery/door/window/left/directional/south{
 	base_state = "right";
-	dir = 2;
 	icon_state = "right";
 	layer = 3.1;
 	name = "Upload Console Window";
@@ -5741,7 +5718,7 @@
 	id = "AI"
 	},
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "yX" = (
 /obj/machinery/computer/pod/old/mass_driver_controller/ordnancedriver{
 	pixel_y = 24
@@ -5823,10 +5800,10 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
@@ -5839,7 +5816,7 @@
 /area/station/hallway/primary/aft)
 "zl" = (
 /turf/closed/wall/r_wall,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "zn" = (
 /obj/effect/landmark/start/cook,
 /obj/structure/cable,
@@ -5904,7 +5881,7 @@
 	dir = 1
 	},
 /obj/machinery/camera/preset/ordnance{
-	dir = 5
+	dir = 10
 	},
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plating/airless,
@@ -5918,7 +5895,7 @@
 /area/station/engineering/atmos)
 "zE" = (
 /obj/structure/window/reinforced/spawner/directional/west,
-/obj/machinery/photocopier{
+/obj/machinery/photocopier/prebuilt{
 	pixel_y = 3
 	},
 /turf/open/floor/carpet/green,
@@ -5999,7 +5976,7 @@
 	dir = 4
 	},
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/area/station/ai/satellite/interior)
 "Ac" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
@@ -6121,7 +6098,7 @@
 "AB" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/west,
-/mob/living/simple_animal/slime,
+/mob/living/basic/slime,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "AC" = (
@@ -6203,9 +6180,7 @@
 	pixel_y = 2
 	},
 /obj/item/book/manual/wiki/security_space_law,
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
+/obj/item/kirbyplants/organic/plant21,
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
@@ -6214,7 +6189,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/red/corner{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/computer/atmos_control/ordnancemix{
 	dir = 1
@@ -6294,8 +6269,7 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "Bl" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
-/obj/machinery/door/window/right/directional/south{
-	dir = 1;
+/obj/machinery/door/window/right/directional/north{
 	name = "Engineering";
 	req_access = list("engineering")
 	},
@@ -6305,7 +6279,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "Bn" = (
-/obj/structure/industrial_lift/public,
+/obj/structure/transport/linear,
 /obj/item/radio/intercom/directional/south{
 	freerange = 1;
 	frequency = 1447;
@@ -6315,7 +6289,7 @@
 	},
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/openspace,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "Bp" = (
 /obj/structure/railing{
 	dir = 4
@@ -6387,10 +6361,9 @@
 /obj/structure/cable,
 /obj/effect/landmark/start/cyborg,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "BM" = (
 /obj/structure/ladder,
-/obj/effect/landmark/start/virologist,
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "BN" = (
@@ -6486,7 +6459,7 @@
 	},
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/table/wood,
-/obj/item/clothing/mask/cigarette/cigar,
+/obj/item/cigarette/cigar,
 /obj/item/reagent_containers/cup/glass/mug/nanotrasen,
 /obj/item/reagent_containers/cup/glass/bottle/hooch,
 /turf/open/floor/wood,
@@ -6631,7 +6604,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "Db" = (
 /obj/structure/lattice,
 /turf/open/space/openspace,
@@ -6726,7 +6699,7 @@
 /obj/effect/turf_decal/tile/dark_blue/diagonal_edge,
 /obj/effect/turf_decal/tile/dark_red/diagonal_centre,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /obj/item/radio/intercom/directional/east{
 	pixel_y = 26
@@ -6743,7 +6716,7 @@
 /obj/machinery/camera/autoname/directional/north,
 /obj/structure/window/reinforced/plasma/spawner/directional/east,
 /turf/open/floor/plating,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "Dw" = (
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/effect/turf_decal/box,
@@ -6774,7 +6747,7 @@
 	},
 /area/space/nearstation)
 "DF" = (
-/obj/item/storage/secure/safe/directional/north,
+/obj/structure/secure_safe/directional/north,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -6782,12 +6755,12 @@
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/captain/private)
 "DM" = (
-/obj/machinery/modular_computer/console/preset/engineering{
+/obj/machinery/modular_computer/preset/engineering{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
@@ -6814,9 +6787,9 @@
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "DV" = (
-/obj/structure/industrial_lift/public,
+/obj/structure/transport/linear,
 /obj/machinery/lift_indicator/directional/north{
 	linked_elevator_id = "test_vator";
 	pixel_x = 24
@@ -6829,7 +6802,7 @@
 	pixel_x = 32
 	},
 /turf/open/openspace,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "DW" = (
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/north,
@@ -6982,7 +6955,7 @@
 	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -7034,7 +7007,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/mob/living/simple_animal/sloth/citrus,
+/mob/living/basic/sloth/citrus,
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
@@ -7136,12 +7109,13 @@
 /area/station/service/bar/backroom)
 "FB" = (
 /obj/effect/landmark/start/ai,
-/obj/structure/industrial_lift/public,
-/obj/effect/landmark/lift_id{
-	specific_lift_id = "test_vator"
+/obj/structure/transport/linear,
+/obj/effect/landmark/transport/transport_id{
+	 = None;
+	specific_transport_id = "test_vator"
 	},
 /turf/open/openspace,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "FE" = (
 /obj/structure/lattice,
 /obj/machinery/camera/autoname/directional/east,
@@ -7210,7 +7184,7 @@
 "Gi" = (
 /obj/machinery/teleport/hub,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/area/station/ai/satellite/interior)
 "Gp" = (
 /obj/structure/ladder,
 /obj/structure/cable,
@@ -7304,10 +7278,8 @@
 	name = "External Gas to Loop"
 	},
 /obj/structure/cable,
-/obj/machinery/airalarm/engine{
-	pixel_y = 24;
-	dir = 1
-	},
+/obj/machinery/airalarm/directional/north,
+/obj/effect/mapping_helpers/airalarm/engine_access,
 /obj/item/pipe_dispenser,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -7444,7 +7416,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "Hz" = (
 /turf/closed/wall,
 /area/space)
@@ -7513,7 +7485,7 @@
 	},
 /obj/effect/turf_decal/box/red,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/command/nuke_storage)
+/area/station/command/vault)
 "HK" = (
 /obj/machinery/stasis{
 	dir = 4
@@ -7561,7 +7533,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "HT" = (
 /obj/machinery/door/airlock/external{
 	name = "Mining Dock Airlock"
@@ -7657,7 +7629,7 @@
 /area/station/engineering/supermatter/room)
 "It" = (
 /obj/structure/rack,
-/obj/item/storage/secure/safe/directional/east,
+/obj/structure/secure_safe/directional/east,
 /obj/effect/turf_decal/bot_red,
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 5
@@ -7688,7 +7660,7 @@
 	pixel_y = 2
 	},
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "Iv" = (
 /obj/structure/closet/secure_closet/warden,
 /obj/item/gun/energy/e_gun/mini,
@@ -7805,7 +7777,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "IY" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "outerbrig";
@@ -7877,7 +7849,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "Jk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7914,7 +7886,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/command/nuke_storage)
+/area/station/command/vault)
 "Jr" = (
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/trimline/red/filled/warning{
@@ -8003,7 +7975,7 @@
 /turf/open/floor/engine/air,
 /area/station/engineering/atmos)
 "JS" = (
-/obj/machinery/modular_computer/console/preset/id{
+/obj/machinery/modular_computer/preset/id{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/wood{
@@ -8050,7 +8022,7 @@
 	piping_layer = 4
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/blue{
@@ -8074,7 +8046,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "Kj" = (
-/obj/structure/bed/roller,
+/obj/structure/bed/medical/emergency,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -8106,7 +8078,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -8251,7 +8223,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
@@ -8394,7 +8366,7 @@
 "Lv" = (
 /obj/structure/lattice/catwalk,
 /turf/closed/wall/r_wall,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/area/station/ai/satellite/interior)
 "Lw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -8416,7 +8388,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "LE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/effect/turf_decal/tile/yellow,
@@ -8535,9 +8507,8 @@
 /area/station/service/janitor)
 "Md" = (
 /obj/structure/table/reinforced,
-/obj/item/computer_disk/atmos,
-/mob/living/simple_animal/parrot/poly,
-/obj/item/stamp/ce,
+/mob/living/basic/parrot/poly,
+/obj/item/stamp/head/ce,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/diagonal_centre,
@@ -8547,7 +8518,7 @@
 /area/station/command/heads_quarters/ce)
 "Me" = (
 /obj/structure/table/glass,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray/full,
 /obj/item/clothing/glasses/hud/health,
 /obj/item/storage/belt/medical,
 /obj/item/healthanalyzer,
@@ -8572,7 +8543,7 @@
 /area/station/command/heads_quarters/cmo)
 "Mg" = (
 /obj/structure/table/wood,
-/obj/item/storage/book/bible,
+/obj/item/book/bible,
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/grimy,
@@ -8619,7 +8590,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "Mx" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/trimline/green/filled/corner{
@@ -8651,7 +8622,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "MC" = (
 /obj/structure/rack,
 /obj/machinery/camera/motion/directional/east,
@@ -8694,7 +8665,7 @@
 /obj/item/gun/energy/e_gun/dragnet,
 /obj/item/gun/energy/e_gun/dragnet,
 /turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "MG" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -8742,7 +8713,7 @@
 	},
 /area/station/hallway/primary/aft)
 "MT" = (
-/obj/structure/industrial_lift/public,
+/obj/structure/transport/linear,
 /obj/item/radio/intercom/directional/west{
 	freerange = 1;
 	listening = 0;
@@ -8751,7 +8722,7 @@
 	},
 /obj/effect/landmark/start/ai/secondary,
 /turf/open/openspace,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "Nb" = (
 /obj/machinery/door/airlock/research{
 	name = "Robotics Lab"
@@ -8788,12 +8759,12 @@
 /obj/effect/turf_decal/tile/dark_blue/diagonal_edge,
 /obj/effect/turf_decal/tile/dark_red/diagonal_centre,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /obj/machinery/recharger{
 	pixel_x = 8
 	},
-/obj/item/stamp/hos,
+/obj/item/stamp/head/hos,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "Nl" = (
@@ -8938,7 +8909,7 @@
 /obj/effect/turf_decal/tile/dark_blue/diagonal_edge,
 /obj/effect/turf_decal/tile/blue/diagonal_centre,
 /obj/structure/bed/dogbed/runtime,
-/mob/living/simple_animal/pet/cat/runtime,
+/mob/living/basic/pet/cat/runtime,
 /obj/item/toy/cattoy,
 /obj/machinery/computer/security/telescreen/cmo{
 	pixel_y = 30
@@ -8959,7 +8930,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/item/storage/secure/safe/caps_spare/directional/west,
+/obj/structure/secure_safe/caps_spare{
+	pixel_x = -32
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "NM" = (
@@ -9063,16 +9036,16 @@
 	dir = 10
 	},
 /obj/machinery/requests_console/directional/east{
-	announcementConsole = 1;
 	department = "Research Lab";
 	name = "Research Requests Console";
-	receive_ore_updates = 1;
-	assistance_requestable = 1;
-	anon_tips_receiver = 1;
 	dir = 2;
 	pixel_y = -30;
 	pixel_x = 0
 	},
+/obj/effect/mapping_helpers/requests_console/announcement,
+/obj/effect/mapping_helpers/requests_console/ore_update,
+/obj/effect/mapping_helpers/requests_console/information,
+/obj/effect/mapping_helpers/requests_console/assistance,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "Og" = (
@@ -9113,7 +9086,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/station/engineering/gravity_generator)
@@ -9210,7 +9183,7 @@
 	linked_elevator_id = "test_vator"
 	},
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/area/station/ai/satellite/interior)
 "OI" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -9250,7 +9223,6 @@
 /obj/structure/chair/office/light{
 	dir = 1
 	},
-/obj/effect/landmark/start/virologist,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/green/filled/corner,
@@ -9273,7 +9245,7 @@
 "OS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "OU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -9296,7 +9268,7 @@
 /area/station/command/heads_quarters/captain/private)
 "Pd" = (
 /turf/closed/wall/r_wall,
-/area/station/ai_monitored/security/armory)
+/area/station/security/armory)
 "Pf" = (
 /obj/structure/railing{
 	dir = 8
@@ -9327,10 +9299,10 @@
 /turf/closed/wall/r_wall,
 /area/station/science/server)
 "Pk" = (
-/obj/structure/industrial_lift/public,
+/obj/structure/transport/linear,
 /obj/effect/landmark/start/ai/secondary,
 /turf/open/openspace,
-/area/station/ai_monitored/turret_protected/ai)
+/area/station/ai/satellite/chamber)
 "Pl" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/spawner/random/entertainment/arcade,
@@ -9468,7 +9440,7 @@
 /obj/effect/turf_decal/stripes/full,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "PS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9487,7 +9459,7 @@
 	},
 /obj/machinery/light/directional/west,
 /obj/structure/bed/dogbed/renault,
-/mob/living/simple_animal/pet/fox/renault,
+/mob/living/basic/pet/fox/renault,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain/private)
 "PX" = (
@@ -9610,7 +9582,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "QG" = (
 /obj/effect/landmark/start/mime,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -9671,7 +9643,7 @@
 /obj/structure/cable/multilayer/multiz,
 /obj/structure/window/reinforced/plasma/spawner/directional/south,
 /turf/open/floor/plating,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/area/station/ai/satellite/interior)
 "QP" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
@@ -9995,7 +9967,7 @@
 /obj/machinery/camera/autoname/directional/south,
 /obj/machinery/light/red/directional/north,
 /turf/open/floor/plating,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/area/station/ai/satellite/interior)
 "Sr" = (
 /obj/effect/landmark/start/paramedic,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10016,7 +9988,7 @@
 /area/station/command/heads_quarters/cmo)
 "St" = (
 /turf/closed/wall/r_wall,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/area/station/ai/satellite/interior)
 "Su" = (
 /obj/structure/closet/emcloset,
 /obj/effect/spawner/random/engineering/vending_restock,
@@ -10065,7 +10037,7 @@
 /area/station/security/lockers)
 "SE" = (
 /obj/structure/cable,
-/obj/item/storage/secure/safe/directional/north{
+/obj/structure/secure_safe/directional/north{
 	name = "evidence safe";
 	dir = 2;
 	pixel_y = -32
@@ -10093,12 +10065,12 @@
 /area/station/engineering/gravity_generator)
 "SI" = (
 /obj/machinery/requests_console/directional/east{
-	announcementConsole = 1;
 	department = "Captain's Desk";
-	name = "Captain's Requests Console";
-	assistance_requestable = 1;
-	anon_tips_receiver = 1
+	name = "Captain's Requests Console"
 	},
+/obj/effect/mapping_helpers/requests_console/announcement,
+/obj/effect/mapping_helpers/requests_console/information,
+/obj/effect/mapping_helpers/requests_console/assistance,
 /obj/machinery/button/door/directional/south{
 	id = "bridge blast";
 	name = "Captain's Office Privacy Control";
@@ -10111,7 +10083,7 @@
 	},
 /obj/structure/closet/secure_closet/captains,
 /obj/item/pinpointer/nuke,
-/obj/item/stamp/captain,
+/obj/item/stamp/head/captain,
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/captain/private)
 "SK" = (
@@ -10291,7 +10263,7 @@
 	dir = 1
 	},
 /turf/open/openspace,
-/area/station/ai_monitored/turret_protected/ai_upload)
+/area/station/ai/upload/chamber)
 "TH" = (
 /obj/machinery/vending/wardrobe/chef_wardrobe,
 /turf/open/floor/iron/cafeteria,
@@ -10341,7 +10313,7 @@
 /obj/effect/turf_decal/siding/blue{
 	dir = 9
 	},
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/surgery_tray/full,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "TT" = (
@@ -10353,7 +10325,7 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 4
 	},
-/obj/structure/chair/stool/bar/directional/north,
+/obj/structure/chair/stool/bar/directional/south,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10480,7 +10452,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "Uv" = (
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
@@ -10495,7 +10467,7 @@
 "UA" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/east,
-/mob/living/simple_animal/slime,
+/mob/living/basic/slime,
 /obj/structure/sign/warning/biohazard/directional/north,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
@@ -10576,7 +10548,7 @@
 /turf/open/floor/carpet/green,
 /area/station/service/library)
 "US" = (
-/obj/effect/spawner/random/structure/crate_empty,
+/obj/effect/spawner/random/structure/closet_empty/crate,
 /obj/effect/spawner/random/food_or_drink/donkpockets{
 	pixel_x = -9;
 	pixel_y = 3
@@ -10655,7 +10627,7 @@
 /area/station/service/hydroponics)
 "Vl" = (
 /turf/closed/wall/r_wall,
-/area/station/ai_monitored/command/nuke_storage)
+/area/station/command/vault)
 "Vn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/green/filled/line,
@@ -10689,7 +10661,7 @@
 /obj/item/stack/sheet/mineral/plasma/five,
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/station/engineering/gravity_generator)
@@ -10712,7 +10684,7 @@
 	},
 /obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/area/station/ai/satellite/interior)
 "VC" = (
 /obj/machinery/pdapainter{
 	pixel_y = 2
@@ -10748,7 +10720,7 @@
 /obj/structure/cable,
 /obj/structure/window/reinforced/plasma/spawner/directional/south,
 /turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/area/station/ai/satellite/interior)
 "VI" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/start/warden,
@@ -10767,8 +10739,7 @@
 /area/station/security/warden)
 "VK" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/left/directional/west{
-	dir = 1;
+/obj/machinery/door/window/left/directional/north{
 	name = "Cargo Desk";
 	req_access = list("cargo")
 	},
@@ -11051,7 +11022,7 @@
 /obj/machinery/computer/prisoner/management{
 	dir = 4
 	},
-/obj/machinery/keycard_auth/directional/west,
+/obj/machinery/keycard_auth/wall_mounted/directional/west,
 /obj/effect/turf_decal/tile/dark_blue/diagonal_edge,
 /obj/effect/turf_decal/tile/dark_red/diagonal_centre,
 /obj/machinery/camera/autoname/directional/west,
@@ -11093,7 +11064,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -11185,19 +11156,19 @@
 /obj/structure/closet/secure_closet/hop,
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/light/directional/west,
-/obj/item/stamp/hop{
+/obj/item/stamp/head/hop{
 	pixel_x = -4;
 	pixel_y = 4
 	},
 /obj/machinery/requests_console/directional/north{
-	announcementConsole = 1;
 	department = "Head of Personnel's Desk";
 	name = "Head of Personnel's Requests Console";
-	assistance_requestable = 1;
-	anon_tips_receiver = 1;
 	pixel_x = -30;
 	pixel_y = 0
 	},
+/obj/effect/mapping_helpers/requests_console/announcement,
+/obj/effect/mapping_helpers/requests_console/information,
+/obj/effect/mapping_helpers/requests_console/assistance,
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/hop)
 "XE" = (
@@ -11275,9 +11246,7 @@
 "XV" = (
 /obj/effect/turf_decal/tile/dark_blue/diagonal_edge,
 /obj/effect/turf_decal/tile/blue/diagonal_centre,
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
+/obj/item/kirbyplants/organic/plant21,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -11302,8 +11271,7 @@
 /area/station/service/kitchen)
 "Yf" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/right/directional/east{
-	dir = 8;
+/obj/machinery/door/window/right/directional/west{
 	name = "Pharmacy Desk";
 	req_access = list("pharmacy")
 	},
@@ -11411,13 +11379,13 @@
 	},
 /obj/machinery/light/small/directional/west,
 /obj/machinery/requests_console/directional/east{
-	announcementConsole = 1;
 	department = "Quartermaster's Desk";
 	name = "Quartermaster's Requests Console";
-	supplies_requestable = 1;
 	pixel_y = -30;
 	pixel_x = 0
 	},
+/obj/effect/mapping_helpers/requests_console/announcement,
+/obj/effect/mapping_helpers/requests_console/supplies,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/qm)
 "YA" = (
@@ -11479,7 +11447,7 @@
 	pixel_x = 7;
 	pixel_y = 9
 	},
-/obj/item/stamp/qm{
+/obj/item/stamp/head/qm{
 	pixel_x = 7;
 	pixel_y = -2
 	},
@@ -11504,7 +11472,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "YV" = (
-/obj/structure/bed/roller,
+/obj/structure/bed/medical/emergency,
 /obj/machinery/iv_drip,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -11618,7 +11586,7 @@
 /obj/structure/window/spawner/directional/north,
 /obj/structure/window/spawner/directional/east,
 /obj/structure/window/spawner/directional/south,
-/obj/item/kirbyplants/dead,
+/obj/item/kirbyplants/random/dead,
 /turf/open/floor/grass,
 /area/station/maintenance/central)
 "ZG" = (
@@ -11680,7 +11648,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/eva)
+/area/station/command/eva)
 "ZZ" = (
 /obj/structure/window/reinforced/plasma/spawner/directional/west,
 /obj/machinery/power/energy_accumulator/tesla_coil/anchored,

--- a/StationMaps/SokobanStation/Sokoban.dmm
+++ b/StationMaps/SokobanStation/Sokoban.dmm
@@ -7111,7 +7111,6 @@
 /obj/effect/landmark/start/ai,
 /obj/structure/transport/linear,
 /obj/effect/landmark/transport/transport_id{
-	 = None;
 	specific_transport_id = "test_vator"
 	},
 /turf/open/openspace,


### PR DESCRIPTION
Can run in the editor with no invalid types window. Tested in-game.

The nested folders in some of the maps in this depot are confusing...