### PR TITLE
kilostation revamp pt. 1

### DIFF
--- a/StationMaps/KiloStation/KiloStation.dmm
+++ b/StationMaps/KiloStation/KiloStation.dmm
@@ -5708,6 +5708,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/lesser)
 "bXX" = (
@@ -8592,6 +8593,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "cVb" = (
@@ -9262,6 +9264,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "dfS" = (
@@ -15859,6 +15862,7 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "fol" = (
@@ -17155,6 +17159,7 @@
 /obj/structure/cable,
 /obj/structure/sign/poster/contraband/random/directional/west,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "fGC" = (
@@ -18592,6 +18597,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/lesser)
 "gdI" = (
@@ -26209,6 +26215,7 @@
 /obj/structure/grille/broken,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "iwB" = (
@@ -30169,11 +30176,11 @@
 /area/station/maintenance/port/fore)
 "jJN" = (
 /obj/effect/turf_decal/stripes/end,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/east,
+/obj/machinery/atmospherics/components/unary/airlock_pump{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "jJW" = (
@@ -31151,6 +31158,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/aft)
 "kbn" = (
@@ -33682,6 +33690,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "kUS" = (
@@ -40343,10 +40352,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/components/unary/airlock_pump,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "ncB" = (
@@ -43143,6 +43152,7 @@
 /obj/structure/grille/broken,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "ofe" = (
@@ -45536,6 +45546,7 @@
 /obj/structure/grille/broken,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "oWG" = (
@@ -61549,6 +61560,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "tZK" = (
@@ -61821,6 +61833,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "ueY" = (
@@ -68305,6 +68318,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "wer" = (
@@ -71190,6 +71204,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "xaz" = (
@@ -72740,6 +72755,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "xCp" = (

--- a/StationMaps/KiloStation/KiloStation.dmm
+++ b/StationMaps/KiloStation/KiloStation.dmm
@@ -17,6 +17,7 @@
 /obj/machinery/atmospherics/components/unary/airlock_pump{
 	dir = 1
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
 /area/station/ai/satellite/atmos)
 "aap" = (
@@ -273,6 +274,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "acK" = (
@@ -312,10 +314,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/box/corners{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "add" = (
@@ -4415,9 +4417,6 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
-	},
 /turf/closed/wall,
 /area/station/security/office)
 "bzo" = (
@@ -5171,6 +5170,7 @@
 /area/station/science/xenobiology)
 "bPK" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "bPP" = (
@@ -7278,10 +7278,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
-"cui" = (
-/mob/living/basic/mining/goliath/ancient,
-/turf/open/misc/asteroid/airless,
-/area/space/nearstation)
 "cup" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -8224,6 +8220,7 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
+/obj/effect/turf_decal/box/corners,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "cOp" = (
@@ -9157,6 +9154,7 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "ddW" = (
@@ -10560,6 +10558,9 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "dyw" = (
@@ -10951,7 +10952,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "dGX" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -11519,9 +11519,6 @@
 "dPK" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/commissary)
 "dPR" = (
@@ -14787,9 +14784,9 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "eWd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "eWu" = (
@@ -15866,7 +15863,7 @@
 /area/station/maintenance/port/lesser)
 "fol" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/commissary)
 "fov" = (
@@ -16943,6 +16940,7 @@
 /obj/machinery/atmospherics/components/unary/airlock_pump{
 	dir = 4
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
 "fCX" = (
@@ -17255,6 +17253,7 @@
 /obj/machinery/atmospherics/components/unary/airlock_pump{
 	dir = 8
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "fIn" = (
@@ -19317,6 +19316,7 @@
 "gpH" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/effect/turf_decal/stripes/corner,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "gpI" = (
@@ -20505,6 +20505,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/station_engineer,
+/obj/effect/turf_decal/box,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "gIX" = (
@@ -21358,6 +21359,7 @@
 "gYm" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/structure/closet/firecloset,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "gYx" = (
@@ -22882,6 +22884,9 @@
 "hyt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/commissary)
 "hyJ" = (
@@ -23689,6 +23694,7 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "hKQ" = (
@@ -24209,6 +24215,9 @@
 "hRO" = (
 /obj/structure/chair{
 	dir = 8
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
@@ -27391,6 +27400,7 @@
 	dir = 8
 	},
 /obj/structure/closet/emcloset,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "iNL" = (
@@ -28527,6 +28537,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/box,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "jgu" = (
@@ -30523,6 +30534,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
 "jQE" = (
@@ -32229,6 +32241,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "kwV" = (
@@ -33052,6 +33065,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/contraband/random/directional/east,
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/commissary)
 "kMs" = (
@@ -34788,9 +34802,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/airlock_pump/unbolt_only{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
 "lmr" = (
@@ -35599,6 +35612,7 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/iron,
 /area/station/security/processing)
 "lzv" = (
@@ -36083,10 +36097,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /obj/machinery/atmospherics/components/unary/airlock_pump{
 	dir = 1
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/security/processing)
 "lIs" = (
@@ -36621,6 +36635,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
 "lRS" = (
@@ -40841,7 +40856,10 @@
 /area/station/command/teleporter)
 "noj" = (
 /obj/machinery/light/small/directional/north,
-/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/atmospherics/components/unary/airlock_pump/unbolt_only{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
 "nol" = (
@@ -41890,13 +41908,11 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/aft)
 "nFg" = (
-/obj/structure/lattice,
-/obj/structure/lattice/catwalk,
-/obj/structure/marker_beacon/burgundy{
-	name = "landing marker"
+/obj/effect/turf_decal/box/corners{
+	dir = 8
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "nFm" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -44174,6 +44190,12 @@
 "oye" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/closet/emcloset/anchored,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/service/chapel)
 "oyA" = (
@@ -46481,6 +46503,7 @@
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "plG" = (
@@ -47375,6 +47398,7 @@
 "pBR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "pBU" = (
@@ -47989,6 +48013,7 @@
 /obj/machinery/atmospherics/components/unary/airlock_pump/unbolt_only{
 	dir = 1
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "pKM" = (
@@ -48783,6 +48808,13 @@
 /obj/machinery/atmospherics/components/unary/airlock_pump{
 	dir = 8
 	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/service/chapel)
 "pXt" = (
@@ -48911,10 +48943,11 @@
 /area/station/hallway/primary/starboard)
 "qaa" = (
 /obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/very_dim/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "qai" = (
@@ -53070,6 +53103,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/effect/turf_decal/box,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "ruo" = (
@@ -53191,6 +53225,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/box,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "rvW" = (
@@ -53810,6 +53845,10 @@
 "rFN" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/components/unary/airlock_pump/unbolt_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "rFS" = (
@@ -54928,9 +54967,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/airlock_pump/unbolt_only{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
 "rZc" = (
@@ -58265,6 +58303,12 @@
 /area/station/maintenance/disposal/incinerator)
 "sYM" = (
 /obj/machinery/light/small/directional/south,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/service/chapel)
 "sZb" = (
@@ -58420,6 +58464,8 @@
 	name = "Arrival Shuttle Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/entry)
 "tbS" = (
@@ -60050,6 +60096,7 @@
 "tBn" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "tBJ" = (
@@ -61646,10 +61693,10 @@
 /turf/open/floor/grass,
 /area/station/security/prison/garden)
 "udg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "udn" = (
@@ -64936,6 +64983,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/structure/noticeboard/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/commissary)
 "vhp" = (
@@ -65655,6 +65703,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/effect/turf_decal/box,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "vtf" = (
@@ -65700,7 +65749,10 @@
 /area/station/hallway/primary/central/fore)
 "vuk" = (
 /obj/machinery/light/small/directional/south,
-/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/atmospherics/components/unary/airlock_pump/unbolt_only{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
 "vum" = (
@@ -68186,6 +68238,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/box,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "wdf" = (
@@ -70401,6 +70454,10 @@
 "wNr" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/small/directional/east,
+/obj/machinery/atmospherics/components/unary/airlock_pump/unbolt_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "wNs" = (
@@ -70721,6 +70778,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "wSU" = (
@@ -71169,6 +71228,8 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "xbH" = (
@@ -83582,7 +83643,7 @@ tdY
 ptQ
 tgh
 myp
-cui
+aeU
 aeU
 aeu
 aeu
@@ -117246,7 +117307,7 @@ qjK
 lFC
 fQb
 uAe
-cdl
+udg
 cdt
 rCi
 cic
@@ -117493,10 +117554,10 @@ jij
 wJe
 otA
 hRO
-udg
+dsh
 tej
 lFC
-lFC
+nFg
 ycy
 vOW
 dfY
@@ -118017,7 +118078,7 @@ cKz
 lFC
 fQb
 uAe
-cdl
+udg
 tBn
 vOW
 qeH
@@ -118274,7 +118335,7 @@ qjK
 lFC
 fQb
 uAe
-cdl
+udg
 tBn
 dhY
 qYN
@@ -119819,9 +119880,9 @@ aaa
 aaa
 aaa
 aaa
-nFg
+qJs
 acm
-nFg
+qJs
 aaa
 aaa
 aaa

--- a/StationMaps/KiloStation/KiloStation.dmm
+++ b/StationMaps/KiloStation/KiloStation.dmm
@@ -3559,6 +3559,7 @@
 /area/station/engineering/main)
 "bji" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/machinery/wall_healer/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "bjk" = (
@@ -7277,6 +7278,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/box,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "cup" = (
@@ -10596,7 +10599,7 @@
 "dyH" = (
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit/departure_lounge)
 "dyK" = (
@@ -12641,6 +12644,9 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter/room)
 "ekp" = (
+/obj/machinery/atmospherics/components/unary/airlock_pump{
+	dir = 1
+	},
 /turf/open/floor/plating/airless,
 /area/station/maintenance/disposal/incinerator)
 "ekB" = (
@@ -13479,14 +13485,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "eyl" = (
-/mob/living/basic/bear{
-	desc = "Once a trained show bear, this creature has been left abandoned and unfed.";
-	environment_smash = 0;
-	health = 160;
-	maxHealth = 160;
-	melee_damage_upper = 25;
-	name = "hungry show bear"
-	},
 /turf/open/floor/wood,
 /area/station/maintenance/port/fore)
 "eyv" = (
@@ -14790,6 +14788,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/wall_healer/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "eWu" = (
@@ -17229,6 +17228,9 @@
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /turf/open/floor/iron/showroomfloor,
 /area/station/engineering/atmos)
+"fHN" = (
+/turf/open/floor/plating,
+/area/station/cargo/sorting)
 "fHZ" = (
 /obj/structure/table,
 /obj/item/assembly/signaler{
@@ -18043,6 +18045,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/wall_healer/directional/north,
 /turf/open/floor/iron/dark/corner{
 	dir = 4
 	},
@@ -19892,6 +19895,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
+"gzd" = (
+/obj/machinery/door/airlock/external{
+	name = "Atmospherics External Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "atmos_end_big_lad"
+	},
+/turf/open/floor/plating/airless,
+/area/station/maintenance/disposal/incinerator)
 "gzh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -20772,6 +20785,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/decal/remains/human,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/fore)
 "gNI" = (
@@ -23804,7 +23818,6 @@
 /area/station/service/kitchen)
 "hMo" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "hMx" = (
@@ -27050,6 +27063,7 @@
 	},
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted,
 /obj/effect/turf_decal/tile/yellow,
+/obj/machinery/wall_healer/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "iIF" = (
@@ -43411,11 +43425,11 @@
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/structure/sign/warning/secure_area/directional/east,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/wall_healer/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "ojs" = (
@@ -45063,7 +45077,7 @@
 /turf/open/floor/plating,
 /area/station/cargo/warehouse/upper)
 "oNO" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/cargo/office)
 "oOW" = (
@@ -46612,8 +46626,8 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/primary)
 "pmy" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/cargo/drone_bay)
 "pmA" = (
@@ -49095,6 +49109,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/machinery/wall_healer/directional/south,
 /turf/open/floor/iron/stairs/left{
 	dir = 4
 	},
@@ -61553,6 +61568,7 @@
 /obj/effect/landmark/secequipment,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/machinery/wall_healer/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "tZG" = (
@@ -65097,6 +65113,18 @@
 "vkh" = (
 /turf/closed/wall,
 /area/station/hallway/primary/central)
+"vkm" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "atmos_end_big_lad"
+	},
+/obj/machinery/door/airlock/external{
+	name = "Atmospherics External Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating/airless,
+/area/station/maintenance/disposal/incinerator)
 "vkq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -66427,11 +66455,8 @@
 /area/station/security/courtroom)
 "vCV" = (
 /obj/structure/cable,
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/box,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
 "vDk" = (
@@ -72484,6 +72509,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/wall_healer/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
 "xwO" = (
@@ -101413,7 +101439,7 @@ ePm
 bfA
 fdp
 mLN
-vqj
+mLN
 nmo
 gxi
 qmR
@@ -101669,7 +101695,7 @@ nqn
 nDX
 bfA
 vCV
-mLN
+vkm
 ekp
 dtb
 xWT
@@ -101927,7 +101953,7 @@ qsv
 bfA
 drk
 mLN
-bjJ
+gzd
 dtb
 laf
 pOG
@@ -104942,7 +104968,7 @@ mlw
 eDT
 vJH
 bji
-qTC
+ijQ
 iRt
 hVU
 mCs
@@ -112678,7 +112704,7 @@ jYL
 oJd
 uov
 uIx
-uqI
+fHN
 rpN
 bHl
 drl
@@ -114988,7 +115014,7 @@ suA
 mEH
 fOX
 iIp
-etO
+tOy
 gzv
 yaF
 pOq
@@ -118107,7 +118133,7 @@ ffa
 ffa
 ffa
 ffa
-ffa
+vJm
 dyH
 cmU
 oAg

--- a/StationMaps/KiloStation/KiloStation.dmm
+++ b/StationMaps/KiloStation/KiloStation.dmm
@@ -12,11 +12,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /obj/machinery/airalarm/directional/west,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/airlock_pump{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/ai/satellite/atmos)
 "aap" = (
@@ -268,6 +268,13 @@
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/rust,
 /area/station/engineering/atmos)
+"acJ" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "acK" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -298,10 +305,19 @@
 /turf/open/misc/asteroid,
 /area/space/nearstation)
 "acZ" = (
-/obj/structure/flora/grass/jungle/a/style_random,
-/obj/structure/flora/bush/ferny/style_random,
-/turf/open/misc/asteroid,
-/area/space/nearstation)
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "add" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
 /obj/structure/flora/bush/lavendergrass/style_random,
@@ -354,6 +370,7 @@
 "adR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/ai/satellite/atmos)
 "adT" = (
@@ -414,12 +431,12 @@
 /turf/closed/wall/rust,
 /area/station/service/lawoffice)
 "aeH" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 1;
 	id = "chemistry_shutters";
 	name = "Chemistry Lobby Shutters"
 	},
+/obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
 "aeJ" = (
@@ -769,6 +786,10 @@
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "alv" = (
@@ -860,11 +881,17 @@
 /turf/open/floor/wood,
 /area/station/commons/locker)
 "amq" = (
-/mob/living/basic/mining/basilisk{
-	environment_smash = 0
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/camera/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 1
 	},
-/turf/open/misc/asteroid/airless,
-/area/space/nearstation)
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "amr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -1028,24 +1055,18 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/starboard)
 "aov" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable,
+/turf/open/floor/circuit/red,
+/area/station/engineering/supermatter/room)
 "aoz" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/misc/asteroid/lowpressure,
 /area/space/nearstation)
 "aoE" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit/departure_lounge)
 "aoL" = (
 /turf/closed/wall/r_wall/rust,
 /area/station/service/chapel/monastery)
@@ -1063,9 +1084,8 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
 "apl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/brown/half/contrasted,
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "apm" = (
@@ -1171,11 +1191,11 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/greater)
 "aqv" = (
-/obj/structure/transit_tube/junction,
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/structure/c_transit_tube/crossing,
 /turf/open/space/basic,
 /area/space/nearstation)
 "aqQ" = (
@@ -1196,6 +1216,7 @@
 "ari" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
 "arl" = (
@@ -1266,6 +1287,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "asZ" = (
@@ -1354,6 +1376,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "auS" = (
@@ -1579,6 +1602,11 @@
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/crew_quarters/bar)
+"ayC" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/open/floor/iron/dark,
+/area/station/medical/treatment_center)
 "ayY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1651,8 +1679,8 @@
 /turf/open/floor/engine,
 /area/station/ai/upload/chamber)
 "aAu" = (
-/turf/open/floor/plating,
-/area/station/security/prison/mess)
+/turf/closed/wall/rust,
+/area/station/medical/office)
 "aAy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1692,7 +1720,6 @@
 /obj/structure/sign/warning/no_smoking{
 	pixel_y = 30
 	},
-/obj/structure/spider/stickyweb,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/greater)
@@ -1703,8 +1730,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "aAU" = (
-/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "aBi" = (
@@ -1801,8 +1830,14 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/medbay/central)
 "aDD" = (
-/turf/open/floor/plating,
-/area/station/security/prison)
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/obj/structure/closet/secure_closet/paramedic,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/camera/autoname/directional/east,
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/paramedic)
 "aDF" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -1821,12 +1856,12 @@
 /turf/open/floor/iron/dark,
 /area/station/construction/mining/aux_base)
 "aDL" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 4;
 	id = "chemistry_shutters";
 	name = "Chemistry Lobby Shutters"
 	},
+/obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
 "aDO" = (
@@ -2108,9 +2143,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/main)
 "aGZ" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -2143,7 +2178,6 @@
 	},
 /obj/machinery/status_display/evac/directional/east,
 /obj/machinery/light/directional/north,
-/obj/structure/curtain,
 /obj/structure/bed/medical{
 	dir = 4
 	},
@@ -2151,7 +2185,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/medical/exam_room)
+/area/station/medical/treatment_center)
 "aHD" = (
 /obj/effect/spawner/random/vending/snackvend,
 /obj/machinery/light/directional/north,
@@ -2486,8 +2520,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "aNp" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -2692,7 +2724,7 @@
 	name = "Emergency Medical Lockdown Shutters"
 	},
 /turf/open/floor/grass,
-/area/station/medical/paramedic)
+/area/station/medical/office)
 "aQl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2722,11 +2754,8 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/exam_room)
+/area/station/medical/treatment_center)
 "aRa" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/window/right/directional/west,
@@ -2867,22 +2896,8 @@
 /turf/open/floor/iron/recharge_floor,
 /area/station/science/robotics/mechbay)
 "aUh" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/safe{
-	pixel_x = 3
-	},
-/obj/item/stack/spacecash/c500{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/storage/belt/bandolier,
-/obj/item/gun/ballistic/rifle/boltaction/pipegun,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/port/greater)
+/turf/open/misc/asteroid/airless,
+/area/space)
 "aUn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -2906,7 +2921,6 @@
 /obj/structure/table,
 /obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/stack/medical/gauze,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "aUW" = (
@@ -2923,6 +2937,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "aVn" = (
@@ -3010,6 +3025,8 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
 "aWI" = (
@@ -3017,8 +3034,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/turf/open/floor/iron/dark/corner,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "aXf" = (
 /obj/machinery/atmospherics/components/binary/valve,
@@ -3057,6 +3074,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"aYd" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "aYu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
 /turf/closed/wall,
@@ -3192,12 +3213,18 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "baG" = (
-/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plating,
-/area/station/security/prison)
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters{
+	id = "commissaryshutter";
+	name = "Vacant Commissary Shutter"
+	},
+/turf/open/floor/wood,
+/area/station/commons/vacant_room/commissary)
 "baK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3218,6 +3245,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/fore)
 "bbA" = (
@@ -3430,7 +3458,6 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/noticeboard/directional/south,
-/obj/structure/spider/stickyweb,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
@@ -3524,20 +3551,16 @@
 /area/station/security/execution/transfer)
 "bjb" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 1
-	},
+/obj/structure/closet/radiation,
+/obj/item/clothing/glasses/meson,
 /turf/open/floor/iron/dark,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/main)
 "bji" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "bjk" = (
 /obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -3586,13 +3609,10 @@
 /turf/open/misc/asteroid,
 /area/space/nearstation)
 "bkn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/delivery,
+/obj/item/clothing/glasses/meson,
+/obj/structure/closet/radiation,
+/turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "bks" = (
 /obj/effect/turf_decal/loading_area{
@@ -3921,6 +3941,7 @@
 	dir = 4
 	},
 /obj/structure/sign/poster/contraband/random/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "bqd" = (
@@ -4089,12 +4110,6 @@
 /area/station/service/library)
 "bsR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/medbay/central)
 "bsT" = (
@@ -4195,12 +4210,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
 "buq" = (
-/obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/effect/turf_decal/stripes/corner,
-/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/exam_room)
+/area/station/medical/treatment_center)
 "buu" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
@@ -4263,16 +4275,11 @@
 /area/station/maintenance/disposal/incinerator)
 "bwk" = (
 /obj/machinery/holopad,
-/obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/brown/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/iron,
-/area/station/commons/vacant_room/commissary)
+/turf/open/floor/iron/showroomfloor,
+/area/station/engineering/circuit_workshop)
 "bwA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -4307,7 +4314,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/security/prison)
 "bxs" = (
 /obj/effect/turf_decal/box,
@@ -4404,17 +4411,14 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "bzc" = (
-/obj/structure/table,
-/obj/machinery/recharger,
 /obj/machinery/computer/security/telescreen/prison{
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/closed/wall,
 /area/station/security/office)
 "bzo" = (
 /obj/effect/turf_decal/stripes/line{
@@ -4424,6 +4428,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "bzp" = (
@@ -4448,10 +4453,10 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
 "bzS" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/transit_tube/crossing,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "bAc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
@@ -4494,12 +4499,11 @@
 	},
 /obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/green/opposingcorners,
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/virology)
+/area/station/medical/pharmacy)
 "bAS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/directional/west,
@@ -4521,14 +4525,12 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/greater)
 "bBe" = (
-/obj/effect/spawner/random/vending/colavend,
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/storage)
+/obj/structure/closet/crate/freezer/blood,
+/obj/effect/mapping_helpers/airalarm/tlv_cold_room,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/station/medical/coldroom)
 "bBr" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Emergency Storage"
@@ -4555,12 +4557,14 @@
 /turf/closed/wall/r_wall,
 /area/station/science/robotics/lab)
 "bBJ" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/door/airlock/external{
+	name = "Medical Escape Pod";
+	space_dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/machinery/light/small/directional/north,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "bBK" = (
@@ -4794,6 +4798,24 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"bGj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "bGx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -4813,10 +4835,6 @@
 /obj/structure/cable/layer3,
 /turf/open/floor/engine,
 /area/station/ai/satellite/chamber)
-"bGY" = (
-/obj/structure/sign/warning/engine_safety,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/room)
 "bHj" = (
 /obj/structure/table,
 /obj/item/paper_bin/construction{
@@ -4846,7 +4864,6 @@
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/bot,
 /obj/machinery/status_display/evac/directional/north,
-/obj/item/clothing/mask/russian_balaclava,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
@@ -5001,30 +5018,24 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
 "bKc" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/rack,
-/obj/item/storage/backpack/duffelbag/med{
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/blood/random{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/blood/random,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/station/maintenance/department/medical/central)
 "bKj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/iron/white,
 /area/station/security/prison/mess)
 "bKl" = (
-/obj/structure/flora/rock/pile/style_random,
-/turf/open/misc/asteroid,
-/area/space/nearstation)
+/obj/machinery/door/airlock/virology{
+	name = "Virology Isolation B"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/virology)
 "bKM" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/power/emitter/welded{
@@ -5042,7 +5053,7 @@
 /obj/machinery/status_display/evac/directional/west,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron/dark,
-/area/station/medical/paramedic)
+/area/station/medical/office)
 "bLf" = (
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 4
@@ -5081,15 +5092,12 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "bMH" = (
-/obj/structure/table,
 /obj/structure/extinguisher_cabinet/directional/south,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/commons/vacant_room/commissary)
+/obj/effect/turf_decal/delivery,
+/obj/machinery/module_duplicator,
+/obj/effect/turf_decal/tile/purple/half/contrasted,
+/turf/open/floor/iron/showroomfloor,
+/area/station/engineering/circuit_workshop)
 "bMN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5162,12 +5170,9 @@
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
 "bPK" = (
-/obj/structure/flora/bush/sparsegrass/style_random,
-/obj/structure/flora/bush/lavendergrass/style_random,
-/obj/structure/flora/bush/ferny/style_random,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/misc/asteroid/airless,
-/area/station/hallway/secondary/entry)
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "bPP" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/flora/grass/jungle/b/style_random,
@@ -5193,11 +5198,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "bPZ" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/grass/jungle/b/style_random,
-/turf/open/misc/asteroid/airless,
-/area/station/hallway/secondary/entry)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/service/chapel)
 "bQb" = (
 /obj/structure/flora/bush/leavy/style_random,
 /obj/structure/flora/bush/ferny/style_random,
@@ -5231,7 +5235,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/engine,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "bQN" = (
 /obj/effect/decal/remains/human,
@@ -5383,9 +5388,7 @@
 /area/station/command/heads_quarters/captain)
 "bTT" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/grass/jungle/a/style_random,
-/turf/open/misc/asteroid/airless,
+/turf/closed/wall,
 /area/station/hallway/secondary/entry)
 "bUd" = (
 /obj/effect/turf_decal/stripes/line{
@@ -5654,8 +5657,11 @@
 	},
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/machinery/iv_drip,
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/exam_room)
+/area/station/medical/treatment_center)
 "bXf" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
@@ -5875,7 +5881,6 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/machinery/nuclearbomb/beer,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse/upper)
 "cbJ" = (
@@ -5938,6 +5943,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"ccR" = (
+/obj/structure/sign/warning/engine_safety/directional/north,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "ccW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -5956,21 +5971,14 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/fore)
 "ccY" = (
-/obj/structure/transit_tube/curved,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/closed/wall,
+/area/station/medical/treatment_center)
 "cdd" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 4
 	},
 /obj/machinery/status_display/evac/directional/east,
 /obj/structure/disposalpipe/segment,
-/obj/structure/table,
-/obj/machinery/fax{
-	fax_name = "Medical";
-	name = "Medical Fax Machine"
-	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
@@ -6001,24 +6009,25 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/maintenance/department/chapel/monastery)
 "cdl" = (
-/obj/structure/transit_tube/curved/flipped,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "cdt" = (
-/obj/structure/transit_tube/curved/flipped{
-	dir = 1
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/status_display/evac/directional/south,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "cdu" = (
-/obj/structure/transit_tube/curved{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "cdD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/event_spawn,
@@ -6034,7 +6043,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/surgery/aft)
+/area/station/medical/surgery/theatre)
 "cdF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -6192,10 +6201,11 @@
 /area/station/science/ordnance/storage)
 "ceW" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/closet/radiation,
-/obj/item/clothing/glasses/meson,
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/modular_computer/preset/engineering{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
@@ -6247,17 +6257,7 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/aft)
 "cfN" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/safe{
-	pixel_x = 3
-	},
-/obj/item/stack/spacecash/c500{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/lazarus_injector,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/spider/stickyweb,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
@@ -6422,10 +6422,15 @@
 /turf/closed/wall/r_wall,
 /area/station/ai/satellite/foyer)
 "chM" = (
-/obj/structure/transit_tube/diagonal,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical/glass{
+	name = "Paramedic Dispatch Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/paramedic,
+/turf/open/floor/iron/dark,
+/area/station/medical/paramedic)
 "chO" = (
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall,
@@ -6484,7 +6489,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/paramedic)
+/area/station/medical/office)
 "ciI" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -6618,9 +6623,6 @@
 /obj/structure/table,
 /obj/item/soap/nanotrasen,
 /obj/item/hand_labeler,
-/obj/item/gun/syringe{
-	pixel_y = 5
-	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
@@ -6748,8 +6750,13 @@
 	dir = 1
 	},
 /obj/machinery/iv_drip,
+/obj/machinery/light/directional/north,
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/exam_room)
+/area/station/medical/treatment_center)
 "clL" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
@@ -6940,8 +6947,8 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/turf/open/floor/plating,
+/area/station/security/prison)
 "cow" = (
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
@@ -7275,10 +7282,6 @@
 /mob/living/basic/mining/goliath/ancient,
 /turf/open/misc/asteroid/airless,
 /area/space/nearstation)
-"cuj" = (
-/mob/living/basic/mining/hivelord,
-/turf/open/misc/asteroid/airless,
-/area/space/nearstation)
 "cup" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -7315,12 +7318,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/door/airlock/medical{
-	name = "Operating Theater A"
-	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medical Break Room"
+	},
 /turf/open/floor/iron/dark,
-/area/station/medical/surgery/fore)
+/area/station/medical/break_room)
 "cuV" = (
 /turf/closed/wall,
 /area/station/maintenance/starboard/aft)
@@ -7399,7 +7402,7 @@
 	pixel_y = -34
 	},
 /turf/open/floor/iron/dark,
-/area/station/medical/paramedic)
+/area/station/medical/office)
 "cvM" = (
 /obj/structure/sign/warning/secure_area{
 	name = "EMERGENCY STORAGE"
@@ -7700,10 +7703,10 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/machinery/smartfridge/organ,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/structure/sink/directional/south,
 /turf/open/floor/iron/dark,
-/area/station/medical/surgery/aft)
+/area/station/medical/surgery/theatre)
 "cDZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -7745,6 +7748,7 @@
 /obj/effect/mapping_helpers/airlock/unres/delayed,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
 /obj/effect/mapping_helpers/airlock/access/any/service/janitor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/aft)
 "cFO" = (
@@ -7898,6 +7902,11 @@
 /obj/structure/grille/broken,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"cHO" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/sign/poster/official/random/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "cHZ" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/poddoor/preopen{
@@ -8054,8 +8063,18 @@
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "cKz" = (
-/turf/closed/wall/rust,
-/area/station/engineering/gravity_generator)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/random/entertainment/arcade,
+/obj/effect/turf_decal/box/corners,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "cKR" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/chair/stool/bar/directional/south,
@@ -8198,25 +8217,23 @@
 /turf/open/floor/plating/lowpressure,
 /area/space/nearstation)
 "cOf" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/security/prison)
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "cOp" = (
 /obj/structure/sign/warning/docking,
 /turf/closed/wall/rust,
 /area/space/nearstation)
 "cOt" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
-/obj/item/folder/yellow,
-/obj/item/pen,
-/obj/machinery/door/window/left/directional/south{
-	name = "Cargo Desk";
-	req_access = list("shipping")
-	},
-/turf/open/floor/plating,
-/area/station/hallway/secondary/exit/departure_lounge)
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/virology)
 "cON" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8247,6 +8264,11 @@
 /obj/effect/landmark/navigate_destination/research,
 /turf/open/floor/iron/dark,
 /area/station/science/research)
+"cOY" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/medical/virology)
 "cPp" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold/green/visible,
@@ -8363,12 +8385,12 @@
 /turf/open/floor/carpet/orange,
 /area/station/command/heads_quarters/qm)
 "cRW" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 4;
 	id = "chemistry_shutters_2";
 	name = "Chemistry Hall Shutters"
 	},
+/obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
 "cSl" = (
@@ -8502,18 +8524,16 @@
 /area/space/nearstation)
 "cUk" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/psychology)
+/area/station/medical/cryo)
 "cUw" = (
 /obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/security/prison)
 "cUA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
@@ -8911,10 +8931,10 @@
 /area/station/maintenance/port/lesser)
 "cZo" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/airlock_pump{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "cZT" = (
@@ -9133,6 +9153,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
+"ddT" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "ddW" = (
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
@@ -9143,9 +9169,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -9269,6 +9292,21 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/command/heads_quarters/cmo)
+"dfY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/random/entertainment/arcade,
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "dgg" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/pipedispenser/disposal,
@@ -9399,12 +9437,11 @@
 /turf/open/floor/iron/dark,
 /area/station/service/bar/atrium)
 "dhY" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron,
-/area/station/medical/medbay/central)
+/obj/machinery/door/airlock/external{
+	name = "Auxiliary Airlock"
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit/departure_lounge)
 "dif" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
 	dir = 4
@@ -9454,12 +9491,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/brown/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/iron,
-/area/station/commons/vacant_room/commissary)
+/obj/effect/turf_decal/tile/purple/half/contrasted,
+/turf/open/floor/iron/showroomfloor,
+/area/station/engineering/circuit_workshop)
 "diQ" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line{
@@ -9666,12 +9700,15 @@
 /turf/open/floor/engine/vacuum,
 /area/station/engineering/atmos)
 "dmf" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Cargo Requests"
+/obj/structure/sign/poster/official/random/directional/west,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/engine_equipment,
-/turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "dmp" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -9758,6 +9795,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/structure/closet/firecloset,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "dnt" = (
@@ -9886,13 +9924,17 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
 "doU" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
+/obj/machinery/shower/directional/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/box,
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
 "dpc" = (
 /obj/effect/turf_decal/siding/thinplating/dark/end{
 	dir = 4
@@ -9940,9 +9982,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "dpR" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron,
 /area/station/engineering/main)
 "dpT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9999,6 +10045,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "drk" = (
@@ -10130,7 +10177,6 @@
 /area/station/command/bridge)
 "dsm" = (
 /obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/barricade/wooden/crude,
 /obj/effect/mapping_helpers/airlock/unres/delayed{
@@ -10181,7 +10227,6 @@
 	pixel_y = 4
 	},
 /obj/item/stock_parts/power_store/cell/high,
-/obj/effect/decal/cleanable/cobweb,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
@@ -10290,14 +10335,6 @@
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "duU" = (
-/obj/machinery/door/airlock/external{
-	name = "Ferry Shuttle Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/lesser)
 "duW" = (
@@ -10516,9 +10553,15 @@
 /turf/closed/wall/rust,
 /area/station/security/checkpoint/supply)
 "dyu" = (
-/obj/structure/flora/bush/jungle/b,
-/turf/open/misc/asteroid,
-/area/space/nearstation)
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "dyw" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -10546,6 +10589,12 @@
 /obj/machinery/air_sensor/nitrogen_tank,
 /turf/open/floor/engine/n2,
 /area/station/engineering/atmos)
+"dyH" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit/departure_lounge)
 "dyK" = (
 /obj/structure/sign/warning/electric_shock,
 /turf/closed/wall/r_wall,
@@ -10553,7 +10602,7 @@
 "dyX" = (
 /obj/structure/reagent_dispensers/cooking_oil,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "dzp" = (
 /obj/effect/decal/cleanable/dirt,
@@ -10567,10 +10616,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "dzt" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8;
-	name = "Gas to Cold Loop"
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
@@ -10578,6 +10623,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "dzy" = (
@@ -10636,13 +10682,12 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/lobby)
 "dAB" = (
-/obj/structure/chair/office/light,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/virology)
 "dAQ" = (
@@ -10751,7 +10796,7 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/cold/directional/west,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "dCX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
@@ -10908,8 +10953,9 @@
 "dGX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
-/turf/open/floor/iron/dark,
-/area/station/engineering/supermatter/room)
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "dHc" = (
 /turf/open/floor/iron/stairs/old{
 	dir = 8
@@ -10918,12 +10964,10 @@
 "dHe" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/security/prison)
 "dHg" = (
-/obj/structure/flora/grass/jungle/a/style_random,
-/obj/structure/flora/bush/lavendergrass/style_random,
-/turf/open/floor/grass,
+/turf/open/floor/iron/showroomfloor,
 /area/station/medical/psychology)
 "dHi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -11276,12 +11320,12 @@
 	dir = 1
 	},
 /obj/machinery/light/small/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/components/unary/airlock_pump{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "dLy" = (
@@ -11328,7 +11372,7 @@
 /area/station/maintenance/port/aft)
 "dMp" = (
 /obj/effect/decal/cleanable/food/flour,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "dMq" = (
 /obj/machinery/door/airlock/external/glass{
@@ -11353,7 +11397,6 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/machinery/photocopier,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "dMR" = (
@@ -11421,15 +11464,20 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "dOF" = (
-/obj/structure/sign/warning/no_smoking{
-	pixel_x = -30
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 1
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "dOL" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -11469,19 +11517,13 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter)
 "dPK" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/machinery/light/small/directional/south,
+/obj/effect/mapping_helpers/broken_floor,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/port/lesser)
+/turf/open/floor/wood,
+/area/station/commons/vacant_room/commissary)
 "dPR" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -11499,11 +11541,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "dQx" = (
-/obj/structure/bed/medical/emergency,
-/obj/machinery/iv_drip,
-/obj/effect/turf_decal/bot_white/left,
-/obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/computer/records/medical{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -11706,20 +11748,25 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "dTd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
+/obj/structure/table,
+/obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/commons/vacant_room/commissary)
+/obj/item/compact_remote,
+/obj/item/controller,
+/obj/item/integrated_circuit/loaded/speech_relay,
+/obj/item/mmi,
+/obj/item/mmi,
+/obj/item/integrated_circuit/loaded/hello_world,
+/turf/open/floor/iron/showroomfloor,
+/area/station/engineering/circuit_workshop)
 "dTQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
@@ -11773,12 +11820,6 @@
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
-	},
-/obj/machinery/button/door/directional/west{
-	id = "virologysurgery";
-	name = "Virology Privacy Toggle";
-	pixel_y = 6;
-	req_access = list("virology")
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -12054,23 +12095,25 @@
 /area/station/maintenance/port/greater)
 "eao" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/grunge{
-	id_tag = "commissarydoor";
-	name = "Vacant Commissary"
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Circuit Workshop"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room/commissary)
 "ear" = (
-/obj/structure/flora/grass/jungle/a/style_random,
-/obj/structure/flora/bush/lavendergrass/style_random,
-/obj/structure/flora/bush/flowers_yw/style_random,
 /obj/machinery/light/directional/east,
-/mob/living/carbon/human/species/monkey{
-	name = "mankey"
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
 	},
-/turf/open/floor/grass,
-/area/station/medical/virology)
+/obj/machinery/computer/crew{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/paramedic)
 "eaw" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 10
@@ -12171,10 +12214,15 @@
 /turf/closed/wall/rust,
 /area/station/service/chapel/storage)
 "ecF" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plating,
-/area/space/nearstation)
+/obj/structure/table,
+/obj/item/folder/white,
+/obj/item/pen,
+/obj/item/restraints/handcuffs,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/virology)
 "ecY" = (
 /obj/structure/sign/warning/docking,
 /turf/closed/wall,
@@ -12197,21 +12245,13 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
-/obj/structure/table,
-/obj/item/stack/medical/mesh{
-	pixel_x = -4;
-	pixel_y = 3
+/obj/machinery/vitals_reader/advanced/directional/south,
+/obj/machinery/stasis{
+	dir = 4
 	},
-/obj/item/stack/medical/gauze{
-	pixel_x = 8
-	},
-/obj/item/reagent_containers/chem_pack{
-	pixel_x = 10;
-	pixel_y = 10
-	},
-/obj/structure/sign/poster/random/directional/south,
+/obj/effect/turf_decal/box,
 /turf/open/floor/iron/dark,
-/area/station/medical/exam_room)
+/area/station/medical/treatment_center)
 "eeb" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -12249,10 +12289,8 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/aft)
 "eer" = (
-/obj/effect/turf_decal/tile/brown/half/contrasted,
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/turf/closed/wall,
+/area/station/medical/office)
 "eeC" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Command Maintenance"
@@ -12377,6 +12415,7 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/virology)
 "egV" = (
@@ -12608,7 +12647,7 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/exam_room)
+/area/station/medical/treatment_center)
 "ekL" = (
 /turf/closed/wall/rust,
 /area/station/service/kitchen/coldroom)
@@ -12686,14 +12725,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown/half/contrasted{
-	dir = 1
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/commons/vacant_room/commissary)
+/turf/open/floor/iron/showroomfloor,
+/area/station/engineering/circuit_workshop)
 "elD" = (
 /obj/machinery/vending/dinnerware,
 /obj/effect/turf_decal/bot,
@@ -12873,6 +12909,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
+"eoG" = (
+/obj/machinery/door/airlock/virology{
+	name = "Operating Theater B"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/virology)
 "eoM" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "brigfrontdoor";
@@ -12912,6 +12958,11 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
+"epv" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "epA" = (
 /obj/item/kirbyplants/organic/plant5,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -12942,8 +12993,8 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/xenobiology)
 "epN" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/closed/wall,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "eqx" = (
 /obj/machinery/conveyor{
@@ -13139,11 +13190,12 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/starboard)
 "eto" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
-	dir = 4
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "etB" = (
@@ -13249,18 +13301,26 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "evD" = (
-/obj/structure/flora/bush/large/style_random,
-/obj/structure/flora/bush/flowers_yw/style_random,
-/turf/open/floor/grass,
-/area/station/medical/virology)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/paramedic)
 "evE" = (
-/turf/closed/wall/mineral/plastitanium,
-/area/station/maintenance/port/greater)
+/obj/docking_port/stationary/random{
+	dir = 4;
+	name = "lavaland";
+	shuttle_id = "pod_2_lavaland"
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "ewa" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/effect/landmark/event_spawn,
+/obj/machinery/holopad,
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/exam_room)
+/area/station/medical/treatment_center)
 "ewe" = (
 /turf/closed/wall/rust,
 /area/station/maintenance/central)
@@ -13351,7 +13411,7 @@
 "exD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/main)
 "exH" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/vending/colavend,
@@ -13478,11 +13538,12 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain)
 "ezC" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating/rust,
-/area/station/security/prison)
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "ezV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/cafeteria,
@@ -13587,7 +13648,7 @@
 /mob/living/basic/goat/pete{
 	name = "Pete"
 	},
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "eBx" = (
 /obj/item/kirbyplants/random,
@@ -13604,6 +13665,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/medbay/central)
 "eBQ" = (
@@ -13653,7 +13716,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/small/directional/east,
-/turf/open/floor/plating/rust,
+/turf/open/floor/iron,
 /area/station/security/prison)
 "eCy" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -13792,10 +13855,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/main)
 "eFn" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
@@ -13869,6 +13936,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
 "eGW" = (
@@ -13934,11 +14002,14 @@
 /obj/effect/turf_decal/siding/blue{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
+/obj/structure/disposalpipe/sorting/mail{
+	name = "Virology Junction"
+	},
+/obj/effect/mapping_helpers/mail_sorting/medbay/virology,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/medbay/central)
 "eHY" = (
@@ -14051,17 +14122,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
-"eJs" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "eJy" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/burgundy{
@@ -14237,13 +14297,10 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/virology/glass{
-	name = "Isolation B"
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/virology)
 "eMX" = (
@@ -14344,17 +14401,20 @@
 /turf/open/floor/circuit/red,
 /area/station/ai/upload/chamber)
 "eOW" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/turf/open/floor/iron/dark,
-/area/station/engineering/supermatter/room)
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "ePb" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/structure/c_transit_tube/crossing,
 /turf/open/space/basic,
 /area/space/nearstation)
 "ePe" = (
@@ -14404,11 +14464,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "eQb" = (
-/obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 4
-	},
+/obj/effect/turf_decal/bot,
+/obj/structure/bed/medical/emergency,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/central)
 "eQf" = (
@@ -14420,14 +14478,16 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "eQg" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters{
-	dir = 8;
-	id = "virologysurgery";
-	name = "Virology Privacy Shutters"
-	},
+/obj/structure/window/spawner/directional/south,
+/obj/structure/window/spawner/directional/north,
+/obj/structure/window/spawner/directional/east,
+/obj/structure/window/spawner/directional/west,
+/obj/structure/flora/bush/ferny/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/style_random,
+/obj/structure/flora/bush/sunny/style_random,
 /turf/open/floor/plating,
-/area/station/medical/virology)
+/area/station/hallway/secondary/exit/departure_lounge)
 "eQj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -14598,7 +14658,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/surgery/aft)
+/area/station/medical/surgery/theatre)
 "eSY" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/quantum_server,
@@ -14628,6 +14688,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "eTS" = (
@@ -14726,9 +14787,11 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "eWd" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/medical/storage)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "eWu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -14740,9 +14803,11 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "eWH" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/carpet,
-/area/station/medical/psychology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/shower/directional/west,
+/obj/effect/turf_decal/box,
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/cryo)
 "eWP" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/port/fore)
@@ -15001,7 +15066,6 @@
 /area/station/maintenance/port/fore)
 "fbz" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -15042,12 +15106,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/door/airlock/medical{
-	name = "Psychology"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
 /turf/open/floor/iron/dark,
-/area/station/medical/psychology)
+/area/station/medical/cryo)
 "fcM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -15097,9 +15157,6 @@
 /area/station/maintenance/disposal/incinerator)
 "fdA" = (
 /obj/structure/table_frame/wood,
-/mob/living/basic/mining/basilisk{
-	environment_smash = 0
-	},
 /turf/open/floor/carpet/green,
 /area/station/cargo/warehouse/upper)
 "fdC" = (
@@ -15174,12 +15231,8 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "ffa" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/deathsposal{
-	layer = 4
-	},
 /turf/open/floor/plating,
-/area/station/medical/virology)
+/area/station/hallway/secondary/exit/departure_lounge)
 "ffi" = (
 /obj/effect/landmark/start/hangover,
 /obj/effect/turf_decal/tile/green{
@@ -15216,7 +15269,7 @@
 "ffv" = (
 /obj/machinery/gibber,
 /obj/effect/turf_decal/stripes/box,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "ffC" = (
 /obj/machinery/vending/assist,
@@ -15247,8 +15300,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Gas to Cold Loop"
+	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "fgb" = (
@@ -15483,14 +15538,16 @@
 /area/station/ai/upload/chamber)
 "fjn" = (
 /obj/structure/sink/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/firealarm/directional/north{
 	pixel_x = 26
 	},
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
 	dir = 4
 	},
+/obj/machinery/light/directional/north,
+/obj/structure/closet/l3closet/virology,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/virology)
 "fjw" = (
@@ -15503,6 +15560,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
 "fjz" = (
@@ -15594,6 +15652,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
 "flt" = (
@@ -15624,6 +15683,7 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "flL" = (
@@ -15805,16 +15865,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "fol" = (
-/obj/docking_port/stationary{
-	dir = 4;
-	dwidth = 11;
-	height = 18;
-	name = "KiloStation emergency evac bay";
-	shuttle_id = "emergency_home";
-	width = 30
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/wood,
+/area/station/commons/vacant_room/commissary)
 "fov" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -15844,7 +15898,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/paramedic)
+/area/station/medical/office)
 "foQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -15871,13 +15925,6 @@
 /area/station/service/lawoffice)
 "fph" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/medbay/central)
 "fpk" = (
@@ -15897,16 +15944,15 @@
 	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green/anticorner/contrasted,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/virology)
 "fpz" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Electrical Maintenance"
 	},
-/obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/spider/stickyweb,
 /obj/effect/mapping_helpers/airlock/unres/delayed{
 	dir = 4
 	},
@@ -16040,6 +16086,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "frh" = (
@@ -16056,16 +16103,15 @@
 /turf/closed/wall/r_wall,
 /area/station/science/genetics)
 "frP" = (
-/obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/checker,
-/area/station/security/processing/cremation)
+/area/station/security/mechbay)
 "frT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -16151,13 +16197,16 @@
 /area/station/security/prison/safe)
 "fth" = (
 /obj/machinery/firealarm/directional/south,
-/obj/machinery/smartfridge/organ,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/structure/table/glass,
+/obj/machinery/microwave{
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/surgery/fore)
+/area/station/medical/break_room)
 "fti" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -16345,7 +16394,6 @@
 	},
 /obj/machinery/light/small/directional/east,
 /obj/item/kirbyplants/organic/plant21,
-/obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/dark,
@@ -16445,6 +16493,12 @@
 /obj/item/shovel/spade,
 /obj/item/cultivator,
 /obj/item/hatchet,
+/obj/item/plant_analyzer,
+/obj/item/reagent_containers/cup/bottle/nutrient/rh{
+	pixel_x = 2;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/cup/bottle/nutrient/ez,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics/garden)
 "fxd" = (
@@ -16485,7 +16539,7 @@
 	},
 /obj/machinery/disposal/bin/tagger,
 /turf/open/floor/iron/dark,
-/area/station/medical/paramedic)
+/area/station/medical/office)
 "fxB" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/bridge_pipe/purple/visible,
@@ -16524,7 +16578,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/security/prison)
 "fxW" = (
 /obj/effect/turf_decal/stripes/line,
@@ -16591,20 +16645,18 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/camera/directional/north{
 	c_tag = "Medbay Aux Storage";
 	name = "medical camera";
 	network = list("ss13","medical")
 	},
-/obj/effect/turf_decal/bot,
-/obj/item/toy/figure/paramedic,
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
+/obj/structure/table/glass,
 /turf/open/floor/iron/dark,
-/area/station/medical/paramedic)
+/area/station/medical/office)
 "fyG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -16885,12 +16937,12 @@
 	dir = 1
 	},
 /obj/machinery/light/small/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/components/unary/airlock_pump{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
 "fCX" = (
@@ -17068,8 +17120,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "fFH" = (
-/obj/structure/flora/bush/large/style_random,
-/turf/open/floor/grass,
+/obj/structure/chair/sofa/right/brown,
+/obj/effect/landmark/start/psychologist,
+/obj/machinery/camera/autoname/directional/north,
+/turf/open/floor/carpet,
 /area/station/medical/psychology)
 "fFK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -17131,21 +17185,16 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
 "fGQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 2;
-	name = "virology sorting disposal pipe"
-	},
-/obj/effect/mapping_helpers/mail_sorting/medbay/virology,
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 4
 	},
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/virology)
 "fHj" = (
@@ -17203,6 +17252,9 @@
 /area/station/science/ordnance)
 "fIl" = (
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/components/unary/airlock_pump{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "fIn" = (
@@ -17332,6 +17384,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
 "fJv" = (
@@ -17560,6 +17613,7 @@
 	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green/half/contrasted,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/virology)
 "fMs" = (
@@ -17779,14 +17833,8 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/medical)
 "fQb" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "fQf" = (
 /obj/effect/decal/cleanable/dirt,
@@ -18138,8 +18186,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/turf/open/floor/iron/dark/corner,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "fVM" = (
 /obj/effect/turf_decal/delivery,
@@ -18179,14 +18227,15 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
 "fWK" = (
-/obj/structure/chair/sofa/right/brown,
-/obj/structure/sign/poster/official/love_ian/directional/north,
-/turf/open/floor/carpet,
-/area/station/medical/psychology)
+/obj/machinery/cryo_cell,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/turf/open/floor/iron/dark,
+/area/station/medical/cryo)
 "fWL" = (
-/obj/effect/landmark/start/psychologist,
-/turf/open/floor/carpet,
-/area/station/medical/psychology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/cryo)
 "fWX" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -18273,7 +18322,7 @@
 /area/station/service/janitor)
 "fYw" = (
 /turf/closed/wall/r_wall,
-/area/station/medical/surgery/aft)
+/area/station/medical/surgery/theatre)
 "fYy" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/mineral/random/labormineral,
@@ -18382,24 +18431,23 @@
 "gbd" = (
 /obj/structure/cable,
 /obj/structure/sink/directional/east,
-/obj/structure/mirror/directional/west,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
+/obj/structure/sign/poster/official/cleanliness/directional/west,
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/surgery/fore)
+/area/station/medical/break_room)
 "gbf" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/station/medical/surgery/fore)
+/area/station/medical/break_room)
 "gbh" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/structure/sign/warning/biohazard/directional/north,
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -18417,24 +18465,22 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/central)
 "gbp" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/item/clipboard{
-	pixel_x = 8;
-	pixel_y = 2
+/obj/effect/turf_decal/delivery,
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/power_store/cell/high,
+/obj/item/stock_parts/power_store/cell/high{
+	pixel_x = 4;
+	pixel_y = 4
 	},
-/obj/item/toy/figure/assistant{
-	pixel_x = 8;
-	pixel_y = 2
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/commons/vacant_room/commissary)
+/turf/open/floor/iron/showroomfloor,
+/area/station/engineering/circuit_workshop)
 "gbs" = (
 /obj/effect/spawner/random/trash/moisture_trap,
 /obj/effect/decal/cleanable/dirt,
@@ -18470,6 +18516,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "gbO" = (
@@ -18614,7 +18661,6 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/greater)
 "geO" = (
-/obj/structure/table/optable,
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -18622,6 +18668,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/door_buttons/airlock_controller{
+	idExterior = "virology_airlock_exterior";
+	idInterior = "virology_airlock_interior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Console";
+	pixel_x = 24;
+	pixel_y = -24;
+	req_access = list("virology")
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/virology)
 "geV" = (
@@ -18700,18 +18756,7 @@
 /turf/open/floor/iron/chapel,
 /area/station/service/chapel)
 "ggF" = (
-/obj/structure/table,
 /obj/structure/disposalpipe/segment,
-/obj/item/clipboard,
-/obj/item/toy/figure/engineer{
-	pixel_x = 8;
-	pixel_y = 6
-	},
-/obj/item/paper_bin{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/pen,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
@@ -18749,12 +18794,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light_switch/directional/west,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "ght" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "ghO" = (
@@ -18906,6 +18952,7 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "gjx" = (
@@ -19268,14 +19315,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "gpH" = (
-/obj/machinery/door/airlock/external{
-	name = "Ferry Shuttle Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/port/lesser)
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "gpI" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 1
@@ -19477,7 +19520,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/exam_room)
+/area/station/medical/treatment_center)
 "gsu" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -19496,8 +19539,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "gsy" = (
-/turf/closed/wall,
-/area/station/medical/exam_room)
+/obj/machinery/light/directional/west,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/station/medical/treatment_center)
 "gsB" = (
 /obj/structure/table,
 /obj/item/pipe_dispenser,
@@ -19521,17 +19566,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
-"gtd" = (
-/obj/structure/flora/bush/pale/style_random{
-	icon_state = "fullgrass_2"
-	},
-/obj/structure/flora/bush/jungle/c/style_2,
-/turf/open/misc/asteroid,
-/area/space/nearstation)
 "gtj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "gtq" = (
@@ -19710,11 +19749,6 @@
 	pixel_y = 8;
 	specialfunctions = 4
 	},
-/obj/machinery/button/door/directional/east{
-	id = "Shower_2Privacy";
-	name = "Shower 2 Privacy Toggle";
-	pixel_y = -8
-	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
 "gwI" = (
@@ -19753,25 +19787,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/button/door/directional/east{
-	id = "commissaryshutter";
-	name = "Commissary Shutter Toggle";
-	pixel_x = 26;
-	pixel_y = 7
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 1
 	},
-/obj/machinery/button/door/directional/east{
-	id = "commissarydoor";
-	name = "Commissary Door Lock";
-	normaldoorcontrol = 1;
-	pixel_x = 26;
-	pixel_y = -2;
-	specialfunctions = 4
-	},
-/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/commons/vacant_room/commissary)
+/turf/open/floor/iron/showroomfloor,
+/area/station/engineering/circuit_workshop)
 "gxe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/east,
@@ -19810,8 +19830,11 @@
 /turf/closed/wall,
 /area/station/maintenance/starboard)
 "gyb" = (
-/turf/open/floor/plating/rust,
-/area/station/security/prison)
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit/departure_lounge)
 "gyd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
@@ -19975,13 +19998,13 @@
 "gBC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/grunge{
-	id_tag = "commissarydoor";
-	name = "Vacant Commissary"
-	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/open/floor/iron/dark,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/machinery/door/airlock/maintenance{
+	name = "Circuit Workshop Maintenance"
+	},
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "gBJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -20350,9 +20373,8 @@
 /area/station/security/courtroom)
 "gHd" = (
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/turf_decal/box,
-/obj/machinery/shower/directional/east{
-	name = "emergency shower"
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
@@ -20483,8 +20505,6 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/station_engineer,
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "gIX" = (
@@ -20586,13 +20606,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "gKd" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron,
-/area/station/medical/medbay/central)
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit/departure_lounge)
 "gKg" = (
 /obj/structure/railing,
 /obj/structure/disposalpipe/segment{
@@ -20624,15 +20642,14 @@
 /turf/closed/wall/rust,
 /area/station/cargo/miningoffice)
 "gKR" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
-/turf/open/floor/iron/dark,
-/area/station/engineering/supermatter/room)
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "gLm" = (
 /obj/machinery/status_display/ai/directional/south,
 /obj/effect/decal/cleanable/dirt,
-/mob/living/basic/spider/giant/hunter/scrawny,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "gLn" = (
@@ -20712,14 +20729,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "gMC" = (
-/obj/machinery/suit_storage_unit/engine,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/light/directional/east,
-/obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
+/obj/machinery/camera/directional/south{
+	c_tag = "Engineering Storage";
+	name = "engineering camera";
+	network = list("ss13","engine")
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/turf/open/floor/iron,
 /area/station/engineering/main)
 "gME" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -20807,6 +20824,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
 "gOG" = (
@@ -20873,11 +20891,12 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "gPS" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron/showroomfloor,
-/area/station/medical/exam_room)
+/obj/structure/table/glass,
+/obj/item/crowbar/red,
+/obj/item/healthanalyzer,
+/turf/open/floor/iron/dark,
+/area/station/medical/treatment_center)
 "gPX" = (
 /obj/structure/reflector/box/anchored{
 	dir = 1
@@ -21198,10 +21217,10 @@
 "gVg" = (
 /obj/effect/turf_decal/bot,
 /obj/item/radio/intercom/directional/north,
-/obj/machinery/suit_storage_unit/medical,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/structure/closet/secure_closet/personal/patient,
 /turf/open/floor/iron/dark,
-/area/station/medical/paramedic)
+/area/station/medical/office)
 "gVi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -21336,6 +21355,11 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/station/security/brig)
+"gYm" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/structure/closet/firecloset,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "gYx" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 1;
@@ -21354,7 +21378,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/security/prison)
 "gYK" = (
 /obj/effect/turf_decal/stripes/line{
@@ -21397,14 +21421,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"gZu" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/station/medical/treatment_center)
 "gZI" = (
-/obj/structure/water_source/puddle,
-/obj/structure/flora/bush/reed/style_random{
-	pixel_y = 5
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/obj/effect/spawner/random/engineering/tracking_beacon,
-/turf/open/floor/grass,
-/area/station/medical/virology)
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/paramedic)
 "hah" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner,
@@ -21551,9 +21577,9 @@
 /obj/structure/kitchenspike,
 /obj/effect/turf_decal/bot/left,
 /obj/machinery/airalarm/directional/north,
-/obj/effect/mapping_helpers/airalarm/tlv_cold_room,
 /obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron/freezer,
+/obj/effect/mapping_helpers/airalarm/tlv_cold_room,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "hdo" = (
 /obj/effect/spawner/structure/window,
@@ -21633,14 +21659,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "heX" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Office"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/all/supply/general,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "hfl" = (
 /obj/effect/turf_decal/bot,
@@ -21754,7 +21775,7 @@
 "hhp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/security/prison)
 "hhE" = (
 /obj/item/kirbyplants/organic/plant18,
@@ -21791,18 +21812,23 @@
 /turf/open/floor/iron/dark,
 /area/station/construction/mining/aux_base)
 "hih" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/closet/l3closet/virology,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/station/medical/virology)
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/pharmacy)
 "hiQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -21815,6 +21841,9 @@
 	name = "Gravity Generator Access"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
+/obj/machinery/door/airlock/highsecurity{
+	name = "Gravity Generator Room"
+	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/aft)
 "hja" = (
@@ -21833,12 +21862,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /obj/machinery/light/small/directional/south,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/components/unary/airlock_pump{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
 "hjh" = (
@@ -21847,31 +21876,30 @@
 	name = "medical camera";
 	network = list("ss13","medical")
 	},
-/obj/structure/table,
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/suit/apron/surgical,
-/obj/item/clipboard{
-	pixel_x = 4;
-	pixel_y = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/machinery/vending/wallmed/directional/south,
+/obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/surgery/fore)
+/area/station/medical/break_room)
 "hjj" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Supermatter Maintenance"
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/power/terminal{
+	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
-/area/station/maintenance/starboard/aft)
+/area/station/engineering/supermatter/room)
 "hjk" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/ordnance_burn_chamber_input,
 /turf/open/floor/engine/vacuum,
@@ -21949,7 +21977,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/warning/electric_shock/directional/north,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/spider/stickyweb,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
@@ -22010,7 +22037,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/security/prison)
 "hkI" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -22054,13 +22081,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/armory)
 "hkW" = (
-/obj/structure/plasticflaps/opaque,
-/obj/machinery/door/window/left/directional/south{
-	name = "Cargo Delivery Access";
-	req_access = list("shipping")
+/obj/machinery/atmospherics/components/unary/airlock_pump{
+	dir = 8
 	},
 /turf/open/floor/plating,
-/area/station/hallway/secondary/exit/departure_lounge)
+/area/station/maintenance/disposal/incinerator)
 "hlb" = (
 /obj/structure/sign/poster/official/safety_eye_protection/directional/south{
 	pixel_x = 32
@@ -22092,14 +22117,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/engine,
 /area/station/ai/satellite/chamber)
-"hlJ" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/modular_computer/preset/engineering{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/lobby)
 "hlP" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/broken_floor,
@@ -22249,25 +22266,15 @@
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "hnD" = (
-/obj/structure/table,
-/obj/item/stack/package_wrap,
-/obj/item/crowbar,
 /obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/item/electronics/airlock{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/electronics/airlock{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/hand_labeler,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/rnd/production/circuit_imprinter,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "hnL" = (
@@ -22377,7 +22384,7 @@
 /area/station/science/research)
 "hpv" = (
 /turf/closed/wall,
-/area/station/medical/surgery/aft)
+/area/station/medical/surgery/theatre)
 "hpz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22420,16 +22427,13 @@
 /area/station/cargo/miningdock)
 "hpQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/psychology)
+/area/station/medical/cryo)
 "hpS" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -22602,14 +22606,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
-"hsJ" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/flora/bush/grassy/style_random,
-/obj/structure/flora/bush/lavendergrass/style_random,
-/obj/structure/flora/bush/leavy/style_random,
-/mob/living/basic/butterfly,
-/turf/open/floor/grass,
-/area/station/hallway/primary/fore)
 "hsO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -22621,15 +22617,12 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/storage/art)
 "hsW" = (
-/obj/machinery/stasis{
-	dir = 4
-	},
-/obj/effect/turf_decal/box,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
+/obj/structure/table/reinforced/rglass,
 /turf/open/floor/iron/dark,
-/area/station/medical/exam_room)
+/area/station/medical/treatment_center)
 "htJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -22657,20 +22650,21 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/medical{
-	name = "Operating Theater B"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
+/obj/machinery/door/airlock/medical{
+	name = "Operating Theater"
+	},
 /turf/open/floor/iron/dark,
-/area/station/medical/surgery/aft)
+/area/station/medical/surgery/theatre)
 "htZ" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/engine,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "huc" = (
 /obj/effect/turf_decal/stripes/line{
@@ -22694,7 +22688,7 @@
 /area/station/security/prison/safe)
 "huK" = (
 /obj/item/shrapnel/bullet,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/security/prison)
 "huR" = (
 /obj/effect/turf_decal/tile/blue{
@@ -22703,11 +22697,8 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
-/obj/effect/turf_decal/loading_area{
-	dir = 8
-	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/exam_room)
+/area/station/medical/treatment_center)
 "huS" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -22779,9 +22770,8 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "hwN" = (
-/obj/machinery/rnd/production/circuit_imprinter,
-/obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "hwY" = (
@@ -22889,6 +22879,11 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"hyt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/wood,
+/area/station/commons/vacant_room/commissary)
 "hyJ" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/ore_box,
@@ -23212,9 +23207,11 @@
 /area/station/engineering/atmos)
 "hDX" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/medbay/central)
@@ -23390,7 +23387,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
+/obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
@@ -23417,11 +23414,8 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
+/obj/structure/bed/medical/emergency,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/central)
 "hHj" = (
@@ -23518,7 +23512,6 @@
 /area/station/science/genetics)
 "hIs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/mob/living/basic/ghost,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/fore)
 "hIS" = (
@@ -23646,6 +23639,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
 "hKg" = (
@@ -23691,6 +23685,12 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"hKP" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "hKQ" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
@@ -23718,26 +23718,20 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "hLr" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/bot,
 /obj/machinery/light/small/directional/east,
 /obj/machinery/airalarm/directional/south,
-/obj/item/storage/toolbox/emergency{
-	pixel_y = 4
-	},
-/obj/item/wrench,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/directional/east{
 	c_tag = "Vacant Commissary";
 	name = "cargo camera";
 	network = list("ss13","qm")
 	},
 /obj/machinery/light_switch/directional/east,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/commons/vacant_room/commissary)
+/obj/effect/turf_decal/delivery,
+/obj/machinery/bci_implanter,
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/iron/showroomfloor,
+/area/station/engineering/circuit_workshop)
 "hLz" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8;
@@ -23816,16 +23810,9 @@
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
 "hMC" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 2;
-	height = 11;
-	name = "port bay 2";
-	shuttle_id = "ferry_home";
-	width = 5
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
+/area/station/security/prison)
 "hMN" = (
 /turf/closed/wall,
 /area/station/service/chapel/funeral)
@@ -23919,6 +23906,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/solars/port/aft)
 "hOm" = (
@@ -23991,11 +23979,6 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/dock)
 "hON" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 4
-	},
-/obj/item/storage/belt/utility,
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/camera/directional/north{
 	c_tag = "Engineering Desk";
@@ -24008,10 +23991,8 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
 	},
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/storage/box/donkpockets{
-	pixel_y = 5
-	},
+/obj/machinery/rnd/production/protolathe/department/engineering,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "hOU" = (
@@ -24086,15 +24067,10 @@
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "hPV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/medical/medbay/central)
+/obj/structure/flora/rock/pile/style_random,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
+/area/station/security/prison)
 "hPW" = (
 /turf/closed/wall/r_wall/rust,
 /area/station/tcommsat/computer)
@@ -24234,12 +24210,6 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "hRU" = (
@@ -24258,6 +24228,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "hRZ" = (
@@ -24312,15 +24283,12 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/customs)
 "hSJ" = (
-/obj/structure/transit_tube/curved{
-	dir = 8
-	},
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/effect/turf_decal/stripes/line{
-	dir = 6
+	dir = 10
 	},
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/station/ai/satellite/foyer)
 "hTb" = (
 /obj/structure/closet/secure_closet/research_director,
@@ -24474,6 +24442,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
+"hVy" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/item/toy/plush/nukeplushie,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "hVF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -24547,6 +24520,14 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/maintenance/port/fore)
+"hXe" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "hXK" = (
 /obj/structure/sign/directions/security{
 	pixel_y = -40
@@ -24594,8 +24575,11 @@
 /area/station/commons/locker)
 "hYa" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance/two,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "hYo" = (
@@ -24619,11 +24603,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /obj/machinery/light/small/directional/south,
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/airlock_pump/unbolt_only{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
 "hYY" = (
@@ -24870,12 +24854,12 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/armory)
 "ibL" = (
-/obj/structure/table,
-/obj/item/healthanalyzer,
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/structure/table,
+/obj/item/surgery_tray/full,
 /turf/open/floor/iron/dark,
-/area/station/medical/surgery/aft)
+/area/station/medical/surgery/theatre)
 "ibN" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 4
@@ -24894,6 +24878,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "icp" = (
@@ -24971,10 +24956,6 @@
 	dir = 4
 	},
 /obj/effect/landmark/generic_maintenance_landmark,
-/obj/machinery/button/door/directional/north{
-	id = "greylair";
-	name = "Lair Privacy Toggle"
-	},
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
@@ -25332,10 +25313,10 @@
 "iju" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/blood/old,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/virology)
 "ijy" = (
@@ -25607,6 +25588,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "ilI" = (
@@ -25667,12 +25649,9 @@
 	dir = 4
 	},
 /obj/machinery/defibrillator_mount/directional/west,
-/obj/effect/turf_decal/box,
-/obj/machinery/stasis{
-	dir = 4
-	},
+/obj/structure/table/reinforced/rglass,
 /turf/open/floor/iron/dark,
-/area/station/medical/exam_room)
+/area/station/medical/treatment_center)
 "imS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -25686,18 +25665,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "inf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
+/turf/closed/wall/rust,
+/area/station/engineering/circuit_workshop)
 "ing" = (
 /turf/closed/wall/rust,
 /area/station/service/chapel/dock)
@@ -25734,6 +25703,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/ai/upload/chamber)
+"ioQ" = (
+/turf/closed/wall,
+/area/station/engineering/circuit_workshop)
 "ioT" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/sign/warning/secure_area/directional/west{
@@ -25919,7 +25891,6 @@
 /obj/machinery/door/airlock/maintenance{
 	id_tag = "bankvault"
 	},
-/obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/barricade/wooden/crude,
 /obj/structure/cable,
@@ -26057,6 +26028,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "isO" = (
@@ -26105,11 +26077,13 @@
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "itZ" = (
-/obj/structure/flora/bush/sparsegrass/style_random,
-/obj/structure/flora/bush/grassy/style_random,
-/obj/structure/flora/bush/flowers_pp/style_random,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/grass,
+/obj/structure/table/wood,
+/obj/machinery/fax{
+	fax_name = "Psychology Office";
+	name = "Psychology Office Fax Machine"
+	},
+/turf/open/floor/iron/showroomfloor,
 /area/station/medical/psychology)
 "iug" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/plasma_input{
@@ -26207,18 +26181,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security)
-"ivY" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/camera/directional/south{
-	c_tag = "Departures Cargo Dock";
-	name = "shuttle camera"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/hallway/secondary/exit/departure_lounge)
 "iwf" = (
 /obj/structure/transit_tube/curved/flipped{
 	dir = 1
@@ -26266,6 +26228,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "iwT" = (
@@ -26306,7 +26269,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "ixj" = (
-/obj/machinery/modular_computer/preset/engineering,
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/directional/west,
 /obj/machinery/requests_console/directional/west{
@@ -26318,6 +26280,7 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/computer/station_alert,
 /turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "ixn" = (
@@ -26447,7 +26410,6 @@
 /obj/machinery/newscaster/directional/north,
 /obj/machinery/light/small/directional/north,
 /obj/structure/flora/bush/flowers_pp/style_random,
-/obj/machinery/hydroponics/constructable,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "izf" = (
@@ -26534,7 +26496,6 @@
 "iAR" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/spider/stickyweb,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -26557,7 +26518,8 @@
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical,
 /obj/item/multitool,
-/turf/open/floor/engine,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "iBc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -26683,6 +26645,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
 "iCV" = (
@@ -26690,7 +26653,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/exam_room)
+/area/station/medical/treatment_center)
 "iCW" = (
 /obj/item/kirbyplants/organic/plant5,
 /obj/machinery/camera/directional/north{
@@ -27151,6 +27114,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "iJv" = (
@@ -27331,10 +27295,8 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science/research)
 "iMr" = (
-/obj/structure/flora/bush/sparsegrass/style_random,
-/obj/structure/flora/bush/grassy/style_random,
-/obj/structure/flora/bush/flowers_pp/style_random,
-/turf/open/floor/grass,
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/iron/showroomfloor,
 /area/station/medical/psychology)
 "iMx" = (
 /obj/effect/turf_decal/siding/wood,
@@ -27423,6 +27385,14 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"iNK" = (
+/obj/machinery/status_display/evac/directional/south,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 8
+	},
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "iNL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -27595,7 +27565,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/surgery/aft)
+/area/station/medical/surgery/theatre)
 "iRR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -27853,6 +27823,7 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/mining,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
 "iVy" = (
@@ -27947,8 +27918,10 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/customs)
 "iWT" = (
-/obj/structure/sign/departments/cargo,
-/turf/closed/wall,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plating,
 /area/station/hallway/secondary/exit/departure_lounge)
 "iXd" = (
 /obj/structure/disposalpipe/segment{
@@ -27986,11 +27959,13 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/brig)
 "iXZ" = (
-/obj/docking_port/stationary/escape_pod{
-	dir = 8
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
 	},
-/turf/open/space/basic,
-/area/space)
+/mob/living/basic/bot/secbot/beepsky/armsky,
+/turf/open/floor/iron/showroomfloor,
+/area/station/security/armory)
 "iYa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28017,9 +27992,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/virology{
-	name = "Operating Theater B"
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
@@ -28027,6 +27999,13 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/virology{
+	autoclose = 0;
+	frequency = 1449;
+	id_tag = "virology_airlock_interior";
+	name = "Virology Interior Airlock"
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/virology)
 "iYj" = (
@@ -28062,12 +28041,6 @@
 /area/station/service/chapel)
 "iYA" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/closet/l3closet/virology,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /obj/machinery/light/small/directional/east,
 /obj/machinery/camera/directional/north{
 	c_tag = "Virology Airlock";
@@ -28078,8 +28051,9 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/vending/drugs,
 /turf/open/floor/iron/dark,
-/area/station/medical/virology)
+/area/station/medical/pharmacy)
 "iYI" = (
 /obj/effect/turf_decal/arrows,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -28109,6 +28083,15 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/machinery/door_buttons/access_button{
+	dir = 1;
+	idDoor = "virology_airlock_interior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Button";
+	pixel_x = -24;
+	pixel_y = -2;
+	req_access = list("virology")
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/virology)
 "iZm" = (
@@ -28295,7 +28278,6 @@
 "jco" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "jcp" = (
@@ -28376,13 +28358,8 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "jdR" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters{
-	dir = 1;
-	id = "virologysurgery";
-	name = "Virology Privacy Shutters"
-	},
-/turf/open/floor/plating,
+/obj/structure/sign/warning/biohazard,
+/turf/closed/wall/r_wall,
 /area/station/medical/virology)
 "jdW" = (
 /obj/structure/table/reinforced,
@@ -28549,8 +28526,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/red,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "jgu" = (
@@ -28593,6 +28569,7 @@
 	name = "Kitchen Cold Room Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/obj/structure/plasticflaps/kitchen,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/bridge)
 "jgC" = (
@@ -28703,15 +28680,11 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "jhX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/sand/plating,
+/obj/machinery/power/floodlight,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/turf/open/floor/iron/showroomfloor,
-/area/station/medical/storage)
+/turf/open/floor/plating,
+/area/station/security/prison)
 "jia" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
 	dir = 1
@@ -29067,6 +29040,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/unres/delayed,
 /obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/lesser)
 "jpX" = (
@@ -29221,10 +29195,10 @@
 /turf/open/floor/iron/dark,
 /area/station/service/bar/backroom)
 "jsj" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/multilayer/connected,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/station/ai/satellite/foyer)
 "jso" = (
@@ -29280,7 +29254,6 @@
 /obj/machinery/power/port_gen/pacman,
 /obj/structure/sign/warning/no_smoking/directional/north,
 /obj/effect/decal/cleanable/cobweb,
-/obj/structure/spider/stickyweb,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
@@ -29345,13 +29318,12 @@
 /area/station/engineering/supermatter/room)
 "jvh" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/closet/radiation,
-/obj/item/clothing/glasses/meson,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage_shared)
 "jvl" = (
@@ -29477,6 +29449,7 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "jzh" = (
@@ -29653,10 +29626,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
+/obj/structure/bed/medical/emergency,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/central)
 "jBR" = (
@@ -29743,15 +29713,19 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "jDU" = (
-/obj/effect/turf_decal/loading_area,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/obj/structure/table/glass,
+/obj/structure/cable,
+/obj/structure/fireaxecabinet/jawsofrecovery/directional/east,
+/obj/item/surgicaldrill,
+/obj/item/toy/figure/paramedic,
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/paramedic)
 "jEd" = (
 /obj/structure/table,
 /obj/machinery/firealarm/directional/west,
@@ -29939,14 +29913,16 @@
 /turf/open/floor/iron/dark,
 /area/station/service/janitor)
 "jHo" = (
-/obj/structure/flora/bush/jungle/a/style_random,
-/obj/structure/flora/bush/sunny/style_random,
-/obj/item/food/grown/banana,
-/obj/structure/flora/bush/flowers_yw/style_random,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/mob/living/carbon/human/species/monkey,
-/turf/open/floor/grass,
-/area/station/medical/virology)
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/paramedic)
 "jHy" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -29991,8 +29967,10 @@
 /area/station/service/chapel)
 "jIg" = (
 /obj/structure/cable,
-/turf/open/floor/carpet,
-/area/station/medical/psychology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/meter,
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/cryo)
 "jIt" = (
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	id = "engsm";
@@ -30340,7 +30318,17 @@
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/surgery/aft)
+/area/station/medical/surgery/theatre)
+"jMl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/sign/poster/official/random/directional/east,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "jMo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30470,6 +30458,13 @@
 	},
 /turf/closed/wall/r_wall/rust,
 /area/station/science/ordnance/bomb)
+"jOY" = (
+/obj/structure/cable,
+/obj/machinery/light/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/virology)
 "jOZ" = (
 /obj/machinery/computer/rdservercontrol,
 /obj/effect/turf_decal/bot,
@@ -30740,14 +30735,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "jTt" = (
-/obj/structure/sign/warning/docking,
-/turf/closed/wall/rust,
-/area/station/maintenance/port/greater)
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/hallway/primary/fore)
 "jTu" = (
-/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/light/directional/east,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
-/area/station/medical/exam_room)
+/area/station/medical/treatment_center)
 "jUa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
@@ -30755,24 +30751,21 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "jUi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /obj/structure/table,
-/obj/item/tank/internals/anesthetic{
-	pixel_x = -5
+/obj/item/clipboard{
+	pixel_x = 8;
+	pixel_y = 2
 	},
-/obj/item/tank/internals/anesthetic{
-	pixel_x = -5
+/obj/item/toy/figure/assistant{
+	pixel_x = 8;
+	pixel_y = 2
 	},
-/obj/machinery/vending/wallmed/directional/north{
-	pixel_x = -32
-	},
-/obj/machinery/light/directional/north,
-/obj/machinery/status_display/evac/directional/north,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
-	},
-/obj/effect/spawner/surgery_tray/full,
-/turf/open/floor/iron/dark,
-/area/station/medical/virology)
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/wood,
+/area/station/commons/vacant_room/commissary)
 "jUz" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
@@ -30832,11 +30825,11 @@
 /turf/open/floor/wood,
 /area/station/maintenance/department/crew_quarters/bar)
 "jVZ" = (
-/obj/structure/water_source/puddle,
-/obj/structure/flora/bush/reed/style_random{
-	pixel_y = 5
-	},
-/turf/open/floor/grass,
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/event_spawn,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/showroomfloor,
 /area/station/medical/psychology)
 "jWs" = (
 /obj/machinery/door/airlock/maintenance{
@@ -30967,9 +30960,12 @@
 /turf/open/floor/plating,
 /area/station/security/prison/garden)
 "jYo" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/security/prison)
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "jYp" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -31025,19 +31021,17 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/service/chapel)
 "jZJ" = (
-/obj/structure/table,
-/obj/item/clipboard,
-/obj/item/paper/crumpled{
-	default_raw_text = "The safes have been locked and scrambled. Three thousand space dollars, a bandolier, a custom shotgun, and a lazarus injector have been safely deposited.";
-	name = "bank statement"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/nuclearbomb/beer,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/greater)
 "kac" = (
@@ -31085,19 +31079,21 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "kaM" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/effect/decal/cleanable/blood/old,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/machinery/shower/directional/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/box,
 /turf/open/floor/iron/dark,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/main)
 "kaT" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/exam_room)
+/area/station/medical/treatment_center)
 "kaW" = (
 /obj/structure/girder,
 /obj/effect/decal/cleanable/dirt,
@@ -31191,7 +31187,7 @@
 	c_tag = "Prison Labor";
 	network = list("ss13","prison")
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/security/prison)
 "kbH" = (
 /obj/machinery/computer/records/medical{
@@ -31607,13 +31603,10 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/office)
 "kkC" = (
-/obj/item/toy/beach_ball{
-	pixel_y = 6
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/grass,
+/turf/open/floor/iron/showroomfloor,
 /area/station/medical/psychology)
 "kkP" = (
 /obj/structure/cable,
@@ -31637,11 +31630,9 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/server)
 "kkV" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/station/security/prison)
+/area/station/medical/cryo)
 "kll" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 4
@@ -31706,11 +31697,7 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "kmo" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/station/engineering/main)
 "kmt" = (
 /turf/open/floor/iron/grimy,
@@ -31778,17 +31765,16 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "knL" = (
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/stasis,
+/obj/machinery/vitals_reader/advanced/directional/east,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
-/obj/machinery/shower/directional/west{
-	name = "emergency shower"
-	},
 /obj/effect/turf_decal/box,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
-/turf/open/floor/iron/showroomfloor,
-/area/station/medical/exam_room)
+/turf/open/floor/iron/dark,
+/area/station/medical/treatment_center)
 "knR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31999,7 +31985,7 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/paramedic)
+/area/station/medical/office)
 "krN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -32571,11 +32557,14 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "kCZ" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/obj/machinery/iv_drip,
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/exam_room)
+/area/station/medical/treatment_center)
 "kDe" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -32616,7 +32605,7 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/exam_room)
+/area/station/medical/treatment_center)
 "kDy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -32660,11 +32649,11 @@
 	},
 /area/station/hallway/primary/fore)
 "kEC" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/holopad,
-/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/psychology)
+/area/station/medical/cryo)
 "kEQ" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/tank_dispenser,
@@ -32768,6 +32757,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/solars/port/fore)
 "kGs" = (
@@ -32791,17 +32781,12 @@
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "kHh" = (
-/obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/unres/delayed{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/greater)
 "kHq" = (
@@ -32823,22 +32808,26 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "kHs" = (
-/obj/machinery/modular_computer/preset/cargochat/engineering,
-/turf/open/floor/iron/dark,
+/obj/machinery/modular_computer/preset/cargochat/engineering{
+	dir = 8
+	},
+/obj/machinery/light/directional/east,
+/obj/machinery/light_switch/directional/east,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/station/engineering/main)
 "kHw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/medical/storage)
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/station/medical/coldroom)
 "kHG" = (
 /obj/machinery/smartfridge/chemistry/preloaded,
 /turf/closed/wall,
@@ -32965,7 +32954,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/surgery/aft)
+/area/station/medical/surgery/theatre)
 "kKa" = (
 /obj/structure/table/wood/fancy/blue,
 /obj/effect/turf_decal/siding/wood{
@@ -33028,9 +33017,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "kLx" = (
-/obj/machinery/meter,
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/meter,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "kLy" = (
@@ -33059,6 +33048,12 @@
 "kMe" = (
 /turf/closed/wall/r_wall/rust,
 /area/station/maintenance/solars/port/aft)
+"kMi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/random/directional/east,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/commons/vacant_room/commissary)
 "kMs" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/sign/poster/random/directional/east,
@@ -33125,6 +33120,8 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "kNe" = (
@@ -33643,11 +33640,8 @@
 "kUp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/structure/cable,
-/turf/open/floor/grass,
+/turf/open/floor/iron/showroomfloor,
 /area/station/medical/psychology)
 "kUB" = (
 /obj/structure/table,
@@ -33682,14 +33676,12 @@
 "kUV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/button/crematorium/indestructible{
-	pixel_x = 22
+/obj/machinery/mech_bay_recharge_port{
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/checker,
-/area/station/security/processing/cremation)
+/obj/effect/turf_decal/bot,
+/turf/open/floor/circuit/red,
+/area/station/security/mechbay)
 "kUX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -33820,6 +33812,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/janitor,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/landmark/navigate_destination/disposals,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "kWA" = (
@@ -34058,7 +34051,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/mob/living/basic/spider/giant/tarantula/scrawny,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
@@ -34176,15 +34168,13 @@
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "lbq" = (
-/obj/structure/table,
-/obj/item/stack/rods/twentyfive,
-/obj/item/wrench,
-/obj/item/storage/box/lights/mixed,
 /obj/item/radio/intercom/directional/south,
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 4
 	},
+/obj/item/flatpack/flatpacker,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "lby" = (
@@ -34194,7 +34184,6 @@
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/mask/russian_balaclava,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -34208,17 +34197,19 @@
 /obj/structure/sign/poster/contraband/random/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
-"lbK" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "greylair";
-	name = "Lair Privacy Shutter"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "lbO" = (
 /turf/closed/wall,
 /area/station/service/library)
+"lcg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/secure_closet/personal{
+	name = "Commissary Locker"
+	},
+/turf/open/floor/wood,
+/area/station/commons/vacant_room/commissary)
 "lch" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/blue{
@@ -34292,7 +34283,6 @@
 /obj/machinery/door/airlock/engineering{
 	name = "Electrical Maintenance"
 	},
-/obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/mapping_helpers/airlock/unres/delayed{
 	dir = 4
 	},
@@ -34486,15 +34476,6 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse/upper)
-"lgl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/spider/stickyweb,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/electrical)
 "lgu" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -34576,12 +34557,9 @@
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "lia" = (
-/obj/effect/turf_decal/tile/brown/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/station/medical/paramedic)
 "lie" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/vending/wardrobe/science_wardrobe,
@@ -34619,6 +34597,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "liK" = (
@@ -34765,20 +34744,8 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/lesser)
 "llY" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/virology{
-	name = "Virology Access"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "viro-airlock"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
-/turf/open/floor/iron/dark,
-/area/station/medical/virology)
+/turf/closed/wall/r_wall,
+/area/station/medical/pharmacy)
 "lmb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -34821,7 +34788,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/components/unary/airlock_pump/unbolt_only{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -34863,13 +34830,12 @@
 /turf/closed/wall/rust,
 /area/station/cargo/storage)
 "lnc" = (
-/obj/effect/landmark/start/paramedic,
 /obj/structure/chair/office/light,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/paramedic)
+/area/station/medical/office)
 "lnm" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -34961,10 +34927,6 @@
 "lpt" = (
 /turf/closed/wall/r_wall/rust,
 /area/station/command/heads_quarters/captain)
-"lpF" = (
-/obj/structure/sign/warning/docking,
-/turf/closed/wall,
-/area/station/maintenance/port/greater)
 "lpH" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot,
@@ -35055,7 +35017,6 @@
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/obj/item/grenade/flashbang,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -35202,6 +35163,7 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
 "lsE" = (
@@ -35455,7 +35417,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/security/processing/cremation)
+/area/station/security/mechbay)
 "lwu" = (
 /turf/closed/wall,
 /area/station/security/medical)
@@ -35504,16 +35466,15 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
 "lxp" = (
-/obj/structure/table,
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/newscaster/directional/south,
-/obj/item/stack/package_wrap,
-/obj/item/hand_labeler,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
+/obj/effect/turf_decal/delivery,
+/obj/machinery/component_printer,
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/station/commons/vacant_room/commissary)
+/turf/open/floor/iron/showroomfloor,
+/area/station/engineering/circuit_workshop)
 "lxu" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
@@ -35601,32 +35562,18 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "lyr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
+/obj/structure/closet/secure_closet/medical2,
 /turf/open/floor/iron/dark,
 /area/station/medical/virology)
-"lyu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "lyT" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -35651,6 +35598,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/processing)
 "lzv" = (
@@ -35666,10 +35614,13 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "lzY" = (
-/obj/structure/flora/bush/leavy/style_random,
-/obj/structure/flora/bush/sparsegrass/style_random,
-/turf/open/floor/grass,
-/area/station/hallway/primary/fore)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "lAk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35745,9 +35696,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/checker,
-/area/station/security/processing/cremation)
+/area/station/security/mechbay)
 "lBj" = (
 /obj/structure/table/wood,
 /obj/structure/cable,
@@ -35769,7 +35723,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /obj/item/bedsheet/medical,
 /obj/machinery/light/directional/east,
-/obj/structure/sign/warning/biohazard/directional/east,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
@@ -35803,23 +35756,12 @@
 /area/station/maintenance/department/security)
 "lBU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/psychology)
+/area/station/medical/cryo)
 "lCa" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/table/wood,
-/obj/machinery/computer/records/medical/laptop{
-	dir = 4;
-	pixel_y = 3;
-	pixel_x = 3
-	},
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
 /area/station/medical/psychology)
 "lCs" = (
 /obj/effect/decal/cleanable/dirt,
@@ -35842,6 +35784,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "lCC" = (
@@ -35879,8 +35823,19 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/power/terminal{
+	dir = 4
+	},
 /obj/structure/cable,
-/turf/open/floor/engine,
+/obj/machinery/light/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "lDc" = (
 /obj/structure/lattice/catwalk,
@@ -36002,11 +35957,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "lFN" = (
-/obj/structure/chair/comfy/brown{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/station/medical/psychology)
+/obj/structure/sign/departments/psychology/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/camera/autoname/directional/west,
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/cryo)
 "lFS" = (
 /obj/item/reagent_containers/cup/glass/bottle/rum{
 	pixel_x = -7;
@@ -36100,14 +36055,6 @@
 /obj/structure/table/optable,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
-"lHD" = (
-/obj/docking_port/stationary/random{
-	dir = 8;
-	name = "lavaland";
-	shuttle_id = "pod_2_lavaland"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "lHE" = (
 /obj/structure/table/wood,
 /obj/structure/displaycase/forsale/kitchen{
@@ -36123,11 +36070,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/medbay/central)
@@ -36137,7 +36084,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/caution/stand_clear,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/components/unary/airlock_pump{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -36528,11 +36475,6 @@
 	pixel_y = 8;
 	specialfunctions = 4
 	},
-/obj/machinery/button/door/directional/east{
-	id = "Shower_1Privacy";
-	name = "Shower 1 Privacy Toggle";
-	pixel_y = -8
-	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
 "lPh" = (
@@ -36600,6 +36542,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
 "lQw" = (
@@ -36620,13 +36563,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "lQK" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/caution/stand_clear,
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/iron/dark,
-/area/station/medical/exam_room)
+/area/station/medical/treatment_center)
 "lRd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/event_spawn,
@@ -36677,6 +36620,7 @@
 "lRJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
 "lRS" = (
@@ -36695,6 +36639,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/fore)
 "lSg" = (
@@ -36705,6 +36650,13 @@
 /obj/machinery/bouldertech/refinery,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
+"lSl" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Auxiliary Dock"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "lSt" = (
 /obj/structure/cable,
 /obj/structure/bed/dogbed/ian,
@@ -36745,16 +36697,12 @@
 /turf/closed/wall/rust,
 /area/station/security/medical)
 "lTu" = (
-/obj/machinery/vending/drugs,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue/opposingcorners,
-/turf/open/floor/iron/showroomfloor,
-/area/station/medical/medbay/central)
+/turf/closed/wall,
+/area/station/medical/break_room)
 "lTM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -36879,9 +36827,7 @@
 /obj/item/pen,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/newscaster/directional/north,
-/obj/structure/spider/stickyweb,
 /obj/machinery/button/door/directional/east{
 	id = "bankvault";
 	name = "Bank Door Lock";
@@ -36936,6 +36882,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/solars/starboard/fore)
 "lWr" = (
@@ -36983,7 +36930,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
-/turf/open/floor/engine,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "lXe" = (
 /obj/structure/table,
@@ -37054,11 +37002,9 @@
 /turf/closed/wall,
 /area/station/science/robotics/lab)
 "lYv" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/flora/bush/leavy/style_random,
-/obj/structure/flora/bush/sparsegrass/style_random,
-/turf/open/floor/grass,
-/area/station/hallway/primary/fore)
+/obj/structure/sign/warning/pods,
+/turf/closed/wall,
+/area/station/maintenance/port/greater)
 "lYE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37190,7 +37136,7 @@
 	name = "kitchen camera"
 	},
 /obj/machinery/light/cold/directional/east,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "mbc" = (
 /obj/effect/turf_decal/stripes/line{
@@ -37226,6 +37172,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
 "mbp" = (
@@ -37281,6 +37228,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/solars/starboard/aft)
 "mbW" = (
@@ -37660,7 +37608,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/blood/old,
-/mob/living/basic/spider/giant/hunter/scrawny,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/greater)
@@ -37682,6 +37629,7 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/unres/delayed,
 /obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/aft)
 "mis" = (
@@ -37750,13 +37698,15 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
 "mjc" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/flora/bush/sparsegrass/style_random,
-/obj/structure/flora/bush/grassy/style_random,
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/flora/bush/flowers_yw/style_random,
-/turf/open/floor/grass,
-/area/station/hallway/primary/fore)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/flashlight,
+/obj/item/storage/toolbox/emergency{
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "mjh" = (
 /turf/closed/wall/r_wall/rust,
 /area/station/maintenance/aft)
@@ -37896,7 +37846,6 @@
 /area/station/cargo/office)
 "mlz" = (
 /obj/structure/table,
-/obj/item/stack/medical/gauze,
 /obj/item/stack/medical/mesh,
 /obj/item/stack/medical/suture,
 /obj/effect/turf_decal/tile/neutral{
@@ -38066,22 +38015,17 @@
 /area/station/engineering/atmos)
 "mnG" = (
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/virology{
-	name = "Virology Access"
+/obj/machinery/door/airlock/medical/glass{
+	name = "Pharmacy"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "viro-airlock"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/effect/mapping_helpers/airlock/access/all/medical/pharmacy,
 /turf/open/floor/iron/dark,
-/area/station/medical/virology)
+/area/station/medical/pharmacy)
 "mnK" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Office"
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/general,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "mnO" = (
 /obj/item/radio/intercom/directional/north,
@@ -38392,6 +38336,12 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /turf/open/floor/iron/showroomfloor,
 /area/station/command/heads_quarters/rd)
+"mtr" = (
+/obj/structure/chair/office/light,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/virology)
 "mtw" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
@@ -38411,12 +38361,11 @@
 /area/station/ai/satellite/chamber)
 "mtI" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/bodycontainer/crematorium{
-	dir = 4
-	},
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/checker,
-/area/station/security/processing/cremation)
+/obj/vehicle/sealed/mecha/ripley/paddy/preset,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/circuit/red,
+/area/station/security/mechbay)
 "mtN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38441,6 +38390,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "mug" = (
@@ -38452,6 +38402,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
 "mun" = (
@@ -38571,11 +38522,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "mwR" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance/two,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "mxf" = (
@@ -38629,15 +38580,10 @@
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "myd" = (
-/obj/structure/table/glass,
 /obj/structure/mirror/directional/south,
-/obj/item/mod/module/plasma_stabilizer,
-/obj/item/mod/module/thermal_regulator,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/storage)
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/station/medical/coldroom)
 "myg" = (
 /obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/stripes/line{
@@ -38693,16 +38639,6 @@
 /obj/effect/turf_decal/tile/green/fourcorners,
 /turf/open/floor/iron/checker,
 /area/station/service/hydroponics)
-"mzt" = (
-/obj/structure/flora/grass/jungle/a/style_random{
-	icon_state = "grassb2"
-	},
-/obj/structure/flora/bush/pale/style_random{
-	icon_state = "brflowers_3"
-	},
-/obj/structure/flora/bush/ferny,
-/turf/open/misc/asteroid,
-/area/space/nearstation)
 "mzB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38776,7 +38712,8 @@
 /area/station/science/xenobiology)
 "mBm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/engine,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "mBL" = (
 /obj/item/tank/internals/emergency_oxygen/engi{
@@ -38892,7 +38829,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/spider/stickyweb,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
@@ -38920,6 +38856,7 @@
 /obj/item/radio/intercom/directional/east,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "mDj" = (
@@ -38928,17 +38865,6 @@
 "mDD" = (
 /turf/closed/wall/rust,
 /area/station/cargo/warehouse/upper)
-"mDJ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
-	name = "Head of Security's Office"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/security/hos,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/hos)
 "mDM" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/machinery/light/directional/south,
@@ -38970,10 +38896,6 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/fore)
 "mEt" = (
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -39230,8 +39152,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/mob/living/simple_animal/bot/secbot/pingsky,
 /obj/structure/cable/layer3,
+/mob/living/basic/bot/secbot/pingsky,
 /turf/open/floor/engine,
 /area/station/ai/satellite/interior)
 "mJk" = (
@@ -39319,8 +39241,7 @@
 /area/station/service/hydroponics)
 "mKP" = (
 /obj/machinery/light/small/directional/east,
-/mob/living/basic/cow,
-/turf/open/misc/sandy_dirt,
+/turf/open/water/no_planet_atmos/deep,
 /area/station/service/hydroponics/garden)
 "mLb" = (
 /obj/effect/decal/cleanable/dirt,
@@ -39375,13 +39296,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "mMa" = (
-/obj/machinery/vending/coffee,
 /obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/storage)
+/obj/structure/closet/crate/freezer/blood,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/station/medical/coldroom)
 "mMb" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/cobweb,
@@ -39571,17 +39490,14 @@
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/maintenance/storage)
 "mPC" = (
-/obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters{
-	dir = 1;
-	id = "commissaryshutter";
-	name = "Vacant Commissary Shutter"
-	},
 /obj/effect/turf_decal/delivery,
-/obj/structure/noticeboard/directional/east,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Circuit Workshop"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/plating,
-/area/station/commons/vacant_room/commissary)
+/area/station/engineering/circuit_workshop)
 "mPE" = (
 /obj/structure/sink/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39600,13 +39516,12 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medbay Break Room"
-	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/airlock/medical,
+/obj/structure/plasticflaps/kitchen,
 /turf/open/floor/iron/dark,
-/area/station/medical/storage)
+/area/station/medical/coldroom)
 "mPP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39626,9 +39541,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/main)
 "mPZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -39663,19 +39577,24 @@
 /turf/open/floor/plating,
 /area/station/service/bar/atrium)
 "mQR" = (
-/obj/structure/closet/secure_closet/personal{
-	name = "Commissary Locker"
-	},
-/obj/effect/turf_decal/bot,
 /obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
-/turf/open/floor/iron/dark,
-/area/station/commons/vacant_room/commissary)
+/obj/structure/table,
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 1
+	},
+/obj/item/multitool/circuit{
+	pixel_x = 7
+	},
+/obj/item/multitool/circuit,
+/obj/item/multitool/circuit{
+	pixel_x = -8
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/engineering/circuit_workshop)
 "mQS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39704,6 +39623,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "mRi" = (
@@ -39947,7 +39867,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/security/prison)
 "mVf" = (
 /obj/structure/disposalpipe/segment{
@@ -39981,6 +39901,7 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "mVL" = (
@@ -40122,7 +40043,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/contraband/random/directional/south,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "mYv" = (
 /obj/effect/turf_decal/siding/thinplating/dark/end{
@@ -40234,7 +40155,14 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
 "nan" = (
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
 /area/station/engineering/main)
 "naw" = (
 /obj/machinery/light/directional/west,
@@ -40248,10 +40176,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "nax" = (
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/flora/bush/lavendergrass/style_random,
-/turf/open/floor/grass,
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/turf/open/floor/iron/dark/corner,
 /area/station/hallway/primary/fore)
 "naC" = (
 /obj/machinery/firealarm/directional/west,
@@ -40312,9 +40238,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "nbg" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/station/medical/paramedic)
+/area/station/medical/office)
 "nbn" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
@@ -40640,8 +40566,18 @@
 "ngI" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/security/prison)
+"ngT" = (
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/effect/decal/cleanable/blood/old,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/machinery/camera/autoname/directional/west,
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/virology)
 "ngV" = (
 /obj/machinery/conveyor/inverted{
 	dir = 5;
@@ -40679,7 +40615,6 @@
 "nhy" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/rack,
 /obj/item/storage/backpack/satchel/science,
 /obj/item/analyzer,
@@ -40820,7 +40755,7 @@
 /area/station/security/detectives_office)
 "nlR" = (
 /turf/closed/wall/rust,
-/area/station/medical/virology)
+/area/station/medical/pharmacy)
 "nmo" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
 	dir = 4
@@ -40936,13 +40871,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"noM" = (
+/obj/structure/lattice,
+/obj/structure/sign/warning/secure_area,
+/turf/closed/wall/r_wall,
+/area/station/hallway/secondary/exit/departure_lounge)
 "noO" = (
-/obj/structure/flora/tree/jungle/small/style_random,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/grass,
+/turf/open/floor/carpet,
 /area/station/medical/psychology)
 "npg" = (
 /obj/effect/turf_decal/delivery,
@@ -41185,13 +41124,7 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "nsA" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id = "Shower_1Privacy";
-	name = "Shower 1 Privacy Shutter"
-	},
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/station/commons/toilet/restrooms)
 "nsM" = (
 /obj/effect/turf_decal/bot,
@@ -41236,9 +41169,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/airalarm/directional/south,
+/obj/machinery/atmospherics/components/binary/valve/digital/on{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "ntE" = (
@@ -41384,9 +41319,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "nvH" = (
-/obj/structure/sign/warning/biohazard,
 /turf/closed/wall/r_wall/rust,
-/area/station/medical/virology)
+/area/station/medical/pharmacy)
 "nvI" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -41591,6 +41525,14 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"nym" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Engineering Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/engine_equipment,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "nyw" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Emergency Storage"
@@ -41707,12 +41649,14 @@
 /area/station/security/interrogation)
 "nBZ" = (
 /obj/machinery/newscaster/directional/west,
-/obj/structure/table,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/obj/effect/spawner/surgery_tray/full,
-/turf/open/floor/iron/dark,
-/area/station/medical/surgery/fore)
+/obj/structure/chair/comfy/teal{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/break_room)
 "nCc" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -41742,11 +41686,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "nCA" = (
-/obj/structure/flora/bush/flowers_pp/style_random,
-/obj/structure/flora/bush/reed/style_random,
-/obj/structure/flora/bush/sparsegrass/style_random,
 /obj/machinery/light/directional/south,
-/turf/open/floor/grass,
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/turf/open/floor/iron/dark/corner,
 /area/station/hallway/primary/fore)
 "nCI" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
@@ -41767,15 +41709,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "nCU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green/anticorner/contrasted,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/virology)
+/area/station/medical/pharmacy)
 "nDi" = (
 /obj/machinery/meter,
 /obj/effect/turf_decal/stripes/line{
@@ -41948,6 +41889,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/aft)
+"nFg" = (
+/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/burgundy{
+	name = "landing marker"
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "nFm" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -42003,8 +41952,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/surgery/fore)
+/area/station/medical/break_room)
 "nGE" = (
 /obj/structure/table/wood/fancy,
 /obj/item/food/grown/poppy{
@@ -42098,19 +42048,18 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "nHC" = (
-/obj/effect/turf_decal/stripes/corner{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/directional/north,
+/obj/effect/spawner/random/entertainment/arcade,
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Gas to Mix"
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "nHO" = (
 /turf/closed/wall/rust,
 /area/station/service/janitor)
@@ -42326,10 +42275,10 @@
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "nKV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
 /area/station/medical/medbay/central)
 "nLm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -42755,7 +42704,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/engine,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "nWM" = (
 /obj/structure/cable,
@@ -42774,16 +42724,12 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "nWW" = (
-/obj/structure/closet/secure_closet/psychology,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 1
-	},
-/obj/structure/window/reinforced/spawner/directional/west,
+/obj/machinery/iv_drip,
+/obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/psychology)
+/area/station/medical/virology)
 "nXp" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -42880,7 +42826,6 @@
 /obj/item/clothing/neck/tie/red,
 /obj/item/clothing/mask/animal/small/jackal,
 /obj/item/clothing/mask/animal/small/jackal,
-/obj/structure/spider/stickyweb,
 /obj/machinery/button/door/directional/west{
 	id = "bank";
 	name = "Bank Vault Lock";
@@ -42980,10 +42925,6 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/ordnance)
 "oaF" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/turf_decal/box/corners{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
@@ -42991,6 +42932,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "oaK" = (
@@ -43069,12 +43012,10 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/execution/transfer)
 "oct" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/flora/bush/sparsegrass/style_random,
-/obj/structure/flora/bush/grassy/style_random,
-/obj/structure/flora/bush/flowers_yw/style_random,
-/turf/open/floor/grass,
-/area/station/hallway/primary/fore)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "ocv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -43084,9 +43025,8 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/ordnance)
 "ocx" = (
-/obj/effect/turf_decal/box,
-/obj/machinery/shower/directional/east{
-	name = "emergency shower"
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
@@ -43162,12 +43102,9 @@
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "odA" = (
-/obj/structure/flora/bush/lavendergrass/style_random,
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/flora/bush/grassy/style_random,
-/mob/living/basic/butterfly,
-/turf/open/floor/grass,
-/area/station/hallway/primary/fore)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/iron,
+/area/station/maintenance/port/greater)
 "odE" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/structure/flora/bush/pointy/style_random,
@@ -43272,11 +43209,12 @@
 /turf/open/misc/asteroid,
 /area/station/maintenance/port/lesser)
 "ofB" = (
-/obj/structure/flora/grass/jungle/a/style_random,
-/obj/structure/flora/bush/ferny/style_random,
-/mob/living/carbon/human/species/monkey,
-/turf/open/floor/grass,
-/area/station/medical/virology)
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/paramedic)
 "ogg" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -43471,7 +43409,6 @@
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/directional/west,
-/obj/item/clothing/mask/russian_balaclava,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
@@ -43493,13 +43430,11 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/maintenance/department/chapel/monastery)
 "oki" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/status_display/evac/directional/north,
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/cable,
+/obj/machinery/power/smes/full,
 /turf/open/floor/circuit/green{
 	luminosity = 2
 	},
@@ -43562,17 +43497,16 @@
 "okQ" = (
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/light/directional/east,
-/obj/structure/table/wood,
-/obj/machinery/fax{
-	fax_name = "Psychology Office";
-	name = "Psychology Office Fax Machine"
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
 	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/medical/psychology)
+/turf/open/floor/iron/dark,
+/area/station/medical/cryo)
 "olq" = (
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
 	dir = 4
@@ -43629,21 +43563,17 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
+/obj/structure/disposalpipe/junction/flip{
+	dir = 2
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/medbay/central)
-"omw" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "omH" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "Skynet_launch";
@@ -43958,14 +43888,12 @@
 /area/station/construction/mining/aux_base)
 "otA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "otF" = (
@@ -44014,19 +43942,18 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ouD" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /obj/machinery/light/directional/south,
 /obj/machinery/light_switch/directional/south,
-/obj/structure/closet/crate/freezer/blood,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/structure/table/glass,
+/obj/item/mod/module/thermal_regulator,
+/obj/item/mod/module/plasma_stabilizer,
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/surgery/fore)
+/area/station/medical/break_room)
 "ouE" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line{
@@ -44216,14 +44143,14 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/item/kirbyplants/organic/plant21,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "oxp" = (
-/obj/structure/flora/bush/jungle/a/style_random,
-/obj/structure/flora/bush/flowers_br/style_random,
-/obj/structure/flora/bush/sunny/style_random,
 /obj/machinery/light/directional/west,
-/turf/open/floor/grass,
+/obj/structure/closet/secure_closet/psychology,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/carpet,
 /area/station/medical/psychology)
 "oxC" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -44497,18 +44424,13 @@
 /turf/open/floor/engine,
 /area/station/engineering/gravity_generator)
 "oCo" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/bot,
-/obj/item/electronics/apc,
-/obj/item/electronics/apc,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/mod/module/plasma_stabilizer,
-/obj/item/mod/module/thermal_regulator,
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron,
 /area/station/engineering/main)
 "oCr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44582,9 +44504,25 @@
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/primary/central/fore)
 "oDh" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/recharge_station,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/structure/table,
+/obj/item/stock_parts/power_store/cell/emproof{
+	pixel_x = 6;
+	pixel_y = -6
+	},
+/obj/item/grenade/chem_grenade/smart_metal_foam{
+	pixel_x = 6
+	},
+/obj/item/grenade/chem_grenade/smart_metal_foam{
+	pixel_x = -2
+	},
+/obj/item/crowbar,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "oDt" = (
@@ -44661,7 +44599,6 @@
 /area/station/security/warden)
 "oFt" = (
 /obj/machinery/light/small/directional/east,
-/mob/living/basic/trooper/russian,
 /turf/open/floor/carpet/green,
 /area/station/maintenance/port/greater)
 "oFC" = (
@@ -44688,7 +44625,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "oGu" = (
 /obj/structure/cable,
@@ -44766,14 +44703,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"oHG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "oHP" = (
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /turf/open/floor/iron/showroomfloor,
@@ -44799,6 +44728,12 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
+"oIu" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "oIy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44896,14 +44831,14 @@
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "oJH" = (
-/obj/structure/flora/bush/sparsegrass/style_random,
-/obj/structure/flora/bush/grassy/style_random,
-/obj/structure/flora/bush/flowers_yw/style_random,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/machinery/suit_storage_unit/medical,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 8
 	},
-/turf/open/floor/grass,
-/area/station/medical/virology)
+/obj/machinery/light_switch/directional/west,
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/paramedic)
 "oJU" = (
 /obj/docking_port/stationary/syndicate/northwest{
 	dir = 8
@@ -44931,10 +44866,6 @@
 "oKJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/button/door/directional/north{
-	id = "emmd";
-	name = "Medical Lockdown Toggle"
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -44943,7 +44874,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/surgery/fore)
+/area/station/medical/break_room)
 "oKV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -44975,12 +44906,10 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "oLs" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/flora/bush/lavendergrass/style_random,
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/flora/bush/grassy/style_random,
-/mob/living/basic/butterfly,
-/turf/open/floor/grass,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "oLG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45032,16 +44961,20 @@
 /area/station/science/genetics)
 "oMJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/start/medical_doctor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/turf/open/floor/iron/showroomfloor,
-/area/station/medical/storage)
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/station/medical/coldroom)
+"oMU" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/commons/vacant_room/commissary)
 "oMZ" = (
-/obj/item/radio/intercom/directional/north,
-/turf/open/misc/sandy_dirt,
+/turf/open/water/no_planet_atmos/deep,
 /area/station/service/hydroponics/garden)
 "oNf" = (
 /obj/structure/table,
@@ -45292,13 +45225,6 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/ordnance/freezerchamber)
-"oSq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "oSs" = (
 /obj/structure/flora/grass/jungle/a/style_random,
 /obj/effect/turf_decal/stripes/line{
@@ -45359,7 +45285,6 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "oSX" = (
-/obj/structure/table,
 /obj/item/paper_bin{
 	pixel_x = -4;
 	pixel_y = 4
@@ -45368,6 +45293,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
+/obj/structure/table,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
 "oTd" = (
@@ -45418,7 +45344,6 @@
 /area/station/maintenance/starboard/fore)
 "oTP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/blood/gibs/old,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
@@ -45595,7 +45520,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/iron/white,
 /area/station/security/prison/mess)
 "oWI" = (
 /obj/structure/table/reinforced,
@@ -45614,7 +45539,7 @@
 	},
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/paramedic)
+/area/station/medical/office)
 "oWX" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/shieldgen,
@@ -45743,10 +45668,10 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -45869,14 +45794,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+/obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/exam_room)
+/area/station/medical/treatment_center)
 "pbk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -45888,7 +45810,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/paramedic)
+/area/station/medical/office)
 "pbs" = (
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall/rust,
@@ -45924,12 +45846,22 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "pcC" = (
-/obj/structure/sign/warning/secure_area,
-/turf/closed/wall/r_wall,
-/area/station/hallway/secondary/entry)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "pcG" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
@@ -46009,8 +45941,9 @@
 "pdI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/psychology)
+/area/station/medical/cryo)
 "pdR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -46030,15 +45963,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "pem" = (
-/obj/structure/transit_tube/curved/flipped{
-	dir = 4
-	},
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/effect/turf_decal/stripes/line{
-	dir = 10
+	dir = 6
 	},
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/station/ai/satellite/foyer)
 "pet" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
@@ -46760,8 +46690,8 @@
 	},
 /obj/structure/sign/warning/vacuum/external/directional/east,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/components/unary/airlock_pump,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "pog" = (
@@ -46787,6 +46717,7 @@
 	dir = 10
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "poK" = (
@@ -46938,7 +46869,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/medical/paramedic)
+/area/station/medical/office)
 "pqB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/box,
@@ -46970,10 +46901,7 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "pqS" = (
-/obj/structure/flora/bush/sparsegrass/style_random,
-/obj/structure/flora/bush/grassy/style_random,
-/obj/structure/flora/bush/flowers_br/style_random,
-/turf/open/floor/grass,
+/turf/open/floor/carpet,
 /area/station/medical/psychology)
 "pra" = (
 /turf/open/floor/iron,
@@ -47035,15 +46963,8 @@
 /area/station/hallway/primary/aft)
 "prW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/commons/vacant_room/commissary)
+/turf/open/floor/iron/showroomfloor,
+/area/station/engineering/circuit_workshop)
 "prX" = (
 /obj/machinery/status_display/shuttle,
 /turf/closed/wall,
@@ -47117,10 +47038,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/garden)
-"pue" = (
-/obj/structure/sign/warning/pods,
-/turf/closed/wall/rust,
-/area/station/maintenance/port/greater)
 "puy" = (
 /obj/structure/flora/grass/jungle/b/style_random,
 /obj/structure/flora/bush/grassy/style_random,
@@ -47245,12 +47162,16 @@
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/maintenance/storage)
 "pwo" = (
-/obj/machinery/computer/station_alert,
 /obj/effect/turf_decal/bot,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/structure/table,
+/obj/item/storage/box/donkpockets{
+	pixel_y = 5
+	},
+/obj/machinery/microwave/engineering/cell_included,
 /turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "pwx" = (
@@ -47284,7 +47205,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/surgery/aft)
+/area/station/medical/surgery/theatre)
 "pwT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -47347,6 +47268,9 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"pyr" = (
+/turf/closed/wall,
+/area/station/medical/coldroom)
 "pyJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -47457,7 +47381,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "pCa" = (
 /obj/machinery/door/poddoor/preopen{
@@ -47504,7 +47428,7 @@
 "pCP" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/security/prison)
 "pCX" = (
 /obj/structure/table/wood,
@@ -47525,7 +47449,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/mob/living/simple_animal/bot/secbot/beepsky/armsky,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
@@ -47615,6 +47538,8 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/medical/central)
 "pEu" = (
@@ -47656,6 +47581,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "pFq" = (
@@ -47726,7 +47652,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/paramedic)
+/area/station/medical/office)
 "pGe" = (
 /obj/item/kirbyplants,
 /obj/effect/turf_decal/tile/neutral{
@@ -47764,27 +47690,21 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "pGE" = (
-/obj/structure/table,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/crowbar,
-/obj/item/grenade/chem_grenade/smart_metal_foam{
-	pixel_x = 6
-	},
-/obj/item/grenade/chem_grenade/smart_metal_foam{
-	pixel_x = -2
-	},
-/obj/item/stock_parts/power_store/cell/emproof{
-	pixel_x = 6;
-	pixel_y = -6
-	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/light/directional/east,
+/obj/structure/rack,
+/obj/item/mod/module/thermal_regulator,
+/obj/item/mod/module/plasma_stabilizer,
+/obj/item/stack/cable_coil,
+/obj/item/electronics/apc,
+/obj/item/stack/cable_coil,
+/obj/item/electronics/apc,
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "pGM" = (
@@ -47887,6 +47807,17 @@
 /obj/structure/cable/layer3,
 /turf/open/floor/engine,
 /area/station/ai/satellite/chamber)
+"pID" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "pIK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
@@ -47916,7 +47847,6 @@
 	name = "Head of Security's Fax Machine"
 	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "pIT" = (
@@ -47943,25 +47873,16 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation)
 "pJr" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
+	},
 /obj/structure/table,
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
-/obj/item/storage/box/rxglasses{
-	pixel_x = 6;
-	pixel_y = 8
+/obj/machinery/fax{
+	fax_name = "Medical";
+	name = "Medical Fax Machine"
 	},
-/obj/item/storage/box/gloves{
-	pixel_y = 8;
-	pixel_x = -6
-	},
-/obj/item/storage/box/masks{
-	pixel_y = 4;
-	pixel_x = -6
-	},
-/obj/item/storage/box/bodybags{
-	pixel_x = -6
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/exam_room)
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/treatment_center)
 "pJs" = (
 /obj/structure/sign/warning/fire,
 /turf/closed/wall,
@@ -48062,12 +47983,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/components/unary/airlock_pump/unbolt_only{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "pKM" = (
@@ -48202,10 +48123,7 @@
 /area/station/construction/mining/aux_base)
 "pMj" = (
 /obj/effect/landmark/start/paramedic,
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron/showroomfloor,
 /area/station/medical/medbay/central)
 "pMS" = (
 /obj/effect/decal/cleanable/dirt,
@@ -48281,6 +48199,7 @@
 	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green/half/contrasted,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/virology)
 "pOd" = (
@@ -48330,17 +48249,14 @@
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
 "pOI" = (
-/obj/structure/transit_tube/station/reverse{
-	dir = 8
-	},
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/transit_tube_pod{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/transit_tube/station/dispenser/reverse{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/hallway/primary/central/fore)
 "pOO" = (
@@ -48495,6 +48411,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse/upper)
+"pRf" = (
+/obj/structure/table,
+/obj/item/folder/white,
+/obj/item/restraints/handcuffs,
+/obj/item/pen,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/virology)
 "pRu" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/window/left/directional/south{
@@ -48573,14 +48499,24 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/genetics)
 "pSh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/effect/turf_decal/delivery,
+/obj/structure/table,
+/obj/item/storage/box/lights/mixed,
+/obj/item/stack/rods/twentyfive,
+/obj/item/wrench,
+/obj/item/hand_labeler,
+/obj/item/crowbar,
+/obj/item/electronics/airlock{
+	pixel_x = -6;
+	pixel_y = 6
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/item/stack/package_wrap,
+/obj/item/electronics/airlock{
+	pixel_x = -6;
+	pixel_y = 6
 	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
 "pSj" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot,
@@ -48601,7 +48537,6 @@
 /area/station/command/bridge)
 "pSu" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/spider/stickyweb,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -48632,7 +48567,7 @@
 "pSN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/security/prison)
 "pST" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -48643,7 +48578,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/components/binary/valve/digital/on{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "pTc" = (
@@ -48652,10 +48589,8 @@
 	},
 /obj/machinery/light/directional/south,
 /obj/machinery/newscaster/directional/south,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
-/turf/open/floor/iron/showroomfloor,
-/area/station/medical/storage)
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/station/medical/coldroom)
 "pTC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event_spawn,
@@ -48775,7 +48710,7 @@
 /obj/item/reagent_containers/condiment/sugar,
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "pWj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -48845,6 +48780,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "pXi" = (
+/obj/machinery/atmospherics/components/unary/airlock_pump{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/service/chapel)
 "pXt" = (
@@ -48971,6 +48909,14 @@
 	dir = 8
 	},
 /area/station/hallway/primary/starboard)
+"qaa" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "qai" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -49002,7 +48948,7 @@
 "qaR" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall,
-/area/station/medical/paramedic)
+/area/station/medical/office)
 "qaZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/mix_output{
 	dir = 1
@@ -49036,7 +48982,7 @@
 /area/station/hallway/primary/central/fore)
 "qbk" = (
 /turf/closed/wall/rust,
-/area/station/medical/exam_room)
+/area/station/medical/treatment_center)
 "qbv" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -49091,15 +49037,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "qbO" = (
-/obj/structure/flora/bush/sparsegrass/style_random,
-/obj/structure/flora/bush/grassy/style_random,
-/obj/structure/flora/bush/ferny/style_random,
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/grass,
-/area/station/medical/psychology)
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "qbP" = (
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/door/firedoor/border_only{
@@ -49189,7 +49135,6 @@
 "qdM" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb,
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
@@ -49225,12 +49170,18 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/machinery/door/window/left/directional/west{
-	name = "Soothing Nature Exhibit";
-	req_access = list("psychology")
+/obj/machinery/door/airlock/medical{
+	name = "Psychology"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/psychology)
+"qeH" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit/departure_lounge)
 "qeJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -49278,7 +49229,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "qfe" = (
 /turf/closed/wall/r_wall/rust,
@@ -49439,11 +49390,18 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "qip" = (
-/obj/structure/flora/bush/jungle/b/style_random,
 /obj/machinery/airalarm/directional/east,
-/mob/living/carbon/human/species/monkey,
-/turf/open/floor/grass,
-/area/station/medical/virology)
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/computer/records/medical{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/paramedic)
 "qiB" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/item/kirbyplants/random,
@@ -49467,12 +49425,12 @@
 "qiM" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/abandoned,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/unres/delayed{
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/lesser)
 "qjq" = (
@@ -49505,15 +49463,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "qjM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/window/left/directional/east{
-	name = "Monkey Pen";
-	req_access = list("virology")
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/dark,
-/area/station/medical/virology)
+/turf/closed/wall/r_wall,
+/area/station/medical/paramedic)
 "qkf" = (
 /obj/structure/sign/warning/docking,
 /turf/closed/wall,
@@ -49605,16 +49556,15 @@
 /turf/open/floor/engine,
 /area/station/command/vault)
 "qlw" = (
-/obj/structure/table,
-/obj/item/folder/white,
-/obj/effect/decal/cleanable/blood/old,
 /obj/machinery/airalarm/directional/south,
-/obj/item/restraints/handcuffs,
-/obj/item/pen,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
 /area/station/medical/virology)
 "qly" = (
 /obj/structure/frame/computer{
@@ -49853,7 +49803,7 @@
 	},
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/paramedic)
+/area/station/medical/office)
 "qpT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -49877,20 +49827,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "qqB" = (
-/obj/structure/table,
-/obj/item/healthanalyzer,
-/obj/item/crowbar/red,
-/obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
 /obj/machinery/defibrillator_mount/directional/west,
-/obj/item/book/manual/wiki/medicine{
-	pixel_x = -9;
-	pixel_y = 6
+/obj/machinery/vitals_reader/advanced/directional/north,
+/obj/machinery/stasis{
+	dir = 4
 	},
+/obj/effect/turf_decal/box,
 /turf/open/floor/iron/dark,
-/area/station/medical/exam_room)
+/area/station/medical/treatment_center)
 "qqJ" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -49978,26 +49925,6 @@
 /obj/effect/turf_decal/siding/blue{
 	dir = 4
 	},
-/obj/structure/table,
-/obj/item/clipboard{
-	pixel_x = -6
-	},
-/obj/item/reagent_containers/cup/beaker/cryoxadone{
-	pixel_x = 6;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/cup/beaker/cryoxadone{
-	pixel_x = 6
-	},
-/obj/item/reagent_containers/cup/beaker/cryoxadone{
-	pixel_x = -6;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/cup/beaker/cryoxadone{
-	pixel_x = -6
-	},
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/syringe,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -50134,6 +50061,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/atmos)
 "qvh" = (
@@ -50157,7 +50085,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /turf/open/floor/iron/dark,
-/area/station/medical/paramedic)
+/area/station/medical/office)
 "qvq" = (
 /obj/structure/flora/rock/style_random,
 /turf/open/misc/asteroid/lowpressure,
@@ -50425,6 +50353,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "qAc" = (
@@ -50436,7 +50365,7 @@
 "qAg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/security/prison)
 "qAn" = (
 /obj/machinery/door/firedoor,
@@ -50453,7 +50382,6 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "qAx" = (
@@ -50468,7 +50396,6 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
@@ -50558,13 +50485,14 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "qCZ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "qDp" = (
@@ -50790,15 +50718,15 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
 "qHG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/navigate_destination/dockescpod3,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
 /obj/machinery/door/airlock/external{
 	name = "Medical Escape Pod";
 	space_dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/burnt_floor,
-/obj/effect/landmark/navigate_destination/dockescpod3,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "qHV" = (
@@ -50870,11 +50798,11 @@
 /turf/closed/wall/r_wall/rust,
 /area/station/maintenance/port/aft)
 "qJY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance/two,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "qKf" = (
@@ -51443,15 +51371,15 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/toilet/restrooms)
 "qSO" = (
-/obj/machinery/computer/records/medical{
-	dir = 4
-	},
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/modular_computer/preset/cargochat/medical{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -51479,14 +51407,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "qTY" = (
-/obj/structure/table,
-/obj/machinery/light_switch/directional/north,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
-/obj/item/book/manual/wiki/surgery,
-/obj/item/razor,
-/obj/machinery/vending/wallmed/directional/north,
+/obj/structure/table/optable,
+/obj/machinery/vitals_reader/directional/north,
 /turf/open/floor/iron/dark,
-/area/station/medical/surgery/aft)
+/area/station/medical/surgery/theatre)
 "qUb" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/table,
@@ -51512,14 +51437,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "qUJ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/grass,
-/area/station/medical/psychology)
+/obj/structure/sign/warning/radiation/directional/east,
+/turf/open/floor/engine,
+/area/station/engineering/main)
 "qUO" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/stripes/line{
@@ -51647,17 +51574,14 @@
 /area/station/engineering/storage_shared)
 "qVQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/emcloset{
-	name = "plasmaperson emergency closet"
-	},
-/obj/item/clothing/under/plasmaman,
-/obj/item/clothing/under/plasmaman,
-/obj/item/clothing/head/helmet/space/plasmaman,
-/obj/item/clothing/head/helmet/space/plasmaman,
-/obj/item/tank/internals/plasmaman/belt/full,
-/obj/item/tank/internals/plasmaman/belt/full,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "qVR" = (
@@ -51827,12 +51751,22 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/medbay/central)
 "qYy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
+/turf/closed/wall/r_wall/rust,
+/area/station/medical/paramedic)
+"qYN" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 2;
+	height = 11;
+	name = "port bay 2";
+	shuttle_id = "ferry_home";
+	width = 5
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit/departure_lounge)
 "qZf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -51871,11 +51805,12 @@
 "qZS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
@@ -51920,8 +51855,9 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/vitals_reader/directional/south,
 /turf/open/floor/iron/dark,
-/area/station/medical/surgery/aft)
+/area/station/medical/surgery/theatre)
 "raY" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -51945,8 +51881,12 @@
 /turf/open/floor/engine/n2,
 /area/station/engineering/atmos)
 "rbp" = (
-/obj/structure/sign/departments/cargo/directional/east,
-/turf/open/floor/iron/dark,
+/obj/item/radio/intercom/directional/east,
+/obj/machinery/computer/station_alert{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
 /area/station/engineering/main)
 "rbz" = (
 /obj/machinery/disposal/bin/tagger,
@@ -52200,7 +52140,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/security/prison)
 "rfg" = (
 /obj/structure/chair/bronze,
@@ -52322,6 +52262,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
 "riB" = (
@@ -52444,12 +52385,11 @@
 /area/station/maintenance/starboard)
 "rjU" = (
 /obj/effect/landmark/start/medical_doctor,
-/obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/exam_room)
+/area/station/medical/treatment_center)
 "rkn" = (
 /obj/item/stack/cable_coil,
 /turf/open/misc/asteroid/airless,
@@ -52543,17 +52483,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "rmu" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters{
-	dir = 1;
-	id = "commissaryshutter";
-	name = "Vacant Commissary Shutter"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/blood/old,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/commons/vacant_room/commissary)
+/area/station/engineering/circuit_workshop)
 "rmK" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/conveyor{
@@ -52602,8 +52534,8 @@
 /area/station/service/chapel/storage)
 "rnp" = (
 /obj/structure/sign/poster/contraband/missing_gloves/directional/east,
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable,
+/obj/machinery/suit_storage_unit/engine,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/circuit/red,
 /area/station/engineering/supermatter/room)
 "rnB" = (
@@ -52629,7 +52561,7 @@
 /area/station/hallway/secondary/service)
 "rnJ" = (
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/surgery/aft)
+/area/station/medical/surgery/theatre)
 "rnP" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -52675,14 +52607,11 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 1
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/virology)
+/area/station/medical/pharmacy)
 "rou" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
@@ -52709,15 +52638,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "roy" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "Cold Loop to Gas"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "roF" = (
@@ -52897,7 +52823,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -53000,25 +52925,8 @@
 /turf/open/floor/wood,
 /area/station/service/bar/atrium)
 "rsd" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/stamp/denied{
-	pixel_x = 8;
-	pixel_y = 6
-	},
-/obj/item/stamp/granted{
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/item/pen,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/hallway/secondary/exit/departure_lounge)
+/turf/closed/wall/rock/porous,
+/area/space/nearstation)
 "rsw" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/effect/turf_decal/tile/neutral,
@@ -53162,8 +53070,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown/half/contrasted,
-/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "ruo" = (
@@ -53265,12 +53171,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/medbay/central)
@@ -53326,8 +53232,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "rwr" = (
-/turf/closed/wall/rust,
-/area/station/medical/psychology)
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/medical/cryo)
 "rwu" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/secure_area/directional/north{
@@ -53476,7 +53385,6 @@
 	pixel_y = 6
 	},
 /obj/item/storage/toolbox/electrical,
-/obj/structure/spider/stickyweb,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "ryn" = (
@@ -53536,14 +53444,12 @@
 /turf/open/floor/iron/dark,
 /area/station/service/library)
 "rzB" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/suit/apron/surgical,
 /obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/machinery/light_switch/directional/north,
+/obj/machinery/computer/operating,
 /turf/open/floor/iron/dark,
-/area/station/medical/surgery/aft)
+/area/station/medical/surgery/theatre)
 "rzE" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 1
@@ -53566,7 +53472,7 @@
 /area/station/engineering/gravity_generator)
 "rzV" = (
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "rAr" = (
 /obj/effect/turf_decal/delivery,
@@ -53662,17 +53568,21 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "rBS" = (
-/obj/structure/flora/bush/jungle/b/style_random,
-/obj/structure/flora/bush/flowers_pp/style_random,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/camera/directional/west{
 	c_tag = "Virology Monkey Pen";
 	name = "medical camera";
 	network = list("ss13","medical")
 	},
-/mob/living/carbon/human/species/monkey,
-/turf/open/floor/grass,
-/area/station/medical/virology)
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/paramedic)
 "rBV" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/mmi,
@@ -53781,6 +53691,7 @@
 /obj/effect/landmark/start/shaft_miner,
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "rEE" = (
@@ -53883,7 +53794,6 @@
 "rFK" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/bot,
-/obj/item/clothing/mask/russian_balaclava,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
@@ -53986,7 +53896,8 @@
 /turf/open/floor/iron/dark,
 /area/station/command/eva)
 "rIk" = (
-/turf/open/floor/engine,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "rIl" = (
 /obj/structure/sign/departments/holy{
@@ -54096,8 +54007,9 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "rKk" = (
-/turf/closed/wall/rust,
-/area/station/medical/surgery/aft)
+/obj/machinery/smartfridge/organ,
+/turf/open/floor/plating,
+/area/station/medical/surgery/theatre)
 "rKm" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/computer/atmos_alert,
@@ -54107,9 +54019,6 @@
 "rKn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
-	},
-/obj/machinery/power/terminal{
-	dir = 4
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
@@ -54153,7 +54062,7 @@
 	name = "Emergency Medical Lockdown Shutters"
 	},
 /turf/open/floor/grass,
-/area/station/medical/paramedic)
+/area/station/medical/office)
 "rKV" = (
 /obj/machinery/power/emitter/welded{
 	dir = 8
@@ -54365,6 +54274,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "rNX" = (
@@ -54531,7 +54441,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/paramedic)
+/area/station/medical/office)
 "rQG" = (
 /obj/structure/bodycontainer/crematorium,
 /obj/effect/turf_decal/stripes/line{
@@ -54697,7 +54607,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/paramedic)
+/area/station/medical/office)
 "rSe" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/power/emitter,
@@ -54706,11 +54616,10 @@
 /area/station/engineering/supermatter/room)
 "rSi" = (
 /turf/closed/wall/rust,
-/area/station/medical/surgery/fore)
+/area/station/medical/break_room)
 "rSL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/mob/living/basic/spider/giant/hunter/scrawny,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "rSN" = (
@@ -54779,15 +54688,15 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/armory)
 "rTD" = (
-/obj/structure/transit_tube/station{
-	dir = 1
-	},
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/obj/structure/transit_tube/station/dispenser/reverse{
+	dir = 4
+	},
+/turf/open/floor/engine,
 /area/station/ai/satellite/foyer)
 "rTS" = (
 /obj/effect/decal/cleanable/dirt,
@@ -54795,7 +54704,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/spider/stickyweb,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/greater)
@@ -55020,7 +54928,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/components/unary/airlock_pump/unbolt_only{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -55146,6 +55054,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
 "sby" = (
@@ -55181,8 +55090,9 @@
 "sbJ" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/status_display/evac/directional/west,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/medbay/central)
 "sbX" = (
@@ -55414,6 +55324,15 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"seO" = (
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/shutters{
+	id = "commissaryshutter";
+	name = "Vacant Commissary Shutter"
+	},
+/turf/open/floor/wood,
+/area/station/commons/vacant_room/commissary)
 "seU" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/yellow,
@@ -55422,7 +55341,8 @@
 	pixel_y = 6
 	},
 /obj/item/stock_parts/power_store/cell/high,
-/turf/open/floor/engine,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "seW" = (
 /obj/effect/decal/cleanable/dirt,
@@ -55521,6 +55441,11 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/security/glass{
+	name = "Cremator Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/security/office)
 "shk" = (
@@ -55608,7 +55533,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/medical/paramedic,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/medical/central)
 "siF" = (
@@ -55802,17 +55733,6 @@
 "slC" = (
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"slM" = (
-/obj/machinery/door/airlock/external{
-	name = "Medical Escape Pod";
-	space_dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "smb" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
@@ -56152,11 +56072,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "srg" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/obj/machinery/cryo_cell,
-/turf/open/floor/iron/dark,
-/area/station/medical/medbay/central)
+/obj/structure/sign/warning/biohazard/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/virology)
 "srs" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
@@ -56167,8 +56087,9 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/medical/surgery/aft)
+/area/station/medical/surgery/theatre)
 "srA" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -56348,6 +56269,7 @@
 /obj/structure/cable,
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "stA" = (
@@ -56393,8 +56315,6 @@
 /turf/open/floor/engine,
 /area/station/tcommsat/computer)
 "suQ" = (
-/obj/structure/sink/directional/west,
-/obj/structure/mirror/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
@@ -56404,7 +56324,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/surgery/aft)
+/area/station/medical/surgery/theatre)
 "suU" = (
 /obj/docking_port/stationary/escape_pod,
 /turf/open/space/basic,
@@ -56584,10 +56504,11 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "sza" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating/rust,
-/area/station/security/prison)
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit/departure_lounge)
 "szg" = (
 /obj/machinery/computer/telecomms/monitor,
 /obj/effect/turf_decal/bot,
@@ -56599,7 +56520,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/plating/rust,
+/turf/open/floor/iron,
 /area/station/security/prison)
 "szL" = (
 /obj/structure/disposalpipe/trunk{
@@ -56637,7 +56558,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/security/prison)
 "sAr" = (
 /obj/effect/turf_decal/bot,
@@ -56759,12 +56680,11 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central/fore)
 "sCr" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
 /area/station/engineering/main)
 "sCC" = (
 /obj/effect/turf_decal/stripes/line{
@@ -56814,7 +56734,10 @@
 "sCV" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Cold Loop to Gas"
+	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "sCY" = (
@@ -56916,17 +56839,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/medical)
-"sEx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "sEK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -56960,13 +56872,19 @@
 /area/station/science/ordnance)
 "sFu" = (
 /obj/structure/cable,
-/obj/structure/chair/sofa/left/brown,
-/obj/item/toy/plush/moth{
-	name = "Big Moffer"
-	},
 /obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/carpet,
-/area/station/medical/psychology)
+/obj/structure/table,
+/obj/item/wrench/medical,
+/obj/item/storage/pill_bottle/mannitol{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/cup/beaker/cryoxadone,
+/obj/item/reagent_containers/cup/beaker/cryoxadone,
+/obj/item/reagent_containers/cup/beaker/cryoxadone,
+/obj/item/reagent_containers/cup/beaker/cryoxadone,
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/cryo)
 "sFv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -57077,12 +56995,21 @@
 /turf/closed/wall,
 /area/station/service/bar/atrium)
 "sHn" = (
-/obj/structure/bed/medical/emergency,
-/obj/machinery/iv_drip,
-/obj/effect/turf_decal/bot_white/left,
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/door_buttons/access_button{
+	dir = 1;
+	idDoor = "virology_airlock_exterior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Button";
+	pixel_y = -24;
+	req_access = list("virology")
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/computer/crew{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -57167,9 +57094,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "sIr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/light/directional/south,
+/obj/item/kirbyplants/organic/plant5,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "sIx" = (
@@ -57282,7 +57209,7 @@
 /area/station/tcommsat/computer)
 "sJM" = (
 /turf/closed/wall,
-/area/station/medical/surgery/fore)
+/area/station/medical/break_room)
 "sJS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -57478,6 +57405,7 @@
 /obj/structure/chair/office{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
 "sMf" = (
@@ -57626,21 +57554,18 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "sOJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/sign/poster/contraband/random/directional/north,
-/obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "sOS" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/effect/turf_decal/siding/green,
-/turf/open/misc/sandy_dirt,
+/turf/open/water/no_planet_atmos,
 /area/station/service/hydroponics/garden)
 "sOV" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
@@ -57683,17 +57608,10 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)
 "sPK" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/medical/exam_room)
+/obj/effect/turf_decal/sand/plating,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/security/prison)
 "sPP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -58013,7 +57931,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/paramedic)
+/area/station/medical/office)
 "sUq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -58184,13 +58102,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
 "sWj" = (
-/obj/machinery/computer/station_alert{
-	dir = 8
-	},
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/table,
+/obj/item/clothing/mask/gas,
+/obj/item/storage/toolbox/electrical,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "sWl" = (
@@ -58573,10 +58491,10 @@
 /obj/structure/flora/bush/generic/style_random,
 /obj/structure/flora/bush/flowers_pp/style_random,
 /obj/structure/flora/bush/sunny/style_random,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/spawner/directional/north,
+/obj/structure/window/spawner/directional/south,
+/obj/structure/window/spawner/directional/west,
+/obj/structure/window/spawner/directional/east,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
 "tds" = (
@@ -58600,11 +58518,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/exam_room)
+/area/station/medical/treatment_center)
 "tdW" = (
 /obj/machinery/light_switch/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -58899,9 +58814,12 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
 "thU" = (
-/mob/living/basic/mining/goliath/ancient,
-/turf/open/misc/asteroid/lowpressure,
-/area/space/nearstation)
+/obj/structure/cable,
+/obj/structure/grille/broken,
+/obj/item/shard,
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/station/security/prison)
 "thW" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -59035,6 +58953,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/item/kirbyplants/organic/plant21,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "tlb" = (
@@ -59042,6 +58961,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"tlc" = (
+/obj/docking_port/stationary{
+	dir = 4;
+	dwidth = 11;
+	height = 18;
+	name = "KiloStation emergency evac bay";
+	shuttle_id = "emergency_home";
+	width = 30
+	},
+/turf/open/space/basic,
+/area/space)
 "tlu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -59360,6 +59290,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/janitor)
+"toG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit/departure_lounge)
 "toN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate{
@@ -59471,7 +59407,6 @@
 	},
 /obj/item/wallframe/camera,
 /obj/item/screwdriver,
-/obj/structure/spider/stickyweb,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "tpY" = (
@@ -59511,7 +59446,7 @@
 /area/station/maintenance/port/greater)
 "tqD" = (
 /obj/structure/sign/warning/fire,
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/station/maintenance/port/lesser)
 "tqG" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -59525,6 +59460,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "tqQ" = (
@@ -59909,20 +59846,24 @@
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "tyA" = (
-/obj/structure/flora/bush/jungle/c/style_random,
-/turf/open/floor/grass,
+/obj/structure/table/wood,
+/obj/machinery/computer/records/medical/laptop{
+	dir = 4;
+	pixel_y = 3;
+	pixel_x = 3
+	},
+/turf/open/floor/iron/showroomfloor,
 /area/station/medical/psychology)
 "tyI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/corner,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/main)
 "tzg" = (
 /obj/machinery/door/poddoor/shutters{
 	dir = 4;
@@ -60013,6 +59954,9 @@
 /obj/item/reagent_containers/spray/cleaner,
 /obj/machinery/light_switch/directional/north,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/item/gun/syringe{
+	pixel_y = 5
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
 "tzU" = (
@@ -60036,13 +59980,10 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "tAx" = (
-/obj/item/kirbyplants/organic/plant18,
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/medical/storage)
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/station/medical/coldroom)
 "tAI" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -60092,12 +60033,14 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "tBh" = (
-/obj/structure/table/optable,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/obj/machinery/defibrillator_mount/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/medical/surgery/fore)
+/obj/structure/table,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/obj/structure/sign/poster/official/random/directional/north,
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/break_room)
 "tBj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/decal/cleanable/food/flour,
@@ -60105,13 +60048,8 @@
 /turf/open/floor/iron/dark,
 /area/station/service/kitchen)
 "tBn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/brown/half/contrasted,
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "tBJ" = (
@@ -60291,16 +60229,10 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/bar/atrium)
 "tEt" = (
-/obj/machinery/microwave{
-	pixel_y = 5
-	},
-/obj/structure/table/glass,
 /obj/structure/sign/poster/official/no_erp/directional/south,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/storage)
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/station/medical/coldroom)
 "tEE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -60806,10 +60738,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -61019,6 +60951,10 @@
 	name = "Ore Redemtion Window";
 	req_access = list("mineral_storeroom")
 	},
+/obj/machinery/door/window/right/directional/east{
+	name = "Cargo Security Window";
+	req_access = list("shipping")
+	},
 /turf/open/floor/plating,
 /area/station/cargo/office)
 "tQM" = (
@@ -61068,10 +61004,22 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "tSc" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
-/area/station/medical/exam_room)
+/obj/structure/table/glass,
+/obj/item/stack/medical/mesh{
+	pixel_x = -4;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/chem_pack{
+	pixel_x = 10;
+	pixel_y = 10
+	},
+/obj/item/book/manual/wiki/medicine{
+	pixel_x = -9;
+	pixel_y = 6
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/treatment_center)
 "tSk" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/item/kirbyplants/organic/plant5,
@@ -61220,6 +61168,7 @@
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 8
 	},
+/obj/machinery/recharger,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "tVt" = (
@@ -61340,11 +61289,17 @@
 /area/station/maintenance/department/bridge)
 "tXm" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical{
-	name = "Operating Theater Secondary"
-	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
+/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/virology{
+	autoclose = 0;
+	frequency = 1449;
+	id_tag = "virology_airlock_exterior";
+	name = "Virology Exterior Airlock"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/central)
 "tXr" = (
@@ -61557,10 +61512,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
-"tZP" = (
-/obj/structure/sign/warning/docking,
-/turf/closed/wall/rust,
-/area/station/maintenance/port/lesser)
 "tZX" = (
 /obj/structure/flora/bush/pale/style_random,
 /turf/open/misc/asteroid,
@@ -61629,8 +61580,9 @@
 /area/station/maintenance/port/greater)
 "ubJ" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/medical/surgery/aft)
+/area/station/medical/surgery/theatre)
 "ubM" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -61734,12 +61686,11 @@
 /area/station/service/hydroponics)
 "udI" = (
 /obj/machinery/newscaster/directional/south,
-/obj/machinery/vending/medical,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/virology)
@@ -61845,7 +61796,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "ufc" = (
-/obj/structure/table,
 /obj/machinery/requests_console/directional/east{
 	department = "Garden";
 	name = "Garden Requests Console"
@@ -61853,12 +61803,6 @@
 /obj/effect/turf_decal/siding/green{
 	dir = 8
 	},
-/obj/item/reagent_containers/cup/bottle/nutrient/ez,
-/obj/item/reagent_containers/cup/bottle/nutrient/rh{
-	pixel_x = 2;
-	pixel_y = 1
-	},
-/obj/item/plant_analyzer,
 /obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -61927,7 +61871,7 @@
 /obj/item/radio/intercom/directional/south,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/surgery/aft)
+/area/station/medical/surgery/theatre)
 "ufX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -61941,13 +61885,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "ugc" = (
-/obj/structure/flora/grass/jungle/b/style_random,
-/obj/structure/flora/bush/flowers_pp/style_random,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable,
-/turf/open/floor/grass,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/carpet,
 /area/station/medical/psychology)
 "ugp" = (
 /obj/structure/chair/sofa/bench/right,
@@ -61961,7 +61903,6 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central/fore)
 "ugq" = (
-/obj/structure/sign/departments/psychology/directional/north,
 /obj/structure/chair{
 	desc = "A gray chair. Nothing more relaxing while waiting for therapy than watching the dying.";
 	dir = 8;
@@ -61974,7 +61915,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/exam_room)
+/area/station/medical/treatment_center)
 "ugr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
@@ -62024,6 +61965,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
+/obj/machinery/fishing_portal_generator,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
 "ugY" = (
@@ -62099,8 +62041,21 @@
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
 "uiu" = (
-/obj/structure/flora/bush/jungle/b/style_random,
-/turf/open/floor/grass,
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/obj/machinery/status_display/evac/directional/north,
+/obj/item/folder/white{
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/obj/item/pen{
+	pixel_x = 6;
+	pixel_y = 1
+	},
+/turf/open/floor/carpet,
 /area/station/medical/psychology)
 "uiE" = (
 /obj/machinery/ai_slipper{
@@ -62181,13 +62136,12 @@
 /area/station/hallway/primary/central/fore)
 "uko" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/vending/drugs,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/exam_room)
+/area/station/medical/treatment_center)
 "ukM" = (
 /obj/structure/sign/warning/vacuum/external/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -62241,6 +62195,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/structure/table,
+/obj/item/storage/medkit/regular,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "ulg" = (
@@ -62337,16 +62294,12 @@
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
 "umJ" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/door/airlock/security/glass{
-	name = "Cremator Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/checker,
-/area/station/security/processing/cremation)
+/area/station/security/mechbay)
 "umL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
@@ -62428,19 +62381,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "unz" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/blood/old,
-/obj/machinery/light/small/directional/south,
-/obj/machinery/iv_drip,
 /obj/effect/turf_decal/bot_white/right,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/showroomfloor,
 /area/station/medical/virology)
 "unE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -62524,7 +62472,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/folder/red,
-/obj/structure/spider/stickyweb,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/greater)
 "uoL" = (
@@ -62620,8 +62567,8 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "uqF" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
 /area/station/medical/virology)
 "uqI" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -62739,8 +62686,8 @@
 /area/station/science/ordnance)
 "uso" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/suit_storage_unit/engine,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "usp" = (
@@ -62815,12 +62762,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/theater)
-"utf" = (
-/obj/machinery/rnd/production/protolathe/department/engineering,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/box,
-/turf/open/floor/iron,
-/area/station/engineering/lobby)
 "utj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -62859,9 +62800,6 @@
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/machinery/modular_computer/preset/cargochat/medical{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -62886,11 +62824,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "utU" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown/half/contrasted,
-/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "uuu" = (
@@ -62932,13 +62866,9 @@
 /turf/open/floor/plating,
 /area/station/command/eva)
 "uvm" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering Storage"
-	},
+/obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/engine_equipment,
-/turf/open/floor/iron/dark,
+/turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "uvG" = (
 /obj/effect/turf_decal/stripes/line{
@@ -62947,8 +62877,12 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "uvO" = (
-/turf/closed/wall,
-/area/station/engineering/gravity_generator)
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/atmospherics/components/unary/airlock_pump{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/disposal/incinerator)
 "uvT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -63136,17 +63070,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "uAe" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
+/obj/structure/window/spawner/directional/south,
+/obj/structure/window/spawner/directional/east,
+/obj/structure/window/spawner/directional/west,
+/obj/structure/window/spawner/directional/north,
+/obj/structure/flora/bush/ferny/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/style_random,
+/obj/structure/flora/bush/sunny/style_random,
+/turf/open/floor/plating,
 /area/station/hallway/secondary/exit/departure_lounge)
 "uAh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -63246,20 +63178,14 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "viro-airlock"
+/obj/machinery/door/airlock/medical/glass{
+	name = "Paramedic Dispatch Access"
 	},
-/obj/machinery/door/airlock/virology{
-	name = "Virology Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/effect/mapping_helpers/airlock/access/all/medical/paramedic,
 /turf/open/floor/iron/dark,
-/area/station/medical/virology)
+/area/station/medical/pharmacy)
 "uCa" = (
-/obj/machinery/cryo_cell,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/showroomfloor,
 /area/station/medical/medbay/central)
 "uCd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -63365,23 +63291,27 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/primary/central)
+"uEw" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/medical/cryo)
 "uEC" = (
 /obj/effect/turf_decal/siding/wideplating/dark/corner,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "uEX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green/opposingcorners,
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/virology)
+/area/station/medical/pharmacy)
 "uFb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/corner,
@@ -63435,6 +63365,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "uFN" = (
@@ -63452,6 +63383,7 @@
 /obj/structure/cable,
 /obj/structure/sign/poster/contraband/random/directional/south,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "uGn" = (
@@ -63498,15 +63430,17 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 8;
+	name = "virology sorting disposal pipe"
+	},
+/obj/effect/mapping_helpers/mail_sorting/medbay/virology,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/medbay/central)
 "uHc" = (
@@ -63554,6 +63488,10 @@
 	},
 /obj/item/folder/yellow{
 	pixel_x = 3
+	},
+/obj/item/toy/figure/engineer{
+	pixel_x = 8;
+	pixel_y = 6
 	},
 /turf/open/floor/plating,
 /area/station/engineering/lobby)
@@ -63609,11 +63547,12 @@
 /obj/structure/cable,
 /obj/structure/sign/poster/contraband/random/directional/north,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "uIs" = (
 /obj/machinery/turretid{
-	control_area = "/area/station/ai_monitored/turret_protected/aisat_interior";
+	control_area = "/area/station/ai/satellite/interior";
 	name = "Antechamber Turret Control";
 	pixel_y = 28;
 	req_access = list("minisat")
@@ -63687,7 +63626,6 @@
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
@@ -63731,14 +63669,11 @@
 /turf/open/floor/iron/dark,
 /area/station/service/janitor)
 "uKc" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/rack,
-/obj/item/storage/toolbox/emergency{
-	pixel_y = 5
+/obj/docking_port/stationary/escape_pod{
+	dir = 4
 	},
-/obj/item/flashlight,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/turf/open/space/basic,
+/area/space/nearstation)
 "uKi" = (
 /obj/machinery/telecomms/receiver/preset_left,
 /obj/effect/turf_decal/stripes/line{
@@ -63758,6 +63693,11 @@
 /obj/structure/cable,
 /turf/open/floor/engine/telecomms,
 /area/station/tcommsat/server)
+"uKE" = (
+/obj/structure/lattice,
+/obj/item/toy/plush/carpplushie,
+/turf/open/space/basic,
+/area/space/nearstation)
 "uKO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -63855,24 +63795,15 @@
 /turf/open/floor/engine,
 /area/station/tcommsat/computer)
 "uMk" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "uMz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/table,
-/obj/item/wrench/medical,
-/obj/item/storage/pill_bottle/mannitol{
-	pixel_x = 8;
-	pixel_y = 7
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/iron/showroomfloor,
 /area/station/medical/medbay/central)
 "uMD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -64010,7 +63941,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/spider/stickyweb,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -64248,7 +64178,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/paramedic)
+/area/station/medical/office)
 "uUA" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/closed/wall,
@@ -64286,7 +64216,7 @@
 	name = "Emergency Medical Lockdown Shutters"
 	},
 /turf/open/floor/grass,
-/area/station/medical/paramedic)
+/area/station/medical/office)
 "uVQ" = (
 /turf/closed/wall,
 /area/station/maintenance/solars/starboard/fore)
@@ -64336,7 +64266,6 @@
 /area/space/nearstation)
 "uWS" = (
 /obj/structure/rack,
-/obj/item/stack/medical/gauze,
 /obj/item/stack/medical/bruise_pack,
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/small/directional/north,
@@ -64369,8 +64298,7 @@
 /turf/open/floor/grass,
 /area/station/security/prison/garden)
 "uXB" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/firecloset,
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "uXI" = (
@@ -64559,10 +64487,7 @@
 /area/station/cargo/warehouse/upper)
 "uZT" = (
 /obj/effect/landmark/start/medical_doctor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron/showroomfloor,
 /area/station/medical/medbay/central)
 "uZX" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
@@ -64733,7 +64658,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "vbT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -64803,13 +64729,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
-"vdK" = (
-/obj/structure/flora/bush/pale/style_random{
-	icon_state = "fullgrass_2"
-	},
-/obj/structure/flora/grass/jungle/b/style_5,
-/turf/open/misc/asteroid,
-/area/space/nearstation)
 "vdS" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
@@ -64829,12 +64748,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/commons/locker)
-"vef" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/east,
-/obj/effect/spawner/random/structure/crate,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "vek" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/dirt,
@@ -65018,6 +64931,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
+"vhn" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/structure/noticeboard/directional/east,
+/turf/open/floor/wood,
+/area/station/commons/vacant_room/commissary)
 "vhp" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
@@ -65082,7 +65002,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "viW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -65119,9 +65040,24 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/turf/open/floor/iron/showroomfloor,
-/area/station/medical/exam_room)
+/obj/structure/table/glass,
+/obj/item/storage/box/bodybags{
+	pixel_x = -6
+	},
+/obj/item/storage/box/masks{
+	pixel_y = 4;
+	pixel_x = -6
+	},
+/obj/item/storage/box/gloves{
+	pixel_y = 8;
+	pixel_x = -6
+	},
+/obj/item/storage/box/rxglasses{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/treatment_center)
 "vkr" = (
 /obj/item/radio/intercom/directional/east,
 /obj/structure/disposalpipe/segment,
@@ -65321,6 +65257,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "vmZ" = (
@@ -65482,6 +65419,10 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
+"vpP" = (
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/virology)
 "vpV" = (
 /obj/structure/chair{
 	dir = 4
@@ -65593,9 +65534,9 @@
 /area/station/science/robotics/lab)
 "vrd" = (
 /obj/machinery/firealarm/directional/north,
-/obj/structure/flora/bush/pointy/style_random,
-/obj/structure/flora/bush/sparsegrass/style_random,
-/obj/machinery/hydroponics/constructable,
+/obj/structure/table,
+/obj/item/storage/toolbox/fishing,
+/obj/item/fishing_rod,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "vrf" = (
@@ -65693,9 +65634,13 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "vsJ" = (
-/obj/structure/flora/bush/jungle/b/style_random,
-/obj/structure/flora/bush/flowers_pp/style_random,
-/turf/open/floor/grass,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/obj/structure/chair/sofa/left/brown,
+/obj/item/toy/plush/moth{
+	name = "Big Moffer"
+	},
+/turf/open/floor/carpet,
 /area/station/medical/psychology)
 "vsR" = (
 /obj/effect/turf_decal/bot,
@@ -65707,10 +65652,7 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/medbay/lobby)
 "vte" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -65749,12 +65691,8 @@
 /turf/open/floor/bronze,
 /area/station/maintenance/department/chapel)
 "vtF" = (
-/obj/item/kirbyplants/organic/plant21,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/brown/anticorner/contrasted,
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/treatment_center)
 "vuj" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -65843,14 +65781,12 @@
 /turf/open/floor/plating,
 /area/station/science/robotics/mechbay)
 "vvf" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/virology)
 "vvn" = (
@@ -66405,7 +66341,13 @@
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "vCM" = (
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "vCO" = (
@@ -66534,10 +66476,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "vFc" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/misc/asteroid/airless,
-/area/station/hallway/secondary/entry)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/virology)
 "vFk" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -66642,7 +66585,7 @@
 /area/station/service/hydroponics)
 "vGu" = (
 /obj/structure/sign/warning/secure_area,
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/aft)
 "vGJ" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -66676,9 +66619,6 @@
 "vHa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Cooling Loop Bypass"
 	},
 /obj/machinery/light/directional/east,
 /turf/open/floor/engine,
@@ -66851,10 +66791,9 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/aft)
 "vJm" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/light/directional/east,
-/turf/open/floor/plating/airless,
-/area/station/hallway/secondary/entry)
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit/departure_lounge)
 "vJv" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/component_printer,
@@ -66894,11 +66833,10 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "vJH" = (
-/obj/effect/mob_spawn/corpse/human/charredskeleton,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/disposal/incinerator)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/mob/living/basic/bot/secbot/beepsky,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "vJN" = (
 /obj/machinery/hydroponics/constructable,
 /obj/structure/railing{
@@ -66970,11 +66908,9 @@
 	},
 /area/station/command/vault)
 "vKj" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
+/area/station/engineering/main)
 "vKm" = (
 /turf/open/floor/engine/vacuum,
 /area/station/maintenance/disposal/incinerator)
@@ -67046,13 +66982,21 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/lockers)
 "vLG" = (
-/obj/structure/closet/radiation,
-/obj/structure/grille/broken,
-/obj/effect/decal/cleanable/cobweb,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/modular_computer/preset/engineering{
+	dir = 8
+	},
+/obj/structure/sign/warning/electric_shock/directional/east,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "vLI" = (
 /turf/closed/wall/r_wall/rust,
 /area/station/service/chapel/funeral)
@@ -67232,39 +67176,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "vOq" = (
-/obj/structure/table,
-/obj/item/stack/sheet/plasteel/fifty{
-	pixel_x = -2;
-	pixel_y = 2
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Power Monitoring"
 	},
-/obj/item/stack/sheet/rglass{
-	amount = 50;
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/item/electronics/airlock,
-/obj/item/electronics/airlock,
-/obj/item/stock_parts/power_store/cell/high,
-/obj/item/stock_parts/power_store/cell/high,
-/obj/machinery/camera/directional/south{
-	c_tag = "Engineering Storage";
-	name = "engineering camera";
-	network = list("ss13","engine")
-	},
-/obj/machinery/light_switch/directional/east,
-/obj/item/stock_parts/power_store/cell/emproof{
-	pixel_x = 3;
-	pixel_y = 7
-	},
-/obj/item/stock_parts/power_store/cell/emproof{
-	pixel_x = -6;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/supermatter/room)
 "vOH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -67311,6 +67230,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "vOW" = (
@@ -67339,10 +67259,10 @@
 /obj/structure/flora/bush/generic/style_random,
 /obj/structure/flora/bush/flowers_pp/style_random,
 /obj/structure/flora/bush/sunny/style_random,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/spawner/directional/north,
+/obj/structure/window/spawner/directional/south,
+/obj/structure/window/spawner/directional/west,
+/obj/structure/window/spawner/directional/east,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
 "vPG" = (
@@ -67409,6 +67329,8 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
 "vQD" = (
@@ -67692,7 +67614,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/medical/paramedic)
+/area/station/medical/office)
 "vUs" = (
 /obj/structure/bed,
 /obj/machinery/iv_drip,
@@ -67704,6 +67626,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/central)
 "vUt" = (
@@ -67737,9 +67660,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Mix to Engine"
-	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "vUH" = (
@@ -67816,15 +67736,6 @@
 "vVT" = (
 /turf/closed/wall/r_wall/rust,
 /area/station/engineering/storage/tech)
-"vVX" = (
-/obj/structure/flora/bush/pale/style_random{
-	icon_state = "fullgrass_2"
-	},
-/obj/structure/flora/bush/pale/style_random{
-	icon_state = "genericbush_1"
-	},
-/turf/open/misc/asteroid,
-/area/space/nearstation)
 "vWv" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -67880,8 +67791,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "vWY" = (
-/turf/closed/wall,
-/area/station/security/processing/cremation)
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/north,
+/obj/machinery/computer/mech_bay_power_console{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/checker,
+/area/station/security/mechbay)
 "vXa" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/decal/cleanable/dirt,
@@ -67897,10 +67815,13 @@
 	network = list("ss13","medical")
 	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
-/obj/structure/closet/crate/freezer/blood,
-/obj/effect/turf_decal/bot,
+/obj/structure/sign/poster/official/cleanliness/directional/north,
+/obj/structure/table,
+/obj/item/clothing/suit/apron/surgical,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/gloves/latex,
 /turf/open/floor/iron/dark,
-/area/station/medical/surgery/aft)
+/area/station/medical/surgery/theatre)
 "vXn" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
@@ -67956,7 +67877,6 @@
 /area/station/service/bar/atrium)
 "vYs" = (
 /obj/structure/chair,
-/mob/living/simple_animal/bot/secbot/beepsky/officer,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
@@ -68232,11 +68152,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/holopad,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/turf/open/floor/iron/showroomfloor,
-/area/station/medical/exam_room)
+/obj/machinery/medical_kiosk,
+/obj/effect/turf_decal/box,
+/turf/open/floor/iron/dark,
+/area/station/medical/treatment_center)
 "wcP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -68696,11 +68615,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "wkB" = (
-/obj/item/kirbyplants/organic/plant5,
-/obj/machinery/light/directional/south,
-/obj/effect/landmark/start/hangover,
-/obj/effect/turf_decal/tile/brown/half/contrasted,
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "wkC" = (
@@ -68717,7 +68637,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/security/prison)
 "wkP" = (
 /obj/structure/weightmachine/weightlifter,
@@ -68840,11 +68760,11 @@
 "wmG" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/station/commons/vacant_room/commissary)
+/turf/open/floor/iron/showroomfloor,
+/area/station/engineering/circuit_workshop)
 "wmJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -68865,16 +68785,11 @@
 /turf/open/floor/wood,
 /area/station/service/theater)
 "wnl" = (
-/obj/machinery/power/port_gen/pacman,
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 5
-	},
-/obj/effect/turf_decal/delivery,
 /obj/machinery/firealarm/directional/west,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/station/engineering/main)
 "wno" = (
 /obj/machinery/mecha_part_fabricator/maint{
@@ -68885,7 +68800,7 @@
 "wny" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "wnJ" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
@@ -68950,23 +68865,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "wog" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green{
-	pixel_x = -7;
-	pixel_y = 5
-	},
-/obj/machinery/status_display/evac/directional/north,
-/obj/item/radio/intercom/directional/west,
-/obj/item/folder/white{
-	pixel_x = 7;
-	pixel_y = 5
-	},
-/obj/item/pen{
-	pixel_x = 6;
-	pixel_y = 1
-	},
-/turf/open/floor/carpet,
-/area/station/medical/psychology)
+/obj/machinery/light/directional/north,
+/obj/machinery/cryo_cell,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/turf/open/floor/iron/dark,
+/area/station/medical/cryo)
 "woj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -69002,9 +68906,6 @@
 /area/space/nearstation)
 "woB" = (
 /obj/machinery/airalarm/directional/west,
-/obj/structure/table,
-/obj/item/book/manual/wiki/surgery,
-/obj/item/razor,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -69016,8 +68917,9 @@
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 8
 	},
+/obj/machinery/vending/coffee,
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/surgery/fore)
+/area/station/medical/break_room)
 "woG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/directional/north,
@@ -69310,16 +69212,12 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "wtP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/psychology)
+/area/station/medical/cryo)
 "wua" = (
 /obj/machinery/modular_computer/preset/civilian{
 	dir = 1
@@ -69424,7 +69322,7 @@
 "wwj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/turretid{
-	control_area = "/area/station/ai_monitored/turret_protected/ai_upload";
+	control_area = "/area/station/ai/upload/chamber";
 	name = "AI Upload Turret Control";
 	pixel_x = -30
 	},
@@ -69480,7 +69378,6 @@
 	id_tag = "bank";
 	name = "Bank Vault"
 	},
-/obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/mapping_helpers/airlock/access/all/supply/vault,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/greater)
@@ -69583,7 +69480,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/computer/shuttle/mining/common,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
@@ -69593,6 +69489,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/machinery/computer/shuttle/mining/common,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "wyY" = (
@@ -69686,7 +69583,7 @@
 	pixel_x = -7
 	},
 /turf/open/floor/iron/dark,
-/area/station/medical/paramedic)
+/area/station/medical/office)
 "wzY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -69757,7 +69654,7 @@
 /area/station/tcommsat/server)
 "wBf" = (
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/security/prison)
 "wBo" = (
 /obj/structure/railing/corner{
@@ -69895,17 +69792,33 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/bar/atrium)
 "wEJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/dim/directional/north,
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/item/wrench,
+/obj/item/storage/toolbox/emergency{
+	pixel_y = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/item/hand_labeler,
+/obj/item/stack/package_wrap,
+/obj/machinery/button/door/directional/east{
+	id = "commissaryshutter";
+	name = "Commissary Shutter Toggle";
+	pixel_x = 26;
+	pixel_y = 7
 	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
+/obj/machinery/button/door/directional/east{
+	id = "commissarydoor";
+	name = "Commissary Door Lock";
+	normaldoorcontrol = 1;
+	pixel_x = 26;
+	pixel_y = -2;
+	specialfunctions = 4
 	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/medical/medbay/central)
+/turf/open/floor/wood,
+/area/station/commons/vacant_room/commissary)
 "wEM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -69958,11 +69871,14 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/medbay/central)
 "wFs" = (
-/obj/item/food/grown/banana,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/grass,
-/area/station/medical/virology)
+/obj/machinery/recharge_station,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/paramedic)
 "wFu" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -70041,6 +69957,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
 "wGp" = (
@@ -70094,7 +70011,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/surgery/fore)
+/area/station/medical/break_room)
 "wGG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/electrolyzer,
@@ -70262,7 +70179,7 @@
 "wIL" = (
 /obj/structure/kitchenspike,
 /obj/effect/turf_decal/bot/left,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "wIR" = (
 /obj/effect/turf_decal/siding/blue/corner{
@@ -70323,11 +70240,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/exam_room)
+/area/station/medical/treatment_center)
 "wJD" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
@@ -70416,6 +70332,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/medbay/central)
 "wMt" = (
@@ -70554,13 +70473,11 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/medbay/central)
 "wOy" = (
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
-/obj/machinery/medical_kiosk{
-	pixel_x = -2
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
 	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/medical/exam_room)
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/treatment_center)
 "wOB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -70620,12 +70537,12 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
+/obj/item/gun/ballistic/automatic/battle_rifle,
 /turf/open/floor/iron/dark,
 /area/station/security/armory)
 "wPU" = (
-/obj/machinery/power/smes/engineering,
 /obj/structure/sign/warning/electric_shock/directional/east,
-/obj/structure/cable,
+/obj/machinery/recharge_station,
 /turf/open/floor/circuit/red,
 /area/station/engineering/supermatter/room)
 "wPX" = (
@@ -70769,7 +70686,6 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/directional/west,
-/obj/item/clothing/mask/russian_balaclava,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 4
 	},
@@ -70836,19 +70752,14 @@
 /turf/open/floor/engine,
 /area/station/ai/satellite/interior)
 "wTe" = (
-/obj/machinery/light/directional/east,
-/obj/machinery/camera/directional/north{
-	c_tag = "Supermatter Cooler";
-	name = "engineering camera";
-	network = list("ss13","engine")
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/grunge{
+	id_tag = "commissarydoor";
+	name = "Vacant Commissary"
 	},
-/obj/effect/decal/cleanable/blood/old,
-/obj/machinery/firealarm/directional/east,
-/obj/structure/cable,
-/obj/machinery/modular_computer/preset/engineering,
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/turf/open/floor/iron/dark,
-/area/station/engineering/supermatter/room)
+/turf/open/floor/wood,
+/area/station/commons/vacant_room/commissary)
 "wTh" = (
 /obj/machinery/food_cart,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -70914,11 +70825,14 @@
 /turf/open/floor/iron,
 /area/station/command/teleporter)
 "wVD" = (
-/obj/machinery/computer/operating,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/turf/open/floor/iron/dark,
-/area/station/medical/surgery/fore)
+/obj/structure/chair/comfy/teal{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/break_room)
 "wVE" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/red/half/contrasted,
@@ -70971,9 +70885,16 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "wWk" = (
-/obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/random/directional/south,
+/obj/structure/closet/emcloset{
+	name = "plasmaperson emergency closet"
+	},
+/obj/item/tank/internals/plasmaman/belt/full,
+/obj/item/tank/internals/plasmaman/belt/full,
+/obj/item/clothing/head/helmet/space/plasmaman,
+/obj/item/clothing/head/helmet/space/plasmaman,
+/obj/item/clothing/under/plasmaman,
+/obj/item/clothing/under/plasmaman,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "wWm" = (
@@ -71148,9 +71069,11 @@
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/hos)
 "wYX" = (
-/obj/structure/sign/warning,
-/turf/closed/wall,
-/area/station/maintenance/port/lesser)
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit/departure_lounge)
 "wZW" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
@@ -71198,15 +71121,11 @@
 /area/station/security/brig)
 "xau" = (
 /obj/machinery/firealarm/directional/west,
-/obj/machinery/recharge_station,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/medical/storage)
+/obj/structure/closet/crate/freezer,
+/obj/item/food/popsicle,
+/obj/machinery/camera/autoname/directional/north,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/station/medical/coldroom)
 "xav" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -71298,7 +71217,7 @@
 "xcj" = (
 /obj/effect/turf_decal/siding/green,
 /obj/machinery/door/window/right/directional/south,
-/turf/open/misc/sandy_dirt,
+/turf/open/water/no_planet_atmos,
 /area/station/service/hydroponics/garden)
 "xck" = (
 /obj/machinery/power/tracker,
@@ -71338,11 +71257,8 @@
 /turf/open/floor/iron/dark,
 /area/station/service/library)
 "xcR" = (
-/obj/structure/flora/grass/jungle/a/style_random{
-	icon_state = "bushc2"
-	},
-/turf/open/misc/asteroid,
-/area/space/nearstation)
+/turf/closed/wall/r_wall,
+/area/station/commons/fitness/recreation)
 "xcT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -71437,6 +71353,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
+/obj/machinery/door/airlock/highsecurity{
+	name = "Gravity Generator Room"
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "xeq" = (
@@ -71487,7 +71406,6 @@
 /obj/machinery/power/smes,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/warning/electric_shock/directional/south,
-/obj/structure/spider/stickyweb,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
@@ -71517,11 +71435,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
 "xfZ" = (
-/obj/structure/flora/bush/sparsegrass/style_random,
-/obj/structure/flora/bush/grassy/style_random,
-/obj/structure/flora/bush/flowers_br/style_random,
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/grass,
+/turf/open/floor/iron/showroomfloor,
 /area/station/medical/psychology)
 "xgs" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -71625,7 +71540,6 @@
 /area/station/medical/medbay/central)
 "xja" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/vacuum/external/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -71653,15 +71567,8 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "xju" = (
-/obj/item/storage/medkit/regular,
-/obj/machinery/light/directional/east,
-/obj/structure/table,
 /obj/machinery/newscaster/directional/east,
-/obj/structure/sign/poster/official/random/directional/north,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
+/turf/closed/wall/r_wall,
 /area/station/commons/fitness/recreation)
 "xjv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -71883,6 +71790,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
 "xlr" = (
@@ -71951,10 +71859,12 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
 "xmI" = (
-/obj/structure/flora/grass/jungle/b/style_random,
-/obj/structure/flora/bush/flowers_br/style_random,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/grass,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/bin/tagger,
+/turf/open/floor/iron/showroomfloor,
 /area/station/medical/psychology)
 "xmO" = (
 /obj/machinery/door/airlock/security/glass{
@@ -72070,11 +71980,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "xoK" = (
-/obj/structure/flora/bush/sparsegrass/style_random,
-/obj/structure/flora/bush/grassy/style_random,
-/obj/structure/flora/bush/ferny/style_random,
-/turf/open/floor/grass,
-/area/station/medical/virology)
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/paramedic)
 "xoO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -72159,7 +72070,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/iron/dark,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/main)
 "xqM" = (
 /obj/structure/flora/grass/jungle/a/style_random,
 /obj/structure/flora/bush/fullgrass/style_random,
@@ -72303,15 +72214,9 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/bar/atrium)
 "xtO" = (
+/obj/machinery/suit_storage_unit/engine,
 /obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/storage/toolbox/electrical,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/iron/dark,
+/turf/open/floor/circuit/red,
 /area/station/engineering/supermatter/room)
 "xtV" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -72516,7 +72421,7 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron/showroomfloor,
-/area/station/medical/paramedic)
+/area/station/medical/office)
 "xwU" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags{
@@ -72554,7 +72459,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/medical/paramedic)
+/area/station/medical/office)
 "xxJ" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -72626,6 +72531,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "xzi" = (
@@ -72638,19 +72544,16 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "xzA" = (
-/obj/structure/disposalpipe/trunk{
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
-/obj/machinery/camera/directional/east{
-	c_tag = "Medbay Psychology Office";
-	name = "medical camera";
-	network = list("ss13","medical")
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
-/obj/machinery/disposal/bin/tagger,
-/turf/open/floor/iron/showroomfloor,
-/area/station/medical/psychology)
+/turf/open/floor/iron/dark,
+/area/station/medical/cryo)
 "xzC" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -72708,11 +72611,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "xAQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/security/prison)
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
+/obj/structure/sign/warning/cold_temp/directional/north,
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/cryo)
 "xAW" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/delivery,
@@ -72740,6 +72643,7 @@
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 8
 	},
+/obj/item/fishing_rod,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
 "xBs" = (
@@ -72755,14 +72659,6 @@
 /obj/structure/flora/bush/sparsegrass/style_random,
 /turf/open/floor/grass,
 /area/station/security/prison/garden)
-"xBz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/spawner/random/structure/crate,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
 "xBI" = (
 /turf/closed/wall/rust,
 /area/station/maintenance/port/fore)
@@ -72807,13 +72703,36 @@
 /area/station/hallway/primary/port)
 "xCr" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/suit_storage_unit/engine,
 /obj/structure/extinguisher_cabinet/directional/north,
-/obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/obj/structure/table,
+/obj/item/stock_parts/power_store/cell/emproof{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/item/stock_parts/power_store/cell/emproof{
+	pixel_x = 3;
+	pixel_y = 7
+	},
+/obj/item/stock_parts/power_store/cell/high,
+/obj/item/stock_parts/power_store/cell/high,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/stack/sheet/rglass{
+	amount = 50;
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/stack/sheet/plasteel/fifty{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
 /area/station/engineering/main)
 "xCy" = (
 /obj/effect/decal/cleanable/dirt,
@@ -73019,14 +72938,9 @@
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
 "xFt" = (
-/obj/structure/flora/grass/jungle/a/style_random,
-/obj/structure/flora/bush/ferny/style_random,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/structure/cable,
-/turf/open/floor/grass,
+/turf/open/floor/carpet,
 /area/station/medical/psychology)
 "xFw" = (
 /obj/machinery/computer/camera_advanced/xenobio{
@@ -73116,9 +73030,12 @@
 /turf/open/misc/asteroid/airless,
 /area/space/nearstation)
 "xGN" = (
-/obj/structure/cable,
-/turf/open/floor/plating/rust,
-/area/station/security/prison)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "xGQ" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/air,
@@ -73171,6 +73088,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/structure/plasticflaps/kitchen,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/greater)
 "xIm" = (
@@ -73231,20 +73149,10 @@
 /turf/open/floor/circuit/telecomms,
 /area/station/science/xenobiology)
 "xIQ" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Operating Theatre Secondary";
-	name = "medical camera";
-	network = list("ss13","medical")
-	},
-/obj/item/radio/intercom/directional/south,
-/obj/machinery/computer/operating{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/virology)
+/obj/effect/turf_decal/sand/plating,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating,
+/area/station/security/prison)
 "xIS" = (
 /obj/machinery/newscaster/directional/north,
 /obj/machinery/camera/directional/north{
@@ -73326,7 +73234,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/chair/stool/bar/directional/west,
-/mob/living/basic/trooper/russian,
 /turf/open/floor/carpet/green,
 /area/station/maintenance/port/greater)
 "xKr" = (
@@ -73384,9 +73291,8 @@
 	},
 /obj/structure/table,
 /obj/effect/spawner/surgery_tray/full,
-/obj/machinery/defibrillator_mount/directional/south,
 /turf/open/floor/iron/dark,
-/area/station/medical/surgery/aft)
+/area/station/medical/surgery/theatre)
 "xLk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -73551,9 +73457,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "xNP" = (
-/obj/machinery/power/smes/engineering,
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/structure/cable,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 5
+	},
+/obj/machinery/power/port_gen/pacman,
 /turf/open/floor/circuit/red,
 /area/station/engineering/supermatter/room)
 "xOa" = (
@@ -73575,7 +73483,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/mob/living/basic/mining/mook/worker,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/fore)
 "xOh" = (
@@ -73931,11 +73838,11 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/sign/warning/vacuum/external/directional/east,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/components/unary/airlock_pump,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "xUQ" = (
@@ -74384,23 +74291,24 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/greater)
 "ybO" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id = "Shower_2Privacy";
-	name = "Shower 2 Privacy Shutter"
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/commons/toilet/restrooms)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/item/kirbyplants/organic/plant18,
+/obj/machinery/camera/autoname/directional/east,
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron/showroomfloor,
+/area/station/medical/break_room)
 "ybS" = (
 /obj/structure/flora/grass/jungle/a/style_random,
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/structure/flora/bush/leavy/style_random,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/spawner/directional/north,
+/obj/structure/window/spawner/directional/south,
+/obj/structure/window/spawner/directional/west,
+/obj/structure/window/spawner/directional/east,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
 "ycd" = (
@@ -74411,9 +74319,9 @@
 /turf/open/floor/iron/dark,
 /area/station/ai/upload/chamber)
 "ycp" = (
-/mob/living/basic/mining/hivelord,
-/turf/open/misc/asteroid/lowpressure,
-/area/space/nearstation)
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/hos)
 "ycr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
@@ -74443,15 +74351,17 @@
 /area/station/maintenance/port/greater)
 "ycy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/box/corners{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown/half/contrasted,
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "ycF" = (
@@ -74505,6 +74415,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
 "yef" = (
@@ -74556,21 +74467,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain)
-"yeH" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/basic/ghost,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/starboard/fore)
 "yeK" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/light/directional/south,
-/obj/effect/spawner/random/structure/crate_abandoned,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/hallway/secondary/exit/departure_lounge)
+/obj/effect/turf_decal/sand/plating,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/security/prison)
 "yeY" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -74617,8 +74518,7 @@
 /area/station/hallway/primary/central/fore)
 "yfS" = (
 /obj/machinery/light/small/directional/west,
-/mob/living/basic/chicken,
-/turf/open/misc/sandy_dirt,
+/turf/open/water/no_planet_atmos/deep,
 /area/station/service/hydroponics/garden)
 "ygj" = (
 /obj/item/radio/intercom/directional/east,
@@ -80313,7 +80213,7 @@ aaa
 aeU
 aeu
 aeU
-amq
+aeU
 aeU
 aeu
 dWG
@@ -81090,18 +80990,18 @@ aeU
 mWy
 gCY
 gYA
-aDD
-aDD
+mqC
+mqC
 hkF
 mqC
 cUw
 pSN
 hhp
-aDD
+mqC
 clR
 mqC
-aDD
-sza
+mqC
+hhp
 kiW
 mWy
 aeu
@@ -81345,20 +81245,20 @@ aeu
 aeU
 aeU
 mWy
-cOf
-kkV
+ssF
+goj
 eCu
-kkV
-kkV
 goj
-kkV
-baG
+goj
+goj
+goj
+eCu
 mUA
-kkV
+goj
 gYA
 goj
 gYA
-kkV
+goj
 ssF
 mWy
 aeu
@@ -81610,9 +81510,9 @@ aes
 dWG
 sAv
 sAv
-xGN
-gyb
-gyb
+ssF
+mqC
+mqC
 sAv
 pCP
 sAm
@@ -81865,14 +81765,14 @@ toh
 fmm
 wJw
 dWG
-aaa
+hMC
 mWy
 tFn
 ajw
 ajw
 hvB
-aDD
-kkV
+mqC
+goj
 sAv
 sAv
 aeU
@@ -82122,14 +82022,14 @@ dWG
 hYo
 bNO
 dWG
-aaa
+sPK
 mWy
 hhi
 xlA
 xlA
 mWy
-jYo
-kkV
+xlA
+goj
 sAv
 aeU
 aeU
@@ -82368,10 +82268,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-vku
+aeU
+aeu
+aeu
+rsd
 nKO
 eJN
 eJN
@@ -82379,14 +82279,14 @@ nKO
 eJN
 eJN
 nKO
-qJs
+sPK
 sAv
 xDG
 pTC
 xlA
 mWy
 wBf
-kkV
+goj
 myp
 jYh
 jYh
@@ -82625,25 +82525,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-acm
-acm
-acm
-acK
-acm
-acm
-acm
-acm
-acm
+aUz
+aeu
+aeu
+rsd
+hMC
+hMC
+hMC
+hMC
+hMC
+hMC
+yeK
+sPK
 sAv
 woG
 bMw
 xlA
 vhZ
 ssF
-ezC
+goj
 iQg
 smC
 smC
@@ -82882,25 +82782,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-acm
-aaa
-aaa
-acK
-aaa
-aaa
-aaa
-aaa
-aaa
-mWy
+aeU
+aeu
+aeu
+rsd
+hMC
+hMC
+hMC
+hMC
+hMC
+hMC
+hMC
+sPK
+thU
 glo
 jsI
 xlA
 sAv
-aDD
-kkV
+mqC
+goj
 myp
 jYh
 jYh
@@ -83139,18 +83039,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-acm
-aaa
-aaa
-acK
-aaa
-aaa
-aaa
-aaa
-aaa
+aeU
+aeu
+aeu
+rsd
+hMC
+hMC
+jhX
+hMC
+yeK
+hMC
+hMC
+sPK
 twX
 nQK
 twX
@@ -83394,20 +83294,20 @@ aUz
 aeU
 aeU
 aeU
+aUz
+aaa
 aeU
-aaa
-aaa
-aaa
-aaa
-acm
-aaa
-aaa
-acm
-aaa
-aaa
-aaa
-aaa
-aaa
+aeu
+aeu
+rsd
+hMC
+xIQ
+sPK
+hMC
+hMC
+hMC
+xIQ
+sPK
 giH
 mTJ
 tMu
@@ -83653,25 +83553,25 @@ aeu
 aeu
 aeU
 aeU
-aaa
-aaa
-aaa
-acm
-aaa
-aaa
-qJs
-aaa
-aaa
-aaa
-aaa
-aaa
+aeU
+aeu
+aeu
+rsd
+hMC
+yeK
+sPK
+hMC
+hMC
+hMC
+hMC
+sPK
 twX
 rpB
 kYP
 pKm
 uzK
 bxj
-kkV
+goj
 dAu
 qWN
 sAv
@@ -83911,24 +83811,24 @@ aeu
 aeu
 aeu
 aeU
-aaa
-aaa
-acm
-aaa
-aaa
-acm
-aaa
-aaa
-aaa
-aaa
-aaa
+aeu
+aeU
+rsd
+hMC
+hMC
+sPK
+hMC
+yeK
+hMC
+hMC
+sPK
 twX
 miK
 lPU
 tns
 twX
-jYo
-ezC
+xlA
+goj
 jrT
 pLi
 mWy
@@ -84169,23 +84069,23 @@ mtV
 aeu
 aeu
 aeu
-aaa
-acm
-aaa
-aaa
-acK
-aaa
-aaa
-aaa
-aaa
-aaa
+aeu
+rsd
+hMC
+hMC
+sPK
+xIQ
+hMC
+hMC
+hMC
+sPK
 twX
 hTQ
 twX
 nQK
 twX
 kbC
-kkV
+goj
 avs
 yjM
 sAv
@@ -84421,25 +84321,25 @@ aeu
 mtV
 cfN
 jZJ
-aUh
+cfN
 mtV
 aeu
 aeu
 aeu
 aeu
-vku
-aUz
-aaa
-acK
-aaa
-aaa
-aaa
-aaa
-aaa
+rsd
+hPV
+hMC
+sPK
+hMC
+hMC
+hMC
+yeK
+sPK
 mWy
 huK
 szK
-xAQ
+szK
 wkN
 reX
 fxV
@@ -84684,22 +84584,22 @@ aeu
 aeu
 pqD
 stu
-pqD
-iza
-pqD
-acK
-aaa
-aaa
-aaa
-aaa
-aaa
+wDz
+wDz
+wDz
+jhX
+sPK
+sPK
+sPK
+sPK
+jhX
 mWy
 qAg
-kkV
+goj
 dHe
-jYo
-aDD
-kkV
+xlA
+mqC
+goj
 sAv
 xky
 sAv
@@ -84927,8 +84827,8 @@ aeu
 aeu
 aeu
 aeu
-aaa
-aaa
+aUh
+aUh
 aeu
 aeu
 aeu
@@ -84944,12 +84844,12 @@ tIu
 pYm
 iZV
 tqD
-acm
-aaa
-aaa
-aaa
-aaa
-aaa
+hMC
+hMC
+hMC
+hMC
+hMC
+hMC
 nKO
 dWG
 oCE
@@ -85183,9 +85083,9 @@ aeu
 aeu
 aeu
 aeu
-vku
-aeo
-aeo
+aeu
+aeu
+aeu
 aeu
 aeu
 aeu
@@ -85200,19 +85100,19 @@ pqD
 jhB
 atT
 ccf
-pqD
-qJs
-aaa
-aaa
-aaa
-aaa
-aaa
+wDz
+hMC
+yeK
+hMC
+hMC
+hMC
+hMC
 dWG
 wEy
 mbh
 xZn
 eJN
-aAu
+saW
 avT
 gSF
 dsn
@@ -85440,11 +85340,11 @@ aeu
 aeu
 aeu
 aeu
-aaQ
-aaa
-aaa
-aaa
-vku
+aeu
+aeu
+aeu
+aeu
+aeu
 aeu
 ycx
 oxK
@@ -85457,13 +85357,13 @@ pqD
 iza
 pqD
 uzD
-iza
-acm
-aaa
-aaa
+wDz
 hMC
-aaa
-aaa
+hMC
+hMC
+hMC
+hMC
+hMC
 dWG
 eXX
 mbh
@@ -85697,11 +85597,11 @@ aeu
 aeu
 aeu
 aeu
-qJs
-acK
-acm
-acK
-qJs
+aeu
+aeU
+aeu
+aeu
+aeu
 aeu
 vjh
 lVD
@@ -85714,12 +85614,12 @@ pqD
 mMb
 iza
 ugY
-pqD
-acm
-acm
-iTq
-gpH
-iTq
+wDz
+hMC
+hMC
+xIQ
+hMC
+hMC
 cov
 dWG
 vgz
@@ -85954,11 +85854,11 @@ aeu
 wDI
 aeu
 aeu
-aDT
-omw
-lHD
-omw
-sRm
+aeu
+aeu
+aeu
+aeu
+aeu
 aeu
 ycx
 vjh
@@ -85971,12 +85871,12 @@ cUD
 gFE
 txb
 swR
-pqD
-wYX
-iTq
-iTq
-dPK
-iTq
+wDz
+wDz
+wDz
+wDz
+wDz
+wDz
 iyk
 yhf
 dWG
@@ -86211,11 +86111,11 @@ ycx
 vjh
 vjh
 aeu
-aDU
-aaa
-aaa
-aaa
-aoe
+aeU
+aeu
+aeu
+aeu
+aeu
 aeu
 vjh
 aAR
@@ -86231,9 +86131,9 @@ pwT
 drG
 pqD
 kNP
-tZP
+iza
 duU
-kzl
+pqD
 hxL
 wDz
 wKG
@@ -86468,11 +86368,11 @@ tuP
 xGQ
 wuI
 aeu
-evE
-aaa
-aaa
-aaa
-evE
+aeu
+aeu
+aeu
+aUz
+aeu
 aeu
 vjh
 hah
@@ -86725,11 +86625,11 @@ pdE
 lGY
 vjh
 aeu
-jTt
-aaa
-aaa
-aaa
-lpF
+aeu
+aeu
+aeu
+aeu
+aeu
 aeu
 vjh
 ycx
@@ -86983,9 +86883,9 @@ vVC
 ycx
 vjh
 vjh
-aaa
-iXZ
-aaa
+aeu
+aeu
+aeu
 ycx
 vjh
 vjh
@@ -87240,9 +87140,9 @@ vOl
 jhy
 aHB
 vjh
-epN
-slM
-epN
+vjh
+vjh
+vjh
 vjh
 kQf
 fXy
@@ -87497,7 +87397,7 @@ mtV
 mtV
 jhy
 ycx
-bBJ
+qJY
 qJY
 mwR
 vjh
@@ -87755,7 +87655,7 @@ hBJ
 cYy
 vjh
 epN
-qHG
+epN
 epN
 ycx
 aNp
@@ -88012,7 +87912,7 @@ mtV
 jhy
 ycx
 vKV
-oSq
+vBi
 lnm
 xja
 foQ
@@ -88271,8 +88171,8 @@ vjh
 qwB
 vBi
 aiI
-vef
-udn
+vBi
+oVz
 dBg
 oVz
 vjh
@@ -88526,10 +88426,10 @@ hBJ
 cYy
 vjh
 vjh
-pue
+ycx
 kHh
-vjh
-vjh
+vBi
+vBi
 vjh
 vBi
 vmu
@@ -88785,7 +88685,7 @@ jBr
 vjh
 rPO
 jAc
-uKc
+vBi
 uXB
 vjh
 ycx
@@ -89043,7 +88943,7 @@ dgi
 rPN
 wzi
 bpI
-vBi
+mjc
 vjh
 bJv
 bJv
@@ -89299,8 +89199,8 @@ sXT
 udn
 vjh
 wWk
-ycx
-qXJ
+vBi
+lYv
 vjh
 bJv
 bJv
@@ -89555,9 +89455,9 @@ hPx
 vwv
 duA
 rNj
-vBi
-vBi
-hYa
+oct
+qHG
+oct
 ycx
 bJv
 bJv
@@ -89813,7 +89713,7 @@ dhe
 ycx
 vjh
 qVQ
-vBi
+lzY
 hYa
 vjh
 bJv
@@ -90070,8 +89970,8 @@ qsn
 otO
 vjh
 eNQ
-eNQ
-vjh
+bBJ
+odA
 vjh
 bJv
 bJv
@@ -90325,10 +90225,10 @@ mtV
 rPU
 dHL
 tPC
-lbK
-aaO
-ecF
-kLy
+eNQ
+cry
+uKc
+cry
 npr
 bJv
 bJv
@@ -90513,8 +90413,8 @@ wQN
 qeO
 wXa
 xFH
+bPZ
 qci
-wXa
 siH
 dEX
 rBa
@@ -90582,10 +90482,10 @@ mtV
 icR
 uJZ
 tPC
-lbK
-abJ
-ecF
-gtd
+eNQ
+cry
+cry
+cry
 npr
 bJv
 bJv
@@ -90770,7 +90670,7 @@ bbO
 rNx
 mZS
 bAs
-wXa
+bPZ
 foB
 ing
 fty
@@ -90802,7 +90702,7 @@ aeu
 aeu
 aeu
 aUz
-cui
+aeU
 aeu
 aeu
 aeu
@@ -90839,10 +90739,10 @@ llr
 vDU
 tSY
 tPC
-lbK
-bKl
-ecF
-vVX
+eNQ
+cry
+cry
+cry
 npr
 bJv
 bJv
@@ -91096,10 +90996,10 @@ vjh
 jjP
 woV
 fRz
-lbK
-mzt
-ecF
-vdK
+eNQ
+cry
+evE
+cry
 xDc
 bJv
 bJv
@@ -91646,7 +91546,7 @@ iBi
 fnL
 iBi
 hlS
-tSP
+ezC
 uey
 mWV
 vek
@@ -92373,9 +92273,9 @@ eUs
 vRU
 vRN
 gNq
-jop
+pyr
 xau
-jhX
+kHw
 myd
 ycx
 kex
@@ -92887,10 +92787,10 @@ ktA
 hdA
 kSx
 ruU
-jop
+pyr
 tAx
 pTc
-qGK
+pyr
 vjh
 wFG
 ycx
@@ -93128,7 +93028,7 @@ jcj
 qVD
 pVz
 oxp
-qbO
+noO
 xfZ
 tyA
 gHC
@@ -93144,10 +93044,10 @@ wcC
 hLz
 lRq
 fzG
-jop
+pyr
 mMa
 bBe
-qGK
+pyr
 cDJ
 eSu
 iRJ
@@ -93314,7 +93214,7 @@ aeu
 aeu
 aeu
 aeU
-cuj
+aeU
 aeU
 aap
 aeu
@@ -93409,12 +93309,12 @@ vXf
 pwF
 ufU
 vjh
-vjh
-eNQ
-eNQ
-eNQ
-eNQ
-vjh
+mtV
+mtV
+mtV
+mtV
+mtV
+mtV
 xju
 eKU
 jiR
@@ -93449,7 +93349,7 @@ dUE
 aVI
 oKW
 joh
-mDJ
+joh
 afL
 afL
 afL
@@ -93652,8 +93552,8 @@ kbH
 wKa
 tZc
 mfs
-eWd
-eWd
+jop
+jop
 qGK
 gQo
 qyo
@@ -93666,13 +93566,13 @@ ibL
 cdD
 rnJ
 xLd
-hpv
-aDQ
-ecF
+ubJ
+nWW
+ngT
+nKC
+nWW
+ngT
 xcR
-uiX
-xDc
-xDc
 xDc
 xDc
 vqr
@@ -93706,7 +93606,7 @@ pUA
 gFD
 oKW
 mlv
-qCZ
+ycp
 etB
 pya
 lsS
@@ -93924,12 +93824,12 @@ pwF
 kJH
 srx
 ubJ
-add
+mtr
 ecF
-acW
-aaO
-aDQ
-ybO
+nKC
+mtr
+pRf
+nsA
 gwn
 jiU
 tIk
@@ -94155,18 +94055,18 @@ pVz
 dYM
 eyj
 xBI
+hOY
 pqS
-pqS
-qUJ
+kUp
 iMr
-gsy
+ccY
 qqB
 hsW
 imP
 edU
-gsy
+ccY
 uMz
-dhY
+nKV
 nKV
 sbJ
 wue
@@ -94180,13 +94080,13 @@ rzB
 jMa
 suQ
 raS
-ubJ
-aaO
-ecF
-dyu
+fYw
+eoG
+cOY
+dEF
 bKl
-add
-osy
+cOY
+nsA
 uNO
 uNO
 bDV
@@ -94412,24 +94312,24 @@ xBI
 oRz
 pVz
 pVz
-nWW
+eUN
 lCa
 qez
 eUN
-gsy
+ccY
 clH
-sPK
+huR
 huR
 bXe
 gsy
-srg
+uCa
 uZT
-gKd
+uCa
 pMj
 dKa
 wCR
 sJM
-sJM
+ybO
 oKJ
 fth
 sJM
@@ -94438,11 +94338,11 @@ htS
 rKk
 hpv
 fYw
-nKC
-nKC
-dEF
-acZ
-adf
+srg
+vFc
+jOY
+vFc
+cOt
 nsA
 lOZ
 iun
@@ -94672,15 +94572,15 @@ wog
 lFN
 lBU
 hpQ
-eUN
+uEw
 pJr
 aQQ
 rjU
 kaT
 ekB
-gsy
+ayC
 uCa
-hPV
+uCa
 fph
 bsR
 aOS
@@ -94695,11 +94595,11 @@ gbk
 dQx
 sHn
 gkv
-jUi
-xIQ
 dEF
-nKC
-nKC
+dEF
+dEF
+vFc
+vpP
 dEF
 osy
 uNO
@@ -94931,11 +94831,11 @@ kEC
 wtP
 rwr
 wOy
-aQQ
+vtF
 tSc
 gPS
 buq
-gsy
+gZu
 mEt
 anI
 son
@@ -95211,7 +95111,7 @@ aDo
 gkv
 fjn
 hGm
-jdR
+dEF
 iju
 unz
 hkp
@@ -95439,18 +95339,18 @@ lCV
 pVz
 iTZ
 pVz
-hOY
+xAQ
 eWH
 okQ
 xzA
-eUN
+kkV
 ugq
 iCV
 ewa
 kDw
 kCZ
 jTu
-wEJ
+mEt
 kRu
 rFt
 sSJ
@@ -95466,7 +95366,7 @@ lBB
 sRZ
 cjS
 gkv
-eQg
+dEF
 iYf
 iyI
 eMW
@@ -95701,7 +95601,7 @@ jUU
 dkh
 jUU
 dkh
-gsy
+ccY
 aHC
 uko
 gsr
@@ -95721,8 +95621,8 @@ ofg
 ofg
 nlR
 uBX
-iyI
-dEF
+ofg
+llY
 iYW
 wEw
 dUn
@@ -95958,12 +95858,12 @@ vJg
 uJs
 pri
 eMB
-xvW
-xvW
+eer
+eer
 nbg
 qvi
-xvW
-xvW
+eer
+eer
 mbc
 rUP
 sSJ
@@ -95976,7 +95876,7 @@ xJN
 fPc
 ijC
 pIT
-iyI
+ofg
 rot
 bAQ
 nvH
@@ -96215,12 +96115,12 @@ yhI
 eby
 rhs
 gtK
-xvW
+eer
 bKU
 uUm
 oWQ
 fxx
-pBd
+aAu
 cTI
 gAO
 rFt
@@ -96472,12 +96372,12 @@ gGR
 ryC
 fgB
 axp
-pBd
+aAu
 gVg
 rQx
 xwO
 cvL
-xvW
+eer
 dAz
 kqn
 rFt
@@ -96490,10 +96390,10 @@ cSl
 lkl
 jMU
 jJd
-iyI
+ofg
 iYA
 hih
-iyI
+llY
 lyr
 oYu
 aLC
@@ -96536,7 +96436,7 @@ ctt
 ibJ
 tFS
 rTB
-ams
+iXZ
 hZg
 aka
 aeu
@@ -96729,8 +96629,8 @@ vxZ
 tLh
 lrc
 lHy
-xvW
-xvW
+eer
+eer
 rRZ
 pbk
 qpP
@@ -96747,13 +96647,13 @@ vbT
 etY
 nri
 wNQ
-iyI
-iyI
-nKC
-iyI
+ofg
+xvW
+chM
 qjM
-ffa
-hkp
+qjM
+qjM
+qYy
 dEF
 dEF
 dEF
@@ -97005,12 +96905,12 @@ fxt
 fbK
 rtr
 eDr
-nlR
+pBd
 jHo
 rBS
 wFs
 oJH
-iyI
+xvW
 gbh
 umL
 bwW
@@ -97262,7 +97162,7 @@ erH
 gaE
 uNK
 qCj
-nKC
+lia
 xoK
 evD
 gZI
@@ -97505,7 +97405,7 @@ dkh
 fyw
 vUr
 xxz
-xvW
+eer
 fXm
 nes
 uTM
@@ -97519,12 +97419,12 @@ ouK
 fKf
 fyZ
 qNL
-iyI
-evD
+xvW
+jDU
 ear
 qip
-nlR
-iyI
+aDD
+xvW
 tqG
 cZT
 rhN
@@ -97751,8 +97651,8 @@ efG
 ogg
 eFR
 fVJ
-oLs
-odA
+eFR
+eFR
 nax
 dkh
 jUU
@@ -97762,7 +97662,7 @@ dkh
 uVJ
 rKT
 aPT
-pBd
+aAu
 mlz
 gOh
 nes
@@ -97776,11 +97676,11 @@ ofg
 cRW
 yaH
 cRW
-iyI
-iyI
-iyI
-iyI
-iyI
+xvW
+xvW
+xvW
+xvW
+xvW
 bKc
 lCz
 ryK
@@ -98008,8 +97908,8 @@ qlC
 tbn
 lLp
 aWI
-lYv
-lzY
+eFR
+eFR
 nCA
 cXZ
 kxU
@@ -98265,9 +98165,9 @@ efG
 xIS
 eFR
 aWI
-mjc
-oct
-hsJ
+eFR
+eFR
+nax
 cXZ
 krg
 idh
@@ -98523,8 +98423,8 @@ fSY
 eFR
 xdY
 vxf
-aSX
-kPf
+jTt
+oLs
 euc
 hHL
 dUQ
@@ -98553,7 +98453,7 @@ gXG
 byS
 ofp
 ryW
-ryW
+hXe
 qNh
 gFR
 uqc
@@ -99892,7 +99792,7 @@ aaa
 acm
 kCk
 pLC
-vJH
+arU
 arU
 arU
 jvQ
@@ -101686,7 +101586,7 @@ oaK
 oLp
 tvH
 osW
-oNr
+uvO
 mLN
 nqn
 nDX
@@ -102714,7 +102614,7 @@ nDi
 fqO
 unr
 sni
-pBh
+hkW
 mLN
 mSm
 vEt
@@ -103130,9 +103030,9 @@ iGD
 lTc
 mMj
 uba
-ccY
-bzS
-cdt
+acm
+acK
+acm
 acm
 aaa
 aaa
@@ -103390,7 +103290,7 @@ pem
 eTp
 acm
 aaa
-cev
+acm
 aaa
 aaa
 acm
@@ -103645,9 +103545,9 @@ aed
 jsj
 rTD
 ePb
-aoE
-aoE
-aoE
+aqv
+aqv
+aqv
 aqv
 awb
 axk
@@ -103904,7 +103804,7 @@ hSJ
 eTp
 acm
 aaa
-chM
+acm
 aaa
 aaa
 acm
@@ -104158,9 +104058,9 @@ irE
 ill
 aSa
 gMy
-cdl
-bzS
-cdu
+acm
+acK
+acm
 acm
 aaa
 aaa
@@ -104963,7 +104863,7 @@ tGZ
 wLu
 mlw
 eDT
-fzL
+vJH
 bji
 qTC
 iRt
@@ -105942,7 +105842,7 @@ anH
 aeu
 aeu
 aeU
-amq
+aeU
 aeu
 aeu
 aeu
@@ -107515,7 +107415,7 @@ cIX
 cIX
 fvU
 plG
-yeH
+exP
 yaY
 uIZ
 wxI
@@ -108784,7 +108684,7 @@ aeU
 aeu
 aeu
 aeU
-cui
+aeU
 aeU
 aeu
 aeu
@@ -109395,7 +109295,7 @@ qfg
 ulF
 abq
 ffQ
-qfg
+jYo
 vHa
 qAo
 kLx
@@ -109892,8 +109792,8 @@ xOI
 hON
 wcX
 hwN
-hlJ
-utf
+hwN
+hwN
 oBP
 ocQ
 gTr
@@ -110393,7 +110293,7 @@ qzv
 qur
 iNi
 jmE
-uJV
+ioQ
 mQR
 elz
 lxp
@@ -110668,8 +110568,8 @@ vfd
 ePY
 vfd
 iKg
-ekm
-twN
+uSH
+xOB
 xqE
 exD
 ekm
@@ -110925,7 +110825,7 @@ evb
 tNW
 oCo
 wnl
-doU
+oCo
 eOW
 aGR
 eEZ
@@ -111164,7 +111064,7 @@ lgv
 khe
 hNi
 etm
-qBs
+inf
 gbp
 wmG
 hLr
@@ -111181,8 +111081,8 @@ snU
 oDh
 dJw
 jgt
-bkn
-uvm
+kmo
+kmo
 dGX
 tyI
 pSh
@@ -111421,10 +111321,10 @@ fVj
 gne
 sHC
 vzy
-vzy
-vzy
-vzy
-nHO
+ioQ
+ioQ
+ioQ
+inf
 cuV
 cuV
 bhJ
@@ -111439,10 +111339,10 @@ uso
 afH
 gII
 sCr
-doU
+kmo
 gKR
 mPS
-bjb
+bkn
 rea
 mSC
 kHK
@@ -111698,7 +111598,7 @@ uMk
 pGE
 doU
 kaM
-mPS
+qUJ
 bjb
 rea
 mSC
@@ -111952,15 +111852,15 @@ fvC
 xCr
 kmo
 gMC
-vOq
-bGY
-wTe
-inf
-eJs
-uJN
-nHC
+uSH
+uSH
+uSH
+uSH
+uSH
+ekm
+vUD
 iwS
-wXM
+shH
 uYM
 sJH
 shH
@@ -112206,19 +112106,19 @@ qZX
 jjs
 qZX
 qZX
-uSH
-dmf
-xOB
-qZX
-qZX
-qZX
-hjj
-jjs
-qZX
-rKn
-lyu
+ccR
+kmo
+vKj
+uvm
+amq
 lDb
-lyu
+hjj
+bGj
+vOq
+rKn
+vRo
+vRo
+vRo
 vRo
 ifB
 cfs
@@ -112462,16 +112362,16 @@ iFa
 cAq
 oQk
 wHr
-cuV
+qZX
 kHs
 rbp
 nan
-cuV
+uvm
 vLG
-cuV
-sOJ
 aov
-qZX
+aov
+aov
+ekm
 xNP
 wPU
 xtO
@@ -112719,16 +112619,16 @@ mFb
 qeX
 cXQ
 cAq
-cuV
-fuB
-cuV
-cuV
-cuV
-aAU
-oQk
-xBz
-gDM
 qZX
+qZX
+qZX
+nym
+ekm
+ekm
+ekm
+ekm
+ekm
+ekm
 pKR
 fyj
 qZX
@@ -112978,8 +112878,8 @@ jxy
 jID
 qqZ
 iHN
+sOJ
 mFb
-pDm
 mwG
 xJc
 hDy
@@ -112997,7 +112897,7 @@ vBR
 isD
 cFq
 aVl
-dOF
+pDm
 tJh
 dOz
 jYe
@@ -113504,16 +113404,16 @@ bUI
 caP
 cuV
 fuB
-cuV
-cuV
-fuB
+qZX
+qZX
+qZX
 hiQ
 vGu
-cuV
+qZX
 gDM
 dqL
-vHF
-vHF
+aAU
+aAU
 stx
 wuv
 tmH
@@ -113761,12 +113661,12 @@ bUN
 bUd
 iVL
 iVL
-cKz
+usr
 oki
 oCd
 mqK
 qGi
-cuV
+qZX
 jIR
 cuV
 kuK
@@ -114018,12 +113918,12 @@ bUN
 bUe
 iVL
 iVL
-uvO
+usr
 fqe
 qOQ
 rzR
 nCf
-fuB
+qZX
 cuV
 qZX
 qpj
@@ -116304,7 +116204,7 @@ cQR
 cQR
 cQR
 vOW
-wJe
+aoE
 sMh
 iCW
 gLK
@@ -116313,10 +116213,10 @@ vOW
 miM
 jYb
 sIr
-fSC
-lia
-qYy
-vtF
+rCi
+rCi
+rCi
+rCi
 mkk
 rCi
 mkk
@@ -116508,7 +116408,7 @@ asj
 pSu
 esO
 pCj
-lgl
+esO
 esO
 rou
 rZV
@@ -116558,26 +116458,26 @@ aaa
 acm
 aaa
 acm
-wJe
-rMI
-iSU
-jij
-wJe
-mHu
+uJV
+lcg
+hyt
+dPK
+wTe
+acZ
 seN
 chg
 ybS
 noE
 tej
-wkB
-iWT
-iOW
+lFC
+lFC
+utU
 mnK
-iOW
-vOW
-iVL
-iVL
-vFc
+oIu
+eQg
+ddT
+iNK
+bTT
 bUN
 bUN
 bUN
@@ -116815,26 +116715,26 @@ jAF
 xqQ
 jAF
 acm
-vOW
-dSw
-qiL
-msZ
-gHA
+qBs
+wEJ
+fol
+oMU
+baG
 oaF
 gLK
 vQf
 vOW
 xnU
 dSt
-eer
-cOt
+lFC
+lFC
 vte
 ruc
-rsd
-sMh
-iVL
-bPK
-bPZ
+fQb
+lSl
+xGN
+gYm
+bTT
 bUN
 bUN
 bUN
@@ -117072,25 +116972,25 @@ aaa
 aaa
 aaa
 acK
-wJe
-hQs
-gsl
-bHL
-wJe
+uJV
+jUi
+kMi
+vhn
+seO
 mHu
 hVF
 chg
 tdn
 xWJ
 cua
-eer
-hkW
-jDU
-apl
-ivY
-sMh
-iVL
-iVL
+lFC
+lFC
+heX
+qjK
+fQb
+lSl
+xGN
+bzS
 bTT
 bUO
 bUN
@@ -117329,26 +117229,26 @@ aaa
 aaa
 aaa
 acK
+vOW
+vOW
+vOW
 sMh
-iZX
-lkp
-nqx
-awt
-qjK
+vOW
+eWd
 evu
 seN
 iVy
 gLK
 rZO
 qjK
-heX
-oHG
-tBn
-yeK
-vOW
-iVL
-iVL
-vJm
+jMl
+qjK
+lFC
+fQb
+uAe
+cdl
+cdt
+rCi
 cic
 cic
 cic
@@ -117587,24 +117487,24 @@ aaa
 aaa
 acK
 wJe
-twj
-unb
-wGh
+rMI
+iSU
+jij
 wJe
 otA
-uAe
-udg
-vKj
-vCM
 hRO
+udg
+tej
+lFC
+lFC
 ycy
-iOW
-sEx
-utU
-fQb
-sMh
-rCi
-rCi
+vOW
+dfY
+lFC
+cHO
+vOW
+qaa
+bPK
 cVr
 bYe
 bYe
@@ -117616,8 +117516,8 @@ bYe
 mkk
 rCi
 rCi
-pcC
-aeU
+rCi
+rCi
 cmU
 cmU
 nNb
@@ -117844,38 +117744,38 @@ aaa
 aaa
 acm
 vOW
-wJe
-wJe
-iCP
-pZA
-fGM
-iOW
-cYN
-qwa
-kQO
-iOW
-fGM
+dSw
+qiL
+msZ
+gHA
+wkB
+lFC
+lFC
+lFC
+lFC
+dsh
+pcC
 sMh
-fkT
-iOW
-iOW
+nHC
+lFC
+apl
 vOW
-aeu
-aeu
-acm
-acm
-acK
-acK
-acm
-acK
-acK
-acm
-acm
-aeu
-aeu
-aeU
-aeU
-cmU
+cdl
+gpH
+vOW
+gyb
+gKd
+gKd
+gKd
+gKd
+gKd
+gKd
+gKd
+gKd
+gKd
+wYX
+sMh
+hVy
 kgD
 kgD
 gix
@@ -118049,7 +117949,7 @@ aeu
 aeu
 aeU
 aeU
-cui
+aeU
 aeu
 aeu
 aeu
@@ -118100,38 +118000,38 @@ aaa
 aaa
 aaa
 acm
-aaa
-aaa
-iOW
-lmk
-iOW
-lmk
-iOW
-iOW
-tbi
-iOW
-iOW
-lmk
-iOW
-rZb
-iOW
-acm
-aeu
-aeu
-aUz
-acm
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-acm
-cmU
-aeU
-cmU
-aUz
+wJe
+hQs
+gsl
+bHL
+wJe
+wkB
+dsh
+lFC
+epv
+lFC
+lFC
+dOF
+vOW
+cKz
+lFC
+fQb
+uAe
+cdl
+tBn
+vOW
+qeH
+ffa
+ffa
+ffa
+ffa
+ffa
+ffa
+ffa
+ffa
+ffa
+ffa
+dyH
 cmU
 oAg
 oAg
@@ -118356,39 +118256,39 @@ aaa
 aaa
 aaa
 aaa
-qJs
 acm
-qJs
-iOW
-noj
-iOW
-vuk
-iOW
-tlA
-oVP
-juq
-iOW
-noj
-iOW
-vuk
-iOW
-qJs
-acm
-acm
-acm
-qJs
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-qJs
-cmU
-aaa
-acm
-aaa
+sMh
+iZX
+lkp
+nqx
+awt
+wkB
+lFC
+lFC
+lFC
+dsh
+lFC
+qjK
+dmf
+qjK
+lFC
+fQb
+uAe
+cdl
+tBn
+dhY
+qYN
+ffa
+ffa
+ffa
+ffa
+ffa
+ffa
+ffa
+ffa
+ffa
+vJm
+vOW
 cmU
 kgD
 kgD
@@ -118495,7 +118395,7 @@ aeu
 aeU
 aeU
 aeU
-cuj
+aeU
 aeU
 aeu
 aeu
@@ -118613,39 +118513,39 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-iOW
-jQy
-iOW
-jQy
-iOW
-iOW
-tbi
-iOW
-iOW
-jQy
-iOW
-jQy
-iOW
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 acm
-aaa
-acm
-aaa
+wJe
+twj
+unb
+wGh
+wJe
+cdu
+dyu
+lFC
+lFC
+lFC
+cOf
+pID
+vCM
+pID
+qbO
+aYd
+uAe
+cdl
+hKP
+vOW
+qeH
+ffa
+ffa
+ffa
+ffa
+ffa
+ffa
+ffa
+ffa
+ffa
+vJm
+vOW
 acm
 aaa
 nNb
@@ -118870,39 +118770,39 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-iOW
-wkT
-wzy
-emb
-iOW
-qJs
 acm
-qJs
+vOW
+wJe
+wJe
+iCP
+pZA
+fGM
 iOW
-emb
-wzy
-fxw
+cYN
+qwa
+kQO
 iOW
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaQ
-aeo
-aeo
-aeo
-acm
+fGM
+sMh
+fkT
+iOW
+iOW
+vOW
+xGN
+acJ
+vOW
+iWT
+sza
+sza
+sza
+sza
+sza
+sza
+sza
+sza
+sza
+toG
+vOW
 aeo
 acm
 kgD
@@ -119127,39 +119027,39 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-fol
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 acm
 aaa
+aaa
+iOW
+lmk
+iOW
+lmk
+iOW
+iOW
+tbi
+iOW
+iOW
+lmk
+iOW
+rZb
+iOW
+uKE
+vOW
+iOW
+iOW
+vOW
+vOW
+iOW
+iOW
+vOW
+iOW
+iOW
+vOW
+vOW
+vOW
+sMh
+vOW
+noM
 aeo
 aaa
 oAg
@@ -119384,38 +119284,38 @@ aaa
 aaa
 aaa
 aaa
+qJs
+acm
+qJs
+iOW
+noj
+iOW
+vuk
+iOW
+tlA
+oVP
+juq
+iOW
+noj
+iOW
+vuk
+iOW
+acm
+aaa
+acm
+acm
+acm
+acm
+acm
+acm
+acm
+acm
+acm
+acm
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaQ
-aeo
 acm
 aeo
 acm
@@ -119644,31 +119544,31 @@ aaa
 aaa
 aaa
 aaa
+iOW
+jQy
+iOW
+jQy
+iOW
+iOW
+tbi
+iOW
+iOW
+jQy
+iOW
+jQy
+iOW
+acm
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aeo
+aeo
+aaQ
+aeo
+aeo
+aeo
+aeo
+aeo
+aaQ
+aeo
 aaa
 aaa
 aaa
@@ -119901,27 +119801,27 @@ aaa
 aaa
 aaa
 aaa
+iOW
+wkT
+wzy
+emb
+iOW
+qJs
+acm
+qJs
+iOW
+emb
+wzy
+fxw
+iOW
+acm
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaB
+nFg
+acm
+nFg
 aaa
 aaa
 aaa
@@ -120161,7 +120061,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+tlc
 aaa
 aaa
 aaa
@@ -121458,7 +121358,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aaB
 aaa
 aaa
 aaa
@@ -122887,7 +122787,7 @@ aeu
 dvN
 dvN
 dvN
-ycp
+dvN
 dvN
 dvN
 dvN
@@ -123382,7 +123282,7 @@ aeu
 aeu
 aeu
 aeU
-cui
+aeU
 aeU
 aeU
 aeu
@@ -123972,7 +123872,7 @@ aeu
 aeu
 aeu
 aUz
-amq
+aeU
 aeU
 aeu
 aeu
@@ -124169,7 +124069,7 @@ aeu
 aeu
 aap
 aoz
-thU
+dvN
 dvN
 dvN
 aeu
@@ -127831,7 +127731,7 @@ aeU
 aeu
 aeu
 aeu
-cuj
+aeU
 aeu
 aeu
 aeu
@@ -132954,7 +132854,7 @@ aeu
 aeu
 aeu
 aeu
-amq
+aeU
 aeU
 coy
 aeu

--- a/StationMaps/KiloStation/KiloStation.dmm
+++ b/StationMaps/KiloStation/KiloStation.dmm
@@ -6642,6 +6642,16 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"ckg" = (
+/obj/machinery/door/airlock/external{
+	name = "Atmospherics External Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "atmos_end_big_lad"
+	},
+/turf/open/floor/plating/airless,
+/area/station/maintenance/disposal/incinerator)
 "ckn" = (
 /obj/structure/sign/warning/docking,
 /turf/closed/wall,
@@ -9311,6 +9321,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"dgd" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "atmos_end_big_lad"
+	},
+/obj/machinery/door/airlock/external{
+	name = "Atmospherics External Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating/airless,
+/area/station/maintenance/disposal/incinerator)
 "dgg" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/pipedispenser/disposal,
@@ -17228,9 +17250,6 @@
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /turf/open/floor/iron/showroomfloor,
 /area/station/engineering/atmos)
-"fHN" = (
-/turf/open/floor/plating,
-/area/station/cargo/sorting)
 "fHZ" = (
 /obj/structure/table,
 /obj/item/assembly/signaler{
@@ -19894,16 +19913,6 @@
 "gyV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/disposal/incinerator)
-"gzd" = (
-/obj/machinery/door/airlock/external{
-	name = "Atmospherics External Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "atmos_end_big_lad"
-	},
-/turf/open/floor/plating/airless,
 /area/station/maintenance/disposal/incinerator)
 "gzh" = (
 /obj/effect/decal/cleanable/dirt,
@@ -32731,6 +32740,9 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"kFo" = (
+/turf/open/floor/plating,
+/area/station/cargo/sorting)
 "kFw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -37889,6 +37901,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/wall_healer/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/lobby)
 "mlB" = (
@@ -65113,18 +65126,6 @@
 "vkh" = (
 /turf/closed/wall,
 /area/station/hallway/primary/central)
-"vkm" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "atmos_end_big_lad"
-	},
-/obj/machinery/door/airlock/external{
-	name = "Atmospherics External Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating/airless,
-/area/station/maintenance/disposal/incinerator)
 "vkq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -101695,7 +101696,7 @@ nqn
 nDX
 bfA
 vCV
-vkm
+dgd
 ekp
 dtb
 xWT
@@ -101953,7 +101954,7 @@ qsv
 bfA
 drk
 mLN
-gzd
+ckg
 dtb
 laf
 pOG
@@ -112704,7 +112705,7 @@ jYL
 oJd
 uov
 uIx
-fHN
+kFo
 rpN
 bHl
 drl


### PR DESCRIPTION
hi, i am a first time mapper and this is my first time map. this PR revamps kilostation's engineering and medical departments (as well as the prison) to feel less claustrophobic and adds an extra docking bay at departures so the centcomm ferry doesn't have to be in maintenance anymore. this also brings kilo up to date on stuff that it should have (i think anyways, let me know if anything is missing) and fixes some stuff disappearing from being repathed, as well as removing all of the hostile simplemobs from the station z level.

<img width="8160" height="8160" alt="StrongDMM-2026-05-17 16 12 42" src="https://github.com/user-attachments/assets/f347020f-bf44-491d-b891-f530a385d988" />
